### PR TITLE
Extend role permissions data source with remaining permissions documented in OpenAPI spec

### DIFF
--- a/internal/subproviders/morpheus/datasources/rolepermissions/datasource.go
+++ b/internal/subproviders/morpheus/datasources/rolepermissions/datasource.go
@@ -67,9 +67,9 @@ func (d *DataSource) Read(
 	permissionsStruct := permissions{}
 
 	if !data.FeaturePermissions.IsNull() && !data.FeaturePermissions.IsUnknown() {
-		var fpInners []sdk.AddRolesRequestRoleFeaturePermissionsInner
+		var inners []sdk.AddRolesRequestRoleFeaturePermissionsInner
 		featurePermissions := data.FeaturePermissions.String()
-		err := json.Unmarshal([]byte(featurePermissions), &fpInners)
+		err := json.Unmarshal([]byte(featurePermissions), &inners)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"failed to unmarshal feature_permissions to sdk struct",
@@ -78,9 +78,158 @@ func (d *DataSource) Read(
 
 			return
 		}
+		permissionsStruct.FeaturePermissions = inners
 
-		permissionsStruct.FeaturePermissions = fpInners
+	}
 
+	if !data.CloudPermissions.IsNull() && !data.CloudPermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleZonesInner
+		cloudPermissions := data.CloudPermissions.String()
+		err := json.Unmarshal([]byte(cloudPermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal cloud_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.Zones = inners
+	}
+
+	if !data.GroupPermissions.IsNull() && !data.GroupPermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleSitesInner
+		groupPermissions := data.GroupPermissions.String()
+		err := json.Unmarshal([]byte(groupPermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal group_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.Sites = inners
+	}
+
+	if !data.BlueprintPermissions.IsNull() && !data.BlueprintPermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleAppTemplatePermissionsInner
+		blueprintPermissions := data.BlueprintPermissions.String()
+		err := json.Unmarshal([]byte(blueprintPermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal blueprint_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.AppTemplatePermissions = inners
+	}
+
+	if !data.CatalogItemTypePermissions.IsNull() && !data.CatalogItemTypePermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleCatalogItemTypePermissionsInner
+		catalogItemTypePermissions := data.CatalogItemTypePermissions.String()
+		err := json.Unmarshal([]byte(catalogItemTypePermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal catalog_item_type_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.CatalogItemTypePermissions = inners
+	}
+
+	if !data.InstanceTypePermissions.IsNull() && !data.InstanceTypePermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleInstanceTypePermissionsInner
+		instanceTypePermissions := data.InstanceTypePermissions.String()
+		err := json.Unmarshal([]byte(instanceTypePermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal instance_type_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.InstanceTypePermissions = inners
+	}
+
+	if !data.PersonaPermissions.IsNull() && !data.PersonaPermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRolePersonaPermissionsInner
+		personaPermissions := data.PersonaPermissions.String()
+		err := json.Unmarshal([]byte(personaPermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal persona_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.PersonaPermissions = inners
+	}
+
+	if !data.ReportTypePermissions.IsNull() && !data.ReportTypePermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleReportTypePermissionsInner
+		reportTypePermissions := data.ReportTypePermissions.String()
+		err := json.Unmarshal([]byte(reportTypePermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal report_type_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.ReportTypePermissions = inners
+	}
+
+	if !data.TaskPermissions.IsNull() && !data.TaskPermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleTaskPermissionsInner
+		taskPermissions := data.TaskPermissions.String()
+		err := json.Unmarshal([]byte(taskPermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal task_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.TaskPermissions = inners
+	}
+
+	if !data.WorkflowPermissions.IsNull() && !data.WorkflowPermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleTaskSetPermissionsInner
+		workflowPermissions := data.WorkflowPermissions.String()
+		err := json.Unmarshal([]byte(workflowPermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal workflow_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.TaskSetPermissions = inners
+	}
+
+	if !data.VdiPoolPermissions.IsNull() && !data.VdiPoolPermissions.IsUnknown() {
+		var inners []sdk.AddRolesRequestRoleVdiPoolPermissionsInner
+		vdiPoolPermissions := data.VdiPoolPermissions.String()
+		err := json.Unmarshal([]byte(vdiPoolPermissions), &inners)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"failed to unmarshal vdi_pool_permissions to sdk struct",
+				err.Error(),
+			)
+
+			return
+		}
+		permissionsStruct.VdiPoolPermissions = inners
 	}
 
 	if !data.DefaultGroupAccess.IsNull() && !data.DefaultGroupAccess.IsUnknown() {
@@ -132,8 +281,6 @@ func (d *DataSource) Read(
 		defaultVdiPoolAccess := data.DefaultVdiPoolAccess.ValueString()
 		permissionsStruct.GlobalVdiPoolAccess = &defaultVdiPoolAccess
 	}
-
-	// TODO: Do the same as above for the other permissions fields
 
 	// marshal the permissions struct to JSON
 	b, err := json.Marshal(&permissionsStruct)

--- a/internal/subproviders/morpheus/datasources/rolepermissions/datasource_test.go
+++ b/internal/subproviders/morpheus/datasources/rolepermissions/datasource_test.go
@@ -45,6 +45,8 @@ func TestAccMorpheusDataSourceRolePermissionsJsonOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 	t.Parallel()
 
+	// we're testing the construction of a JSON body from a config,
+	// so we'll include both user AND tenant permissions
 	dataSourceConfig := `
 data "hpe_morpheus_role_permissions" "testacc_permissions_json_ok" {
   feature_permissions = [
@@ -54,6 +56,60 @@ data "hpe_morpheus_role_permissions" "testacc_permissions_json_ok" {
     },
     {
       "code"   = "admin-accounts"
+      "access" = "full"
+    }
+  ]
+  cloud_permissions = [
+    {
+      "id"   = 1
+      "access" = "full"
+    }
+  ]
+  group_permissions = [
+    {
+      "id"   = 1
+      "access" = "full"
+    }
+  ]
+  blueprint_permissions = [
+    {
+      "id"   = 1
+      "access" = "full"
+    }
+  ]
+  instance_type_permissions = [
+    {
+      "id"   = 1
+      "access" = "full"
+    }
+  ]
+  persona_permissions = [
+    {
+      "code"   = "standard"
+      "access" = "full"
+    }
+  ]
+  report_type_permissions = [
+    {
+      "code"   = "appCost"
+      "access" = "full"
+    }
+  ]
+  task_permissions = [
+    {
+      "id"   = 1
+      "access" = "full"
+    }
+  ]
+  workflow_permissions = [
+    {
+      "id"   = 1
+      "access" = "full"
+    }
+  ]
+  vdi_pool_permissions = [
+    {
+      "id"   = 1
       "access" = "full"
     }
   ]
@@ -69,8 +125,15 @@ data "hpe_morpheus_role_permissions" "testacc_permissions_json_ok" {
   default_vdi_pool_access = "full"
 }
 `
+	// the json Marshal performed will sort the keys lexicographically
 	expectJSONWithWhitespace := `
 {
+  "appTemplatePermissions": [
+    {
+      "access": "full",
+      "id": 1
+    }
+  ],
   "featurePermissions": [
       {
         "access": "full",
@@ -90,7 +153,55 @@ data "hpe_morpheus_role_permissions" "testacc_permissions_json_ok" {
   "globalTaskAccess": "full",
   "globalTaskSetAccess": "full",
   "globalVdiPoolAccess": "full",
-  "globalZoneAccess": "full"
+  "globalZoneAccess": "full",
+  "instanceTypePermissions": [
+    {
+      "access": "full",
+      "id": 1
+    }
+  ],
+  "personaPermissions": [
+    {
+      "access": "full",
+      "code": "standard"
+    }
+  ],
+  "reportTypePermissions": [
+    {
+      "access": "full",
+      "code": "appCost"
+    }
+  ],
+  "sites": [
+    {
+      "access": "full",
+      "id": 1
+    }
+  ],
+  "taskPermissions": [
+    {
+      "access": "full",
+      "id": 1
+    }
+  ],
+  "taskSetPermissions": [
+    {
+      "access": "full",
+      "id": 1
+    }
+  ],
+  "vdiPoolPermissions": [
+    {
+      "access": "full",
+      "id": 1
+    }
+  ],
+  "zones": [
+    {
+      "access": "full",
+      "id": 1
+    }
+  ]
 }
 `
 	var bufJSONCompact bytes.Buffer
@@ -113,6 +224,78 @@ data "hpe_morpheus_role_permissions" "testacc_permissions_json_ok" {
 			"feature_permissions.*",
 			map[string]string{
 				"code":   "admin-accounts",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"cloud_permissions.*",
+			map[string]string{
+				"id":     "1",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"group_permissions.*",
+			map[string]string{
+				"id":     "1",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"blueprint_permissions.*",
+			map[string]string{
+				"id":     "1",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"instance_type_permissions.*",
+			map[string]string{
+				"id":     "1",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"persona_permissions.*",
+			map[string]string{
+				"code":   "standard",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"report_type_permissions.*",
+			map[string]string{
+				"code":   "appCost",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"task_permissions.*",
+			map[string]string{
+				"id":     "1",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"workflow_permissions.*",
+			map[string]string{
+				"id":     "1",
+				"access": "full",
+			},
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_json_ok",
+			"vdi_pool_permissions.*",
+			map[string]string{
+				"id":     "1",
 				"access": "full",
 			},
 		),
@@ -184,4 +367,123 @@ data "hpe_morpheus_role_permissions" "testacc_permissions_json_ok" {
 			},
 		},
 	})
+}
+
+// tests that when none of the optional properties are set that we get an empty JSON string
+func TestAccMorpheusDataSourceRolePermissionsNoneSetOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	t.Parallel()
+
+	dataSourceConfig := `
+data "hpe_morpheus_role_permissions" "testacc_permissions_none_set_ok" {}
+`
+
+	// a json.Marshal on an empty struct produces "{}"
+	expectJson := "{}"
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"feature_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"cloud_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"group_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"blueprint_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"instance_type_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"persona_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"report_type_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"task_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"workflow_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"vdi_pool_permissions",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_group_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_cloud_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_blueprint_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_catalog_item_type_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_instance_type_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_persona_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_report_type_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_task_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_workflow_access",
+		),
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"default_vdi_pool_access",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_role_permissions.testacc_permissions_none_set_ok",
+			"json",
+			expectJson,
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfigOffline + dataSourceConfig,
+				Check:  checkFn,
+			},
+		},
+	})
+}
+
+// test that we can use the permissions data source to create a user role
+func TestAccMorpheusDataSourceRolePermissionsUserRoleOk(t *testing.T) {
+	//
+
 }

--- a/internal/subproviders/morpheus/datasources/rolepermissions/schema.go
+++ b/internal/subproviders/morpheus/datasources/rolepermissions/schema.go
@@ -1,5 +1,7 @@
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
+//go:build experimental
+
 package rolepermissions
 
 import (
@@ -208,6 +210,283 @@ func RolePermissionsDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Set the access level for the specified permissions.",
 				MarkdownDescription: "Set the access level for the specified permissions.",
 			},
+			"group_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"id": schema.Int64Attribute{
+							Required:            true,
+							Description:         "`id` of the group (site)",
+							MarkdownDescription: "`id` of the group (site)",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified groups (sites). Only applies to user roles.",
+				MarkdownDescription: "Set the access level for the specified groups (sites). Only applies to user roles.",
+			},
+			"cloud_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"id": schema.Int64Attribute{
+							Required:            true,
+							Description:         "`id` of the cloud (zone)",
+							MarkdownDescription: "`id` of the cloud (zone)",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified clouds (zones). Only applies to base account (tenant) roles.",
+				MarkdownDescription: "Set the access level for the specified clouds (zones). Only applies to base account (tenant) roles.",
+			},
+			"blueprint_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"id": schema.Int64Attribute{
+							Required:            true,
+							Description:         "`id` of the blueprint (appTemplate)",
+							MarkdownDescription: "`id` of the blueprint (appTemplate)",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified blueprints (appTemplates)",
+				MarkdownDescription: "Set the access level for the specified blueprints (appTemplates)",
+			},
+			"catalog_item_type_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"id": schema.Int64Attribute{
+							Required:            true,
+							Description:         "`id` of the catalog item type",
+							MarkdownDescription: "`id` of the catalog item type",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified catalog item types",
+				MarkdownDescription: "Set the access level for the specified catalog item types",
+			},
+			"instance_type_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"id": schema.Int64Attribute{
+							Required:            true,
+							Description:         "`id` of the instance type",
+							MarkdownDescription: "`id` of the instance type",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified instance types",
+				MarkdownDescription: "Set the access level for the specified instance types",
+			},
+			"persona_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"code": schema.StringAttribute{
+							Required:            true,
+							Description:         "`code` of the persona",
+							MarkdownDescription: "`code` of the persona",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"standard",
+									"serviceCatalog",
+									"vdi",
+								),
+							},
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified personas",
+				MarkdownDescription: "Set the access level for the specified personas",
+			},
+			"report_type_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"code": schema.StringAttribute{
+							Required:            true,
+							Description:         "`code` of the report type",
+							MarkdownDescription: "`code` of the report type",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified report types",
+				MarkdownDescription: "Set the access level for the specified report types",
+			},
+			"task_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"id": schema.Int64Attribute{
+							Required:            true,
+							Description:         "`id` of the task",
+							MarkdownDescription: "`id` of the task",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified tasks",
+				MarkdownDescription: "Set the access level for the specified tasks",
+			},
+			"workflow_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"id": schema.Int64Attribute{
+							Required:            true,
+							Description:         "`id` of the workflow (taskSet)",
+							MarkdownDescription: "`id` of the workflow (taskSet)",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the default access level for workflows (taskSets)",
+				MarkdownDescription: "Set the default access level for workflows (taskSets)",
+			},
+			"vdi_pool_permissions": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access": schema.StringAttribute{
+							Required:            true,
+							Description:         "The new access level.",
+							MarkdownDescription: "The new access level.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(
+									"default",
+									"full",
+									"read",
+									"none",
+								),
+							},
+						},
+						"id": schema.Int64Attribute{
+							Required:            true,
+							Description:         "`id` of the VDI pool",
+							MarkdownDescription: "`id` of the VDI pool",
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Set the access level for the specified VDI pools",
+				MarkdownDescription: "Set the access level for the specified VDI pools",
+			},
 			"default_group_access": schema.StringAttribute{
 				Optional:            true,
 				Description:         "Set the default access level for for groups (sites). Only applies to user roles.",
@@ -330,6 +609,16 @@ func RolePermissionsDataSourceSchema(ctx context.Context) schema.Schema {
 type RolePermissionsModel struct {
 	Json                         jsontypes.Normalized `tfsdk:"json"`
 	FeaturePermissions           types.Set            `tfsdk:"feature_permissions"`
+	CloudPermissions             types.Set            `tfsdk:"cloud_permissions"`
+	GroupPermissions             types.Set            `tfsdk:"group_permissions"`
+	BlueprintPermissions         types.Set            `tfsdk:"blueprint_permissions"`
+	CatalogItemTypePermissions   types.Set            `tfsdk:"catalog_item_type_permissions"`
+	InstanceTypePermissions      types.Set            `tfsdk:"instance_type_permissions"`
+	PersonaPermissions           types.Set            `tfsdk:"persona_permissions"`
+	ReportTypePermissions        types.Set            `tfsdk:"report_type_permissions"`
+	TaskPermissions              types.Set            `tfsdk:"task_permissions"`
+	WorkflowPermissions          types.Set            `tfsdk:"workflow_permissions"`
+	VdiPoolPermissions           types.Set            `tfsdk:"vdi_pool_permissions"`
 	DefaultGroupAccess           types.String         `tfsdk:"default_group_access"`
 	DefaultCloudAccess           types.String         `tfsdk:"default_cloud_access"`
 	DefaultBlueprintAccess       types.String         `tfsdk:"default_blueprint_access"`


### PR DESCRIPTION
Extends the `schema.go` to have the remaining permissions that are currently available according to OpenAPI spec and updates `datasource.go`.
The validators for these are what is documented in the OpenAPI spec.
Some of them may not be entirely correct; it uses the same schema for all of the permissions.
Adds an additional test to `datasource.go` to test the case of reading the permissions with nothing being set.

A follow-up PR is to come with further testing that should help catch edge cases in the `schema.go`.
