### PR TITLE
Cloud resource: Add generic config block

### DIFF
--- a/docs/resources/morpheus_cloud.md
+++ b/docs/resources/morpheus_cloud.md
@@ -70,7 +70,10 @@ resource "hpe_morpheus_cloud" "example" {
 - `agent_install_mode` (String) The method used to install the Morpheus agent on virtual machines provisioned in the cloud (ssh, cloudInit)
 - `appliance_url` (String) The URL used by workloads provisioned in the cloud for interacting with the Morpheus appliance.
 - `auto_recover_power_state` (Boolean) Automatically Power on VMs
+- `cloud_type_code` (String) Cloud (zone) type code
+- `cloud_type_id` (Number) Cloud (zone) type id
 - `code` (String) Optional code for use with policies
+- `config` (Dynamic) Generic Cloud Configuration
 - `config_hvm` (Attributes) HVM Cloud (see [below for nested schema](#nestedatt--config_hvm))
 - `costing_mode` (String) Whether to enable costing on the cloud (off, costing, reservations, full)
 - `data_center_name` (String) A custom name used to reference the datacenter for the cloud.

--- a/internal/subproviders/morpheus/resources/cloud/schema_gen.go
+++ b/internal/subproviders/morpheus/resources/cloud/schema_gen.go
@@ -49,11 +49,26 @@ func CloudResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Automatically Power on VMs",
 				Default:             booldefault.StaticBool(false),
 			},
+			"cloud_type_code": schema.StringAttribute{
+				Optional:            true,
+				Description:         "Cloud (zone) type code",
+				MarkdownDescription: "Cloud (zone) type code",
+			},
+			"cloud_type_id": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "Cloud (zone) type id",
+				MarkdownDescription: "Cloud (zone) type id",
+			},
 			"code": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Optional code for use with policies",
 				MarkdownDescription: "Optional code for use with policies",
+			},
+			"config": schema.DynamicAttribute{
+				Optional:            true,
+				Description:         "Generic Cloud Configuration",
+				MarkdownDescription: "Generic Cloud Configuration",
 			},
 			"config_hvm": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
@@ -136,11 +151,6 @@ func CloudResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Whether to import existing virtual machines (off, basic, full)",
 				MarkdownDescription: "Whether to import existing virtual machines (off, basic, full)",
 				Validators: []validator.String{
-					stringvalidator.OneOf(
-						"off",
-						"basic",
-						"full",
-					),
 					stringvalidator.OneOf("off", "basic", "full"),
 				},
 			},
@@ -208,7 +218,10 @@ type CloudModel struct {
 	AgentInstallMode      types.String   `tfsdk:"agent_install_mode"`
 	ApplianceUrl          types.String   `tfsdk:"appliance_url"`
 	AutoRecoverPowerState types.Bool     `tfsdk:"auto_recover_power_state"`
+	CloudTypeCode         types.String   `tfsdk:"cloud_type_code"`
+	CloudTypeId           types.Int64    `tfsdk:"cloud_type_id"`
 	Code                  types.String   `tfsdk:"code"`
+	Config                types.Dynamic  `tfsdk:"config"`
 	ConfigHvm             ConfigHvmValue `tfsdk:"config_hvm"`
 	CostingMode           types.String   `tfsdk:"costing_mode"`
 	DataCenterName        types.String   `tfsdk:"data_center_name"`


### PR DESCRIPTION
This PR updates the generated schema code to add a generic (dynamic) config block

Note: cloud_type_code or cloud_type_id is needed when using a generic cloud config