### PR TITLE
Add a schema for the Morpheus subprovider

### DIFF
--- a/internal/subproviders/morpheus/model/model.go
+++ b/internal/subproviders/morpheus/model/model.go
@@ -3,5 +3,8 @@
 package model
 
 type SubModel struct {
-	URL string `tfsdk:"url"`
+	URL         string `tfsdk:"url"`
+	Username    string `tfsdk:"username"`
+	Password    string `tfsdk:"password"`
+	AccessToken string `tfsdk:"access_token"`
 }

--- a/internal/subproviders/morpheus/morpheus.go
+++ b/internal/subproviders/morpheus/morpheus.go
@@ -51,10 +51,17 @@ func (SubProvider) GetName(_ context.Context) string {
 
 func (SubProvider) GetSchema(_ context.Context) map[string]schema.Attribute {
 	parentBlock := path.MatchRelative().AtParent()
+
 	return map[string]schema.Attribute{
 		"url": schema.StringAttribute{
 			MarkdownDescription: "Morpheus instance URL",
 			Required:            true,
+			Validators: []validator.String{
+				stringvalidator.Any(
+					stringvalidator.AlsoRequires(parentBlock.AtName("username")),
+					stringvalidator.AlsoRequires(parentBlock.AtName("access_token")),
+				),
+			},
 		},
 		"username": schema.StringAttribute{
 			MarkdownDescription: "Morpheus username for authentication, required if password is set",


### PR DESCRIPTION
Adds a first-pass of a schema for the Morpheus subprovider.
Includes validation to ensure that a password is always specifed along with the username and that the access token is not specified when using user authentication.
