### PR TITLE
Extend Role resource with permissions support

### DIFF
--- a/docs/resources/morpheus_role.md
+++ b/docs/resources/morpheus_role.md
@@ -31,7 +31,10 @@ resource "hpe_morpheus_role" "example" {
 ### Optional
 
 - `description` (String) Description
+- `landing_url` (String) An optional override for the default landing page after login for a user.
 - `multitenant` (Boolean) Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant*
+- `multitenant_locked` (Boolean) Multitenant Locked, prevents sub-tenant users from modifying their copy of multienant roles. *Only available to master tenant*
+- `permissions` (String) A JSON document containing the set of permissions to assign to the role
 - `role_type` (String) Role type
 
 ### Read-Only

--- a/internal/subproviders/morpheus/resources/role/resource.go
+++ b/internal/subproviders/morpheus/resources/role/resource.go
@@ -4,6 +4,7 @@ package role
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/compare"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
@@ -72,9 +74,27 @@ func getRoleAsState(
 	state.Id = convert.Int64ToType(r.Role.Id)
 	state.Name = convert.StrToType(r.Role.Name)
 	state.Description = convert.StrToType(r.Role.Description)
+	state.LandingUrl = convert.StrToType(r.Role.LandingUrl)
 	state.Multitenant = convert.BoolToType(r.Role.Multitenant)
+	state.MultitenantLocked = convert.BoolToType(r.Role.MultitenantLocked)
 	state.RoleType = convert.StrToType(r.Role.RoleType)
 
+	// for sorting the permission keys and storing to state, we don't want the Role properties,
+	// only the permission related ones
+	r.Role = nil
+
+	sortedPermissions, err := json.Marshal(r)
+	if err != nil {
+		diags.AddError(
+			"get role (read permissions)",
+			fmt.Sprintf("role %d: failed to marshal permissions: "+err.Error(), id),
+		)
+		return state, diags
+	}
+
+	sortedPermissionsStr := string(sortedPermissions)
+
+	state.Permissions = convert.StrToType(&sortedPermissionsStr)
 	return state, diags
 }
 
@@ -91,27 +111,52 @@ func (r *Resource) Create(
 	}
 
 	addRole := sdk.NewAddRolesRequestRoleWithDefaults()
+	name := plan.Name.ValueString()
+
+	// Only add to create request if user has set permissions explicitly.
+	// Also, set permissions first so that it doesn't override the other
+	// addRole fields when we unmarshal.
+	if !plan.Permissions.IsNull() && !plan.Permissions.IsUnknown() {
+
+		data := []byte(plan.Permissions.ValueString())
+
+		// populate the addRole request with user-provided config data
+		err := json.Unmarshal(data, &addRole)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"create role resource",
+				"role "+name+": failed to unmarshal permissions to request: "+err.Error(),
+			)
+
+			return
+
+		}
+	}
 
 	// required
-	name := plan.Name.ValueString()
 	addRole.SetAuthority(name)
 
 	// optional
 	if !plan.Description.IsUnknown() {
 		addRole.SetDescription(plan.Description.ValueString())
 	}
+
+	if !plan.LandingUrl.IsUnknown() {
+		addRole.SetLandingUrl(plan.LandingUrl.ValueString())
+	}
+
+	// optional_computed
 	if !plan.Multitenant.IsUnknown() {
+		// default: false
 		addRole.SetMultitenant(plan.Multitenant.ValueBool())
 	}
