### PR TITLE
Add ability to trace http requests

### DIFF
--- a/internal/subproviders/morpheus/client/client.go
+++ b/internal/subproviders/morpheus/client/client.go
@@ -1,7 +1,11 @@
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
-
 package client
 
+import (
+	"net/http"
+)
+
 type Client struct {
-	URL string
+	HTTPClient *http.Client // HTTP client to use for requests
+	URL        string
 }

--- a/internal/subproviders/morpheus/clientfactory/clientfactory.go
+++ b/internal/subproviders/morpheus/clientfactory/clientfactory.go
@@ -4,19 +4,38 @@ package clientfactory
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/client"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/httptrace"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/model"
 )
 
 func New(m model.SubModel) *ClientFactory {
-	return &ClientFactory{model: m}
+	t := http.DefaultTransport
+
+	if httptrace.Enabled() {
+		t = httptrace.New(t)
+	}
+
+	return &ClientFactory{
+		transport: t,
+		model:     m,
+	}
 }
 
 type ClientFactory struct {
-	model model.SubModel
+	transport http.RoundTripper
+	model     model.SubModel
 }
 
 func (c ClientFactory) New(_ context.Context) client.Client {
-	return client.Client{URL: c.model.URL.ValueString()}
+	httpClient := &http.Client{
+		Transport: c.transport,
+	}
+
+	return client.Client{
+		HTTPClient: httpClient,
+		URL:        c.model.URL.ValueString(),
+	}
 }

--- a/internal/subproviders/morpheus/httptrace/httptrace.go
+++ b/internal/subproviders/morpheus/httptrace/httptrace.go
@@ -1,0 +1,63 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package httptrace
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ http.RoundTripper = TraceRoundTripper{}
+
+func Enabled() bool {
+	_, enabled := os.LookupEnv("MORPHEUS_API_HTTPTRACE")
+
+	return enabled
+}
+
+func New(
+	transport http.RoundTripper,
+) http.RoundTripper {
+	return TraceRoundTripper{
+		Transport: transport,
+	}
+}
+
+type TraceRoundTripper struct {
+	Transport http.RoundTripper
+}
+
+func (t TraceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqBytes, err := httputil.DumpRequestOut(req, true)
+	if err == nil {
+		tflog.Info(req.Context(),
+			"\n\n->TX\n\n"+
+				string(reqBytes)+
+				"--\n")
+	} else {
+		msg := fmt.Sprintf("Error tracing request: %v", err)
+		tflog.Error(req.Context(), msg)
+	}
+
+	resp, err := t.Transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	respBytes, err := httputil.DumpResponse(resp, true)
+	if err == nil {
+		tflog.Info(req.Context(),
+			"\n\n<-RX\n\n"+
+				string(respBytes)+
+				"\n--\n")
+	} else {
+		msg := fmt.Sprintf("Error tracing response: %v", err)
+		tflog.Error(req.Context(), msg)
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
Setting the environment variable `MORPHEUS_API_HTTPTRACE` to any value, eg:

```
export MORPHEUS_API_HTTPTRACE=1
```

will allow tracing of everything in each http request and response in this format:

```
->TX

POST /foo HTTP/1.1
Host: localhost:8080
User-Agent: Go-http-client/1.1
Accept: application/json
Authorization: Bearer abcdefghijklmnopqrstuvwxyz-0123456789
Content-Type: application/json

{"name":"foo"}

<-RX
.
.
.

```

Note: sensitive data such as tokens will be displayed (this is intended for
debug purposes only).

This should become active once we start using a 'real' client and
propagate the `context` appropriately.