### PR TITLE
Enable use of access token in testhelpers client

### DIFF
--- a/internal/subproviders/morpheus/testhelpers/client.go
+++ b/internal/subproviders/morpheus/testhelpers/client.go
@@ -20,6 +20,6 @@ func newClient(ctx context.Context, t *testing.T) *sdk.APIClient {
 		os.Getenv("TF_VAR_testacc_morpheus_url"),
 		os.Getenv("TF_VAR_testacc_morpheus_username"),
 		os.Getenv("TF_VAR_testacc_morpheus_password"),
-		"",
+		os.Getenv("TF_VAR_testacc_morpheus_access_token"),
 		clientfactory.WithInsecureTLS())
 }


### PR DESCRIPTION
So that we aren't limited to credentials when running acceptance tests.