### PR TITLE
Undo storing user and tenant-specific fields in state as null

### DIFF
--- a/internal/subproviders/morpheus/resources/role/resource.go
+++ b/internal/subproviders/morpheus/resources/role/resource.go
@@ -1379,13 +1379,6 @@ func (r *Resource) Create(
 
 	}
 
-	// Don't track multitenant and multitenant locked in state for Tenant Roles
-	// These fields don't do anything for Tenant Roles.
-	if apiState.RoleType.ValueString() == RoleTypeAccount {
-		apiState.Multitenant = types.BoolNull()
-		apiState.MultitenantLocked = types.BoolNull()
-	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &apiState)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1550,22 +1543,6 @@ func (r *Resource) Read(
 
 			apiState.Permissions.FeaturePermissions = featuresSetWithComputed
 		}
-	}
-
-	// Perform additional validation of default group/cloud access based on the role_type.
-	// We have to do it here in Read so that it's supported by import.
-	// Morpheus API does not perform validation like this, but the Morpheus UI does.
-
-	// Only account roles should be able to set default_cloud_access
-	if apiState.RoleType.ValueString() == RoleTypeUser {
-		apiState.Permissions.DefaultCloudAccess = types.StringNull()
-	}
-
-	// Only user roles should be able to set multitenant, multitenant_locked and default_group_access
-	if apiState.RoleType.ValueString() == RoleTypeAccount {
-		apiState.Multitenant = types.BoolNull()
-		apiState.MultitenantLocked = types.BoolNull()
-		apiState.Permissions.DefaultGroupAccess = types.StringNull()
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &apiState)...)
@@ -1903,7 +1880,7 @@ func (r *Resource) ImportState(
 
 // This method is called by Terraform's ValidateResourceConfig RPC.
 // We use this to perform the validation of attributes specific to user and account roles.
-// We need to use the ValidateConfig method as schema validators
+// We need to use the ValidateConfig method as the built-in validators
 // do not have access to config values other than the attribute they're defined for.
 // Only user roles can set group permissions.
 // Only account roles can set cloud permissions.

--- a/internal/subproviders/morpheus/resources/role/resource_test.go
+++ b/internal/subproviders/morpheus/resources/role/resource_test.go
@@ -163,13 +163,15 @@ resource "hpe_morpheus_role" "example_required" {
 			"account",
 		),
 		// checks for fields not applicable to tenant roles
-		resource.TestCheckNoResourceAttr(
+		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.example_required",
 			"multitenant",
+			"false",
 		),
-		resource.TestCheckNoResourceAttr(
+		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.example_required",
 			"multitenant_locked",
+			"false",
 		),
 	}
 
@@ -294,6 +296,7 @@ resource "hpe_morpheus_role" "example_all" {
 				ImportStateVerifyIgnore: []string{
 					"permissions.feature_permissions",
 					"permissions.default_catalog_item_type_access",
+					"permissions.default_cloud_access",
 					"permissions.default_instance_type_access",
 					"permissions.default_persona_access",
 					"permissions.default_report_type_access",
@@ -466,11 +469,14 @@ resource "hpe_morpheus_role" "default_access_permissions_ok" {
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true, // Check state post import
-				ImportStateVerifyIgnore: []string{"permissions.feature_permissions"},
-				ResourceName:            "hpe_morpheus_role.default_access_permissions_ok",
-				Check:                   checkFn,
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				ImportStateVerifyIgnore: []string{
+					"permissions.feature_permissions",
+					"permissions.default_cloud_access",
+				},
+				ResourceName: "hpe_morpheus_role.default_access_permissions_ok",
+				Check:        checkFn,
 			},
 		},
 	})
@@ -599,6 +605,7 @@ resource "morpheus_groovy_script_task" "testacc_role_example_legacy_provider_tas
 					"permissions.workflow_permissions",
 					"permissions.vdi_pool_permissions",
 					"permissions.default_group_access",
+					"permissions.default_cloud_access",
 					"permissions.default_catalog_item_type_access",
 					"permissions.default_instance_type_access",
 					"permissions.default_persona_access",
@@ -890,11 +897,14 @@ resource "hpe_morpheus_role" "testacc_role_all_permissions_user_role_ok" {
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true, // Check state post import
-				ImportStateVerifyIgnore: []string{"permissions.feature_permissions"},
-				ResourceName:            "hpe_morpheus_role.testacc_role_all_permissions_user_role_ok",
-				Check:                   checkFn,
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				ImportStateVerifyIgnore: []string{
+					"permissions.feature_permissions",
+					"permissions.default_cloud_access",
+				},
+				ResourceName: "hpe_morpheus_role.testacc_role_all_permissions_user_role_ok",
+				Check:        checkFn,
 			},
 		},
 	})
@@ -1045,15 +1055,17 @@ resource "hpe_morpheus_role" "testacc_role_all_permissions_account_role_ok" {
 			"role_type",
 			"account",
 		),
-		// check fields not available for account roles
-		resource.TestCheckNoResourceAttr(
+		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.testacc_role_all_permissions_account_role_ok",
 			"multitenant",
+			"false",
 		),
-		resource.TestCheckNoResourceAttr(
+		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.testacc_role_all_permissions_account_role_ok",
 			"multitenant_locked",
+			"false",
 		),
+		// check fields not available for account roles
 		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_role.testacc_role_all_permissions_account_role_ok",
 			"permissions.default_group_access",
