### PR TITLE
Add test sweeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,7 @@ docs-experimental:
 	go generate -tags=experimental ./...
 	cd tools && env GOFLAGS="-tags=experimental" go generate
 	rm -rf templates-combined-temp
+
+sweep:
+	go test -v ./internal/subproviders/morpheus/test/sweep/... \
+	  -sweep=all -sweep-run=hpe_morpheus_network

--- a/docs/resources/morpheus_network.md
+++ b/docs/resources/morpheus_network.md
@@ -138,6 +138,7 @@ resource "hpe_morpheus_network" "aws" {
   visibility                 = var.visibility
   cidr                       = var.cidr
   zone_pool_id               = var.zone_pool_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 
   lifecycle {
     ignore_changes = [name, display_name, description]
@@ -256,6 +257,7 @@ resource "hpe_morpheus_network" "all_attrs" {
   active                     = var.active
   dhcp_server                = var.dhcp_server
   appliance_url_proxy_bypass = var.appliance_url_proxy_bypass
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
   config = {
     "resourceGroupId" = var.config_resource_group_id
     "subnetName"      = var.config_subnet_name
@@ -372,6 +374,7 @@ resource "hpe_morpheus_network" "gcp" {
   visibility                 = var.visibility
   cidr                       = var.cidr
   zone_pool_id               = var.zone_pool_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 }
 ```
 
@@ -458,6 +461,7 @@ resource "hpe_morpheus_network" "host" {
   tenant_ids                 = [1]
   visibility                 = var.visibility
   cidr                       = var.cidr
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 }
 ```
 
@@ -565,6 +569,7 @@ resource "hpe_morpheus_network" "ovs_port_group" {
   cidr                       = var.cidr
   zone_pool_id               = var.zone_pool_id
   vlan_id                    = var.vlan_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 
   lifecycle {
     ignore_changes = [name, display_name, description]

--- a/examples/resources/hpe_morpheus_network/azure/resource.tf
+++ b/examples/resources/hpe_morpheus_network/azure/resource.tf
@@ -106,6 +106,7 @@ resource "hpe_morpheus_network" "all_attrs" {
   active                     = var.active
   dhcp_server                = var.dhcp_server
   appliance_url_proxy_bypass = var.appliance_url_proxy_bypass
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
   config = {
     "resourceGroupId" = var.config_resource_group_id
     "subnetName"      = var.config_subnet_name

--- a/examples/resources/hpe_morpheus_network/gcp/resource.tf
+++ b/examples/resources/hpe_morpheus_network/gcp/resource.tf
@@ -100,4 +100,5 @@ resource "hpe_morpheus_network" "gcp" {
   visibility                 = var.visibility
   cidr                       = var.cidr
   zone_pool_id               = var.zone_pool_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 }

--- a/examples/resources/hpe_morpheus_network/host/resource.tf
+++ b/examples/resources/hpe_morpheus_network/host/resource.tf
@@ -78,4 +78,5 @@ resource "hpe_morpheus_network" "host" {
   tenant_ids                 = [1]
   visibility                 = var.visibility
   cidr                       = var.cidr
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 }

--- a/examples/resources/hpe_morpheus_network/ovs_port_group/resource.tf
+++ b/examples/resources/hpe_morpheus_network/ovs_port_group/resource.tf
@@ -99,6 +99,7 @@ resource "hpe_morpheus_network" "ovs_port_group" {
   cidr                       = var.cidr
   zone_pool_id               = var.zone_pool_id
   vlan_id                    = var.vlan_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 
   lifecycle {
     ignore_changes = [name, display_name, description]

--- a/examples/resources/hpe_morpheus_network/resource.tf
+++ b/examples/resources/hpe_morpheus_network/resource.tf
@@ -100,6 +100,7 @@ resource "hpe_morpheus_network" "aws" {
   visibility                 = var.visibility
   cidr                       = var.cidr
   zone_pool_id               = var.zone_pool_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 
   lifecycle {
     ignore_changes = [name, display_name, description]

--- a/internal/subproviders/morpheus/resources/network/create_test.go
+++ b/internal/subproviders/morpheus/resources/network/create_test.go
@@ -86,6 +86,7 @@ resource "hpe_morpheus_network" "foo" {
   group_id = var.group_id
   type_id  = var.type_id
   cidr     = var.cidr
+  labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
   config = {
     "resourceGroupId" = var.config_resource_group_id
     "subnetName"      = var.config_subnet_name
@@ -120,6 +121,17 @@ resource "hpe_morpheus_network" "foo" {
 						"hpe_morpheus_network.foo", "config.subnetName", "example-subnet"),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.foo", "config.subnetCidr", "10.0.1.0/24"),
+					// Check labels
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_network.foo", "labels.#", "4"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.foo", "labels.*", "terraform"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.foo", "labels.*", "acctest"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.foo", "labels.*", "hpe_morpheus_network"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.foo", "labels.*", "sweepable"),
 					// Check resource permissions (computed-only)
 					resource.TestCheckResourceAttrSet(
 						"hpe_morpheus_network.foo", "resource_permissions.all"),

--- a/internal/subproviders/morpheus/resources/network/import_test.go
+++ b/internal/subproviders/morpheus/resources/network/import_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/testhelpers"
 )
 
-func TestAccMorpheusNetworkImport(t *testing.T) {
+func TestAccMorpheusNetworkResourceImport(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -31,7 +31,7 @@ func TestAccMorpheusNetworkImport(t *testing.T) {
 variable "name" {
   description = "Network name"
   type        = string
-  default     = "TestAccMorpheusNetworkImport"
+  default     = "TestAccMorpheusNetworkResourceImport"
 }
 
 variable "description" {
@@ -114,6 +114,7 @@ resource "hpe_morpheus_network" "net1" {
 	tenant_ids = [1,2]
 	visibility = var.visibility
 	cidr = var.cidr
+	labels = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 }
 `
 
@@ -212,6 +213,32 @@ destroy = false
 			"hpe_morpheus_network.net1",
 			"visibility",
 			"private",
+		),
+		// Check labels
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_network.net1",
+			"labels.#",
+			"4",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_network.net1",
+			"labels.*",
+			"terraform",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_network.net1",
+			"labels.*",
+			"acctest",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_network.net1",
+			"labels.*",
+			"hpe_morpheus_network",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_network.net1",
+			"labels.*",
+			"sweepable",
 		),
 		// Check resource permissions (computed-only)
 		resource.TestCheckResourceAttrSet(

--- a/internal/subproviders/morpheus/resources/network/update_test.go
+++ b/internal/subproviders/morpheus/resources/network/update_test.go
@@ -131,6 +131,7 @@ resource "hpe_morpheus_network" "foo" {
 	dhcp_server                  = var.dhcp_server
 	appliance_url_proxy_bypass   = var.appliance_url_proxy_bypass
 	tenant_ids                   = [1]
+	labels                       = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	config = {
 		"resourceGroupId" = var.config_resource_group_id
 		"subnetName"      = var.config_subnet_name
@@ -373,6 +374,17 @@ resource "hpe_morpheus_network" "foo" {
 						"hpe_morpheus_network.foo", "group_id", "1"),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.foo", "type_id", "35"),
+					// Check labels
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_network.foo", "labels.#", "4"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.foo", "labels.*", "terraform"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.foo", "labels.*", "acctest"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.foo", "labels.*", "hpe_morpheus_network"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.foo", "labels.*", "sweepable"),
 					resource.TestCheckResourceAttrSet(
 						"hpe_morpheus_network.foo", "id"),
 				),
@@ -454,6 +466,7 @@ resource "hpe_morpheus_network" "name_change_test" {
   type_id  = var.type_id
   cidr     = var.cidr
   tenant_ids = [1]
+  labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
   config = {
     "resourceGroupId" = var.config_resource_group_id
     "subnetName"      = var.config_subnet_name
@@ -495,6 +508,17 @@ resource "hpe_morpheus_network" "name_change_test" {
 						"hpe_morpheus_network.name_change_test", "tenant_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttr(
 						"hpe_morpheus_network.name_change_test", "tenant_ids.*", "1"),
+					// Check labels
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_network.name_change_test", "labels.#", "4"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.name_change_test", "labels.*", "terraform"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.name_change_test", "labels.*", "acctest"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.name_change_test", "labels.*", "hpe_morpheus_network"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.name_change_test", "labels.*", "sweepable"),
 					resource.TestCheckResourceAttrSet(
 						"hpe_morpheus_network.name_change_test", "resource_permissions.all"),
 					// Check that the resource was created with an ID and store it
@@ -542,6 +566,17 @@ resource "hpe_morpheus_network" "name_change_test" {
 						"hpe_morpheus_network.name_change_test", "tenant_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttr(
 						"hpe_morpheus_network.name_change_test", "tenant_ids.*", "1"),
+					// Check labels
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_network.name_change_test", "labels.#", "4"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.name_change_test", "labels.*", "terraform"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.name_change_test", "labels.*", "acctest"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.name_change_test", "labels.*", "hpe_morpheus_network"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.name_change_test", "labels.*", "sweepable"),
 					resource.TestCheckResourceAttrSet(
 						"hpe_morpheus_network.name_change_test", "resource_permissions.all"),
 					// Check that the resource has a new ID (replacement occurred)
@@ -645,6 +680,7 @@ resource "hpe_morpheus_network" "cidr_change_test" {
   cidr      = var.cidr
   cidr_ipv6 = var.cidr_ipv6
   tenant_ids = [1]
+  labels    = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
   config = {
     "resourceGroupId" = var.config_resource_group_id
     "subnetName"      = var.config_subnet_name
@@ -688,6 +724,17 @@ resource "hpe_morpheus_network" "cidr_change_test" {
 						"hpe_morpheus_network.cidr_change_test", "tenant_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttr(
 						"hpe_morpheus_network.cidr_change_test", "tenant_ids.*", "1"),
+					// Check labels
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.#", "4"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.*", "terraform"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.*", "acctest"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.*", "hpe_morpheus_network"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.*", "sweepable"),
 					resource.TestCheckResourceAttrSet(
 						"hpe_morpheus_network.cidr_change_test", "resource_permissions.all"),
 					// Check that the resource was created with an ID and store it
@@ -738,6 +785,17 @@ resource "hpe_morpheus_network" "cidr_change_test" {
 						"hpe_morpheus_network.cidr_change_test", "tenant_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttr(
 						"hpe_morpheus_network.cidr_change_test", "tenant_ids.*", "1"),
+					// Check labels
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.#", "4"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.*", "terraform"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.*", "acctest"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.*", "hpe_morpheus_network"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.cidr_change_test", "labels.*", "sweepable"),
 					resource.TestCheckResourceAttrSet(
 						"hpe_morpheus_network.cidr_change_test", "resource_permissions.all"),
 					// Check that the resource has a new ID (replacement occurred)
@@ -900,6 +958,7 @@ resource "hpe_morpheus_network" "tenant_change_test" {
   type_id    = var.type_id
   cidr       = var.cidr
   tenant_ids = var.tenant_ids
+  labels     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
   config = {
     "resourceGroupId" = var.config_resource_group_id
     "subnetName"      = var.config_subnet_name
@@ -943,6 +1002,17 @@ resource "hpe_morpheus_network" "tenant_change_test" {
 						"hpe_morpheus_network.tenant_change_test", "config.subnetName", "tenant-change-subnet"),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.tenant_change_test", "config.subnetCidr", "10.3.1.0/24"),
+					// Check labels
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.#", "4"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.*", "terraform"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.*", "acctest"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.*", "hpe_morpheus_network"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.*", "sweepable"),
 					resource.TestCheckResourceAttrSet(
 						"hpe_morpheus_network.tenant_change_test", "resource_permissions.all"),
 					// Check that the resource was created with an ID and store it
@@ -995,6 +1065,17 @@ resource "hpe_morpheus_network" "tenant_change_test" {
 						"hpe_morpheus_network.tenant_change_test", "config.subnetName", "tenant-change-subnet"),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.tenant_change_test", "config.subnetCidr", "10.3.1.0/24"),
+					// Check labels
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.#", "4"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.*", "terraform"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.*", "acctest"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.*", "hpe_morpheus_network"),
+					resource.TestCheckTypeSetElemAttr(
+						"hpe_morpheus_network.tenant_change_test", "labels.*", "sweepable"),
 					resource.TestCheckResourceAttrSet(
 						"hpe_morpheus_network.tenant_change_test", "resource_permissions.all"),
 					// Check that the resource has a new ID (replacement occurred)

--- a/internal/subproviders/morpheus/resources/network/validation_test.go
+++ b/internal/subproviders/morpheus/resources/network/validation_test.go
@@ -24,6 +24,7 @@ resource "hpe_morpheus_network" "test" {
 	cloud_id = 1
 	group_id = 1
 	type_id  = 1
+	labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	# name is missing - this should cause validation error
 }
 `
@@ -55,6 +56,7 @@ resource "hpe_morpheus_network" "test" {
 	name     = "TestAccMorpheusNetworkResourceValidationMissingCloudId"
 	group_id = 1
 	type_id  = 1
+	labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	# cloud_id is missing - this should cause validation error
 }
 `
@@ -86,6 +88,7 @@ resource "hpe_morpheus_network" "test" {
 	name     = "TestAccMorpheusNetworkResourceValidationMissingGroupId"
 	cloud_id = 1
 	type_id  = 1
+	labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	# group_id is missing - this should cause validation error
 }
 `
@@ -117,6 +120,7 @@ resource "hpe_morpheus_network" "test" {
 	name     = "TestAccMorpheusNetworkResourceValidationMissingTypeId"
 	cloud_id = 1
 	group_id = 1
+	labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	# type_id is missing - this should cause validation error
 }
 `
@@ -150,6 +154,7 @@ resource "hpe_morpheus_network" "test" {
 	cloud_id = 1
 	group_id = 1
 	type_id  = 1
+	labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	config   = "invalid"
 }
 `
@@ -183,6 +188,7 @@ resource "hpe_morpheus_network" "test" {
 	cloud_id = 1
 	group_id = 1
 	type_id  = 1
+	labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	pool_id  = "not_valid_int"
 }
 `
@@ -216,6 +222,7 @@ resource "hpe_morpheus_network" "test" {
 	cloud_id   = 1
 	group_id   = 1
 	type_id    = 1
+	labels     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	tenant_ids = "not_valid_set"
 }
 `
@@ -251,6 +258,7 @@ resource "hpe_morpheus_network" "test" {
 	cloud_id = 1
 	group_id = 1
 	type_id  = 1
+	labels   = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
 	config   = null
 }
 `

--- a/internal/subproviders/morpheus/test/sweep/client.go
+++ b/internal/subproviders/morpheus/test/sweep/client.go
@@ -1,0 +1,59 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package sweep
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/clientfactory"
+)
+
+func NewSweepClient(ctx context.Context) (*sdk.APIClient, error) {
+	var username, password string
+
+	url, ok := os.LookupEnv("TF_VAR_testacc_morpheus_url")
+	if !ok {
+		return nil, errors.New("TF_VAR_testacc_morpheus_url not set")
+	}
+
+	token, ok := os.LookupEnv("TF_VAR_testacc_morpheus_access_token")
+	if !ok {
+		username, ok = os.LookupEnv("TF_VAR_testacc_morpheus_username")
+		if !ok {
+			return nil, errors.New(
+				"one of TF_VAR_testacc_morpheus_access_token or " +
+					"TF_VAR_testacc_morpheus_username must be set",
+			)
+		}
+
+		password, ok = os.LookupEnv("TF_VAR_testacc_morpheus_password")
+		if !ok {
+			return nil, errors.New(
+				"one of TF_VAR_testacc_morpheus_access_token or " +
+					"TF_VAR_testacc_morpheus_password must be set",
+			)
+		}
+	}
+
+	// If set to any value, use insecure
+	_, insecure := os.LookupEnv("TF_VAR_testacc_morpheus_insecure")
+	var opts []clientfactory.ClientOption
+	if insecure {
+		opts = append(opts, clientfactory.WithInsecureTLS())
+	}
+
+	client := clientfactory.NewAPIClient(
+		ctx,
+		url,
+		username,
+		password,
+		token,
+		opts...,
+	)
+
+	return client, nil
+}

--- a/internal/subproviders/morpheus/test/sweep/networks.go
+++ b/internal/subproviders/morpheus/test/sweep/networks.go
@@ -1,0 +1,127 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+// Package sweep allows deletion of dangling test resources
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
+)
+
+// Networks whose name begins with this string will be eligible for deletion
+const testNetworkPrefix = "TestAccMorpheusNetworkResource"
+
+// All of these labels must be present for the network to be deleted
+var requiredSweepLabels = []string{
+	"terraform",
+	"acctest",
+	"hpe_morpheus_network",
+	"sweepable",
+}
+
+func hasRequiredLabels(labels []string) bool {
+	if labels == nil {
+		return false
+	}
+
+	labelMap := make(map[string]bool)
+	for _, label := range labels {
+		labelMap[label] = true
+	}
+
+	for _, requiredLabel := range requiredSweepLabels {
+		if !labelMap[requiredLabel] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func Networks() {
+	resource.AddTestSweepers(
+		"hpe_morpheus_network",
+		&resource.Sweeper{
+			Name: "hpe_morpheus_network",
+			F:    testSweepMorpheusNetworks,
+		})
+}
+
+func testSweepMorpheusNetworks(_ string) error {
+	ctx := context.Background()
+
+	client, err := NewSweepClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	networks, hresp, err := client.NetworksAPI.ListNetworks(ctx).
+		Phrase(testNetworkPrefix).Execute()
+	if err != nil || hresp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to list networks: %s", errors.ErrMsg(err, hresp))
+	}
+
+	networkList := networks.GetNetworks()
+	var sweptCount int
+	var sweepErrors []string
+
+	for _, network := range networkList {
+		name, ok := network.GetNameOk()
+		if !ok || name == nil {
+			continue
+		}
+
+		if strings.HasPrefix(*name, testNetworkPrefix) {
+			labels, ok := network.GetLabelsOk()
+			if !ok || !hasRequiredLabels(labels) {
+				log.Printf("[INFO] Skipping network (labels): %s", *name)
+
+				continue
+			}
+
+			id, ok := network.GetIdOk()
+			if !ok || id == nil {
+				log.Printf("[INFO] Skipping network (id): %s", *name)
+
+				continue
+			}
+
+			log.Printf("[INFO] Sweeping network: %s (id: %d)", *name, *id)
+
+			// Delete the network
+			_, hresp, err := client.NetworksAPI.DeleteNetwork(ctx, *id).Execute()
+			if err != nil || hresp.StatusCode != http.StatusOK {
+				errMsg := fmt.Sprintf(
+					"failed to delete network %s (id: %d): %s",
+					*name, *id, errors.ErrMsg(err, hresp),
+				)
+				log.Printf("[ERROR] %s", errMsg)
+				sweepErrors = append(sweepErrors, errMsg)
+
+				continue
+			}
+
+			sweptCount++
+		} else {
+			log.Printf("[INFO] Skipping network (name): %s", *name)
+		}
+	}
+
+	log.Printf(
+		"[INFO] Network sweep completed. Networks swept: %d, errors: %d",
+		sweptCount, len(sweepErrors),
+	)
+
+	if len(sweepErrors) > 0 {
+		return fmt.Errorf("%s", strings.Join(sweepErrors, "\n"))
+	}
+
+	return nil
+}

--- a/internal/subproviders/morpheus/test/sweep/sweep_test.go
+++ b/internal/subproviders/morpheus/test/sweep/sweep_test.go
@@ -1,0 +1,17 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package sweep
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	Networks()
+}
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}


### PR DESCRIPTION
Add an initial network sweeper which can be run to delete any dangling
resources as a result of running network acceptance tests.

The sweeper searchs for networks matching the testing naming scheme.
To avoid deleting non-test related networks an additional four labels are
checked, and deletion only proceeds if those four labels are present.

A make target was added

```
$ make sweep
```

The types of resources to be swept can be specified on the command
line using the relevant HCL resource names. Currently just `hpe_morpheus_network`
is implemented.

Example output of running `make sweep`

```
go test -v ./internal/subproviders/morpheus/test/sweep/...  -sweep=all \
  -sweep-run=hpe_morpheus_network
2025/09/23 15:02:26 [DEBUG] Running Sweepers for region (all):
2025/09/23 15:02:26 [DEBUG] Running Sweeper (hpe_morpheus_network) in region (all)
2025/09/23 15:02:28 [INFO] Sweeping network: TestAccMorpheusNetworkResource-0001 (ID: 161681)
2025/09/23 15:02:28 [INFO] Skipping network (labels): TestAccMorpheusNetworkResourceCreateOVSPortGroup-811929217369960017
2025/09/23 15:02:28 [INFO] Skipping network (labels): TestAccMorpheusNetworkResourceCreateOVSPortGroup-938658220289529801
2025/09/23 15:02:28 [INFO] Network sweep completed. Networks swept: 1, errors: 0
2025/09/23 15:02:28 [DEBUG] Completed Sweeper (hpe_morpheus_network) in region (all) in 1.605211565s
2025/09/23 15:02:28 Completed Sweepers for region (all) in 1.605287663s
2025/09/23 15:02:28 Sweeper Tests for region (all) ran successfully:
2025/09/23 15:02:28     - hpe_morpheus_network
ok      github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/test/sweep 1.620s
```