### PR TITLE
Doc templates - fix import

### DIFF
--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -22,5 +22,5 @@ description: |-
 
 Import is supported using the following syntax:
 
-{{ printf "{{codefile \"shell\" %q}}" .ImportFile }}
+{{ codefile "shell" .ImportFile }}
 {{- end }}

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -22,5 +22,5 @@ description: |-
 
 Import is supported using the following syntax:
 
-{{ printf "{{codefile \"shell\" %q}}" .ImportFile }}
+{{ codefile "shell" .ImportFile }}
 {{- end }}


### PR DESCRIPTION
The tooling was including the path to import.sh
rather than the contents of import.sh.