### PR TITLE
Resolving Group ID issues with new SDK version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,4 +74,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/go-viper/mapstructure/v2 v2.3.0 => github.com/ZoeySimone/mapstructure/v2 v2.4.1-0.20250717172041-7e763acbe835
+replace github.com/go-viper/mapstructure/v2 v2.4.0 => github.com/ZoeySimone/mapstructure/v2 v2.4.1-0.20250902104126-099f6e5a61b8

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HPE/terraform-provider-hpe
 go 1.24.1
 
 require (
-	github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250916155611-31cb6a7404f3
+	github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250919151946-3abcc4685d7e
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250916155611-31cb6a7404f3 h1:dL8kEXGhY73PMS9bc3IgKWLuPdvswvgKounkwJYfFw0=
-github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250916155611-31cb6a7404f3/go.mod h1:GPkKVeXv0go/+jzI15RDeM0jIskuQRlMydsvQiKT6VY=
+github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250919151946-3abcc4685d7e h1:zOnwp8cLJ8QCvFY5waSsdLZ8Rm4itwFGWJtubO0oqfw=
+github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250919151946-3abcc4685d7e/go.mod h1:GPkKVeXv0go/+jzI15RDeM0jIskuQRlMydsvQiKT6VY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/ZoeySimone/mapstructure/v2 v2.4.1-0.20250902104126-099f6e5a61b8 h1:E4C6Tuc5dzoKU1sKX8QFS6bzIxojXhcpSdJt20A1CdM=
+github.com/ZoeySimone/mapstructure/v2 v2.4.1-0.20250902104126-099f6e5a61b8/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -40,8 +42,6 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
-github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/subproviders/morpheus/resources/instance/instance.go
+++ b/internal/subproviders/morpheus/resources/instance/instance.go
@@ -192,7 +192,7 @@ func getInstanceAsState(
 	state.Evars = evars
 
 	// group_id
-	state.GroupId = convert.Int64ToType(instance.Group.Get().Id)
+	state.GroupId = convert.Int64ToType(instance.GetGroup().Id)
 
 	// id
 	state.Id = convert.Int64ToType(instance.Id)


### PR DESCRIPTION
- Bumped go mod to correctly replace mapstructure dependency
- Ran go mod tidy to clean up go.sum
- Updated instance resource to safely access Group ID using new SDK method 
 
~~Currently no longer panics because of the use of GetGroup over Group.Get() but still throws error for TestAccMorpheusInstanceExampleOk .~~