### PR TITLE
Add instance resource example and test

### DIFF
--- a/internal/subproviders/morpheus/resources/instance/example.tf
+++ b/internal/subproviders/morpheus/resources/instance/example.tf
@@ -1,0 +1,52 @@
+data "hpe_morpheus_cloud" "vme_cloud" {
+  name = "HPE Alletra VME" 
+}
+
+data "hpe_morpheus_service_plan" "vme_512mb" {
+    name                = "1 CPU, 1GB Memory"
+    provision_type_code = "kvm"
+}
+
+resource "hpe_morpheus_instance" "example" {
+  name               = "TestInstance"
+  cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id   # HPE Alletra VME
+  layout_id          = 5385   # Single KVM VM
+  instance_type_id   = 9 # (HVM) mvm-cluster
+  layout_size        = 1
+
+  group_id           = 1
+  plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
+  
+  instance_context   = "dev"
+  network_interfaces = [
+    {
+      network_id = 103481
+      ip_mode    = "dhcp"
+    }
+  ]
+
+  volumes = [
+    {
+      root_volume  = true
+      name         = "root"
+      size         = 10
+      storage_type = 1
+      datastore_id = 38658
+    }
+  ]
+
+  tags = [
+    {
+      name  = "managed_by"
+      value = "terraform"
+    }
+  ]
+
+  config = {
+    resourcePoolId       = "pool-62299"
+    poolProviderType     = "mvm"
+    nestedVirtualization = "off"
+    noAgent              = true
+    createUser           = false
+  }
+}

--- a/internal/subproviders/morpheus/resources/instance/example.tf.tmpl
+++ b/internal/subproviders/morpheus/resources/instance/example.tf.tmpl
@@ -1,0 +1,52 @@
+data "hpe_morpheus_cloud" "vme_cloud" {
+  name = "HPE Alletra VME" 
+}
+
+data "hpe_morpheus_service_plan" "vme_512mb" {
+    name                = "1 CPU, 1GB Memory"
+    provision_type_code = "kvm"
+}
+
+resource "hpe_morpheus_instance" "example" {
+  name               = "{{.Name}}"
+  cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id   # HPE Alletra VME
+  layout_id          = 5385   # Single KVM VM
+  instance_type_id   = {{.InstanceType}} # (HVM) mvm-cluster
+  layout_size        = 1
+
+  group_id           = 1
+  plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
+  
+  instance_context   = "dev"
+  network_interfaces = [
+    {
+      network_id = 103481
+      ip_mode    = "dhcp"
+    }
+  ]
+
+  volumes = [
+    {
+      root_volume  = true
+      name         = "root"
+      size         = 10
+      storage_type = 1
+      datastore_id = 38658
+    }
+  ]
+
+  tags = [
+    {
+      name  = "managed_by"
+      value = "terraform"
+    }
+  ]
+
+  config = {
+    resourcePoolId       = "{{.ResourcePool}}"
+    poolProviderType     = "mvm"
+    nestedVirtualization = "off"
+    noAgent              = true
+    createUser           = false
+  }
+}

--- a/internal/subproviders/morpheus/resources/instance/instance.go
+++ b/internal/subproviders/morpheus/resources/instance/instance.go
@@ -162,6 +162,10 @@ func getInstanceAsState(
 	// config
 	state.Config = types.DynamicNull()
 
+	if !plan.Config.IsNull() && !plan.Config.IsUnknown() {
+		state.Config = plan.Config
+	}
+
 	// evars
 	// API may respond with more evars than what the user set so we need to
 	// check the /instance/{id}/envs endpoint which gives us the user specified

--- a/internal/subproviders/morpheus/resources/instance/resource_test.go
+++ b/internal/subproviders/morpheus/resources/instance/resource_test.go
@@ -1,0 +1,85 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+//go:generate go run ../../../../../cmd/render example.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
+
+package instance_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/provider"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/testhelpers"
+)
+
+func newProviderWithError() (tfprotov6.ProviderServer, error) {
+	providerInstance := provider.New("test", morpheus.New())()
+
+	return providerserver.NewProtocol6WithError(providerInstance)()
+}
+
+var testAccProtoV6ProviderFactories = map[string]func() (
+	tfprotov6.ProviderServer, error,
+){
+	"hpe": newProviderWithError,
+}
+
+// Tests that our example file template used for docs is a valid config
+func TestAccMorpheusInstanceExampleOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	name := acctest.RandomWithPrefix(t.Name())
+	instanceTypeID := "9"
+	resourcePool := "pool-62299"
+
+	resourceConfig, err := testhelpers.RenderExample(t, "example.tf.tmpl",
+		"Name", name,
+		"InstanceType", instanceTypeID,
+		"ResourcePool", resourcePool,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_instance.example",
+			"name",
+			name,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_instance.example",
+			"instance_type_id",
+			instanceTypeID,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_instance.example",
+			"config.resourcePoolId",
+			resourcePool,
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           false,
+				Check:              checkFn,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds an example of an HVM instance being provisioned through terraform.

Adds a drive by fix for the instance dynamic config caught by the testing.