### PR TITLE
Add utility to compare plan and returned Config stanzas

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,12 @@ linters:
       keywords:
         - OPTIMIZE
     lll:
-      line-length: 100
+      line-length: 120
+    revive:
+      rules:
+        - name: var-naming
+          # Suppress warnings about Id "initialism" - i.e. make Id and ID valid
+          arguments: [ [ "ID", "URL", "API" ] ]
   exclusions:
     generated: lax
     presets:

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
+	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=

--- a/internal/utils/attribute_compare.go
+++ b/internal/utils/attribute_compare.go
@@ -1,0 +1,166 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+)
+
+// CheckPlanAttributeAgainstAPIAttribute compares the keys in a plan Attribute (which is expected to be a
+// basetypes.ObjectValuable or basetypes.DynamicValue of ObjectType) against the keys in the corresponding
+// Attribute returned by the API (which is expected to be a map[string]any or sdk.MappedNullable). It returns
+// a diag.Diagnostics containing warnings for any keys that are in one but not the other.
+// This can help identify misconfigurations or misunderstandings of the API.
+//
+// keyMap is an optional mapping of plan keys to fromApi keys, to account for any differences in naming.
+// Only add differing keys to the map, identical keys do not need to be included.
+//
+// If either planAttribute or apiAttribute is nil, an empty diag.Diagnostics is returned.
+// If either planAttribute or apiAttribute is of an unexpected type, a warning diag is returned.
+//
+// Note that this function only compares the presence of keys, not their values.
+func CheckPlanAttributeAgainstAPIAttribute(
+	ctx context.Context,
+	planAttribute any,
+	apiAttribute any,
+	keyMap map[string]string,
+) diag.Diagnostics {
+	if planAttribute == nil || apiAttribute == nil {
+		// Nothing to compare, return empty diags
+		return diag.Diagnostics{}
+	}
+
+	// Extract ObjectValue from planAttribute, or else return warning diag
+	var planObject basetypes.ObjectValue
+	switch plan := planAttribute.(type) {
+	case basetypes.DynamicValue:
+		// Need to check that this is an Object
+		dynamicValue := plan.UnderlyingValue()
+		dynamicObject, ok := dynamicValue.(basetypes.ObjectValue)
+		if !ok {
+			return diag.Diagnostics{
+				diag.NewWarningDiagnostic(
+					"check config",
+					fmt.Sprintf("expected planAttribute to be basetypes.DynamicValue of ObjectType, got %T", dynamicValue),
+				),
+			}
+		}
+
+		planObject = dynamicObject
+
+	case basetypes.ObjectValuable:
+		// Convert to ObjectValue and execute ToObjectValue to get Object
+		planObjectValue, diagObject := plan.ToObjectValue(ctx)
+		if diagObject.HasError() {
+			return diag.Diagnostics{
+				diag.NewWarningDiagnostic(
+					"check config",
+					fmt.Sprintf("expected planAttribute to be basetypes.ObjectValuable, got error: %v", diagObject),
+				),
+			}
+		}
+
+		planObject = planObjectValue
+
+	default:
+		// Can't do anything with other types
+		return diag.Diagnostics{
+			diag.NewWarningDiagnostic(
+				"check config",
+				fmt.Sprintf("expected planAttribute to be basetypes.DynamicValue or basetypes.ObjectValuable, got %T", plan),
+			),
+		}
+	}
+
+	// Extract map[string]any from apiAttribute, or else return warning diag
+	var fromApiMap map[string]any
+	switch fromApi := apiAttribute.(type) {
+	case map[string]any:
+		// Directly convert
+		fromApiMap = fromApi
+
+	case sdk.MappedNullable:
+		// Convert using ToMap()
+		apiMap, err := fromApi.ToMap()
+		if err != nil {
+			return diag.Diagnostics{
+				diag.NewWarningDiagnostic(
+					"check config",
+					fmt.Sprintf("expected apiAttribute to be sdk.MappedNullable, got error: %v", err),
+				),
+			}
+		}
+
+		fromApiMap = apiMap
+
+	default:
+		// Can't do anything with other types
+		return diag.Diagnostics{
+			diag.NewWarningDiagnostic(
+				"check config",
+				fmt.Sprintf("expected apiAttribute to be map[string]any or sdk.MappedNullable, got %T", fromApi),
+			),
+		}
+	}
+
+	// Check the keys in the planAttribute against fromApiMap
+	planAttrs := planObject.Attributes()
+	// Build map of keys in planAttrs
+	planKeys := make(map[string]struct{})
+	for k := range planAttrs {
+		planKeys[k] = struct{}{}
+	}
+	// Build map of keys in fromApiMap
+	fromApiKeys := make(map[string]struct{})
+	for k := range fromApiMap {
+		fromApiKeys[k] = struct{}{}
+	}
+
+	// Apply keyMap to planKeys to convert to fromApiMap keys
+	if keyMap != nil {
+		convertedPlanKeys := make(map[string]struct{})
+		for k := range planKeys {
+			if newKey, ok := keyMap[k]; ok {
+				convertedPlanKeys[newKey] = struct{}{}
+			} else {
+				convertedPlanKeys[k] = struct{}{}
+			}
+		}
+		planKeys = convertedPlanKeys
+	}
+
+	// Now compare the keys in both maps
+	// Warn if there are keys in one that are not in the other
+	// This is not necessarily an error, as the API may return extra keys
+	// or the planAttribute may have keys that are not returned by the API
+	// But it is worth warning about in case of misconfiguration
+	// or misunderstanding of the API
+	// Find keys in planAttribute that are not in apiAttribute
+	var diags diag.Diagnostics
+	for k := range planKeys {
+		if _, ok := fromApiKeys[k]; !ok {
+			diags.AddWarning(
+				"check config",
+				fmt.Sprintf("key '%s' in plan not found in API response", k),
+			)
+		}
+	}
+
+	// Find keys in fromApiMap that are not in planAttribute
+	for k := range fromApiKeys {
+		if _, ok := planKeys[k]; !ok {
+			diags.AddWarning(
+				"check config",
+				fmt.Sprintf("key '%s' in API response not found in plan", k),
+			)
+		}
+	}
+
+	return diags
+}

