### PR TITLE
user resource: write only password

### DIFF
--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -8,18 +8,16 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
-	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
-
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
@@ -15,11 +14,12 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	//"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -100,6 +100,7 @@ func getUserAsState(
 	return state, diags
 }
 
+// TODO: Add plan modifier that enforces password_wo is set before create is called.
 func (r *Resource) Create(
 	ctx context.Context,
 	req resource.CreateRequest,
@@ -131,12 +132,18 @@ func (r *Resource) Create(
 
 	addUser := sdk.NewAddUserTenantRequestUserWithDefaults()
 
+	var config UserModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// required
 	username := plan.Username.ValueString()
 	addUser.SetUsername(username)
 	addUser.SetEmail(plan.Email.ValueString())
-	addUser.SetPassword(plan.Password.ValueString())
 	addUser.SetRoles(roles)
+	addUser.SetPassword(config.PasswordWo.ValueString())
 
 	// optional
 	if !plan.FirstName.IsUnknown() {
@@ -214,8 +221,8 @@ func (r *Resource) Create(
 		return
 	}
 
-	// special case (for now)
-	state.Password, _ = plan.Password.ToStringValue(ctx)
+	// special case
+	state.PasswordWoVersion = plan.PasswordWoVersion
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -231,6 +238,10 @@ func (r *Resource) Read(
 	var plan UserModel
 
 	diags := req.State.Get(ctx, &plan)
+	if diags.HasError() {
+		return
+	}
+
 	if diags.HasError() {
 		return
 	}
@@ -257,8 +268,8 @@ func (r *Resource) Read(
 		return
 	}
 
-	// special case (for now)
-	state.Password, _ = plan.Password.ToStringValue(ctx)
+	// special case
+	state.PasswordWoVersion = plan.PasswordWoVersion
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -271,6 +282,7 @@ func (r *Resource) Update(
 	_ resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
+	// NOTE: password_wo/password_wo_version will require special handling
 	resp.Diagnostics.AddError(
 		"update user resource",
 		"update of 'user' resources has not been implemented",
@@ -308,15 +320,7 @@ func (r *Resource) ImportState(
 	req resource.ImportStateRequest,
 	resp *resource.ImportStateResponse,
 ) {
-	parts := strings.SplitN(req.ID, ",", 2)
-	if len(parts) != 2 {
-		resp.Diagnostics.AddError(
-			"import user resource",
-			"expected import format: <id>,<password>",
-		)
-	}
-	password := parts[1]
-	id, err := strconv.Atoi(parts[0])
+	id, err := strconv.Atoi(req.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"import user resource",
@@ -328,14 +332,6 @@ func (r *Resource) ImportState(
 
 	diags := resp.State.SetAttribute(
 		ctx, path.Root("id"), id,
-	)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	diags = resp.State.SetAttribute(
-		ctx, path.Root("password"), password,
 	)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -221,7 +221,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	// special case
+	// special case - can't read from API
 	state.PasswordWoVersion = plan.PasswordWoVersion
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -238,10 +238,6 @@ func (r *Resource) Read(
 	var plan UserModel
 
 	diags := req.State.Get(ctx, &plan)
-	if diags.HasError() {
-		return
-	}
-
 	if diags.HasError() {
 		return
 	}
@@ -268,7 +264,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	// special case
+	// special case - can't read from API
 	state.PasswordWoVersion = plan.PasswordWoVersion
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/subproviders/morpheus/resources/user/resource_test.go
@@ -9,9 +9,7 @@ import (
 
 	"github.com/HPE/terraform-provider-hpe/internal/provider"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus"
-
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -93,7 +91,7 @@ resource "hpe_morpheus_user" "foo" {
 	role_ids = [3]
 }
 `
-	resourceConfigWo := `
+	resourceConfigPostImport := `
 resource "hpe_morpheus_user" "foo" {
 	username = "testacc-TestAccMorpheusUserRequiredAttrsOk"
 	email = "foo@hpe.com"
@@ -181,7 +179,7 @@ resource "hpe_morpheus_user" "foo" {
 			{
 				// Check that a post-import plan detects no changes
 				// if write-only fields are omitted
-				Config:             providerConfig + resourceConfigWo,
+				Config:             providerConfig + resourceConfigPostImport,
 				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
 				PlanOnly:           true,

--- a/internal/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/subproviders/morpheus/resources/user/resource_test.go
@@ -7,12 +7,13 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/HPE/terraform-provider-hpe/internal/provider"
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/HPE/terraform-provider-hpe/internal/provider"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus"
 )
 
 func checkRole(

--- a/internal/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/subproviders/morpheus/resources/user/resource_test.go
@@ -84,11 +84,20 @@ provider "hpe" {
 		insecure = var.testacc_morpheus_insecure
 	}
 }
-
+`
+	resourceConfig := `
 resource "hpe_morpheus_user" "foo" {
 	username = "testacc-TestAccMorpheusUserRequiredAttrsOk"
 	email = "foo@hpe.com"
-	password = "Secret123!"
+	password_wo = "Secret123!"
+	role_ids = [3]
+}
+`
+	resourceConfigWo := `
+resource "hpe_morpheus_user" "foo" {
+	username = "testacc-TestAccMorpheusUserRequiredAttrsOk"
+	email = "foo@hpe.com"
+	# password_wo = "Secret123!"
 	role_ids = [3]
 }
 `
@@ -102,11 +111,6 @@ resource "hpe_morpheus_user" "foo" {
 			"hpe_morpheus_user.foo",
 			"email",
 			"foo@hpe.com",
-		),
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_user.foo",
-			"password",
-			"Secret123!",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -135,6 +139,14 @@ resource "hpe_morpheus_user" "foo" {
 			"receive_notifications",
 			"true",
 		),
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_user.foo",
+			"password_wo",
+		),
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_user.foo",
+			"password_wo_version",
+		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
@@ -142,10 +154,16 @@ resource "hpe_morpheus_user" "foo" {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:             providerConfig,
+				Config:   providerConfig + resourceConfig,
+				Check:    checkFn,
+				PlanOnly: false,
+			},
+			{
+				// Check that a post-apply plan detects no changes
+				Config:             providerConfig + resourceConfig,
 				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
-				PlanOnly:           false,
+				PlanOnly:           true,
 			},
 			{
 				ImportState: true,
@@ -154,11 +172,19 @@ resource "hpe_morpheus_user" "foo" {
 					rs := s.RootModule().
 						Resources["hpe_morpheus_user.foo"]
 
-					return rs.Primary.ID + "," + "Secret123!", nil
+					return rs.Primary.ID, nil
 				},
 				ImportStateVerify: true, // Check state post import
 				ResourceName:      "hpe_morpheus_user.foo",
 				Check:             checkFn,
+			},
+			{
+				// Check that a post-import plan detects no changes
+				// if write-only fields are omitted
+				Config:             providerConfig + resourceConfigWo,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+				PlanOnly:           true,
 			},
 		},
 	})
@@ -192,13 +218,16 @@ provider "hpe" {
 #password = "Secret123!"
 #roles = [3,0,1]
 #}
+`
 
+	resourceCfg := `
 resource "hpe_morpheus_user" "foo" {
 	# Assumes tenant_id 1 pre-exists
 	tenant_id = 1
 	username = "testacc-TestAccMorpheusUserAllAttrsOk"
 	email = "foo@hpe.com"
-	password = "Secret123!"
+	password_wo = "Secret123!"
+	password_wo_version = 1
 	role_ids = [3,1]
 	first_name = "foo"
 	last_name = "bar"
@@ -210,7 +239,7 @@ resource "hpe_morpheus_user" "foo" {
 `
 	expectedRoles := map[string]struct{}{"3": {}, "1": {}}
 
-	checks := []resource.TestCheckFunc{
+	baseChecks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"tenant_id",
@@ -226,10 +255,9 @@ resource "hpe_morpheus_user" "foo" {
 			"email",
 			"foo@hpe.com",
 		),
-		resource.TestCheckResourceAttr(
+		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_user.foo",
-			"password",
-			"Secret123!",
+			"password_wo",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -274,28 +302,47 @@ resource "hpe_morpheus_user" "foo" {
 		checkStrayRoles(expectedRoles),
 	}
 
-	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+	passwordWoCheck := resource.TestCheckResourceAttr(
+		"hpe_morpheus_user.foo",
+		"password_wo_version",
+		"1",
+	)
+
+	passwordWoImportCheck := resource.TestCheckNoResourceAttr(
+		"hpe_morpheus_user.foo",
+		"password_wo_version",
+	)
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(
+		append(baseChecks, passwordWoCheck)...,
+	)
+
+	checkImportFn := resource.ComposeAggregateTestCheckFunc(
+		append(baseChecks, passwordWoImportCheck)...,
+	)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:             providerConfig,
-				ExpectNonEmptyPlan: false,
-				Check:              checkFn,
-				PlanOnly:           false,
+				Config:   providerConfig + resourceCfg,
+				Check:    checkFn,
+				PlanOnly: false,
 			},
 			{
+				// state from import test exists in memory (not written to disk)
 				ImportState: true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					// Read ID from the pre-import state
 					rs := s.RootModule().
 						Resources["hpe_morpheus_user.foo"]
 
-					return rs.Primary.ID + "," + "Secret123!", nil
+					return rs.Primary.ID, nil
 				},
-				ImportStateVerify: true, // Check state post import
-				ResourceName:      "hpe_morpheus_user.foo",
-				Check:             checkFn,
+				ImportStateVerify:       true, // Check state post import (in memory)
+				ImportStateVerifyIgnore: []string{"password_wo_version"},
+				ResourceName:            "hpe_morpheus_user.foo",
+				Check:                   checkImportFn,
 			},
 		},
 	})

--- a/internal/subproviders/morpheus/resources/user/user_resource_gen.go
+++ b/internal/subproviders/morpheus/resources/user/user_resource_gen.go
@@ -45,14 +45,20 @@ func UserResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Linux Username, user settings for provisioning",
 				MarkdownDescription: "Linux Username, user settings for provisioning",
 			},
-			"password": schema.StringAttribute{
-				Required:            true,
-				Sensitive:           true,
-				Description:         "Password to apply to the user",
-				MarkdownDescription: "Password to apply to the user",
-			},
 			"password_expired": schema.BoolAttribute{
 				Computed: true,
+			},
+			"password_wo": schema.StringAttribute{
+				Optional:            true,
+				Sensitive:           true,
+				WriteOnly:           true,
+				Description:         "Password to apply to the user (Write Only)",
+				MarkdownDescription: "Password to apply to the user (Write Only)",
+			},
+			"password_wo_version": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "Password version. Used to determine if password_wo has been updated.",
+				MarkdownDescription: "Password version. Used to determine if password_wo has been updated.",
 			},
 			"receive_notifications": schema.BoolAttribute{
 				Optional:            true,
@@ -93,8 +99,9 @@ type UserModel struct {
 	LastName             types.String `tfsdk:"last_name"`
 	LinuxKeyPairId       types.Int64  `tfsdk:"linux_key_pair_id"`
 	LinuxUsername        types.String `tfsdk:"linux_username"`
-	Password             types.String `tfsdk:"password"`
 	PasswordExpired      types.Bool   `tfsdk:"password_expired"`
+	PasswordWo           types.String `tfsdk:"password_wo"`
+	PasswordWoVersion    types.Int64  `tfsdk:"password_wo_version"`
 	ReceiveNotifications types.Bool   `tfsdk:"receive_notifications"`
 	RoleIds              types.Set    `tfsdk:"role_ids"`
 	TenantId             types.Int64  `tfsdk:"tenant_id"`


### PR DESCRIPTION
Switch to a write only password. This `password_wo` is not
persisted in the state file.

We also introduce `password_wo_version` which can be used (later) in Update()
to determine if the password has been changed. (This is required because
terraform cannot determine if the write-only password has changed by
examining the state.)