### PR TITLE
Perform role type validation on default group/cloud access levels

### DIFF
--- a/internal/subproviders/morpheus/resources/role/resource.go
+++ b/internal/subproviders/morpheus/resources/role/resource.go
@@ -917,6 +917,20 @@ func (r *Resource) Read(
 		}
 	}
 
+	// Perform additional validation of default group/cloud access based on the role_type.
+	// We have to do it here in Read so that it's supported by import.
+	// Morpheus API does not perform validation like this, but the Morpheus UI does.
+
+	// Only account roles should be able to set default cloud access
+	if apiState.RoleType.ValueString() == RoleTypeUser {
+		apiState.Permissions.DefaultCloudAccess = types.StringNull()
+	}
+
+	// Only user roles should be able to set default group access
+	if apiState.RoleType.ValueString() == RoleTypeAccount {
+		apiState.Permissions.DefaultGroupAccess = types.StringNull()
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &apiState)...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
We've agreed to enforce additional validation of these fields on the provider side.
This cleans up importing of a role, as now in Terraform state the incompatible `default access` level will be stored as null.
Morpheus UI suggests that the unsupported `default access` level for the given role type should not be accessible to a user.