### PR TITLE
Add UseStateForNullOrUnknown Bool plan modifier

### DIFF
--- a/internal/subproviders/morpheus/modifiers/boolmodifiers/use_state_for_null_or_unknown.go
+++ b/internal/subproviders/morpheus/modifiers/boolmodifiers/use_state_for_null_or_unknown.go
@@ -1,0 +1,41 @@
+package boolmodifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func UseStateForNullOrUnknown() planmodifier.Bool {
+	return useStateForNullOrUnknownModifier{}
+}
+
+// useStateForNullOrUnknownModifier implements the plan modifier.
+type useStateForNullOrUnknownModifier struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useStateForNullOrUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useStateForNullOrUnknownModifier) MarkdownDescription(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// PlanModifyBool implements the plan modification logic.
+func (m useStateForNullOrUnknownModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// If we get to here, we have an unknown planned value OR a null planned value.
+	resp.PlanValue = req.StateValue
+}

--- a/internal/subproviders/morpheus/modifiers/boolmodifiers/use_state_for_null_or_unknown.go
+++ b/internal/subproviders/morpheus/modifiers/boolmodifiers/use_state_for_null_or_unknown.go
@@ -1,3 +1,5 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
 package boolmodifiers
 
 import (
@@ -24,8 +26,11 @@ func (m useStateForNullOrUnknownModifier) MarkdownDescription(_ context.Context)
 }
 
 // PlanModifyBool implements the plan modification logic.
-func (m useStateForNullOrUnknownModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-
+func (m useStateForNullOrUnknownModifier) PlanModifyBool(
+	_ context.Context,
+	req planmodifier.BoolRequest,
+	resp *planmodifier.BoolResponse,
+) {
 	// Do nothing if there is a known planned value.
 	if !req.PlanValue.IsUnknown() {
 		return


### PR DESCRIPTION
This is required to iron out some problems introduced by #215.

If we run `terraform plan` as part of an update, the `multitenant` and `multitenant_locked` fields will be marked as `known after apply` when we modify a field that isn't one of those two.

The built-in `UseStateForUnknown` modifier only covers the case where the planned value is unknown, not null.

Since these fields can be persisted in state as either `true/false` or `null`, with an apply on a `tenant` role maintaining a literal `null` value since we don't want to track it in state, we'll need a slightly modified version of `UseStateForUnknown`.