-	if !plan.RoleType.IsUnknown() {
-		if plan.RoleType.ValueString() != "user" {
-			resp.Diagnostics.AddError(
-				"create role resource",
-				"role "+name+": currently only 'user' role_type is supported",
-			)
+	if !plan.MultitenantLocked.IsUnknown() {
+		// default: false
+		addRole.SetMultitenantLocked(plan.MultitenantLocked.ValueBool())
+	}
 
-			return
-		}
+	if !plan.RoleType.IsUnknown() {
+		// default: user
 		addRole.SetRoleType(plan.RoleType.ValueString())
 	}
 
@@ -167,6 +212,14 @@ func (r *Resource) Create(
 		return
 	}
 
+	// If the user provided a config as part of the create,
+	// then set the state to what was in the plan (optional).
+	// Otherwise, in the case of the user providing NO config,
+	// set it to what was read from the API (computed, set in getRoleAsState).
+	if !plan.Permissions.IsNull() && !plan.Permissions.IsUnknown() {
+		state.Permissions = plan.Permissions
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -178,9 +231,9 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var plan RoleModel
+	var state RoleModel
 
-	diags := req.State.Get(ctx, &plan)
+	diags := req.State.Get(ctx, &state)
 	if diags.HasError() {
 		return
 	}
@@ -195,8 +248,8 @@ func (r *Resource) Read(
 		return
 	}
 
-	id := plan.Id.ValueInt64()
-	state, pdiags := getRoleAsState(ctx, id, client)
+	id := state.Id.ValueInt64()
+	apiState, pdiags := getRoleAsState(ctx, id, client)
 	if pdiags.HasError() {
 		resp.Diagnostics.Append(pdiags...)
 		resp.Diagnostics.AddError(
@@ -207,7 +260,48 @@ func (r *Resource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	var statePermissionData, apiPermissionData sdk.GetRole200Response
+
+	// On import, or when the user does not set the permissions attribute,
+	// the permissions attribute will be null or unknown, so we need to ignore the subset check
+	// and just set it to the API Permissions - i.e. fully computed
+	if !state.Permissions.IsNull() && !state.Permissions.IsUnknown() {
+
+		statePermissionStr := state.Permissions.ValueString()
+		err = json.Unmarshal([]byte(statePermissionStr), &statePermissionData)
+		if err != nil {
+			resp.Diagnostics.Append(pdiags...)
+			resp.Diagnostics.AddError(
+				"read role resource",
+				fmt.Sprintf("role %d: failed to unmarshal permissions from state; permissions: %s", id, statePermissionStr),
+			)
+
+			return
+
+		}
+
+		apiPermissionStr := apiState.Permissions.ValueString()
+		err = json.Unmarshal([]byte(apiPermissionStr), &apiPermissionData)
+		if err != nil {
+			resp.Diagnostics.Append(pdiags...)
+			resp.Diagnostics.AddError(
+				"read role resource",
+				fmt.Sprintf("role %d: failed to unmarshal permissions from api; permissions: %s", id, apiPermissionStr),
+			)
+
+			return
+
+		}
+
+		// If the existing state is a subset of the response from the API,
+		// then we're safe to keep using the existing state as the new state.
+		// Otherwise, it'll attempt to set the state to the API permissions which will show a mismatch.
+		if eq, err := compare.ContainsSubset(apiPermissionData, statePermissionData); eq && err == nil {
+			apiState.Permissions = state.Permissions
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &apiState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/subproviders/morpheus/resources/role/resource.go
+++ b/internal/subproviders/morpheus/resources/role/resource.go
@@ -89,12 +89,14 @@ func getRoleAsState(
 			"get role (read permissions)",
 			fmt.Sprintf("role %d: failed to marshal permissions: "+err.Error(), id),
 		)
+
 		return state, diags
 	}
 
 	sortedPermissionsStr := string(sortedPermissions)
 
 	state.Permissions = convert.StrToType(&sortedPermissionsStr)
+
 	return state, diags
 }
 
@@ -273,7 +275,8 @@ func (r *Resource) Read(
 			resp.Diagnostics.Append(pdiags...)
 			resp.Diagnostics.AddError(
 				"read role resource",
-				fmt.Sprintf("role %d: failed to unmarshal permissions from state; permissions: %s", id, statePermissionStr),
+				fmt.Sprintf("role %d: failed to unmarshal permissions from state; permissions: %s",
+					id, statePermissionStr),
 			)
 
 			return
@@ -286,7 +289,8 @@ func (r *Resource) Read(
 			resp.Diagnostics.Append(pdiags...)
 			resp.Diagnostics.AddError(
 				"read role resource",
-				fmt.Sprintf("role %d: failed to unmarshal permissions from api; permissions: %s", id, apiPermissionStr),
+				fmt.Sprintf("role %d: failed to unmarshal permissions from api; permissions: %s",
+					id, apiPermissionStr),
 			)
 
 			return

--- a/internal/subproviders/morpheus/resources/role/resource_test.go
+++ b/internal/subproviders/morpheus/resources/role/resource_test.go
@@ -41,10 +41,16 @@ var testAccProtoV6ProviderFactories = map[string]func() (
 }
 
 // Some notes about what we expect to happen with Permissions in acceptance test import testing:
-// On import, if the permissions have been computed at create, then the import step will pass happily.
-// If the permissions have been set by the user at create, then the import verification step will fail,
-// because the API permissions being imported do not match the existing resource's permissions in state.
-// Therefore, for any tests using user-set permissions, we skip the permissions import verification check.
+
+// On import, if the permissions have been computed at create,
+// then the import step will pass happily.
+// If the permissions have been set by the user at create,
+// then the import verification step will fail,
+// because the API permissions being imported do not match the
+// existing resource's permissions in state.
+
+// Therefore, for any tests using user-set permissions,
+// we skip the permissions import verification check.
 
 // Check that we can create a role with only required attributes specified
 func TestAccMorpheusRoleRequiredAttrsOk(t *testing.T) {
@@ -146,7 +152,8 @@ resource "hpe_morpheus_role" "example_all" {
   })
 }
 `
-	// jsonencode() will sort the keys in objects
+	// jsonencode() will have sorted the keys in objects
+	//nolint:lll
 	expectedPermissionsJSON := `{"featurePermissions":[{"access":"full","code":"integrations-ansible"}],"globalSiteAccess":"full"}`
 
 	checks := []resource.TestCheckFunc{
@@ -198,8 +205,9 @@ resource "hpe_morpheus_role" "example_all" {
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true,                    // Check state post import
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				//nolint:lll
 				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
 				ResourceName:            "hpe_morpheus_role.example_all",
 				Check:                   checkFn,
@@ -324,9 +332,10 @@ resource "hpe_morpheus_role" "default_access_permissions_ok" {
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true, // Check state post import
-				ResourceName:            "hpe_morpheus_role.default_access_permissions_ok",
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				ResourceName:      "hpe_morpheus_role.default_access_permissions_ok",
+				//nolint:lll
 				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
 				Check:                   checkFn,
 			},
@@ -439,8 +448,9 @@ func TestAccMorpheusRolePermissionsFeaturePermissionsJSONStringOk(t *testing.T) 
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true,                    // Check state post import
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				//nolint:lll
 				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
 				ResourceName:            "hpe_morpheus_role.json_string_ok",
 				Check:                   checkFn,
@@ -476,6 +486,7 @@ permissions = jsonencode({
 `
 
 	// remember, jsonencode() sorts the keys of an object
+	//nolint:lll
 	expectedFeaturePermissionsJSON := `{"featurePermissions":[{"access":"full","code":"integrations-ansible"},{"access":"none","code":"admin-appliance"}]}`
 
 	checks := []resource.TestCheckFunc{
@@ -502,8 +513,9 @@ permissions = jsonencode({
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true,                    // Check state post import
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				//nolint:lll
 				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
 				ResourceName:            "hpe_morpheus_role.json_encode_ok",
 				Check:                   checkFn,
@@ -515,20 +527,23 @@ permissions = jsonencode({
 // Needed for when we want to verify entirely computed permissions in state.
 // We can't compare against a string constant because the IDs of the featurePermissions can
 // differ between Morpheus installs; presumably computed in parallel at Morpheus initialisation.
-func composeCheckFnStatePermissionsEqAPIPermissions(t *testing.T, resource string) resource.TestCheckFunc {
+func composeCheckFnStatePermissionsEqAPIPermissions(
+	t *testing.T,
+	resource string,
+) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[resource]
 		if rs == nil {
 			return fmt.Errorf("resource not found: %s", resource)
 		}
 
-		roleId := rs.Primary.Attributes["id"]
-		roleIdInt, err := strconv.Atoi(roleId)
+		roleID := rs.Primary.Attributes["id"]
+		roleIDInt, err := strconv.Atoi(roleID)
 		if err != nil {
 			return err
 		}
 
-		roleResp, err := testhelpers.GetRole(t, int64(roleIdInt))
+		roleResp, err := testhelpers.GetRole(t, int64(roleIDInt))
 		if err != nil {
 			return err
 		}
@@ -547,10 +562,10 @@ func composeCheckFnStatePermissionsEqAPIPermissions(t *testing.T, resource strin
 
 		// the state Permissions should have already been sorted by a json.Marshal at create time
 		if apiPermissionsStr != statePermisions {
-			return fmt.Errorf("permissions in state do not match API permissions:\nexpected: %s\ngot: %s", statePermisions, apiPermissions)
+			return fmt.Errorf("permissions in state do not match API permissions:\nexpected: %s\ngot: %s",
+				statePermisions, apiPermissions)
 		}
 
 		return nil
-
 	}
 }

--- a/internal/subproviders/morpheus/resources/role/resource_test.go
+++ b/internal/subproviders/morpheus/resources/role/resource_test.go
@@ -524,6 +524,92 @@ permissions = jsonencode({
 	})
 }
 
+// test that there's no change in plan after running an apply
+func TestAccMorpheusRolePermissionsPlanAfterApply(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	resourceConfigGood := `resource "hpe_morpheus_role" "plan_after_apply_good" {
+name = "TestAccMorpheusRolePermissionsPlanAfterApplyGoodPermissions"
+permissions = jsonencode({
+  "featurePermissions": [
+    {
+      "code" = "integrations-ansible"
+      "access" = "full"
+    }
+  ],
+  "globalSiteAccess" = "full"
+})
+}
+`
+	resourceConfigBad := `resource "hpe_morpheus_role" "plan_after_apply_bad" {
+name = "TestAccMorpheusRolePermissionsPlanAfterApplyBadPermissions"
+permissions = jsonencode({
+  "globalSiteAccessFoo" = "full"
+})
+}
+`
+
+	// remember, jsonencode() sorts the keys of an object
+	//nolint:lll
+	expectedGoodPermissionsJSON := `{"featurePermissions":[{"access":"full","code":"integrations-ansible"}],"globalSiteAccess":"full"}`
+
+	expectedBadPermissionsJSON := `{"globalSiteAccessFoo":"full"}`
+
+	checksGood := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.plan_after_apply_good",
+			"name",
+			"TestAccMorpheusRolePermissionsPlanAfterApplyGoodPermissions",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.plan_after_apply_good",
+			"permissions",
+			expectedGoodPermissionsJSON,
+		),
+	}
+
+	checksBad := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.plan_after_apply_bad",
+			"name",
+			"TestAccMorpheusRolePermissionsPlanAfterApplyBadPermissions",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.plan_after_apply_bad",
+			"permissions",
+			expectedBadPermissionsJSON,
+		),
+	}
+
+	checkFnGood := resource.ComposeAggregateTestCheckFunc(checksGood...)
+	checkFnBad := resource.ComposeAggregateTestCheckFunc(checksBad...)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfigGood,
+				ExpectNonEmptyPlan: false, // works on refresh plan after apply, too
+				Check:              checkFnGood,
+				ResourceName:       "hpe_morpheus_role.plan_after_apply_good",
+				PlanOnly:           false,
+			},
+			{
+				Config:             providerConfig + resourceConfigBad,
+				ExpectNonEmptyPlan: true, // works on refresh plan after apply, too
+				Check:              checkFnBad,
+				ResourceName:       "hpe_morpheus_role.plan_after_apply_bad",
+				PlanOnly:           false,
+			},
+		},
+	})
+}
+
 // Needed for when we want to verify entirely computed permissions in state.
 // We can't compare against a string constant because the IDs of the featurePermissions can
 // differ between Morpheus installs; presumably computed in parallel at Morpheus initialisation.

--- a/internal/subproviders/morpheus/resources/role/resource_test.go
+++ b/internal/subproviders/morpheus/resources/role/resource_test.go
@@ -5,7 +5,10 @@
 package role_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/HPE/terraform-provider-hpe/internal/provider"
@@ -16,6 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestMain(m *testing.M) {
@@ -36,6 +40,12 @@ var testAccProtoV6ProviderFactories = map[string]func() (
 	"hpe": newProviderWithError,
 }
 
+// Some notes about what we expect to happen with Permissions in acceptance test import testing:
+// On import, if the permissions have been computed at create, then the import step will pass happily.
+// If the permissions have been set by the user at create, then the import verification step will fail,
+// because the API permissions being imported do not match the existing resource's permissions in state.
+// Therefore, for any tests using user-set permissions, we skip the permissions import verification check.
+
 // Check that we can create a role with only required attributes specified
 func TestAccMorpheusRoleRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
@@ -45,18 +55,28 @@ func TestAccMorpheusRoleRequiredAttrsOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	resourceConfig, err := testhelpers.RenderExample(t, "example-required.tf.tmpl",
-		"Name", "TestAccMorpheusRoleRequiredAttrsOk")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	resourceConfig := `
+resource "hpe_morpheus_role" "example_required" {
+  name = "TestAccMorpheusRoleRequiredAttrsOk"
+}
+`
 	checks := []resource.TestCheckFunc{
+		// required
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.example_required",
 			"name",
 			"TestAccMorpheusRoleRequiredAttrsOk",
 		),
+		// checks for optional
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_role.example_required",
+			"description",
+		),
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_role.example_required",
+			"landing_url",
+		),
+		// checks for computed
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.example_required",
 			"multitenant",
@@ -64,12 +84,17 @@ func TestAccMorpheusRoleRequiredAttrsOk(t *testing.T) {
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.example_required",
+			"multitenant_locked",
+			"false",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.example_required",
 			"role_type",
 			"user",
 		),
-		resource.TestCheckNoResourceAttr(
+		composeCheckFnStatePermissionsEqAPIPermissions(
+			t,
 			"hpe_morpheus_role.example_required",
-			"description",
 		),
 	}
 
@@ -102,14 +127,27 @@ func TestAccMorpheusRoleAllAttrsOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	resourceConfig, err := testhelpers.RenderExample(t, "example-all.tf.tmpl",
-		"Name", "TestAccMorpheusRoleAllAttrsOk",
-		"Multitenant", "true",
-		"Description", "test",
-		"RoleType", "user")
-	if err != nil {
-		t.Fatal(err)
-	}
+	resourceConfig := `
+resource "hpe_morpheus_role" "example_all" {
+  name = "TestAccMorpheusRoleAllAttrsOk"
+  description = "test"
+  landing_url = "https://test.com"
+  multitenant = true
+  multitenant_locked = true
+  role_type = "user"
+  permissions = jsonencode({
+    "featurePermissions": [
+      {
+        "code" = "integrations-ansible"
+        "access" = "full"
+      }
+    ],
+    "globalSiteAccess" = "full"
+  })
+}
+`
+	// jsonencode() will sort the keys in objects
+	expectedPermissionsJSON := `{"featurePermissions":[{"access":"full","code":"integrations-ansible"}],"globalSiteAccess":"full"}`
 
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(
@@ -124,13 +162,28 @@ func TestAccMorpheusRoleAllAttrsOk(t *testing.T) {
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.example_all",
+			"landing_url",
+			"https://test.com",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.example_all",
 			"multitenant",
+			"true",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.example_all",
+			"multitenant_locked",
 			"true",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.example_all",
 			"role_type",
 			"user",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.example_all",
+			"permissions",
+			expectedPermissionsJSON,
 		),
 	}
 
@@ -145,10 +198,11 @@ func TestAccMorpheusRoleAllAttrsOk(t *testing.T) {
 				PlanOnly:           false,
 			},
 			{
-				ImportState:       true,
-				ImportStateVerify: true, // Check state post import
-				ResourceName:      "hpe_morpheus_role.example_all",
-				Check:             checkFn,
+				ImportState:             true,
+				ImportStateVerify:       true,                    // Check state post import
+				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
+				ResourceName:            "hpe_morpheus_role.example_all",
+				Check:                   checkFn,
 			},
 		},
 	})
