### PR TITLE
user resource: add tenant id

### DIFF
--- a/internal/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/subproviders/morpheus/resources/user/resource_test.go
@@ -192,6 +192,8 @@ provider "hpe" {
 #}
 
 resource "hpe_morpheus_user" "foo" {
+	# Assumes tenant_id 1 pre-exists
+	tenant_id = 1
 	username = "testacc-TestAccMorpheusUserAllAttrsOk"
 	email = "foo@hpe.com"
 	password = "Secret123!"
@@ -207,6 +209,11 @@ resource "hpe_morpheus_user" "foo" {
 	expectedRoles := map[string]struct{}{"3": {}, "1": {}}
 
 	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_user.foo",
+			"tenant_id",
+			"1",
+		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"username",

--- a/internal/subproviders/morpheus/resources/user/user_resource_gen.go
+++ b/internal/subproviders/morpheus/resources/user/user_resource_gen.go
@@ -65,6 +65,12 @@ func UserResourceSchema(ctx context.Context) schema.Schema {
 				ElementType: types.Int64Type,
 				Required:    true,
 			},
+			"tenant_id": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Tenant Id (accountId) create user in a sub tenant account instead of your own.",
+				MarkdownDescription: "Tenant Id (accountId) create user in a sub tenant account instead of your own.",
+			},
 			"username": schema.StringAttribute{
 				Required:            true,
 				Description:         "Username (unique per tenant).",
@@ -91,6 +97,7 @@ type UserModel struct {
 	PasswordExpired      types.Bool   `tfsdk:"password_expired"`
 	ReceiveNotifications types.Bool   `tfsdk:"receive_notifications"`
 	RoleIds              types.Set    `tfsdk:"role_ids"`
+	TenantId             types.Int64  `tfsdk:"tenant_id"`
 	Username             types.String `tfsdk:"username"`
 	WindowsUsername      types.String `tfsdk:"windows_username"`
 }


### PR DESCRIPTION
Add ability to target a different tenant id when creating a user.

The tenant id is added to POST requests as the query parameter `accountId` [sic].

```
POST /api/users?accountId=1
```