### PR TITLE
Add example for service plan resource

### DIFF
--- a/internal/subproviders/morpheus/datasources/serviceplan/example-name-provision.tf.tmpl
+++ b/internal/subproviders/morpheus/datasources/serviceplan/example-name-provision.tf.tmpl
@@ -1,4 +1,4 @@
 data "hpe_morpheus_service_plan" "test" {
-    name = {{.Name}}
-    provision_type_code = {{.ProvisionTypeCode}}
+    name = "{{.Name}}"
+    provision_type_code = "{{.ProvisionTypeCode}}"
 }

--- a/internal/subproviders/morpheus/resources/serviceplan/example.tf
+++ b/internal/subproviders/morpheus/resources/serviceplan/example.tf
@@ -1,0 +1,12 @@
+resource "hpe_morpheus_service_plan" "example_service_plan" {
+  name = "ExampleServicePlan"
+  code = "exampleserviceplan"
+  max_memory = 4294967296
+  max_storage = 536870912
+  provision_type_code = "arm"
+  custom_max_storage = true
+  config_ranges = {
+    min_storage = 268435456
+    max_storage = 536870912
+  }
+}

--- a/internal/subproviders/morpheus/resources/serviceplan/example.tf.tmpl
+++ b/internal/subproviders/morpheus/resources/serviceplan/example.tf.tmpl
@@ -1,0 +1,12 @@
+resource "hpe_morpheus_service_plan" "example_service_plan" {
+  name = "{{.Name}}"
+  code = "{{.Code}}"
+  max_memory = {{.MaxMemory}}
+  max_storage = {{.MaxStorage}}
+  provision_type_code = "{{.ProvisionTypeCode}}"
+  custom_max_storage = {{.CustomMaxStorage}}
+  config_ranges = {
+    min_storage = {{.ConfigRangesMinStorage}}
+    max_storage = {{.ConfigRangesMaxStorage}}
+  }
+}

--- a/internal/subproviders/morpheus/resources/serviceplan/resource_test.go
+++ b/internal/subproviders/morpheus/resources/serviceplan/resource_test.go
@@ -1,5 +1,7 @@
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
+//go:generate go run ../../../../../cmd/render example.tf.tmpl Name "ExampleServicePlan" Code "exampleserviceplan" MaxMemory "4294967296" MaxStorage "536870912"  ProvisionTypeCode "arm" CustomMaxStorage "true" ConfigRangesMinStorage "268435456" ConfigRangesMaxStorage "536870912"
+
 //go:build experimental
 
 package serviceplan_test
@@ -141,7 +143,7 @@ resource "hpe_morpheus_service_plan" "example_all" {
   max_cpu                = 0
   max_disks              = 2
   memory_size_type       = "mb"
-  priceset_ids           = [1]
+  price_set_ids           = [1]
   provision_type_code    = "arm"
   sort_order             = 0
   storage_size_type      = "gb"
@@ -253,15 +255,15 @@ resource "hpe_morpheus_service_plan" "example_all" {
 			"gb",
 		),
 
-		// Set (priceset_ids)
+		// Set (price_set_ids)
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_service_plan.example_all",
-			"priceset_ids.#",
+			"price_set_ids.#",
 			"1",
 		),
 		resource.TestCheckTypeSetElemAttr(
 			"hpe_morpheus_service_plan.example_all",
-			"priceset_ids.*",
+			"price_set_ids.*",
 			"1",
 		),
 
@@ -337,6 +339,94 @@ resource "hpe_morpheus_service_plan" "example_all" {
 				ImportState:       true,
 				ImportStateVerify: true, // Check state post import
 				ResourceName:      "hpe_morpheus_service_plan.example_all",
+				Check:             checkFn,
+			},
+		},
+	})
+}
+
+// Tests that our example file template used for docs is a valid config
+func TestAccMorpheusServicePlanExampleOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	name := acctest.RandomWithPrefix(t.Name())
+	code := strings.ToLower(name)
+
+	resourceConfig, err := testhelpers.RenderExample(t, "example.tf.tmpl",
+		"Name", name,
+		"Code", code,
+		"MaxMemory", "4294967296",
+		"MaxStorage", "536870912",
+		"ProvisionTypeCode", "arm",
+		"CustomMaxStorage", "true",
+		"ConfigRangesMinStorage", "268435456",
+		"ConfigRangesMaxStorage", "536870912")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"name",
+			name,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"code",
+			code,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"max_memory",
+			"4294967296",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"max_storage",
+			"536870912",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"provision_type_code",
+			"arm",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"custom_max_storage",
+			"true",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"config_ranges.min_storage",
+			"268435456",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"config_ranges.max_storage",
+			"536870912",
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+				PlanOnly:           false,
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true, // Check state post import
+				ResourceName:      "hpe_morpheus_service_plan.example_service_plan",
 				Check:             checkFn,
 			},
 		},


### PR DESCRIPTION
Adds an `example.tf.tmpl` and generated `example.tf` for the service plan resource.
Also adds accompanying acceptance test for the `example.tf.tmpl`.

Drive-by: update acceptance tests with name change from `priceset_ids` to `price_set_ids` introduced in #225.
Drive-by: Fix formatting on service plan data source `example-name-provision.tf.tmpl`.