@@ -215,4 +269,288 @@ func TestAccMorpheusRoleExampleOk(t *testing.T) {
 	})
 }
 
-// TODO: Add more acceptance tests
+// default == global
+func TestAccMorpheusRolePermissionsDefaultAccessPermissionsOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	resourceConfig := `
+resource "hpe_morpheus_role" "default_access_permissions_ok" {
+	name = "TestAccMorpheusRolePermissionsDefaultAccessPermissionsOk"
+	permissions = jsonencode({
+  "globalSiteAccess" = "full"
+  "globalZoneAccess" = "full"
+  "globalInstanceTypeAccess" = "full"
+  "globalAppTemplateAccess" = "full"
+  "globalCatalogItemTypeAccess" = "full"
+  "globalPersonaAccess" = "full"
+  "globalVdiPoolAccess" = "full"
+  "globalReportTypeAccess" = "full"
+  "globalTaskAccess" = "full"
+  "globalTaskSetAccess" = "full"
+})
+}
+`
+	//nolint:lll
+	// the input will have been sorted by the jsonencode() function
+	expectedDefaultPermissionsJSON := `{"globalAppTemplateAccess":"full","globalCatalogItemTypeAccess":"full","globalInstanceTypeAccess":"full","globalPersonaAccess":"full","globalReportTypeAccess":"full","globalSiteAccess":"full","globalTaskAccess":"full","globalTaskSetAccess":"full","globalVdiPoolAccess":"full","globalZoneAccess":"full"}`
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.default_access_permissions_ok",
+			"name",
+			"TestAccMorpheusRolePermissionsDefaultAccessPermissionsOk",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.default_access_permissions_ok",
+			"permissions",
+			expectedDefaultPermissionsJSON,
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+				PlanOnly:           false,
+			},
+			{
+				ImportState:             true,
+				ImportStateVerify:       true, // Check state post import
+				ResourceName:            "hpe_morpheus_role.default_access_permissions_ok",
+				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
+				Check:                   checkFn,
+			},
+		},
+	})
+}
+
+// check that we correctly store the API-computed permissions in the statefile when
+// the user has not set any permissions
+func TestAccMorpheusRolePermissionsComputedPermissionsOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	resourceConfig := `
+resource "hpe_morpheus_role" "computed_permissions_ok" {
+	name = "TestAccMorpheusRolePermissionsComputedPermissionsOk"
+}
+`
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.computed_permissions_ok",
+			"name",
+			"TestAccMorpheusRolePermissionsComputedPermissionsOk",
+		),
+		composeCheckFnStatePermissionsEqAPIPermissions(
+			t,
+			"hpe_morpheus_role.computed_permissions_ok",
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+				PlanOnly:           false,
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				ResourceName:      "hpe_morpheus_role.computed_permissions_ok",
+				Check:             checkFn,
+			},
+		},
+	})
+}
+
+// test that providing feature permissions with a JSON string literal works
+func TestAccMorpheusRolePermissionsFeaturePermissionsJSONStringOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	featurePermissionsJSON := `
+{
+  "featurePermissions": [
+    {
+      "code": "integrations-ansible",
+      "access": "full"
+    },
+    {
+      "code": "admin-appliance",
+      "access": "none"
+    },
+    {
+      "code": "app-templates",
+      "access": "none"
+    }
+  ]
+}
+`
+	resourceConfig := fmt.Sprintf(`resource "hpe_morpheus_role" "json_string_ok" {
+	name = "TestAccMorpheusRolePermissionsFeaturePermissionsOk"
+	permissions = <<-EOT
+%sEOT
+}
+`, featurePermissionsJSON)
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.json_string_ok",
+			"name",
+			"TestAccMorpheusRolePermissionsFeaturePermissionsOk",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.json_string_ok",
+			"permissions",
+			featurePermissionsJSON,
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+				PlanOnly:           false,
+			},
+			{
+				ImportState:             true,
+				ImportStateVerify:       true,                    // Check state post import
+				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
+				ResourceName:            "hpe_morpheus_role.json_string_ok",
+				Check:                   checkFn,
+			},
+		},
+	})
+}
+
+// test that we can set permissions using jsonencode()
+func TestAccMorpheusRolePermissionsFeaturePermissionsJSONEncodeOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	resourceConfig := `resource "hpe_morpheus_role" "json_encode_ok" {
+name = "TestAccMorpheusRolePermissionsFeaturePermissionsOk"
+permissions = jsonencode({
+  "featurePermissions": [
+    {
+      "code" = "integrations-ansible"
+      "access" = "full"
+    },
+    {
+      "code" = "admin-appliance"
+      "access" = "none"
+    }
+  ]
+})
+}
+`
+
+	// remember, jsonencode() sorts the keys of an object
+	expectedFeaturePermissionsJSON := `{"featurePermissions":[{"access":"full","code":"integrations-ansible"},{"access":"none","code":"admin-appliance"}]}`
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.json_encode_ok",
+			"name",
+			"TestAccMorpheusRolePermissionsFeaturePermissionsOk",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.json_encode_ok",
+			"permissions",
+			expectedFeaturePermissionsJSON,
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+				PlanOnly:           false,
+			},
+			{
+				ImportState:             true,
+				ImportStateVerify:       true,                    // Check state post import
+				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
+				ResourceName:            "hpe_morpheus_role.json_encode_ok",
+				Check:                   checkFn,
+			},
+		},
+	})
+}
+
+// Needed for when we want to verify entirely computed permissions in state.
+// We can't compare against a string constant because the IDs of the featurePermissions can
+// differ between Morpheus installs; presumably computed in parallel at Morpheus initialisation.
+func composeCheckFnStatePermissionsEqAPIPermissions(t *testing.T, resource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs := s.RootModule().Resources[resource]
+		if rs == nil {
+			return fmt.Errorf("resource not found: %s", resource)
+		}
+
+		roleId := rs.Primary.Attributes["id"]
+		roleIdInt, err := strconv.Atoi(roleId)
+		if err != nil {
+			return err
+		}
+
+		roleResp, err := testhelpers.GetRole(t, int64(roleIdInt))
+		if err != nil {
+			return err
+		}
+
+		// don't need it for marshaling to do comparison
+		roleResp.Role = nil
+
+		apiPermissions, err := json.Marshal(roleResp)
+		if err != nil {
+			return err
+		}
+
+		apiPermissionsStr := string(apiPermissions)
+
+		statePermisions := rs.Primary.Attributes["permissions"]
+
+		// the state Permissions should have already been sorted by a json.Marshal at create time
+		if apiPermissionsStr != statePermisions {
+			return fmt.Errorf("permissions in state do not match API permissions:\nexpected: %s\ngot: %s", statePermisions, apiPermissions)
+		}
+
+		return nil
+
+	}
+}

