### PR TITLE
user resource: write only password

### DIFF
--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
@@ -15,11 +14,11 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	//"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -131,12 +130,18 @@ func (r *Resource) Create(
 
 	addUser := sdk.NewAddUserTenantRequestUserWithDefaults()
 
+	var config UserModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// required
 	username := plan.Username.ValueString()
 	addUser.SetUsername(username)
 	addUser.SetEmail(plan.Email.ValueString())
-	addUser.SetPassword(plan.Password.ValueString())
 	addUser.SetRoles(roles)
+	addUser.SetPassword(config.PasswordWo.ValueString())
 
 	// optional
 	if !plan.FirstName.IsUnknown() {
@@ -214,8 +219,17 @@ func (r *Resource) Create(
 		return
 	}
 
-	// special case (for now)
-	state.Password, _ = plan.Password.ToStringValue(ctx)
+	// special case
+	state.PasswordWoVersion, pdiags = plan.PasswordWoVersion.ToInt64Value(ctx)
+	if pdiags.HasError() {
+		resp.Diagnostics.Append(pdiags...)
+		resp.Diagnostics.AddError(
+			"create user resource",
+			fmt.Sprintf("user %d: password version is not integer", id),
+		)
+
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -257,8 +271,17 @@ func (r *Resource) Read(
 		return
 	}
 
-	// special case (for now)
-	state.Password, _ = plan.Password.ToStringValue(ctx)
+	// special case
+	state.PasswordWoVersion, pdiags = plan.PasswordWoVersion.ToInt64Value(ctx)
+	if pdiags.HasError() {
+		resp.Diagnostics.Append(pdiags...)
+		resp.Diagnostics.AddError(
+			"read user resource",
+			fmt.Sprintf("user %d: password version is not integer", id),
+		)
+
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -271,6 +294,7 @@ func (r *Resource) Update(
 	_ resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
+	// NOTE: password_wo/password_wo_version will require special handling
 	resp.Diagnostics.AddError(
 		"update user resource",
 		"update of 'user' resources has not been implemented",
@@ -308,15 +332,7 @@ func (r *Resource) ImportState(
 	req resource.ImportStateRequest,
 	resp *resource.ImportStateResponse,
 ) {
-	parts := strings.SplitN(req.ID, ",", 2)
-	if len(parts) != 2 {
-		resp.Diagnostics.AddError(
-			"import user resource",
-			"expected import format: <id>,<password>",
-		)
-	}
-	password := parts[1]
-	id, err := strconv.Atoi(parts[0])
+	id, err := strconv.Atoi(req.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"import user resource",
@@ -335,7 +351,12 @@ func (r *Resource) ImportState(
 	}
 
 	diags = resp.State.SetAttribute(
-		ctx, path.Root("password"), password,
+		ctx, path.Root("password_wo_version"), 1,
 	)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/subproviders/morpheus/resources/user/resource_test.go
@@ -86,7 +86,8 @@ provider "hpe" {
 resource "hpe_morpheus_user" "foo" {
 	username = "testacc-TestAccMorpheusUserRequiredAttrsOk"
 	email = "foo@hpe.com"
-	password = "Secret123!"
+	password_wo = "Secret123!"
+	password_wo_version = 1
 	role_ids = [3]
 }
 `
@@ -100,11 +101,6 @@ resource "hpe_morpheus_user" "foo" {
 			"hpe_morpheus_user.foo",
 			"email",
 			"foo@hpe.com",
-		),
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_user.foo",
-			"password",
-			"Secret123!",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -133,6 +129,15 @@ resource "hpe_morpheus_user" "foo" {
 			"receive_notifications",
 			"true",
 		),
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_user.foo",
+			"password_wo",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_user.foo",
+			"password_wo_version",
+			"1",
+		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
@@ -152,7 +157,7 @@ resource "hpe_morpheus_user" "foo" {
 					rs := s.RootModule().
 						Resources["hpe_morpheus_user.foo"]
 
-					return rs.Primary.ID + "," + "Secret123!", nil
+					return rs.Primary.ID, nil
 				},
 				ImportStateVerify: true, // Check state post import
 				ResourceName:      "hpe_morpheus_user.foo",
@@ -196,7 +201,8 @@ resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "testacc-TestAccMorpheusUserAllAttrsOk"
 	email = "foo@hpe.com"
-	password = "Secret123!"
+	password_wo = "Secret123!"
+	password_wo_version = 1
 	role_ids = [3,1]
 	first_name = "foo"
 	last_name = "bar"
@@ -224,10 +230,14 @@ resource "hpe_morpheus_user" "foo" {
 			"email",
 			"foo@hpe.com",
 		),
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_user.foo",
+			"password_wo",
+		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
-			"password",
-			"Secret123!",
+			"password_wo_version",
+			"1",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -289,7 +299,7 @@ resource "hpe_morpheus_user" "foo" {
 					rs := s.RootModule().
 						Resources["hpe_morpheus_user.foo"]
 
-					return rs.Primary.ID + "," + "Secret123!", nil
+					return rs.Primary.ID, nil
 				},
 				ImportStateVerify: true, // Check state post import
 				ResourceName:      "hpe_morpheus_user.foo",

--- a/internal/subproviders/morpheus/resources/user/user_resource_gen.go
+++ b/internal/subproviders/morpheus/resources/user/user_resource_gen.go
@@ -45,14 +45,20 @@ func UserResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Linux Username, user settings for provisioning",
 				MarkdownDescription: "Linux Username, user settings for provisioning",
 			},
-			"password": schema.StringAttribute{
-				Required:            true,
-				Sensitive:           true,
-				Description:         "Password to apply to the user",
-				MarkdownDescription: "Password to apply to the user",
-			},
 			"password_expired": schema.BoolAttribute{
 				Computed: true,
+			},
+			"password_wo": schema.StringAttribute{
+				Required:            true,
+				Sensitive:           true,
+				WriteOnly:           true,
+				Description:         "Password to apply to the user (Write Only)",
+				MarkdownDescription: "Password to apply to the user (Write Only)",
+			},
+			"password_wo_version": schema.Int64Attribute{
+				Required:            true,
+				Description:         "Password version. Used to determine if password_wo has been updated.",
+				MarkdownDescription: "Password version. Used to determine if password_wo has been updated.",
 			},
 			"receive_notifications": schema.BoolAttribute{
 				Optional:            true,
@@ -93,8 +99,9 @@ type UserModel struct {
 	LastName             types.String `tfsdk:"last_name"`
 	LinuxKeyPairId       types.Int64  `tfsdk:"linux_key_pair_id"`
 	LinuxUsername        types.String `tfsdk:"linux_username"`
-	Password             types.String `tfsdk:"password"`
 	PasswordExpired      types.Bool   `tfsdk:"password_expired"`
+	PasswordWo           types.String `tfsdk:"password_wo"`
+	PasswordWoVersion    types.Int64  `tfsdk:"password_wo_version"`
 	ReceiveNotifications types.Bool   `tfsdk:"receive_notifications"`
 	RoleIds              types.Set    `tfsdk:"role_ids"`
 	TenantId             types.Int64  `tfsdk:"tenant_id"`


### PR DESCRIPTION
Switch to a write only password. This `password_wo` is not
persisted in the state file.

We also introduce `password_wo_version` which can be used in
Update() to determine if the password has been changed. (This is
required because terraform cannot determine if the write-only
password has changed by examining the state.)