### PR TITLE
Install terraform before running test CI job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,5 +18,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.12.2
       - run: go version
       - run: make test


### PR DESCRIPTION
Hopefully avoids this issue:

```
cannot run Terraform provider tests: error calling terraform version command: fork/exec /tmp/plugintest-terraform4177945157/terraform: text file busy
260
```

See:

https://github.com/hashicorp/terraform-plugin-testing/issues/429