### PR TITLE
Update schema_gen.go with plan modifier for Role permisions field

### DIFF
--- a/internal/subproviders/morpheus/resources/role/schema_gen.go
+++ b/internal/subproviders/morpheus/resources/role/schema_gen.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -62,6 +63,9 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "A JSON document containing the set of permissions to assign to the role",
 				MarkdownDescription: "A JSON document containing the set of permissions to assign to the role",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"role_type": schema.StringAttribute{
 				Optional:            true,


### PR DESCRIPTION
Brings in the changes to the schema to add a `stringplanmodifier.UseStateForUnknown()`.
This is required to correctly use the permissions in state in a `terraform plan` when we modify another non-permissions field.
It's the same reason we need to use `int64planmodifier.UseStateForUnknown` for `id`.
