### PR TITLE
user resource: add plan modifier

### DIFF
--- a/internal/subproviders/morpheus/modifiers/modifiers.go
+++ b/internal/subproviders/morpheus/modifiers/modifiers.go
@@ -1,0 +1,49 @@
+package modifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// RequireOnCreateModifier can be used for corner cases where
+// an attribute is optional for import, but required for create
+type RequireOnCreateModifier struct{}
+
+func (m RequireOnCreateModifier) Description(_ context.Context) string {
+	return "Requires the attribute to be set during resource creation."
+}
+
+func (m RequireOnCreateModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m RequireOnCreateModifier) PlanModifyString(
+	ctx context.Context,
+	req planmodifier.StringRequest,
+	resp *planmodifier.StringResponse,
+) {
+	var id types.Int64
+
+	diags := req.State.GetAttribute(ctx, path.Root("id"), &id)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+
+		return
+	}
+
+	resourceExists := !id.IsNull() && !id.IsUnknown()
+
+	if !resourceExists && req.ConfigValue.IsNull() {
+		name := req.Path.String()
+		msg := "attribute '" + name + "' not set " +
+			"(this attribute is optional for some operations, eg import, " +
+			"but needed during create)"
+		resp.Diagnostics.AddError(
+			"missing attribute",
+			msg,
+		)
+	}
+}

--- a/internal/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/subproviders/morpheus/resources/user/resource_test.go
@@ -442,3 +442,37 @@ resource "hpe_morpheus_user" "foo" {
 		},
 	})
 }
+
+// password_wo is required for create (but not import) here we check that it is
+// correctly identified as missing during plan (i.e. before Create is called)
+func TestAccMorpheusUserMissingPasswordWo(t *testing.T) {
+	providerConfig := `
+provider "hpe" {
+	morpheus {
+		url = ""
+		username = ""
+		password = ""
+	}
+}
+
+resource "hpe_morpheus_user" "foo" {
+	username = "test2"
+	email = "bar@hpe.com"
+	#password_wo = "Secret123!"
+	role_ids = [3,1]
+}
+`
+	expected := `'password_wo' not set`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+				ExpectError:        regexp.MustCompile(expected),
+			},
+		},
+	})
+}

--- a/internal/subproviders/morpheus/resources/user/user_resource_gen.go
+++ b/internal/subproviders/morpheus/resources/user/user_resource_gen.go
@@ -4,7 +4,9 @@ package user
 
 import (
 	"context"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -54,6 +56,9 @@ func UserResourceSchema(ctx context.Context) schema.Schema {
 				WriteOnly:           true,
 				Description:         "Password to apply to the user (Write Only)",
 				MarkdownDescription: "Password to apply to the user (Write Only)",
+				PlanModifiers: []planmodifier.String{
+					modifiers.RequireOnCreateModifier{},
+				},
 			},
 			"password_wo_version": schema.Int64Attribute{
 				Optional:            true,


### PR DESCRIPTION
This plan modifier ensures that if `password_wo` is missing during
plan it is detected and an error is raised.

`password_wo` is a corner case where it is required for create, but
not for import. We do not raise an error in the import case
(tested by existing test).