### PR TITLE
Add the ability to enable tracing

### DIFF
--- a/internal/subproviders/morpheus/clientfactory/clientfactory.go
+++ b/internal/subproviders/morpheus/clientfactory/clientfactory.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/auth"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/httptrace"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/model"
 	"github.com/HewlettPackard/hpe-morpheus-client/client"
 )
@@ -106,6 +107,12 @@ func NewAPIClient(
 			Transport: authTransport,
 			Timeout:   15 * time.Second,
 		}
+	}
+
+	if httptrace.Enabled() {
+		c.GetConfig().HTTPClient.Transport = httptrace.New(
+			c.GetConfig().HTTPClient.Transport,
+		)
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
The tracing code was "dormant". Here we
add the tracing roundtripper when the appropriate
env var is set. This means that setting

```
MORPHEUS_API_HTTPTRACE=1
```

will now produce http request/response tracing, eg

```
->TX

GET /api/users/1 HTTP/1.1
Host: alcatraz-bhyve1.its.hpecorp.net
User-Agent: OpenAPI-Generator/1.0.0/go
Accept: application/json
Accept-Encoding: gzip
.
.
.
```