@@ -1190,11 +1202,14 @@ resource "hpe_morpheus_role" "testacc_role_all_permissions_account_role_ok" {
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true, // Check state post import
-				ImportStateVerifyIgnore: []string{"permissions.feature_permissions"},
-				ResourceName:            "hpe_morpheus_role.testacc_role_all_permissions_account_role_ok",
-				Check:                   checkFn,
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				ImportStateVerifyIgnore: []string{
+					"permissions.feature_permissions",
+					"permissions.default_group_access",
+				},
+				ResourceName: "hpe_morpheus_role.testacc_role_all_permissions_account_role_ok",
+				Check:        checkFn,
 			},
 		},
 	})

--- a/internal/subproviders/morpheus/resources/role/schema_gen.go
+++ b/internal/subproviders/morpheus/resources/role/schema_gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -48,12 +49,14 @@ func RoleResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant*",
 				MarkdownDescription: "Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant*",
+				Default:             booldefault.StaticBool(false),
 			},
 			"multitenant_locked": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Multitenant Locked, prevents sub-tenant users from modifying their copy of multienant roles. *Only available to master tenant*",
 				MarkdownDescription: "Multitenant Locked, prevents sub-tenant users from modifying their copy of multienant roles. *Only available to master tenant*",
+				Default:             booldefault.StaticBool(false),
 			},
 			"name": schema.StringAttribute{
 				Required:            true,

--- a/internal/subproviders/morpheus/resources/role/update_test.go
+++ b/internal/subproviders/morpheus/resources/role/update_test.go
@@ -772,6 +772,7 @@ resource "hpe_morpheus_role" "update_test" {
 					// Feature permissions on import will be the full set of computed permissions,
 					// not just those we set.
 					"permissions.feature_permissions",
+					"permissions.default_cloud_access",
 				},
 				ResourceName: "hpe_morpheus_role.update_test",
 				Check:        updatedCheckFn,
@@ -1051,6 +1052,16 @@ resource "hpe_morpheus_role" "update_test" {
 			"role_type",
 			"account",
 		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.update_test",
+			"multitenant",
+			"false",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.update_test",
+			"multitenant_locked",
+			"false",
+		),
 		// Default access levels
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_role.update_test",
@@ -1253,6 +1264,16 @@ resource "hpe_morpheus_role" "update_test" {
 			"hpe_morpheus_role.update_test",
 			"role_type",
 			"account",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.update_test",
+			"multitenant",
+			"false",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.update_test",
+			"multitenant_locked",
+			"false",
 		),
 		// Default access levels
 		resource.TestCheckResourceAttr(
@@ -1457,6 +1478,16 @@ resource "hpe_morpheus_role" "update_test" {
 			"role_type",
 			"account",
 		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.update_test",
+			"multitenant",
+			"false",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_role.update_test",
+			"multitenant_locked",
+			"false",
+		),
 		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_role.update_test",
 			"permissions",
@@ -1520,6 +1551,7 @@ resource "hpe_morpheus_role" "update_test" {
 					// Feature permissions on import will be the full set of computed permissions,
 					// not just those we set.
 					"permissions.feature_permissions",
+					"permissions.default_group_access",
 				},
 				ResourceName: "hpe_morpheus_role.update_test",
 				Check:        updatedCheckFn,


### PR DESCRIPTION
This PR removes the changes made to store attributes which are specific to `user` and `tenant` roles in state as null. I'm doing this because of limitations that I encountered with the Terraform Plugin Framework around storing the `multitenant` fields dynamically as either `false/true` for `user` roles and `null` for `tenant` roles. Furthermore, avoiding abstracting the API values for these fields keeps consistency between the data source and resource. With these changes an `import` of a Role resource and a read using the role data source behave identically in what information is presented.

The following fields are affected:

- `multitenant`
- `multitenant_locked`
- `default_cloud_access`
- `default_group_access`

`multitenant` and `multitenant_locked` are now stored in state as `false` for `tenant` roles. There is still validation on the Terraform config level to prevent a user from using or modifying these fields for a `tenant` role.

`default_cloud_access` and `default_group_access` now import as `none` (their default value) on `user` and `tenant` roles respectively. In state, these are still stored as `null` if not provided in a config since all the permissions fields are optional. This was done to keep consistency across import behaviour / data source behaviour for the fields intended for particular role types.

The documentation for Role will be updated to remind the user that if using import blocks, they will need to manually edit the generated code to comply with the config validation that is placed on the resource, i.e. remove the `multitenant` fields and remove `default_group_access` if importing a `tenant` role, and remove `default_cloud_access` if importing a `user` role.

For example (both roles created with only required `name` field and `role_type` - no permissions have been configured).

User role:
```
# terraform state show hpe_morpheus_role.example_required_user
# hpe_morpheus_role.example_required_user:
resource "hpe_morpheus_role" "example_required_user" {
    id                 = 986
    multitenant        = false
    multitenant_locked = false
    name               = "ExampleRoleRequiredUser"
    role_type          = "user"
}
```


Tenant role:
```
# terraform state show hpe_morpheus_role.example_required_account
# hpe_morpheus_role.example_required_account:
resource "hpe_morpheus_role" "example_required_account" {
    id                 = 985
    multitenant        = false
    multitenant_locked = false
    name               = "ExampleRoleRequiredAccount"
    role_type          = "account"
```

