### PR TITLE
Make ssl cert error more informative

### DIFF
--- a/internal/subproviders/morpheus/errors/errors.go
+++ b/internal/subproviders/morpheus/errors/errors.go
@@ -6,13 +6,34 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
+
+const sslCertErrorMsg = `
+
+If you understand the potential security risks of accepting an untrusted server
+certificate, you can bypass this error by setting "insecure = true" in your
+provider configuration. Use this option with caution.
+
+provider "hpe" {
+   morpheus {
+     url = "https://..."
+     .
+     .
+     .
+     insecure = true <-- set to true to ignore SSL certificate errors
+  }
+}
+`
 
 func ErrMsg(err error, resp *http.Response) string {
 	var msg string
 
 	if err != nil {
 		msg = err.Error()
+		if strings.Contains(err.Error(), "failed to verify certificate") {
+			msg = msg + sslCertErrorMsg
+		}
 	}
 
 	if resp != nil {


### PR DESCRIPTION
Note: we do not get an SSL error type that we can check back
from the client. (We get wrapped url.Error / string types.)

This is brittle, but if it breaks the behaviour will revert to the
existing behaviour, so no harm will be done in that case.

Some Go projects do custom SSL handling to access the
underlying SSL error. We could consider that in the future.

New, additional output:

```
  | tls: failed to verify certificate: x509: certificate is not valid for any names, but wanted to match foo.example.net"
  |
  | If you understand the potential security risks of accepting an untrusted server
  | certificate, you can bypass this error by setting "insecure = true" in your
  | provider configuration. Use this option with caution.
  |
  | provider "hpe" {
  |    morpheus {
  |      url = "https://..."
  |      .
  |      .
  |      .
  |      insecure = true <-- set to true to ignore SSL certificate errors
  |   }
  | }
```