### PR TITLE
Remove UseStateForUnknown Plan Modifier in Role nested set computed fields

### DIFF
--- a/internal/subproviders/morpheus/resources/role/schema_gen.go
+++ b/internal/subproviders/morpheus/resources/role/schema_gen.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -87,9 +86,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: BlueprintPermissionsType{
@@ -124,9 +120,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: CatalogItemTypePermissionsType{
@@ -162,9 +155,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: CloudPermissionsType{
@@ -205,7 +195,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 						MarkdownDescription: "Set the default access level for for clouds (zones). Only applies to base account (tenant) roles.",
 						Validators: []validator.String{
 							stringvalidator.OneOf(
-								"default",
 								"full",
 								"read",
 								"none",
@@ -218,7 +207,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 						MarkdownDescription: "Set the default access level for for groups (sites). Only applies to user roles.",
 						Validators: []validator.String{
 							stringvalidator.OneOf(
-								"default",
 								"full",
 								"read",
 								"none",
@@ -323,21 +311,12 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"id": schema.Int64Attribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.Int64{
-										int64planmodifier.UseStateForUnknown(),
-									},
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 								"sub_category": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: FeaturePermissionsType{
@@ -373,9 +352,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: GroupPermissionsType{
@@ -405,9 +381,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"code": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 								"id": schema.Int64Attribute{
 									Required:            true,
@@ -416,9 +389,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: InstanceTypePermissionsType{
@@ -460,15 +430,9 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"id": schema.Int64Attribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.Int64{
-										int64planmodifier.UseStateForUnknown(),
-									},
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: PersonaPermissionsType{
@@ -503,15 +467,9 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"id": schema.Int64Attribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.Int64{
-										int64planmodifier.UseStateForUnknown(),
-									},
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: ReportTypePermissionsType{
@@ -541,9 +499,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"code": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 								"id": schema.Int64Attribute{
 									Required:            true,
@@ -552,9 +507,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: TaskPermissionsType{
@@ -589,9 +541,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: VdiPoolPermissionsType{
@@ -626,9 +575,6 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 								},
 								"name": schema.StringAttribute{
 									Computed: true,
-									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
-									},
 								},
 							},
 							CustomType: WorkflowPermissionsType{


### PR DESCRIPTION
When entering a new item into the set containing a field whose attribute shares a value with a set item already in state, the provider will incorrectly compute a value for the new set item's field from state.

This is a known limitation of the unordered collection types in the Terraform Plugin Framework.

This PR adds the regenerated Role `schema_gen.go` to address these issues.

Picks up removal of 'default' as an accepted value for default cloud and group access also (changes from https://github.com/hpe-cds/hpe-morpheus-provider-code-spec/pull/71).
