### PR TITLE
Add strongly typed permissions to role datasource

### DIFF
--- a/internal/subproviders/morpheus/datasources/role/consts/consts.go
+++ b/internal/subproviders/morpheus/datasources/role/consts/consts.go
@@ -7,4 +7,6 @@ const (
 	ErrorNoValidSearchTerms = `no valid search terms - an id or name is required`
 	ErrorRunningPreApply    = `Error running pre-apply plan: exit status 1`
 	ErrorMultipleRoles      = `multiple roles were returned`
+	RoleTypeUser            = "user"
+	RoleTypeAccount         = "account"
 )

--- a/internal/subproviders/morpheus/datasources/role/datasource.go
+++ b/internal/subproviders/morpheus/datasources/role/datasource.go
@@ -387,5 +387,18 @@ func (d *DataSource) Read(
 		return
 	}
 
+	// Perform additional validation of default group/cloud access based on the role_type.
+	// Morpheus API does not perform validation like this, but the Morpheus UI does.
+
+	// Only account roles should be able to set default cloud access
+	if apiState.RoleType.ValueString() == consts.RoleTypeUser {
+		apiState.Permissions.DefaultCloudAccess = types.StringNull()
+	}
+
+	// Only user roles should be able to set default group access
+	if apiState.RoleType.ValueString() == consts.RoleTypeAccount {
+		apiState.Permissions.DefaultGroupAccess = types.StringNull()
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &apiState)...)
 }

--- a/internal/subproviders/morpheus/datasources/role/datasource.go
+++ b/internal/subproviders/morpheus/datasources/role/datasource.go
@@ -289,7 +289,7 @@ func getRoleByID(
 ) (*sdk.GetRole200Response, error) {
 	r, hresp, err := apiClient.RolesAPI.GetRole(ctx, id).Execute()
 	if r == nil || err != nil || hresp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET failed for role %d", id)
+		return nil, fmt.Errorf("GET failed for role %d: %s", id, providererrors.ErrMsg(err, hresp))
 	}
 
 	return r, nil
@@ -318,12 +318,7 @@ func getRoleByName(
 	if len(roles) == 1 {
 		id := roles[0].GetId()
 
-		r, hresp, err := apiClient.RolesAPI.GetRole(ctx, id).Execute()
-		if err != nil || hresp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("GET failed for role %d: %s", id, providererrors.ErrMsg(err, hresp))
-		}
-
-		return r, nil
+		return getRoleByID(ctx, id, apiClient)
 	} else if len(roles) > 1 {
 		return nil, errors.New(consts.ErrorMultipleRoles)
 	}

--- a/internal/subproviders/morpheus/datasources/role/datasource.go
+++ b/internal/subproviders/morpheus/datasources/role/datasource.go
@@ -11,12 +11,16 @@ import (
 	"net/http"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/constants"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/datasources/role/consts"
+	providererrors "github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
 )
 
 const summary = "read role data source"
@@ -55,31 +59,250 @@ func (d *DataSource) Schema(
 	resp.Schema = RoleDataSourceSchema(ctx)
 }
 
