### PR TITLE
Remove sort_order from data source

### DIFF
--- a/internal/subproviders/morpheus/datasources/serviceplan/datasource.go
+++ b/internal/subproviders/morpheus/datasources/serviceplan/datasource.go
@@ -224,7 +224,6 @@ func servicePlanAsState(
 	state.Name = convert.StrToType(servicePlan.Name)
 	state.PriceSetIds = priceSetIDSet
 	state.ProvisionTypeCode = convert.StrToType(servicePlan.ProvisionType.Code)
-	state.SortOrder = convert.Int64ToType(servicePlan.SortOrder)
 	state.StorageSizeType = convert.StrToType(servicePlan.Config.StorageSizeType.Get())
 
 	return state, diags

--- a/internal/subproviders/morpheus/datasources/serviceplan/datasource_test.go
+++ b/internal/subproviders/morpheus/datasources/serviceplan/datasource_test.go
@@ -330,7 +330,6 @@ resource "hpe_morpheus_service_plan" "test_all" {
   memory_size_type       = "mb"
   price_set_ids           = [1]
   provision_type_code    = "arm"
-  sort_order             = 0
   storage_size_type      = "gb"
 
   config_ranges =  {
@@ -438,11 +437,6 @@ data "hpe_morpheus_service_plan" "test_all" {
 			"data.hpe_morpheus_service_plan.test_all",
 			"provision_type_code",
 			"arm",
-		),
-		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_service_plan.test_all",
-			"sort_order",
-			"0",
 		),
 		resource.TestCheckResourceAttr(
 			"data.hpe_morpheus_service_plan.test_all",

--- a/internal/subproviders/morpheus/datasources/serviceplan/schema_gen.go
+++ b/internal/subproviders/morpheus/datasources/serviceplan/schema_gen.go
@@ -154,10 +154,14 @@ func ServicePlanDataSourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Max disks allowed",
 			},
 			"max_memory": schema.Int64Attribute{
-				Computed: true,
+				Computed:            true,
+				Description:         "Max memory size in bytes",
+				MarkdownDescription: "Max memory size in bytes",
 			},
 			"max_storage": schema.Int64Attribute{
-				Computed: true,
+				Computed:            true,
+				Description:         "Max storage size in bytes",
+				MarkdownDescription: "Max storage size in bytes",
 			},
 			"memory_size_type": schema.StringAttribute{
 				Computed: true,
@@ -188,11 +192,6 @@ func ServicePlanDataSourceSchema(ctx context.Context) schema.Schema {
 					}...),
 				},
 			},
-			"sort_order": schema.Int64Attribute{
-				Computed:            true,
-				Description:         "Sort order",
-				MarkdownDescription: "Sort order",
-			},
 			"storage_size_type": schema.StringAttribute{
 				Computed: true,
 			},
@@ -220,7 +219,6 @@ type ServicePlanModel struct {
 	Name              types.String      `tfsdk:"name"`
 	PriceSetIds       types.Set         `tfsdk:"price_set_ids"`
 	ProvisionTypeCode types.String      `tfsdk:"provision_type_code"`
-	SortOrder         types.Int64       `tfsdk:"sort_order"`
 	StorageSizeType   types.String      `tfsdk:"storage_size_type"`
 }
 


### PR DESCRIPTION
We plan to remove this from the resource as it's a UI-specific field that doesn't have much bearing on Terraform state or API behaviour. We may revisit this decision but for now we'll leave it out.

Drive-by: Pick up updated descriptions for `max_memory` and `max_storage`.