### PR TITLE
Add format workflow

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,39 @@
+# Copyright 2025 Hewlett Packard Enterprise Development LP
+
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        go: [ '1.24.1' ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go install golang.org/x/tools/cmd/goimports@v0.33.0
+      - run: |
+          set -euo pipefail
+
+          fail=false
+          FILES=$(find . -name '*.go' | grep -v '_gen.go' || true)
+
+          for FILE in $FILES; do
+            goimports -w -local github.com/HPE "$FILE"
+            if ! git diff --exit-code -- "$FILE"; then
+              echo "goimports failed on $FILE"
+              fail=true
+            fi
+          done
+
+          if [ "$fail" = true ]; then
+            echo "goimports drift detected"
+            exit 1
+          fi

--- a/cmd/terraform-provider-hpe/main.go
+++ b/cmd/terraform-provider-hpe/main.go
@@ -7,9 +7,10 @@ import (
 	"flag"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+
 	"github.com/HPE/terraform-provider-hpe/internal/provider"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus"
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
 var version = "dev"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,6 @@ package provider
 import (
 	"context"
 
-	"github.com/HPE/terraform-provider-hpe/subprovider"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -14,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
+	"github.com/HPE/terraform-provider-hpe/subprovider"
 )
 
 var _ provider.Provider = &hpeProvider{}

--- a/internal/subproviders/morpheus/clientfactory/clientfactory.go
+++ b/internal/subproviders/morpheus/clientfactory/clientfactory.go
@@ -8,10 +8,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/auth"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/httptrace"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/model"
-	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 )
 
 // factory options

--- a/internal/subproviders/morpheus/clientfactory/clientfactory_test.go
+++ b/internal/subproviders/morpheus/clientfactory/clientfactory_test.go
@@ -10,9 +10,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/model"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestSecureTLS(t *testing.T) {

--- a/internal/subproviders/morpheus/configure/datasource.go
+++ b/internal/subproviders/morpheus/configure/datasource.go
@@ -5,11 +5,12 @@ package configure
 import (
 	"context"
 
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/constants"
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/constants"
 )
 
 type DataSourceWithMorpheusConfigure struct {

--- a/internal/subproviders/morpheus/configure/resource.go
+++ b/internal/subproviders/morpheus/configure/resource.go
@@ -5,11 +5,12 @@ package configure
 import (
 	"context"
 
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/constants"
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/constants"
 )
 
 type ResourceWithMorpheusConfigure struct {

--- a/internal/subproviders/morpheus/resources/role/resource.go
+++ b/internal/subproviders/morpheus/resources/role/resource.go
@@ -8,14 +8,15 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/configure"
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/configure"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/subproviders/morpheus/testhelpers/client.go
+++ b/internal/subproviders/morpheus/testhelpers/client.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
 )
 
 func newClient(ctx context.Context, t *testing.T) *sdk.APIClient {


### PR DESCRIPTION
This will check whether running formatting
against the code base will produce any changes,
and if changes are detected the job will fail.
This helps prevent checking in go files whose
imports are out of order.