### PR TITLE
user resource: update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HPE/terraform-provider-hpe
 go 1.24.1
 
 require (
-	github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250605154726-754607ac7710
+	github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250609141639-a37cbeb3d243
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.26.0
@@ -66,3 +66,5 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect
 )
+
+replace github.com/HewlettPackard/hpe-morpheus-go-sdk => /home/sam/git/github.com/HewlettPackard/hpe-morpheus-go-sdk

--- a/go.mod
+++ b/go.mod
@@ -66,5 +66,3 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect
 )
-
-replace github.com/HewlettPackard/hpe-morpheus-go-sdk => /home/sam/git/github.com/HewlettPackard/hpe-morpheus-go-sdk

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250605154726-754607ac7710 h1:mqc1TUEJ4JoJzE2mfRTbZ+9c1pDByIdkcwUubWAV/9o=
-github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250605154726-754607ac7710/go.mod h1:EcMycbe8bj1Ww91MMKjb33eXF9iV58gO20X8aaa0SxY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250609141639-a37cbeb3d243 h1:3EFOPDL506KygpOyLibBHku+LdJT0Dor8eNne90ULLg=
+github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250609141639-a37cbeb3d243/go.mod h1:EcMycbe8bj1Ww91MMKjb33eXF9iV58gO20X8aaa0SxY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/internal/subproviders/morpheus/modifiers/modifiers.go
+++ b/internal/subproviders/morpheus/modifiers/modifiers.go
@@ -63,7 +63,11 @@ func (m NullableStringUpdateModifier) MarkdownDescription(_ context.Context) str
 	return "Force diff when config changes from non-null to null"
 }
 
-func (m NullableStringUpdateModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+func (m NullableStringUpdateModifier) PlanModifyString(
+	_ context.Context,
+	req planmodifier.StringRequest,
+	resp *planmodifier.StringResponse,
+) {
 	if req.ConfigValue.IsNull() && !req.StateValue.IsNull() {
 		resp.PlanValue = types.StringNull()
 	}

--- a/internal/subproviders/morpheus/modifiers/modifiers.go
+++ b/internal/subproviders/morpheus/modifiers/modifiers.go
@@ -47,3 +47,24 @@ func (m RequireOnCreateModifier) PlanModifyString(
 		)
 	}
 }
+
+// NullableStringUpdateModifier can be used when the desired state of
+// a string is null and the current state is non-null. Usually
+// terraform plan will not treat this as something that should
+// trigger an update. But using this modifier will cause plan
+// to trigger an update, eg "foo" -> null
+type NullableStringUpdateModifier struct{}
+
+func (m NullableStringUpdateModifier) Description(ctx context.Context) string {
+	return "Force diff when config changes from non-null to null"
+}
+
+func (m NullableStringUpdateModifier) MarkdownDescription(ctx context.Context) string {
+	return "Force diff when config changes from non-null to null"
+}
+
+func (m NullableStringUpdateModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.ConfigValue.IsNull() && !req.StateValue.IsNull() {
+		resp.PlanValue = types.StringNull()
+	}
+}

