### PR TITLE
Fix network resource delete (again)

### DIFF
--- a/internal/subproviders/morpheus/resources/network/delete.go
+++ b/internal/subproviders/morpheus/resources/network/delete.go
@@ -36,16 +36,20 @@ func (r *Resource) Delete(
 		return
 	}
 
-	id := state.Id.ValueInt64()
-
 	// Create a custom timeout for the delete operation
 	// Mainly needed for GCP network delete, which is
 	// synchronous, and can take some time
-	deleteCtx, cancel := context.WithTimeout(ctx, constants.NetworkDeleteTimeout)
-	defer cancel()
+	// TODO: redo this, we should use the morpheus client
+	// with a context to set timeouts, rather than digging
+	// into the http client like this
+	if httpClient := client.GetConfig().HTTPClient; httpClient != nil {
+		httpClient.Timeout = constants.NetworkDeleteTimeout
+	}
+
+	id := state.Id.ValueInt64()
 
 	tflog.Debug(ctx, fmt.Sprintf("Deleting network %d", id))
-	_, hresp, err := client.NetworksAPI.DeleteNetwork(deleteCtx, id).
+	_, hresp, err := client.NetworksAPI.DeleteNetwork(ctx, id).
 		Execute()
 	if err != nil || hresp.StatusCode != http.StatusOK {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
The previous fix doesn't seem to work. I suspect
I had a stray file on my machine. Rework temporarily.
We need to revisit timeouts generally.