### PR TITLE
Add sort_order of 10000 to service-plan acceptance tests

### DIFF
--- a/docs/resources/morpheus_service_plan.md
+++ b/docs/resources/morpheus_service_plan.md
@@ -18,6 +18,7 @@ Service Plans in HPE Morpheus Enterprise determine the memory, storage, and core
 resource "hpe_morpheus_service_plan" "example_service_plan" {
   name = "ExampleServicePlan"
   code = "exampleserviceplan"
+  sort_order = 10000
   max_memory = 4294967296
   max_storage = 536870912
   provision_type_code = "arm"

--- a/internal/subproviders/morpheus/resources/serviceplan/example.tf
+++ b/internal/subproviders/morpheus/resources/serviceplan/example.tf
@@ -1,6 +1,7 @@
 resource "hpe_morpheus_service_plan" "example_service_plan" {
   name = "ExampleServicePlan"
   code = "exampleserviceplan"
+  sort_order = 10000
   max_memory = 4294967296
   max_storage = 536870912
   provision_type_code = "arm"

--- a/internal/subproviders/morpheus/resources/serviceplan/example.tf.tmpl
+++ b/internal/subproviders/morpheus/resources/serviceplan/example.tf.tmpl
@@ -1,6 +1,7 @@
 resource "hpe_morpheus_service_plan" "example_service_plan" {
   name = "{{.Name}}"
   code = "{{.Code}}"
+  sort_order = {{.SortOrder}}
   max_memory = {{.MaxMemory}}
   max_storage = {{.MaxStorage}}
   provision_type_code = "{{.ProvisionTypeCode}}"

--- a/internal/subproviders/morpheus/resources/serviceplan/resource_test.go
+++ b/internal/subproviders/morpheus/resources/serviceplan/resource_test.go
@@ -1,6 +1,6 @@
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
-//go:generate go run ../../../../../cmd/render example.tf.tmpl Name "ExampleServicePlan" Code "exampleserviceplan" MaxMemory "4294967296" MaxStorage "536870912"  ProvisionTypeCode "arm" CustomMaxStorage "true" ConfigRangesMinStorage "268435456" ConfigRangesMaxStorage "536870912"
+//go:generate go run ../../../../../cmd/render example.tf.tmpl Name "ExampleServicePlan" Code "exampleserviceplan" MaxMemory "4294967296" MaxStorage "536870912"  ProvisionTypeCode "arm" CustomMaxStorage "true" ConfigRangesMinStorage "268435456" ConfigRangesMaxStorage "536870912" SortOrder "10000"
 
 package serviceplan_test
 
@@ -54,6 +54,7 @@ resource "hpe_morpheus_service_plan" "example_required" {
   name                   = "` + name + `"
   code                   = "` + code + `"
   max_memory             = 4294967296
+  sort_order             = 10000
   max_storage            = 0
 	provision_type_code    = "arm"
 }
@@ -84,6 +85,11 @@ resource "hpe_morpheus_service_plan" "example_required" {
 			"hpe_morpheus_service_plan.example_required",
 			"provision_type_code",
 			"arm",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_required",
+			"sort_order",
+			"10000",
 		),
 	}
 
@@ -143,7 +149,7 @@ resource "hpe_morpheus_service_plan" "example_all" {
   memory_size_type       = "mb"
   price_set_ids           = [1]
   provision_type_code    = "arm"
-  sort_order             = 0
+  sort_order             = 10000
   storage_size_type      = "gb"
 
   config_ranges =  {
@@ -245,7 +251,7 @@ resource "hpe_morpheus_service_plan" "example_all" {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_service_plan.example_all",
 			"sort_order",
-			"0",
+			"10000",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_service_plan.example_all",
@@ -358,6 +364,7 @@ func TestAccMorpheusServicePlanExampleOk(t *testing.T) {
 	resourceConfig, err := testhelpers.RenderExample(t, "example.tf.tmpl",
 		"Name", name,
 		"Code", code,
+		"SortOrder", "10000",
 		"MaxMemory", "4294967296",
 		"MaxStorage", "536870912",
 		"ProvisionTypeCode", "arm",


### PR DESCRIPTION
Tommy and Adam have asked us to make sure that any Service Plans created
as part of our tests has a very high display order.  10000 was
suggested.  This PR sets the sort_order to 10000 in acceptance tests.
