### PR TITLE
Don't require creds for some tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,3 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go version
       - run: make test
-        env:
-          TF_VAR_testacc_morpheus_url:
-          TF_VAR_testacc_morpheus_username:
-          TF_VAR_testacc_morpheus_password:
-          TF_VAR_testacc_morpheus_insecure:

--- a/internal/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/subproviders/morpheus/resources/user/resource_test.go
@@ -294,17 +294,11 @@ resource "hpe_morpheus_user" "foo" {
 
 func TestAccMorpheusUserMissingRoles(t *testing.T) {
 	providerConfig := `
-variable "testacc_morpheus_url" {}
-variable "testacc_morpheus_username" {}
-variable "testacc_morpheus_password" {}
-variable "testacc_morpheus_insecure" {}
-
 provider "hpe" {
 	morpheus {
-		url = var.testacc_morpheus_url
-		username = var.testacc_morpheus_username
-		password = var.testacc_morpheus_password
-		insecure = var.testacc_morpheus_insecure
+		url = ""
+		username = ""
+		password = ""
 	}
 }
 
@@ -332,17 +326,11 @@ resource "hpe_morpheus_user" "foo" {
 
 func TestAccMorpheusUserMissingUsername(t *testing.T) {
 	providerConfig := `
-variable "testacc_morpheus_url" {}
-variable "testacc_morpheus_username" {}
-variable "testacc_morpheus_password" {}
-variable "testacc_morpheus_insecure" {}
-
 provider "hpe" {
 	morpheus {
-		url = var.testacc_morpheus_url
-		username = var.testacc_morpheus_username
-		password = var.testacc_morpheus_password
-		insecure = var.testacc_morpheus_insecure
+		url = ""
+		username = ""
+		password = ""
 	}
 }
 
@@ -370,17 +358,11 @@ resource "hpe_morpheus_user" "foo" {
 
 func TestAccMorpheusUserMissingEmail(t *testing.T) {
 	providerConfig := `
-variable "testacc_morpheus_url" {}
-variable "testacc_morpheus_username" {}
-variable "testacc_morpheus_password" {}
-variable "testacc_morpheus_insecure" {}
-
 provider "hpe" {
 	morpheus {
-		url = var.testacc_morpheus_url
-		username = var.testacc_morpheus_username
-		password = var.testacc_morpheus_password
-		insecure = var.testacc_morpheus_insecure
+		url = ""
+		username = ""
+		password = ""
 	}
 }
 


### PR DESCRIPTION
Allow running `make test`  (`go test -short`) without having
environment variables set.

Running `make testacc` still requires valid creds.