### PR TITLE
Return empty slice when Set/List is null or unknown

### DIFF
--- a/internal/subproviders/morpheus/convert/convert.go
+++ b/internal/subproviders/morpheus/convert/convert.go
@@ -162,6 +162,10 @@ func FromSetType[S attr.Value, O any](
 	var out []O
 	var elems []S
 
+	if set.IsNull() || set.IsUnknown() {
+		return nil, nil
+	}
+
 	if diags := set.ElementsAs(ctx, &elems, false); diags.HasError() {
 		return nil, diags
 	}
@@ -183,6 +187,10 @@ func FromListType[S attr.Value, O any](
 ) ([]O, diag.Diagnostics) {
 	var out []O
 	var elems []S
+
+	if list.IsNull() || list.IsUnknown() {
+		return nil, nil
+	}
 
 	if diags := list.ElementsAs(ctx, &elems, false); diags.HasError() {
 		return nil, diags


### PR DESCRIPTION
`FromSetType` and `FromListType` are intended to be used to convert a terraform set/list to a slice to be used with the API. The functions can currently cause errors if the value is null or unknown when we try to convert the elements.
We don't want these functions to return an error, but instead return an empty slice when set/list contains no elements.