--- a/internal/utils/attribute_compare_test.go
+++ b/internal/utils/attribute_compare_test.go
@@ -1,0 +1,350 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/iancoleman/strcase"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testKey1 = "key1"
+	testKey2 = "key2"
+
+	testValue1 = "value1"
+	testValue2 = 42.0
+
+	testCertificateProvider        = "certificate"
+	testApplianceUrl               = "https://morpheus.example.com"
+	testExternalId                 = "external-id"
+	testInventoryLevel             = "level1"
+	testDatacenterName             = "datacenter1"
+	testConsoleKeymap              = "us"
+	testConfigCmdbDiscovery        = true
+	testEnableNetworkTypeSelection = true
+
+	testCertificateKey                = "certificateProvider"
+	testApplianceUrlKey               = "applianceUrl"
+	testExternalIdKey                 = "externalId"
+	testInventoryLevelKey             = "inventoryLevel"
+	testDatacenterNameKey             = "datacenterName"
+	testConsoleKeymapKey              = "consoleKeymap"
+	testConfigCmdbDiscoveryKey        = "configCmdbDiscovery"
+	testEnableNetworkTypeSelectionKey = "enableNetworkTypeSelection"
+)
+
+// examplePlanObject is a struct that implements the necessary interface for testing
+type examplePlanObject struct {
+	objectValue  basetypes.ObjectValue
+	dynamicValue basetypes.DynamicValue
+}
+
+func (e *examplePlanObject) getObjectValue() basetypes.ObjectValue {
+	return e.objectValue
+}
+
+func (e *examplePlanObject) getDynamicValue() basetypes.DynamicValue {
+	return e.dynamicValue
+}
+
+// exampleFromApi is a struct that simulates the API response for testing
+type exampleFromApi struct {
+	data       map[string]interface{}
+	configType sdk.MappedNullable
+}
+
+func (e *exampleFromApi) getData() map[string]interface{} {
+	return e.data
+}
+
+func (e *exampleFromApi) getConfigType() sdk.MappedNullable {
+	return e.configType
+}
+
+// createExamplePlanObjectCloudHVMCamelCase creates an example plan object for testing
+func createExamplePlanObjectCloudHVMCamelCase(t *testing.T) *examplePlanObject {
+	// Define a sample plan as basetypes.ObjectValue
+	planAttrTypes := map[string]attr.Type{
+		testApplianceUrlKey:               basetypes.StringType{},
+		testCertificateKey:                basetypes.StringType{},
+		testConfigCmdbDiscoveryKey:        basetypes.BoolType{},
+		testConsoleKeymapKey:              basetypes.StringType{},
+		testDatacenterNameKey:             basetypes.StringType{},
+		testEnableNetworkTypeSelectionKey: basetypes.BoolType{},
+		testExternalIdKey:                 basetypes.StringType{},
+		testInventoryLevelKey:             basetypes.StringType{},
+	}
+	planAttrValues := map[string]attr.Value{
+		testApplianceUrlKey:               basetypes.NewStringValue(testApplianceUrl),
+		testCertificateKey:                basetypes.NewStringValue(testCertificateProvider),
+		testConfigCmdbDiscoveryKey:        basetypes.NewBoolValue(testConfigCmdbDiscovery),
+		testConsoleKeymapKey:              basetypes.NewStringValue(testConsoleKeymap),
+		testDatacenterNameKey:             basetypes.NewStringValue(testDatacenterName),
+		testEnableNetworkTypeSelectionKey: basetypes.NewBoolValue(testEnableNetworkTypeSelection),
+		testExternalIdKey:                 basetypes.NewStringValue(testExternalId),
+		testInventoryLevelKey:             basetypes.NewStringValue(testInventoryLevel),
+	}
+
+	planObject, diags := basetypes.NewObjectValue(planAttrTypes, planAttrValues)
+	assert.False(t, diags.HasError())
+
+	dynamicValue := basetypes.NewDynamicValue(planObject)
+
+	return &examplePlanObject{
+		objectValue:  planObject,
+		dynamicValue: dynamicValue,
+	}
+}
+
+// createExamplePlanObjectCloudHVMSnakeCase creates an example plan object for testing
+func createExamplePlanObjectCloudHVMSnakeCase(t *testing.T) *examplePlanObject {
+	// Define a sample plan as basetypes.ObjectValue
+	planAttrTypes := map[string]attr.Type{
+		strcase.ToSnake(testApplianceUrlKey):               basetypes.StringType{},
+		strcase.ToSnake(testCertificateKey):                basetypes.StringType{},
+		strcase.ToSnake(testConfigCmdbDiscoveryKey):        basetypes.BoolType{},
+		strcase.ToSnake(testConsoleKeymapKey):              basetypes.StringType{},
+		strcase.ToSnake(testDatacenterNameKey):             basetypes.StringType{},
+		strcase.ToSnake(testEnableNetworkTypeSelectionKey): basetypes.BoolType{},
+		strcase.ToSnake(testExternalIdKey):                 basetypes.StringType{},
+		strcase.ToSnake(testInventoryLevelKey):             basetypes.StringType{},
+	}
+	planAttrValues := map[string]attr.Value{
+		strcase.ToSnake(testApplianceUrlKey):               basetypes.NewStringValue(testApplianceUrl),
+		strcase.ToSnake(testCertificateKey):                basetypes.NewStringValue(testCertificateProvider),
+		strcase.ToSnake(testConfigCmdbDiscoveryKey):        basetypes.NewBoolValue(testConfigCmdbDiscovery),
+		strcase.ToSnake(testConsoleKeymapKey):              basetypes.NewStringValue(testConsoleKeymap),
+		strcase.ToSnake(testDatacenterNameKey):             basetypes.NewStringValue(testDatacenterName),
+		strcase.ToSnake(testEnableNetworkTypeSelectionKey): basetypes.NewBoolValue(testEnableNetworkTypeSelection),
+		strcase.ToSnake(testExternalIdKey):                 basetypes.NewStringValue(testExternalId),
+		strcase.ToSnake(testInventoryLevelKey):             basetypes.NewStringValue(testInventoryLevel),
+	}
+
+	planObject, diags := basetypes.NewObjectValue(planAttrTypes, planAttrValues)
+	assert.False(t, diags.HasError())
+
+	dynamicValue := basetypes.NewDynamicValue(planObject)
+
+	return &examplePlanObject{
+		objectValue:  planObject,
+		dynamicValue: dynamicValue,
+	}
+}
+
+// createExamplePlanObjectGeneric creates an example plan object for testing
+func createExamplePlanObjectGeneric(t *testing.T) *examplePlanObject {
+	// Define a sample plan as basetypes.ObjectValue
+	bigF := &big.Float{}
+	planAttrTypes := map[string]attr.Type{
+		testKey1: basetypes.StringType{},
+		testKey2: basetypes.NumberType{},
+	}
+	planAttrValues := map[string]attr.Value{
+		testKey1: basetypes.NewStringValue(testValue1),
+		testKey2: basetypes.NewNumberValue(bigF.SetFloat64(testValue2)),
+	}
+	planObject, diags := basetypes.NewObjectValue(planAttrTypes, planAttrValues)
+	assert.False(t, diags.HasError())
+
+	dynamicValue := basetypes.NewDynamicValue(planObject)
+
+	return &examplePlanObject{
+		objectValue:  planObject,
+		dynamicValue: dynamicValue,
+	}
+}
+
+// createExampleFromApiCloudHVM creates an example API response for testing
+func createExampleFromApiCloudHVM(t *testing.T) *exampleFromApi {
+	// Define a sample configType
+	hvmConfig := sdk.NewListClouds200ResponseAllOfZonesInnerConfigWithDefaults()
+	hvmConfig.SetCertificateProvider(testCertificateProvider)
+	hvmConfig.SetApplianceUrl(testApplianceUrl)
+	hvmConfig.SetConsoleKeymap(testConsoleKeymap)
+	hvmConfig.SetConfigCmdbDiscovery(testConfigCmdbDiscovery)
+	hvmConfig.SetDatacenterName(testDatacenterName)
+	hvmConfig.SetEnableNetworkTypeSelection(testEnableNetworkTypeSelection)
+	hvmConfig.SetExternalId(testExternalId)
+	hvmConfig.SetInventoryLevel(testInventoryLevel)
+
+	fromApiData, err := hvmConfig.ToMap()
+	assert.NoError(t, err)
+
+	return &exampleFromApi{
+		data:       fromApiData,
+		configType: hvmConfig,
+	}
+}
+
+func createPlanKeyMapHVM() map[string]string {
+	// Create a map of plan keys to API keys for HVM config
+	return map[string]string{
+		strcase.ToSnake(testCertificateKey):                testCertificateKey,
+		strcase.ToSnake(testApplianceUrlKey):               testApplianceUrlKey,
+		strcase.ToSnake(testConsoleKeymapKey):              testConsoleKeymapKey,
+		strcase.ToSnake(testConfigCmdbDiscoveryKey):        testConfigCmdbDiscoveryKey,
+		strcase.ToSnake(testDatacenterNameKey):             testDatacenterNameKey,
+		strcase.ToSnake(testEnableNetworkTypeSelectionKey): testEnableNetworkTypeSelectionKey,
+		strcase.ToSnake(testExternalIdKey):                 testExternalIdKey,
+		strcase.ToSnake(testInventoryLevelKey):             testInventoryLevelKey,
+	}
+}
+
+func diagnosticsKeysPlanFromApi(plan basetypes.ObjectValue, fromApi map[string]any) diag.Diagnostics {
+	planAttrs := plan.Attributes()
+	var diags diag.Diagnostics
+	for k := range planAttrs {
+		diags.AddWarning(
+			"check config",
+			fmt.Sprintf("key '%s' in plan not found in API response", k),
+		)
+	}
+
+	for k := range fromApi {
+		diags.AddWarning(
+			"check config",
+			fmt.Sprintf("key '%s' in API response not found in plan", k),
+		)
+	}
+
+	return diags
+}
+
+func TestCheckPlanAttributeAgainstAPIAttribute(t *testing.T) {
+	// create example plan and fromApi
+	planGeneric := createExamplePlanObjectGeneric(t)
+	planHVMCamelCase := createExamplePlanObjectCloudHVMCamelCase(t)
+	planHVMSnakeCase := createExamplePlanObjectCloudHVMSnakeCase(t)
+	fromApiHVM := createExampleFromApiCloudHVM(t)
+
+	tests := []struct {
+		name      string
+		plan      any
+		fromApi   any
+		keyMap    map[string]string
+		wantDiags diag.Diagnostics
+	}{
+		{
+			name:      "HVM Camel case plan and fromApi match exactly",
+			plan:      planHVMCamelCase.getObjectValue(),
+			fromApi:   fromApiHVM.getConfigType(),
+			keyMap:    nil,
+			wantDiags: nil,
+		},
+		{
+			name:      "HVM Camel case plan Dynamic and fromApi match exactly",
+			plan:      planHVMCamelCase.getDynamicValue(),
+			fromApi:   fromApiHVM.getConfigType(),
+			keyMap:    nil,
+			wantDiags: nil,
+		},
+		{
+			name:      "HVM Camel case plan and fromApi Map match exactly",
+			plan:      planHVMCamelCase.getObjectValue(),
+			fromApi:   fromApiHVM.getData(),
+			keyMap:    nil,
+			wantDiags: nil,
+		},
+		{
+			name:      "HVM Camel case plan Dynamic and fromApi Map match exactly",
+			plan:      planHVMCamelCase.getDynamicValue(),
+			fromApi:   fromApiHVM.getData(),
+			keyMap:    nil,
+			wantDiags: nil,
+		},
+		{
+			name:      "HVM SnakeCase plan and fromApi match exactly with keyMap",
+			plan:      planHVMSnakeCase.getObjectValue(),
+			fromApi:   fromApiHVM.getConfigType(),
+			keyMap:    createPlanKeyMapHVM(),
+			wantDiags: nil,
+		},
+		{
+			name:      "HVM SnakeCase plan Dynamic and fromApi match exactly with keyMap",
+			plan:      planHVMSnakeCase.getObjectValue(),
+			fromApi:   fromApiHVM.getConfigType(),
+			keyMap:    createPlanKeyMapHVM(),
+			wantDiags: nil,
+		},
+		{
+			name:      "HVM SnakeCase plan and fromApi Map match exactly with keyMap",
+			plan:      planHVMSnakeCase.getObjectValue(),
+			fromApi:   fromApiHVM.getData(),
+			keyMap:    createPlanKeyMapHVM(),
+			wantDiags: nil,
+		},
+		{
+			name:      "HVM SnakeCase plan Dynamic and fromApi Map match exactly with keyMap",
+			plan:      planHVMSnakeCase.getDynamicValue(),
+			fromApi:   fromApiHVM.getData(),
+			keyMap:    createPlanKeyMapHVM(),
+			wantDiags: nil,
+		},
+		{
+			name:      "HVM SnakeCase plan Dynamic and fromApi Map no keyMap returns diags",
+			plan:      planHVMSnakeCase.getDynamicValue(),
+			fromApi:   fromApiHVM.getData(),
+			keyMap:    nil,
+			wantDiags: diagnosticsKeysPlanFromApi(planHVMSnakeCase.getObjectValue(), fromApiHVM.getData()),
+		},
+		{
+			name:      "Generic plan Dynamic and fromApi Map no keyMap returns diags",
+			plan:      planGeneric.getDynamicValue(),
+			fromApi:   fromApiHVM.getData(),
+			keyMap:    nil,
+			wantDiags: diagnosticsKeysPlanFromApi(planGeneric.getObjectValue(), fromApiHVM.getData()),
+		},
+		{
+			name:    "Invalid plan type returns diag",
+			plan:    12345,
+			fromApi: fromApiHVM.getConfigType(),
+			keyMap:  nil,
+			wantDiags: diag.Diagnostics{
+				diag.NewWarningDiagnostic(
+					"check config",
+					"expected planAttribute to be basetypes.DynamicValue or basetypes.ObjectValuable, got int",
+				),
+			},
+		},
+		{
+			name:    "Invalid fromApi type returns diag",
+			plan:    planHVMCamelCase.getObjectValue(),
+			fromApi: 12345,
+			keyMap:  nil,
+			wantDiags: diag.Diagnostics{
+				diag.NewWarningDiagnostic(
+					"check config",
+					"expected apiAttribute to be map[string]any or sdk.MappedNullable, got int",
+				),
+			},
+		},
+		{
+			name:    "Invalid plan Dynamic with non-object value returns diag",
+			plan:    basetypes.NewDynamicValue(basetypes.NewStringValue("not-an-object")),
+			fromApi: fromApiHVM.getConfigType(),
+			keyMap:  nil,
+			wantDiags: diag.Diagnostics{
+				diag.NewWarningDiagnostic(
+					"check config",
+					"expected planAttribute to be basetypes.DynamicValue of ObjectType, got basetypes.StringValue",
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDiags := CheckPlanAttributeAgainstAPIAttribute(context.Background(), tt.plan, tt.fromApi, tt.keyMap)
+			assert.ElementsMatch(t, tt.wantDiags, gotDiags)
+		})
+	}
+}


### PR DESCRIPTION
In this PR we:
- create a new internal/utils directory and package
- add a new function CheckPlanAttributeAgainstAPIAttribute and
  unit-tests for it

This function will compare an arbitrary Plan Attribute stanza against an
arbitrary corresponding Attribute stanza returned by the API.  At the
moment it only checks that the keys are the same.  It can be extended in
future to check the types of the values and the actual values
themselves.