### PR TITLE
Add additional test

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -105,8 +105,6 @@ func (p *HPEProvider) Configure(
 				"Failed to configure "+s.GetName(ctx),
 				err.Error(),
 			)
-
-			return
 		}
 		d[s.GetName(ctx)] = v
 	}

--- a/internal/subproviders/morpheus/configure/configure.go
+++ b/internal/subproviders/morpheus/configure/configure.go
@@ -23,21 +23,8 @@ func (r *ResourceWithMorpheusConfigure) Configure(
 	req resource.ConfigureRequest,
 	resp *resource.ConfigureResponse,
 ) {
-	msg := `
-Morpheus resource present, but possible missing morpheus provider block.
-
-provider "hpe" {
-  morpheus { <- missing or duplicate?
-    url = "https://example.com"
-  }
-}`
+	// provider.Configure is not guaranteed to have run yet
 	if req.ProviderData == nil {
-		tflog.Debug(ctx, "Nil ProviderData block")
-		resp.Diagnostics.AddError(
-			constants.SubProviderName+" client creation failed",
-			msg,
-		)
-
 		return
 	}
 
@@ -45,6 +32,14 @@ provider "hpe" {
 	cf, ok := m[constants.SubProviderName].(*clientfactory.ClientFactory)
 	if !ok {
 		tflog.Debug(ctx, "Nil ProviderData sub block")
+		msg := `
+Morpheus resource present, but possible missing morpheus provider block.
+
+provider "hpe" {
+  morpheus { <- missing or duplicate?
+    url = "https://example.com"
+  }
+}`
 		resp.Diagnostics.AddError(
 			constants.SubProviderName+" client creation failed",
 			msg,

--- a/internal/subproviders/morpheus/model/model.go
+++ b/internal/subproviders/morpheus/model/model.go
@@ -3,8 +3,8 @@
 package model
 
 type SubModel struct {
-	URL         string `tfsdk:"url"`
-	Username    string `tfsdk:"username"`
-	Password    string `tfsdk:"password"`
-	AccessToken string `tfsdk:"access_token"`
+	URL         string  `tfsdk:"url"`
+	Username    *string `tfsdk:"username"`
+	Password    *string `tfsdk:"password"`
+	AccessToken *string `tfsdk:"access_token"`
 }

--- a/internal/subproviders/morpheus/morpheus_test.go
+++ b/internal/subproviders/morpheus/morpheus_test.go
@@ -88,6 +88,37 @@ resource "hpe_morpheus_fake" "foo" {
 	})
 }
 
+func TestAccMorpheusSubProviderOk(t *testing.T) {
+	providerConfig := `
+provider "hpe" {
+	morpheus {
+		url = "https://example.com"
+		username = "test-user"
+		password = "test-password"
+	}
+}
+
+resource "hpe_morpheus_fake" "foo" {
+	name = "bar"
+}
+`
+	check := testresource.TestCheckResourceAttr(
+		"hpe_morpheus_fake.foo",
+		"name",
+		"bar",
+	)
+	testresource.Test(t, testresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []testresource.TestStep{
+			{
+				Config:             providerConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              check,
+			},
+		},
+	})
+}
+
 func TestAccMorpheusSubProviderMissingAuth(t *testing.T) {
 	providerConfig := `
 provider "hpe" {
@@ -264,8 +295,8 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var plan FakeModel
-	req.Plan.Get(ctx, &plan)
+	var data FakeModel
+	req.Plan.Get(ctx, &data)
 
 	_, err := r.NewClient(ctx)
 	if err != nil {
@@ -276,6 +307,7 @@ func (r *Resource) Create(
 
 		return
 	}
+	resp.State.Set(ctx, &data)
 }
 
 func (r *Resource) Read(


### PR DESCRIPTION
Add test where sufficient provider block fields are present.

Update per-resource Configure to handle nil ProviderData so that test can pass.