+// This function breaks out the logic of reading permissions from API response to store to state.
+func populateRoleAsStatePermissions(ctx context.Context, r *sdk.GetRole200Response) (PermissionsValue, diag.Diagnostics) {
+
+	var features []FeaturePermissionsValue
+	for _, v := range r.FeaturePermissions {
+		features = append(features, FeaturePermissionsValue{
+			Code:        types.StringValue(v.GetCode()),
+			Access:      types.StringValue(v.GetAccess()),
+			Id:          types.Int64Value(v.GetId()),
+			Name:        types.StringValue(v.GetName()),
+			SubCategory: types.StringValue(v.GetSubCategory()),
+			state:       attr.ValueStateKnown,
+		})
+	}
+
+	var blueprints []BlueprintPermissionsValue
+	for _, v := range r.AppTemplatePermissions {
+		blueprints = append(blueprints, BlueprintPermissionsValue{
+			Name:   types.StringValue(v.GetName()),
+			Id:     types.Int64Value(v.GetId()),
+			Access: types.StringValue(v.GetAccess()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var catalogItemTypes []CatalogItemTypePermissionsValue
+	for _, v := range r.CatalogItemTypePermissions {
+		catalogItemTypes = append(catalogItemTypes, CatalogItemTypePermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Access: types.StringValue(v.GetAccess()),
+			Name:   types.StringValue(v.GetName()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var clouds []CloudPermissionsValue
+	for _, v := range r.Zones {
+		clouds = append(clouds, CloudPermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Access: types.StringValue(v.GetAccess()),
+			Name:   types.StringValue(v.GetName()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var groups []GroupPermissionsValue
+	for _, v := range r.Sites {
+		groups = append(groups, GroupPermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Access: types.StringValue(v.GetAccess()),
+			Name:   types.StringValue(v.GetName()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var instanceTypes []InstanceTypePermissionsValue
+	for _, v := range r.InstanceTypePermissions {
+		instanceTypes = append(instanceTypes, InstanceTypePermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Name:   types.StringValue(v.GetName()),
+			Access: types.StringValue(v.GetAccess()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var personas []PersonaPermissionsValue
+	for _, v := range r.PersonaPermissions {
+		personas = append(personas, PersonaPermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Name:   types.StringValue(v.GetName()),
+			Access: types.StringValue(v.GetAccess()),
+			Code:   types.StringValue(v.GetCode()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var reportTypes []ReportTypePermissionsValue
+	for _, v := range r.ReportTypePermissions {
+		reportTypes = append(reportTypes, ReportTypePermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Name:   types.StringValue(v.GetName()),
+			Access: types.StringValue(v.GetAccess()),
+			Code:   types.StringValue(v.GetCode()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var tasks []TaskPermissionsValue
+	for _, v := range r.TaskPermissions {
+		tasks = append(tasks, TaskPermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Name:   types.StringValue(v.GetName()),
+			Access: types.StringValue(v.GetAccess()),
+			Code:   types.StringPointerValue(v.Code.Get()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var vdiPools []VdiPoolPermissionsValue
+	for _, v := range r.VdiPoolPermissions {
+		vdiPools = append(vdiPools, VdiPoolPermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Name:   types.StringValue(v.GetName()),
+			Access: types.StringValue(v.GetAccess()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	var workflows []WorkflowPermissionsValue
+	for _, v := range r.TaskSetPermissions {
+		workflows = append(workflows, WorkflowPermissionsValue{
+			Id:     types.Int64Value(v.GetId()),
+			Name:   types.StringValue(v.GetName()),
+			Access: types.StringValue(v.GetAccess()),
+			state:  attr.ValueStateKnown,
+		})
+	}
+
+	featuresSet, diags := types.SetValueFrom(ctx, FeaturePermissionsValue{}.Type(ctx), features)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	blueprintsSet, diags := types.SetValueFrom(ctx, BlueprintPermissionsValue{}.Type(ctx), blueprints)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	catalogItemTypesSet, diags := types.SetValueFrom(ctx, CatalogItemTypePermissionsValue{}.Type(ctx), catalogItemTypes)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	cloudsSet, diags := types.SetValueFrom(ctx, CloudPermissionsValue{}.Type(ctx), clouds)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	groupsSet, diags := types.SetValueFrom(ctx, GroupPermissionsValue{}.Type(ctx), groups)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	instanceTypesSet, diags := types.SetValueFrom(ctx, InstanceTypePermissionsValue{}.Type(ctx), instanceTypes)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	personasSet, diags := types.SetValueFrom(ctx, PersonaPermissionsValue{}.Type(ctx), personas)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	reportTypesSet, diags := types.SetValueFrom(ctx, ReportTypePermissionsValue{}.Type(ctx), reportTypes)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	tasksSet, diags := types.SetValueFrom(ctx, TaskPermissionsValue{}.Type(ctx), tasks)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	vdiPoolsSet, diags := types.SetValueFrom(ctx, VdiPoolPermissionsValue{}.Type(ctx), vdiPools)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	workflowsSet, diags := types.SetValueFrom(ctx, WorkflowPermissionsValue{}.Type(ctx), workflows)
+	if diags.HasError() {
+		return PermissionsValue{}, diags
+	}
+
+	return NewPermissionsValue(PermissionsValue{}.AttributeTypes(ctx), map[string]attr.Value{
+		"default_blueprint_access":         convert.StrToType(r.GlobalAppTemplateAccess),
+		"default_catalog_item_type_access": convert.StrToType(r.GlobalCatalogItemTypeAccess),
+		"default_cloud_access":             convert.StrToType(r.GlobalZoneAccess),
+		"default_group_access":             convert.StrToType(r.GlobalSiteAccess),
+		"default_instance_type_access":     convert.StrToType(r.GlobalInstanceTypeAccess),
+		"default_persona_access":           convert.StrToType(r.GlobalPersonaAccess),
+		"default_report_type_access":       convert.StrToType(r.GlobalReportTypeAccess),
+		"default_task_access":              convert.StrToType(r.GlobalTaskAccess),
+		"default_vdi_pool_access":          convert.StrToType(r.GlobalVdiPoolAccess),
+		"default_workflow_access":          convert.StrToType(r.GlobalTaskSetAccess),
+		"feature_permissions":              featuresSet,
+		"blueprint_permissions":            blueprintsSet,
+		"catalog_item_type_permissions":    catalogItemTypesSet,
+		"cloud_permissions":                cloudsSet,
+		"group_permissions":                groupsSet,
+		"instance_type_permissions":        instanceTypesSet,
+		"persona_permissions":              personasSet,
+		"report_type_permissions":          reportTypesSet,
+		"task_permissions":                 tasksSet,
+		"vdi_pool_permissions":             vdiPoolsSet,
+		"workflow_permissions":             workflowsSet,
+	})
+}
+
+func roleAsState(
+	ctx context.Context,
+	role *sdk.GetRole200Response,
+) (RoleModel, diag.Diagnostics) {
+	var state RoleModel
+	var diags diag.Diagnostics
+
+	permissions, diags := populateRoleAsStatePermissions(ctx, role)
+	if diags.HasError() {
+
+		return state, diags
+	}
+
+	state.Id = convert.Int64ToType(role.Role.Id)
+	state.Name = convert.StrToType(role.Role.Name)
+	state.Description = convert.StrToType(role.Role.Description.Get())
+	state.LandingUrl = convert.StrToType(role.Role.LandingUrl.Get())
+	state.Multitenant = convert.BoolToType(role.Role.Multitenant)
+	state.MultitenantLocked = convert.BoolToType(role.Role.MultitenantLocked)
+	state.RoleType = convert.StrToType(role.Role.RoleType)
+	state.Permissions = permissions
+
+	return state, diags
+}
+
 func getRoleByID(
 	ctx context.Context,
 	id int64,
 	apiClient *sdk.APIClient,
-) (*sdk.ListRoles200ResponseAllOfRolesInner, error) {
+) (*sdk.GetRole200Response, error) {
 	r, hresp, err := apiClient.RolesAPI.GetRole(ctx, id).Execute()
 	if r == nil || err != nil || hresp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET failed for role %d", id)
 	}
 
-	role := r.GetRole()
-
-	return &role, nil
+	return r, nil
 }
 
 func getRoleByName(
 	ctx context.Context,
 	data RoleModel,
 	apiClient *sdk.APIClient,
-) (*sdk.ListRoles200ResponseAllOfRolesInner, error) {
+) (*sdk.GetRole200Response, error) {
 	name := data.Name.ValueString()
 
-	req := apiClient.RolesAPI.ListRoles(ctx).Authority(name)
-
-	rs, hresp, err := req.Execute()
+	rs, hresp, err := apiClient.RolesAPI.ListRoles(ctx).Authority(name).Execute()
 	if rs == nil || err != nil || hresp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET failed for role %s", name)
 	}
@@ -93,7 +316,14 @@ func getRoleByName(
 	}
 
 	if len(roles) == 1 {
-		return &roles[0], nil
+		id := roles[0].GetId()
+
+		r, hresp, err := apiClient.RolesAPI.GetRole(ctx, id).Execute()
+		if err != nil || hresp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GET failed for role %d: %s", id, providererrors.ErrMsg(err, hresp))
+		}
+
+		return r, nil
 	} else if len(roles) > 1 {
 		return nil, errors.New(consts.ErrorMultipleRoles)
 	}
@@ -105,7 +335,7 @@ func getRole(
 	ctx context.Context,
 	data RoleModel,
 	apiClient *sdk.APIClient,
-) (*sdk.ListRoles200ResponseAllOfRolesInner, error) {
+) (*sdk.GetRole200Response, error) {
 	if !data.Id.IsNull() {
 		return getRoleByID(ctx, data.Id.ValueInt64(), apiClient)
 	} else if !data.Name.IsNull() {
@@ -150,14 +380,12 @@ func (d *DataSource) Read(
 		return
 	}
 
-	data.Id = convert.Int64ToType(role.Id)
-	data.Name = convert.StrToType(role.Name)
-	data.Description = convert.StrToType(role.Description.Get())
-	data.LandingUrl = convert.StrToType(role.LandingUrl.Get())
-	data.Multitenant = convert.BoolToType(role.Multitenant)
-	data.MultitenantLocked = convert.BoolToType(role.MultitenantLocked)
-	data.RoleType = convert.StrToType(role.RoleType)
+	apiState, diags := roleAsState(ctx, role)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 
-	diags = resp.State.Set(ctx, &data)
-	resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &apiState)...)
 }

--- a/internal/subproviders/morpheus/datasources/role/datasource.go
+++ b/internal/subproviders/morpheus/datasources/role/datasource.go
@@ -316,9 +316,7 @@ func getRoleByName(
 	}
 
 	if len(roles) == 1 {
-		id := roles[0].GetId()
-
-		return getRoleByID(ctx, id, apiClient)
+		return getRoleByID(ctx, roles[0].GetId(), apiClient)
 	} else if len(roles) > 1 {
 		return nil, errors.New(consts.ErrorMultipleRoles)
 	}

--- a/internal/subproviders/morpheus/datasources/role/datasource_test.go
+++ b/internal/subproviders/morpheus/datasources/role/datasource_test.go
@@ -172,8 +172,26 @@ func TestAccMorpheusFindRoleVerifyAttributes(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 
 	resourceConfig := `
-resource "hpe_morpheus_role" "test" {
-  name = "` + name + `"
+resource "hpe_morpheus_role" "test_user" {
+  name = "` + name + `-user"
+  description = "test"
+  landing_url = "https://test.morpheus.com"
+  multitenant = false
+  multitenant_locked = false
+  role_type = "user"
+  permissions = {
+    feature_permissions = [
+    {
+      code = "activity"
+      access = "read"
+    }
+  ]
+    default_blueprint_access = "full"
+  }
+}
+
+resource "hpe_morpheus_role" "test_account" {
+  name = "` + name + `-account"
   description = "test"
   landing_url = "https://test.morpheus.com"
   multitenant = false
@@ -191,50 +209,55 @@ resource "hpe_morpheus_role" "test" {
 }
 `
 	dataSourceConfig := `
-data "hpe_morpheus_role" "test" {
-  name = "` + name + `"
+data "hpe_morpheus_role" "test_user" {
+  name = "` + name + `-user"
+}
+
+data "hpe_morpheus_role" "test_account" {
+  name = "` + name + `-account"
 }
 `
 
 	checks := []resource.TestCheckFunc{
+		// user role
 		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"name",
-			name,
+			name+"-user",
 		),
 		resource.TestCheckResourceAttrPair(
-			"hpe_morpheus_role.test",
+			"hpe_morpheus_role.test_user",
 			"id",
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"id",
 		),
 		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"description",
 			"test",
 		),
 		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"landing_url",
 			"https://test.morpheus.com",
 		),
 		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"multitenant",
 			"false",
 		),
 		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"multitenant_locked",
 			"false",
 		),
 		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"role_type",
-			"account",
+			"user",
 		),
 		resource.TestCheckTypeSetElemNestedAttrs(
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"permissions.feature_permissions.*",
 			map[string]string{
 				"code":   "activity",
@@ -242,9 +265,69 @@ data "hpe_morpheus_role" "test" {
 			},
 		),
 		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test_user",
 			"permissions.default_blueprint_access",
 			"full",
+		),
+		// user roles cannot have cloud access
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role.test_user",
+			"permissions.default_cloud_access",
+		),
+		// account role
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_role.test_account",
+			"name",
+			name+"-account",
+		),
+		resource.TestCheckResourceAttrPair(
+			"hpe_morpheus_role.test_account",
+			"id",
+			"data.hpe_morpheus_role.test_account",
+			"id",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_role.test_account",
+			"description",
+			"test",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_role.test_account",
+			"landing_url",
+			"https://test.morpheus.com",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_role.test_account",
+			"multitenant",
+			"false",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_role.test_account",
+			"multitenant_locked",
+			"false",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_role.test_account",
+			"role_type",
+			"account",
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_role.test_account",
+			"permissions.feature_permissions.*",
+			map[string]string{
+				"code":   "activity",
+				"access": "read",
+			},
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_role.test_account",
+			"permissions.default_blueprint_access",
+			"full",
+		),
+		// account roles cannot have group access
+		resource.TestCheckNoResourceAttr(
+			"data.hpe_morpheus_role.test_account",
+			"permissions.default_group_access",
 		),
 	}
 

--- a/internal/subproviders/morpheus/datasources/role/datasource_test.go
+++ b/internal/subproviders/morpheus/datasources/role/datasource_test.go
@@ -179,6 +179,15 @@ resource "hpe_morpheus_role" "test" {
   multitenant = false
   multitenant_locked = false
   role_type = "account"
+  permissions = {
+    feature_permissions = [
+    {
+      code = "activity"
+      access = "read"
+    }
+  ]
+    default_blueprint_access = "full"
+  }
 }
 `
 	dataSourceConfig := `
@@ -223,6 +232,19 @@ data "hpe_morpheus_role" "test" {
 			"data.hpe_morpheus_role.test",
 			"role_type",
 			"account",
+		),
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"hpe_morpheus_role.test",
+			"permissions.feature_permissions.*",
+			map[string]string{
+				"code":   "activity",
+				"access": "read",
+			},
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.test",
+			"permissions.default_blueprint_access",
+			"full",
 		),
 	}
 

--- a/internal/subproviders/morpheus/datasources/role/datasource_test.go
+++ b/internal/subproviders/morpheus/datasources/role/datasource_test.go
@@ -234,7 +234,7 @@ data "hpe_morpheus_role" "test" {
 			"account",
 		),
 		resource.TestCheckTypeSetElemNestedAttrs(
-			"hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test",
 			"permissions.feature_permissions.*",
 			map[string]string{
 				"code":   "activity",
@@ -242,7 +242,7 @@ data "hpe_morpheus_role" "test" {
 			},
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_role.test",
+			"data.hpe_morpheus_role.test",
 			"permissions.default_blueprint_access",
 			"full",
 		),


### PR DESCRIPTION
Updates the Role data source to use strongly typed permissions, like the resource does.

Contains the following changes:
- Update the `datasource.go` file for the role resource.
- Update the acceptance test to check that values can be read
- Update the generated `schema_gen.go`

When we read permissions via the data source, we get the entire range of API-computed `feature permissions`, not just those that were overridden by the user. This mirrors the behaviour of how the API responds. For the other fine-grained permissions, it will behave as expected, only reading overridden values as the API presents them.

