### PR TITLE
Get zone type id from API. Fix possible panic in data source

### DIFF
--- a/internal/subproviders/morpheus/datasources/cloud/datasource.go
+++ b/internal/subproviders/morpheus/datasources/cloud/datasource.go
@@ -78,7 +78,7 @@ func getCloudByName(
 	req := apiClient.CloudsAPI.ListClouds(ctx).Name(name)
 
 	cs, hresp, err := req.Execute()
-	if err != nil || hresp.StatusCode != http.StatusOK {
+	if cs == nil || err != nil || hresp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET failed for cloud %s", name)
 	}
 


### PR DESCRIPTION
This PR fixes a problem encountered while testing. The test instance seem to tread zone type id 1 as "special" and returns a bad request when trying to use it to create a cloud. We now pull from the API and use the last item in the array.
