### PR TITLE
Revert "Remove docs-experimental from .gitignore so that QA can read to the docs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/
 dist/
 terraform-provider-hpe
 build/
+docs-experimental/
 templates-combined-temp/
 *.tfstate*
 .terraform/


### PR DESCRIPTION
Reverts HPE/terraform-provider-hpe#250

This is generating unrelated documentation which is increasing the maintenance burden on PRs for very little gain.