### PR TITLE
Make Makefile more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,13 @@ testacc:
 
 docs:
 	go generate ./...
-	cd tools; go generate
+	cd tools && go generate
 
-docs-experimental: export GOFLAGS = "-tags=experimental"
 docs-experimental:
 	rm -rf templates-combined-temp
 	mkdir -p templates-combined-temp
 	cp -r ./templates/* templates-combined-temp
 	cp -r ./templates-experimental/* templates-combined-temp
-	go generate ./...
-	cd tools; go generate
+	go generate -tags=experimental ./...
+	cd tools && go generate -tags=experimental
 	rm -rf templates-combined-temp


### PR DESCRIPTION
Do not use GNU Make specific syntax for setting environment variable.

Also tweak `;` to `&&` for composite commands so don't run
the second command if the first one fails.