### PR TITLE
pick up renamed morpheus sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/HPE/terraform-provider-hpe
 go 1.24.1
 
 require (
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk v0.0.0-20250520111125-a51314e0e909
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.26.0
@@ -11,7 +12,6 @@ require (
 )
 
 require (
-	github.com/HewlettPackard/hpe-morpheus-client/client v0.0.0-20250423165706-69d2f05b96d3 // indirect
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/HewlettPackard/hpe-morpheus-client/client v0.0.0-20250423165706-69d2f05b96d3 h1:HXP6IXnHkl1V4HSVmItcVUCvSZGHCpSLQgScoD302lg=
-github.com/HewlettPackard/hpe-morpheus-client/client v0.0.0-20250423165706-69d2f05b96d3/go.mod h1:GXFW4VIoRrRTQ9kBCr546xBccuN+9K5EXLWZU2K+k8w=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk v0.0.0-20250520111125-a51314e0e909 h1:mNwBDv4QqU9i8ZfEpf/zKCJGJZ5uc+YT/laqXzX/xRU=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk v0.0.0-20250520111125-a51314e0e909/go.mod h1:FdJAe4gZMwr8n4/o1TlN47Y8lXniH5WAGZjnqLn+Vrc=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
@@ -106,8 +106,9 @@ github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgf
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -227,8 +228,9 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
 google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
 gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=

--- a/internal/subproviders/morpheus/auth/creds.go
+++ b/internal/subproviders/morpheus/auth/creds.go
@@ -8,14 +8,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/HewlettPackard/hpe-morpheus-client/client"
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type CredsRoundTripper struct {
 	baseTransport http.RoundTripper
 	tokenMu       sync.Mutex
-	client        *client.APIClient
+	client        *sdk.APIClient
 	username      string
 	password      string
 }
@@ -120,10 +120,10 @@ func NewCredsRoundTripper(
 	username string,
 	password string,
 ) http.RoundTripper {
-	morpheusCfg := client.NewConfiguration()
+	morpheusCfg := sdk.NewConfiguration()
 	morpheusCfg.Servers[0].URL = url
 
-	client := client.NewAPIClient(morpheusCfg)
+	client := sdk.NewAPIClient(morpheusCfg)
 
 	morpheusCfg.HTTPClient = &http.Client{
 		Transport: transport,

--- a/internal/subproviders/morpheus/clientfactory/clientfactory.go
+++ b/internal/subproviders/morpheus/clientfactory/clientfactory.go
@@ -11,7 +11,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/auth"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/httptrace"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/model"
-	"github.com/HewlettPackard/hpe-morpheus-client/client"
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 )
 
 // factory options
@@ -43,7 +43,7 @@ func New(m model.SubModel, opts ...FactoryOption) *ClientFactory {
 		options = append(options, WithInsecureTLS())
 	}
 
-	f := func(ctx context.Context) (*client.APIClient, error) {
+	f := func(ctx context.Context) (*sdk.APIClient, error) {
 		client := NewAPIClient(
 			ctx,
 			cf.model.URL.ValueString(),
@@ -64,10 +64,10 @@ func New(m model.SubModel, opts ...FactoryOption) *ClientFactory {
 type ClientFactory struct {
 	httpclient *http.Client
 	model      model.SubModel
-	newClient  func(context.Context) (*client.APIClient, error)
+	newClient  func(context.Context) (*sdk.APIClient, error)
 }
 
-func (c ClientFactory) NewClient(ctx context.Context) (*client.APIClient, error) {
+func (c ClientFactory) NewClient(ctx context.Context) (*sdk.APIClient, error) {
 	return c.newClient(ctx)
 }
 
@@ -98,13 +98,13 @@ func NewAPIClient(
 	password string,
 	token string,
 	opts ...ClientOption,
-) *client.APIClient {
+) *sdk.APIClient {
 	var options clientOpts
 
-	morpheusCfg := client.NewConfiguration()
+	morpheusCfg := sdk.NewConfiguration()
 	morpheusCfg.Servers[0].URL = url
 
-	c := client.NewAPIClient(morpheusCfg)
+	c := sdk.NewAPIClient(morpheusCfg)
 
 	for _, opt := range opts {
 		opt(&options)

--- a/internal/subproviders/morpheus/configure/datasource.go
+++ b/internal/subproviders/morpheus/configure/datasource.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/constants"
-	"github.com/HewlettPackard/hpe-morpheus-client/client"
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -53,6 +53,6 @@ provider "hpe" {
 
 func (r *DataSourceWithMorpheusConfigure) NewClient(
 	ctx context.Context,
-) (*client.APIClient, error) {
+) (*sdk.APIClient, error) {
 	return r.cf.NewClient(ctx)
 }

--- a/internal/subproviders/morpheus/configure/resource.go
+++ b/internal/subproviders/morpheus/configure/resource.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/constants"
-	"github.com/HewlettPackard/hpe-morpheus-client/client"
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -53,6 +53,6 @@ provider "hpe" {
 
 func (r *ResourceWithMorpheusConfigure) NewClient(
 	ctx context.Context,
-) (*client.APIClient, error) {
+) (*sdk.APIClient, error) {
 	return r.cf.NewClient(ctx)
 }

--- a/internal/subproviders/morpheus/datasource/datasource.go
+++ b/internal/subproviders/morpheus/datasource/datasource.go
@@ -3,11 +3,11 @@ package resource
 import (
 	"context"
 
-	"github.com/HewlettPackard/hpe-morpheus-client/client"
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 )
 
 type DataSource interface {
 	datasource.DataSource
-	NewClient(ctx context.Context) *client.APIClient
+	NewClient(ctx context.Context) *sdk.APIClient
 }

--- a/internal/subproviders/morpheus/resource/resource.go
+++ b/internal/subproviders/morpheus/resource/resource.go
@@ -3,11 +3,11 @@ package resource
 import (
 	"context"
 
-	"github.com/HewlettPackard/hpe-morpheus-client/client"
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 type Resource interface {
 	resource.Resource
-	NewClient(ctx context.Context) *client.APIClient
+	NewClient(ctx context.Context) *sdk.APIClient
 }

--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/configure"
-	sdk "github.com/HewlettPackard/hpe-morpheus-client/client"
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"


### PR DESCRIPTION
The upstream sdk was renamed, reflect those
changes here.

```
    go clean -modcache
    go mod edit -go=1.24.1 -toolchain=go1.24.1
    go mod tidy
    make
```