--- a/internal/subproviders/morpheus/resources/role/schema_gen.go
+++ b/internal/subproviders/morpheus/resources/role/schema_gen.go
@@ -4,8 +4,11 @@ package role
 
 import (
 	"context"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/morpheusvalidators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -25,6 +28,14 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "The ID of the role",
 				MarkdownDescription: "The ID of the role",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+			"landing_url": schema.StringAttribute{
+				Optional:            true,
+				Description:         "An optional override for the default landing page after login for a user.",
+				MarkdownDescription: "An optional override for the default landing page after login for a user.",
 			},
 			"multitenant": schema.BoolAttribute{
 				Optional:            true,
@@ -33,10 +44,26 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant*",
 				Default:             booldefault.StaticBool(false),
 			},
+			"multitenant_locked": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Multitenant Locked, prevents sub-tenant users from modifying their copy of multienant roles. *Only available to master tenant*",
+				MarkdownDescription: "Multitenant Locked, prevents sub-tenant users from modifying their copy of multienant roles. *Only available to master tenant*",
+				Default:             booldefault.StaticBool(false),
+			},
 			"name": schema.StringAttribute{
 				Required:            true,
 				Description:         "A unique name for the role",
 				MarkdownDescription: "A unique name for the role",
+			},
+			"permissions": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "A JSON document containing the set of permissions to assign to the role",
+				MarkdownDescription: "A JSON document containing the set of permissions to assign to the role",
+				Validators: []validator.String{
+					morpheusvalidators.JSONValidator{},
+				},
 			},
 			"role_type": schema.StringAttribute{
 				Optional:            true,
@@ -56,9 +83,12 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type RoleModel struct {
-	Description types.String `tfsdk:"description"`
-	Id          types.Int64  `tfsdk:"id"`
-	Multitenant types.Bool   `tfsdk:"multitenant"`
-	Name        types.String `tfsdk:"name"`
-	RoleType    types.String `tfsdk:"role_type"`
+	Description       types.String `tfsdk:"description"`
+	Id                types.Int64  `tfsdk:"id"`
+	LandingUrl        types.String `tfsdk:"landing_url"`
+	Multitenant       types.Bool   `tfsdk:"multitenant"`
+	MultitenantLocked types.Bool   `tfsdk:"multitenant_locked"`
+	Name              types.String `tfsdk:"name"`
+	Permissions       types.String `tfsdk:"permissions"`
+	RoleType          types.String `tfsdk:"role_type"`
 }

--- a/internal/subproviders/morpheus/testhelpers/role.go
+++ b/internal/subproviders/morpheus/testhelpers/role.go
@@ -1,0 +1,25 @@
+package testhelpers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+)
+
+func GetRole(t *testing.T, roleId int64) (*sdk.GetRole200Response, error) {
+	t.Helper()
+
+	ctx := context.TODO()
+
+	client := newClient(ctx, t)
+
+	r, hresp, err := client.RolesAPI.GetRole(ctx, roleId).Execute()
+	if r == nil || err != nil || hresp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET failed for role %w", err)
+	}
+
+	return r, nil
+}

