### PR TITLE
Add tests for using all permissions to create user and account roles

### DIFF
--- a/internal/subproviders/morpheus/datasources/rolepermissions/datasource_test.go
+++ b/internal/subproviders/morpheus/datasources/rolepermissions/datasource_test.go
@@ -481,9 +481,3 @@ data "hpe_morpheus_role_permissions" "testacc_permissions_none_set_ok" {}
 		},
 	})
 }
-
-// test that we can use the permissions data source to create a user role
-func TestAccMorpheusDataSourceRolePermissionsUserRoleOk(t *testing.T) {
-	//
-
-}


### PR DESCRIPTION
Adds acceptance tests for creating a user role and account role using all the permissions.
VDI pool permissions are not tested for now as the OpenAPI spec for VDI Pools is currently inaccurate.

For creating resources which are dependencies, we use a mix of the old and new Terraform provider.