### PR TITLE
Regen service plan data source schema_gen.go - max_memory and max_storage descriptions

### DIFF
--- a/internal/subproviders/morpheus/datasources/serviceplan/schema_gen.go
+++ b/internal/subproviders/morpheus/datasources/serviceplan/schema_gen.go
@@ -154,10 +154,14 @@ func ServicePlanDataSourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Max disks allowed",
 			},
 			"max_memory": schema.Int64Attribute{
-				Computed: true,
+				Computed:            true,
+				Description:         "Max memory size in bytes",
+				MarkdownDescription: "Max memory size in bytes",
 			},
 			"max_storage": schema.Int64Attribute{
-				Computed: true,
+				Computed:            true,
+				Description:         "Max storage size in bytes",
+				MarkdownDescription: "Max storage size in bytes",
 			},
 			"memory_size_type": schema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
We lost some changes to the generated `schema_gen.go` in #248, this just syncs it with the spec repo.

`max_memory` and `max_storage` have their descriptions updated to be in sync with the spec repo.