### PR TITLE
Fix example formatting on service plan documentation

### DIFF
--- a/templates-experimental/data-sources/morpheus_service_plan.md.tmpl
+++ b/templates-experimental/data-sources/morpheus_service_plan.md.tmpl
@@ -10,11 +10,11 @@ Service Plans in HPE Morpheus Enterprise determine the memory, storage, and core
 
 {{ .Description | trimspace }}
 
-{{ if .HasExample -}}
 ## Example Usage
 
-{{ tffile .ExampleFile }}
-{{- end }}
+{{ tffile "internal/subproviders/morpheus/datasources/serviceplan/example-id.tf" }}
+
+{{ tffile "internal/subproviders/morpheus/datasources/serviceplan/example-name-provision.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
 

--- a/templates-experimental/resources/morpheus_service_plan.md.tmpl
+++ b/templates-experimental/resources/morpheus_service_plan.md.tmpl
@@ -12,13 +12,10 @@ Service Plans in HPE Morpheus Enterprise determine the memory, storage, and core
 {{ range $i, $line := $lines }} {{- if gt $i 0 -}}
 {{ $line }}{{ end }}
 {{ end }}
-{{ if .HasExample -}}
+
 ## Example Usage
 
 {{ tffile "internal/subproviders/morpheus/resources/serviceplan/example.tf" }}
-
-{{ tffile .ExampleFile }}
-{{- end }}
 
 {{ .SchemaMarkdown | trimspace }}
 


### PR DESCRIPTION
The rendering of examples was previously not working, this PR fixes them.