--- a/internal/subproviders/morpheus/testhelpers/role.go
+++ b/internal/subproviders/morpheus/testhelpers/role.go
@@ -9,14 +9,14 @@ import (
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 )
 
-func GetRole(t *testing.T, roleId int64) (*sdk.GetRole200Response, error) {
+func GetRole(t *testing.T, roleID int64) (*sdk.GetRole200Response, error) {
 	t.Helper()
 
 	ctx := context.TODO()
 
 	client := newClient(ctx, t)
 
-	r, hresp, err := client.RolesAPI.GetRole(ctx, roleId).Execute()
+	r, hresp, err := client.RolesAPI.GetRole(ctx, roleID).Execute()
 	if r == nil || err != nil || hresp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET failed for role %w", err)
 	}


### PR DESCRIPTION
Adds the ability for a user to set `permissions` for the role they are creating by setting a valid JSON string with the `permissions` attribute.

The provider will correctly compare between API permissions, which are partially computed, and those set by the user.
If permissions are set by the user, then those permissions will be stored in the statefile.
If no permissions are set by the user, then the API-computed permissions will be stored in the statefile.
On import of a Role resource, the existing API permissions will be imported and stored in the statefile.

Adds tests to verify correct behaviour of permissions and import of permissions.

New features:
- Add `permissions` support to Role resource.
- Also add `multitenant_locked`, `landing_url` fields.
- Remove prior restriction on `role_type` field: Now supports `user` and `account` role types.
- Update generated schema.

Testing:
-  Update existing tests to use added attribute fields.
- Remove usage of `.md.tmpl` files in non-documentation example tests.
- Add tests for computed permissions, user-set default access permissions, user-set feature permissions via string and via `jsonencode()`
- Add test helper function for getting a Role.
