### PR TITLE
fix failing acceptance test for example with legacy provider

### DIFF
--- a/internal/subproviders/morpheus/resources/role/resource_test.go
+++ b/internal/subproviders/morpheus/resources/role/resource_test.go
@@ -859,8 +859,10 @@ resource "morpheus_groovy_script_task" "testacc_role_example_legacy_provider_tas
 			{
 				ImportState:       true,
 				ImportStateVerify: true, // Check state post import
-				ResourceName:      "hpe_morpheus_role.testacc_example_role_legacy_provider",
-				Check:             checkFn,
+				//nolint:lll
+				ImportStateVerifyIgnore: []string{"permissions"}, // ignore verification on computed permissions (import)
+				ResourceName:            "hpe_morpheus_role.testacc_example_role_legacy_provider",
+				Check:                   checkFn,
 			},
 		},
 	})


### PR DESCRIPTION
I previously forgot to add the ignore for permissions on import for this acceptance test, this is needed as there's no way for computed permissions from API import to match user-set permissions.