### PR TITLE
Update provider server address

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "github.com/hpe/hpe",
+		Address: "registry.terraform.io/HPE/hpe",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
Now that we've published the provider to the Hashicorp registry we should use the canonical server address. This also enables running the provider with a debugger.