### PR TITLE
network resource: add update

### DIFF
--- a/internal/subproviders/morpheus/resources/network/update.go
+++ b/internal/subproviders/morpheus/resources/network/update.go
@@ -28,16 +28,6 @@ func (r *Resource) Update(
 		return
 	}
 
-	client, err := r.NewClient(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"update network resource",
-			"failed to create client: "+err.Error(),
-		)
-
-		return
-	}
-
 	id := state.Id.ValueInt64()
 	name := plan.Name.ValueString()
 
@@ -224,6 +214,16 @@ func (r *Resource) Update(
 
 	updateNetworkReq := sdk.NewUpdateNetworkRequest()
 	updateNetworkReq.SetNetwork(*network)
+
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"update network resource",
+			"failed to create client: "+err.Error(),
+		)
+
+		return
+	}
 
 	_, hresp, err := client.NetworksAPI.UpdateNetwork(ctx, id).
 		UpdateNetworkRequest(*updateNetworkReq).Execute()


### PR DESCRIPTION
For the Dynamic Attribute `config` block, we assume that changes to
the block are HTTP `PUT`-able, and thus supported by update.

The `config` block entries cannot be fetched by HTTP GET, so we assume
that a successful PUT (200) will have updated the values successfully.

This may not be true for all network types, but it seems a pragmatic first pass for
network support.