### PR TITLE
Perform server cert validation

### DIFF
--- a/internal/subproviders/morpheus/auth/creds.go
+++ b/internal/subproviders/morpheus/auth/creds.go
@@ -3,7 +3,6 @@ package auth
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"sync"
@@ -109,6 +108,7 @@ func (c *CredsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 
 func NewCredsRoundTripper(
 	_ context.Context,
+	transport http.RoundTripper,
 	url string,
 	username string,
 	password string,
@@ -117,17 +117,14 @@ func NewCredsRoundTripper(
 	morpheusCfg.Servers[0].URL = url
 
 	client := client.NewAPIClient(morpheusCfg)
-	t := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-	}
 
 	morpheusCfg.HTTPClient = &http.Client{
-		Transport: t,
+		Transport: transport,
 		Timeout:   15 * time.Second,
 	}
 
 	rt := CredsRoundTripper{
-		baseTransport: t,
+		baseTransport: transport,
 		client:        client,
 		username:      username,
 		password:      password,

--- a/internal/subproviders/morpheus/auth/token.go
+++ b/internal/subproviders/morpheus/auth/token.go
@@ -3,7 +3,6 @@ package auth
 
 import (
 	"context"
-	"crypto/tls"
 	"net/http"
 	"sync"
 )
@@ -39,14 +38,11 @@ func (t *TokenRoundTripper) RoundTrip(
 
 func NewTokenRoundTripper(
 	_ context.Context,
+	transport http.RoundTripper,
 	token string,
 ) http.RoundTripper {
-	t := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-	}
-
 	rt := TokenRoundTripper{
-		baseTransport: t,
+		baseTransport: transport,
 		token:         token,
 	}
 

--- a/internal/subproviders/morpheus/clientfactory/clientfactory_test.go
+++ b/internal/subproviders/morpheus/clientfactory/clientfactory_test.go
@@ -1,0 +1,72 @@
+package clientfactory_test
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/model"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSecureTLS(t *testing.T) {
+	server := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// Simulate a simple 200 OK response
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer server.Close()
+
+	m := model.SubModel{
+		URL:         types.StringValue(server.URL),
+		Username:    types.StringValue("user"),
+		Password:    types.StringValue("secret"),
+		AccessToken: types.StringValue("token"),
+		Insecure:    types.BoolValue(false),
+	}
+	cf := clientfactory.New(m)
+	c, err := cf.NewClient(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create client", err)
+	}
+	u := c.UsersAPI.GetUser(context.Background(), 1)
+	_, _, err = u.Execute()
+	if err == nil {
+		t.Fatal("Failed to raise error", err)
+	}
+	var certErr x509.UnknownAuthorityError
+	if !errors.As(err, &certErr) {
+		t.Fatalf("Expected UnknownAuthorityError, got: %v", err)
+	}
+}
+
+func TestInsecureTLS(t *testing.T) {
+	server := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// Simulate a simple 200 OK response
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer server.Close()
+
+	m := model.SubModel{
+		URL:         types.StringValue(server.URL),
+		Username:    types.StringValue("user"),
+		Password:    types.StringValue("secret"),
+		AccessToken: types.StringValue("token"),
+		Insecure:    types.BoolValue(true),
+	}
+	cf := clientfactory.New(m)
+	c, err := cf.NewClient(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create client", err)
+	}
+	u := c.UsersAPI.GetUser(context.Background(), 1)
+	_, _, err = u.Execute()
+	if err != nil {
+		t.Fatal("Unexpected error", err)
+	}
+}

--- a/internal/subproviders/morpheus/httptrace/httptrace.go
+++ b/internal/subproviders/morpheus/httptrace/httptrace.go
@@ -13,7 +13,7 @@ import (
 
 var _ http.RoundTripper = TraceRoundTripper{}
 
-func Enabled() bool {
+func IsEnabled() bool {
 	_, enabled := os.LookupEnv("MORPHEUS_API_HTTPTRACE")
 
 	return enabled

--- a/internal/subproviders/morpheus/model/model.go
+++ b/internal/subproviders/morpheus/model/model.go
@@ -11,4 +11,5 @@ type SubModel struct {
 	Username    types.String `tfsdk:"username"`
 	Password    types.String `tfsdk:"password"`
 	AccessToken types.String `tfsdk:"access_token"`
+	Insecure    types.Bool   `tfsdk:"insecure"`
 }

--- a/internal/subproviders/morpheus/morpheus.go
+++ b/internal/subproviders/morpheus/morpheus.go
@@ -111,6 +111,12 @@ func (SubProvider) GetSchema(_ context.Context) map[string]schema.Attribute {
 				stringvalidator.ConflictsWith(parentBlock.AtName("password")),
 			},
 		},
+		"insecure": schema.BoolAttribute{
+			MarkdownDescription: "Explicitly allow the provider to perform " +
+				"\"insecure\" SSL requests. If omitted, " +
+				"default value is `false`",
+			Optional: true,
+		},
 	}
 }
 

--- a/internal/subproviders/morpheus/morpheus_test.go
+++ b/internal/subproviders/morpheus/morpheus_test.go
@@ -122,6 +122,7 @@ provider "hpe" {
 		url = "https://127.0.0.1:0"
 		username = "test-user"
 		password = "test-password"
+		insecure = true
 	}
 }
 


### PR DESCRIPTION
Default to enforcing validation of the server TLS cert.
Provide an `insecure` option to the provider block to allow
overriding.