### PR TITLE
API requests: Use Proxy

### DIFF
--- a/internal/subproviders/morpheus/clientfactory/clientfactory.go
+++ b/internal/subproviders/morpheus/clientfactory/clientfactory.go
@@ -118,6 +118,7 @@ func NewAPIClient(
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: options.insecure, //nolint: gosec
 			},
+			Proxy: http.ProxyFromEnvironment,
 		}
 
 		if httptrace.IsEnabled() {


### PR DESCRIPTION
added Proxy field to http.Transport instance 
ProxyFromEnvironment looks for proxy env-vars and defaults to nil
env vars are HTTP_PROXY AND HTTPS_PROXY