### PR TITLE
Update make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@
 .PHONY: build linter lint test docs docs-experimental experimental
 
 build:
-	go build ./...
+	go build
 
 experimental:
-	go build -tags=experimental ./...
+	go build -tags=experimental
 
 linter:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2


### PR DESCRIPTION
Change make build to `go build` rather than
`go build ./...`. This means that the terraform
binary `terraform-provider-hpe` is built and
output to the top level directory.