--- a/internal/subproviders/morpheus/modifiers/modifiers.go
+++ b/internal/subproviders/morpheus/modifiers/modifiers.go
@@ -55,15 +55,15 @@ func (m RequireOnCreateModifier) PlanModifyString(
 // to trigger an update, eg "foo" -> null
 type NullableStringUpdateModifier struct{}
 
-func (m NullableStringUpdateModifier) Description(ctx context.Context) string {
+func (m NullableStringUpdateModifier) Description(_ context.Context) string {
 	return "Force diff when config changes from non-null to null"
 }
 
-func (m NullableStringUpdateModifier) MarkdownDescription(ctx context.Context) string {
+func (m NullableStringUpdateModifier) MarkdownDescription(_ context.Context) string {
 	return "Force diff when config changes from non-null to null"
 }
 
-func (m NullableStringUpdateModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+func (m NullableStringUpdateModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	if req.ConfigValue.IsNull() && !req.StateValue.IsNull() {
 		resp.PlanValue = types.StringNull()
 	}

--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -98,7 +98,6 @@ func getUserAsState(
 	return state, diags
 }
 
-// TODO: Add plan modifier that enforces password_wo is set before create is called.
 func (r *Resource) Create(
 	ctx context.Context,
 	req resource.CreateRequest,
@@ -228,6 +227,151 @@ func (r *Resource) Create(
 	}
 }
 
+func (r *Resource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
+	// Not updateable via API:
+	// LinuxUsername
+	// WindowsUsername
+	// LinuxKeyPairId
+	// ReceiveNotifications
+	// TenantId
+
+	var plan, state, config UserModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var roleIDs []int64
+	if !plan.RoleIds.IsNull() && !plan.RoleIds.IsUnknown() {
+		diags := plan.RoleIds.ElementsAs(ctx, &roleIDs, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	var roles []sdk.UpdateUserRequestUserRolesInner
+	for _, roleID := range roleIDs {
+		rolevalue := sdk.UpdateUserRequestUserRolesInner{
+			Id: roleID,
+		}
+		roles = append(roles, rolevalue)
+	}
+
+	updateUser := sdk.NewUpdateUserRequestUser()
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	username := plan.Username.ValueString()
+
+	// non-nullable
+	updateUser.SetUsername(plan.Username.ValueString())
+	updateUser.SetEmail(plan.Email.ValueString())
+	updateUser.SetRoles(roles)
+
+	if !plan.PasswordWoVersion.Equal(state.PasswordWoVersion) {
+		if config.PasswordWo.IsUnknown() {
+			resp.Diagnostics.AddError(
+				"update user resource",
+				fmt.Sprintf("user %s: 'password_wo_version' changed, "+
+					"but 'password_wo' is not set", username),
+			)
+
+			return
+		}
+		updateUser.SetPassword(config.PasswordWo.ValueString())
+	}
+
+	// nullable
+	if plan.FirstName.IsNull() {
+		updateUser.SetFirstNameNil()
+	} else {
+		updateUser.SetFirstName(plan.FirstName.ValueString())
+	}
+
+	if plan.LastName.IsNull() {
+		updateUser.SetLastNameNil()
+	} else {
+		updateUser.SetLastName(plan.LastName.ValueString())
+	}
+
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"update user resource",
+			"user "+username+": failed to create client: "+err.Error(),
+		)
+
+		return
+	}
+
+	id := plan.Id.ValueInt64()
+	apiUpdateUserReq := client.UsersAPI.UpdateUser(ctx, id)
+
+	updateUserReq := sdk.NewUpdateUserRequest(*updateUser)
+	user, hresp, err := apiUpdateUserReq.UpdateUserRequest(*updateUserReq).Execute()
+
+	if err != nil || hresp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"update user resource",
+			"user "+username+" PUT failed: "+errors.ErrMsg(err, hresp),
+		)
+
+		return
+	}
+
+	if user.GetUser().Id == nil {
+		resp.Diagnostics.AddError(
+			"update user resource",
+			"user "+username+": id is nil",
+		)
+
+		return
+	}
+
+	newid := *user.GetUser().Id
+	if newid != id {
+		resp.Diagnostics.AddError(
+			"update user resource",
+			"user "+username+": id mismatch "+fmt.Sprintf("%d != %d", id, newid),
+		)
+
+		return
+	}
+
+	state, pdiags := getUserAsState(ctx, newid, client)
+	if pdiags.HasError() {
+		resp.Diagnostics.Append(pdiags...)
+		resp.Diagnostics.AddError(
+			"update user resource",
+			fmt.Sprintf("user %d: failed to read from api", id),
+		)
+
+		return
+	}
+
+	// special case - can't read from API
+	state.PasswordWoVersion = plan.PasswordWoVersion
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
 func (r *Resource) Read(
 	ctx context.Context,
 	req resource.ReadRequest,
@@ -271,17 +415,115 @@ func (r *Resource) Read(
 	}
 }
 
+/*
 func (r *Resource) Update(
-	_ context.Context,
-	_ resource.UpdateRequest,
+	ctx context.Context,
+	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	// NOTE: password_wo/password_wo_version will require special handling
-	resp.Diagnostics.AddError(
-		"update user resource",
-		"update of 'user' resources has not been implemented",
-	)
+	var plan UserModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := plan.Id.ValueInt64()
+
+	var roleIDs []int64
+	if !plan.RoleIds.IsNull() && !plan.RoleIds.IsUnknown() {
+		diags := plan.RoleIds.ElementsAs(ctx, &roleIDs, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	var roles []sdk.UpdateUserRequestUserRolesInner
+	for _, roleID := range roleIDs {
+		rolevalue := sdk.UpdateUserRequestUserRolesInner{
+			Id: roleID,
+		}
+		roles = append(roles, rolevalue)
+	}
+
+	updateUser := sdk.NewUpdateUserRequestUser()
+
+	var config UserModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// required
+	username := plan.Username.ValueString()
+	updateUser.SetUsername(username)
+	updateUser.SetEmail(plan.Email.ValueString())
+	updateUser.SetRoles(roles)
+	//updateUser.SetPassword(config.PasswordWo.ValueString())
+
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"update user resource",
+			"user "+username+": failed to create client: "+err.Error(),
+		)
+
+		return
+	}
+
+	apiUpdateUserReq := client.UsersAPI.UpdateUser(ctx, id)
+	updateUserReq := sdk.NewUpdateUserRequest(*updateUser)
+	user, hresp, err := apiUpdateUserReq.UpdateUserRequest(*updateUserReq).Execute()
+
+	if err != nil || hresp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"update user resource",
+			"user "+username+" PUT failed: "+errors.ErrMsg(err, hresp),
+		)
+
+		return
+	}
+
+	if user.GetUser().Id == nil {
+		resp.Diagnostics.AddError(
+			"create user resource",
+			"user "+username+": id is nil",
+		)
+
+		return
+	}
+
+	id = *user.GetUser().Id
+	plan.Id = types.Int64Value(id)
+
+	// write id as soon as possible
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state, pdiags := getUserAsState(ctx, id, client)
+	if pdiags.HasError() {
+		resp.Diagnostics.Append(pdiags...)
+		resp.Diagnostics.AddError(
+			"update user resource",
+			fmt.Sprintf("user %d: failed to read from api", id),
+		)
+
+		return
+	}
+
+	// special case - can't read from API
+	state.PasswordWoVersion = plan.PasswordWoVersion
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 }
+*/
 
 func (r *Resource) Delete(
 	ctx context.Context,

--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -366,9 +366,6 @@ func (r *Resource) Update(
 	state.PasswordWoVersion = plan.PasswordWoVersion
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (r *Resource) Read(

--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -277,7 +277,7 @@ func (r *Resource) Update(
 	username := plan.Username.ValueString()
 
 	// non-nullable
-	updateUser.SetUsername(plan.Username.ValueString())
+	updateUser.SetUsername(username)
 	updateUser.SetEmail(plan.Email.ValueString())
 	updateUser.SetRoles(roles)
 

--- a/internal/subproviders/morpheus/resources/user/resource.go
+++ b/internal/subproviders/morpheus/resources/user/resource.go
@@ -227,18 +227,17 @@ func (r *Resource) Create(
 	}
 }
 
+// Note that the following are not updateable via the API:
+// LinuxUsername
+// WindowsUsername
+// LinuxKeyPairId
+// ReceiveNotifications
+// TenantId
 func (r *Resource) Update(
 	ctx context.Context,
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	// Not updateable via API:
-	// LinuxUsername
-	// WindowsUsername
-	// LinuxKeyPairId
-	// ReceiveNotifications
-	// TenantId
-
 	var plan, state, config UserModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -414,116 +413,6 @@ func (r *Resource) Read(
 		return
 	}
 }
-
-/*
-func (r *Resource) Update(
-	ctx context.Context,
-	req resource.UpdateRequest,
-	resp *resource.UpdateResponse,
-) {
-	var plan UserModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	id := plan.Id.ValueInt64()
-
-	var roleIDs []int64
-	if !plan.RoleIds.IsNull() && !plan.RoleIds.IsUnknown() {
-		diags := plan.RoleIds.ElementsAs(ctx, &roleIDs, false)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
-
-	var roles []sdk.UpdateUserRequestUserRolesInner
-	for _, roleID := range roleIDs {
-		rolevalue := sdk.UpdateUserRequestUserRolesInner{
-			Id: roleID,
-		}
-		roles = append(roles, rolevalue)
-	}
-
-	updateUser := sdk.NewUpdateUserRequestUser()
-
-	var config UserModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// required
-	username := plan.Username.ValueString()
-	updateUser.SetUsername(username)
-	updateUser.SetEmail(plan.Email.ValueString())
-	updateUser.SetRoles(roles)
-	//updateUser.SetPassword(config.PasswordWo.ValueString())
-
-	client, err := r.NewClient(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"update user resource",
-			"user "+username+": failed to create client: "+err.Error(),
-		)
-
-		return
-	}
-
-	apiUpdateUserReq := client.UsersAPI.UpdateUser(ctx, id)
-	updateUserReq := sdk.NewUpdateUserRequest(*updateUser)
-	user, hresp, err := apiUpdateUserReq.UpdateUserRequest(*updateUserReq).Execute()
-
-	if err != nil || hresp.StatusCode != http.StatusOK {
-		resp.Diagnostics.AddError(
-			"update user resource",
-			"user "+username+" PUT failed: "+errors.ErrMsg(err, hresp),
-		)
-
-		return
-	}
-
-	if user.GetUser().Id == nil {
-		resp.Diagnostics.AddError(
-			"create user resource",
-			"user "+username+": id is nil",
-		)
-
-		return
-	}
-
-	id = *user.GetUser().Id
-	plan.Id = types.Int64Value(id)
-
-	// write id as soon as possible
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	state, pdiags := getUserAsState(ctx, id, client)
-	if pdiags.HasError() {
-		resp.Diagnostics.Append(pdiags...)
-		resp.Diagnostics.AddError(
-			"update user resource",
-			fmt.Sprintf("user %d: failed to read from api", id),
-		)
-
-		return
-	}
-
-	// special case - can't read from API
-	state.PasswordWoVersion = plan.PasswordWoVersion
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-}
-*/
 
 func (r *Resource) Delete(
 	ctx context.Context,

--- a/internal/subproviders/morpheus/resources/user/user_resource_gen.go
+++ b/internal/subproviders/morpheus/resources/user/user_resource_gen.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -23,17 +24,28 @@ func UserResourceSchema(ctx context.Context) schema.Schema {
 			"first_name": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The user's first name (optional)",
-				MarkdownDescription: "The user's first name (optional)",
+				Description:         "User's first name (optional)",
+				MarkdownDescription: "User's first name (optional)",
+				PlanModifiers: []planmodifier.String{
+					modifiers.NullableStringUpdateModifier{},
+				},
 			},
 			"id": schema.Int64Attribute{
-				Computed: true,
+				Computed:            true,
+				Description:         "User id",
+				MarkdownDescription: "User id",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"last_name": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The user's last name (optional)",
-				MarkdownDescription: "The user's last name (optional)",
+				Description:         "User's last name (optional)",
+				MarkdownDescription: "User's last name (optional)",
+				PlanModifiers: []planmodifier.String{
+					modifiers.NullableStringUpdateModifier{},
+				},
 			},
 			"linux_key_pair_id": schema.Int64Attribute{
 				Optional:            true,


### PR DESCRIPTION
Add basic ability to update user resource.

We add a plan modifier for nullable strings so that during plan
changes from "foo" to `null` will be detected and trigger an update.

We also set a plan modifier on id - this is also so that the correct
update behaviour is achieved. In this case it is to avoid spurious
updates.

Tests have been written but will be in a separate PR to reduce review size.