### PR TITLE
Add user sweeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Note: this Makefile works with GNUMake and BSDMake
 #
 
-.PHONY: build linter lint test docs docs-experimental experimental
+.PHONY: build linter lint test docs docs-experimental experimental sweep
 
 build:
 	go build
@@ -40,4 +40,4 @@ docs-experimental:
 
 sweep:
 	go test -v ./internal/subproviders/morpheus/test/sweep/... \
-	  -sweep=all -sweep-run=hpe_morpheus_network
+	  -sweep=all -sweep-run=hpe_morpheus_network,hpe_morpheus_user

--- a/docs/resources/morpheus_user.md
+++ b/docs/resources/morpheus_user.md
@@ -15,7 +15,7 @@ description: |-
 resource "hpe_morpheus_user" "example" {
   tenant_id                   = 1
   username                    = "testacc-example"
-  email                       = "user@example.com"
+  email                       = "foo@testacc.com"
   password_wo                 = "Secret123!"
   password_wo_version         = 1
   role_ids                    = [1]

--- a/examples/resources/hpe_morpheus_user/resource.tf
+++ b/examples/resources/hpe_morpheus_user/resource.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_user" "example" {
   tenant_id                   = 1
   username                    = "testacc-example"
-  email                       = "user@example.com"
+  email                       = "foo@testacc.com"
   password_wo                 = "Secret123!"
   password_wo_version         = 1
   role_ids                    = [1]

--- a/internal/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/subproviders/morpheus/resources/user/resource_test.go
@@ -101,7 +101,7 @@ func TestAccMorpheusUserExample(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.example",
 			"email",
-			"user@example.com",
+			"foo@testacc.com",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.example",
@@ -216,7 +216,7 @@ func TestAccMorpheusUserUpdateTestIdOk(t *testing.T) {
 				Config: providerConfig + `
 resource "hpe_morpheus_user" "foo" {
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	role_ids = [3]
 	tenant_id = 1
@@ -231,7 +231,7 @@ resource "hpe_morpheus_user" "foo" {
 				Config: providerConfig + `
 resource "hpe_morpheus_user" "foo" {
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	role_ids = [3]
 	# changed
@@ -260,7 +260,7 @@ func TestAccMorpheusUserRequiredAttrsOk(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_user" "foo" {
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	role_ids = [3]
 }
@@ -268,7 +268,7 @@ resource "hpe_morpheus_user" "foo" {
 	resourceConfigPostImport := `
 resource "hpe_morpheus_user" "foo" {
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	# password_wo = "Secret123!"
 	role_ids = [3]
 }
@@ -282,7 +282,7 @@ resource "hpe_morpheus_user" "foo" {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"email",
-			"foo@hpe.com",
+			"foo@testacc.com",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -396,7 +396,7 @@ func TestAccMorpheusUserUpdateOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"email",
-			"foo@hpe.com",
+			"foo@testacc.com",
 		),
 		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -505,7 +505,7 @@ func TestAccMorpheusUserUpdateOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"email",
-			"bar@hpe.com",
+			"bar@testacc.com",
 		),
 		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -580,7 +580,7 @@ resource "hpe_morpheus_user" "foo" {
 	# Assumes tenant_id 1 pre-exists
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -604,7 +604,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -629,7 +629,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -654,7 +654,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -679,7 +679,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -704,7 +704,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -729,7 +729,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	# changed
 	# password_wo_version = 1
@@ -754,7 +754,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	# changed
 	# password_wo = "Secret123!"
 	password_wo_version = 1
@@ -779,7 +779,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	# changed
@@ -805,7 +805,7 @@ resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	# changed
 	username = "` + name + `Updated"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -829,7 +829,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -854,7 +854,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -879,7 +879,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -904,7 +904,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -929,7 +929,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -954,7 +954,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -981,7 +981,7 @@ resource "hpe_morpheus_user" "foo" {
 	# changed
 	username = "` + name + `Updated"
 	# changed
-	email = "bar@hpe.com"
+	email = "bar@testacc.com"
 	# changed
 	password_wo = "Secret456!"
 	# changed
@@ -1020,7 +1020,7 @@ resource "hpe_morpheus_user" "foo" {
 	# changed
 	username = "` + name + `Updated"
 	# changed
-	email = "bar@hpe.com"
+	email = "bar@testacc.com"
 	# changed
 	password_wo = "Secret456!"
 	# changed
@@ -1085,7 +1085,7 @@ func TestAccMorpheusUserUpdateNoTenantIdOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"email",
-			"foo@hpe.com",
+			"foo@testacc.com",
 		),
 		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -1187,7 +1187,7 @@ func TestAccMorpheusUserUpdateNoTenantIdOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"email",
-			"foo@hpe.com",
+			"foo@testacc.com",
 		),
 		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -1265,7 +1265,7 @@ func TestAccMorpheusUserUpdateNoTenantIdOk(t *testing.T) {
 resource "hpe_morpheus_user" "foo" {
 	# create
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -1288,7 +1288,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	# post create plan
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -1313,7 +1313,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	# update 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -1337,7 +1337,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	# post update 1 plan
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -1360,7 +1360,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	# update 2
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -1390,7 +1390,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	# post update 2 plan
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -1427,7 +1427,7 @@ func TestAccMorpheusUserAllAttrsOk(t *testing.T) {
 # the server and only the other two roles are created
 #resource "hpe_morpheus_user" "bar" {
 #username = "test101"
-#email = "foo@hpe.com"
+#email = "foo@testacc.com"
 #password = "Secret123!"
 #roles = [3,0,1]
 #}
@@ -1435,7 +1435,7 @@ resource "hpe_morpheus_user" "foo" {
 	# Assumes tenant_id 1 pre-exists
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -1467,7 +1467,7 @@ resource "hpe_morpheus_user" "foo" {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"email",
-			"foo@hpe.com",
+			"foo@testacc.com",
 		),
 		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -1623,7 +1623,7 @@ provider "hpe" {
 
 resource "hpe_morpheus_user" "foo" {
 	username = "` + name + `"
-	email = "bar@hpe.com"
+	email = "bar@testacc.com"
 	password = "Secret123!"
 	# role_ids = [3,1]
 }
@@ -1659,7 +1659,7 @@ provider "hpe" {
 
 resource "hpe_morpheus_user" "foo" {
 	#username = "` + name + `"
-	email = "bar@hpe.com"
+	email = "bar@testacc.com"
 	password = "Secret123!"
 	role_ids = [3,1]
 }
@@ -1695,7 +1695,7 @@ provider "hpe" {
 
 resource "hpe_morpheus_user" "foo" {
 	username = "` + name + `"
-	#email = "bar@hpe.com"
+	#email = "bar@testacc.com"
 	password = "Secret123!"
 	role_ids = [3,1]
 }
@@ -1733,7 +1733,7 @@ provider "hpe" {
 
 resource "hpe_morpheus_user" "foo" {
 	username = "` + name + `"
-	email = "bar@hpe.com"
+	email = "bar@testacc.com"
 	#password_wo = "Secret123!"
 	role_ids = [3,1]
 }
@@ -1778,7 +1778,7 @@ resource "hpe_morpheus_user" "foo" {
 	# Assumes tenant_id 1 pre-exists
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	password_wo_version = 1
 	role_ids = [3,1]
@@ -1796,7 +1796,7 @@ resource "hpe_morpheus_user" "foo" {
 	# Assumes tenant_id 1 pre-exists
 	tenant_id = 1
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
         #password_wo = "Secret123!"
         #password_wo_version = 1
 	role_ids = [3,1]
@@ -1846,7 +1846,7 @@ destroy = false
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_user.foo",
 			"email",
-			"foo@hpe.com",
+			"foo@testacc.com",
 		),
 		resource.TestCheckNoResourceAttr(
 			"hpe_morpheus_user.foo",
@@ -2002,7 +2002,7 @@ func TestAccMorpheusUserUpdateLastNameWithoutTenantIdOk(t *testing.T) {
 resource "hpe_morpheus_user" "foo" {
 	# Note: tenant_id is NOT set - uses "state for unknown"
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	role_ids = [3]
 	first_name = "John"
@@ -2028,7 +2028,7 @@ resource "hpe_morpheus_user" "foo" {
 						resource.TestCheckResourceAttr(
 							"hpe_morpheus_user.foo",
 							"email",
-							"foo@hpe.com",
+							"foo@testacc.com",
 						),
 						resource.TestCheckResourceAttr(
 							"hpe_morpheus_user.foo",
@@ -2062,7 +2062,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	# Note: tenant_id is still NOT set - uses "state for unknown"
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	role_ids = [3]
 	first_name = "John"
@@ -2095,7 +2095,7 @@ resource "hpe_morpheus_user" "foo" {
 						resource.TestCheckResourceAttr(
 							"hpe_morpheus_user.foo",
 							"email",
-							"foo@hpe.com",
+							"foo@testacc.com",
 						),
 						resource.TestCheckResourceAttr(
 							"hpe_morpheus_user.foo",
@@ -2134,7 +2134,7 @@ resource "hpe_morpheus_user" "foo" {
 resource "hpe_morpheus_user" "foo" {
 	# Note: tenant_id is still NOT set - uses "state for unknown"
 	username = "` + name + `"
-	email = "foo@hpe.com"
+	email = "foo@testacc.com"
 	password_wo = "Secret123!"
 	role_ids = [3]
 	first_name = "John"

--- a/internal/subproviders/morpheus/test/sweep/sweep_test.go
+++ b/internal/subproviders/morpheus/test/sweep/sweep_test.go
@@ -10,6 +10,7 @@ import (
 
 func init() {
 	Networks()
+	Users()
 }
 
 func TestMain(m *testing.M) {

--- a/internal/subproviders/morpheus/test/sweep/users.go
+++ b/internal/subproviders/morpheus/test/sweep/users.go
@@ -1,0 +1,112 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+// Package sweep allows deletion of dangling test resources
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
+)
+
+// Users whose name begins with this string will be eligible for deletion
+const testUserPrefix = "TestAccMorpheusUser"
+
+// Additionally, the user email must match one of these in order to be deleted
+var sweepableEmails = map[string]bool{
+	"foo@testacc.com": true,
+	"bar@testacc.com": true,
+}
+
+func isSweepableEmail(email string) bool {
+	return sweepableEmails[email]
+}
+
+func Users() {
+	resource.AddTestSweepers(
+		"hpe_morpheus_user",
+		&resource.Sweeper{
+			Name: "hpe_morpheus_user",
+			F:    testSweepMorpheusUsers,
+		})
+}
+
+func testSweepMorpheusUsers(_ string) error {
+	ctx := context.Background()
+
+	client, err := NewSweepClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	users, hresp, err := client.UsersAPI.ListUsers(ctx).
+		Phrase(testUserPrefix).Execute()
+	if err != nil || hresp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to list users: %s", errors.ErrMsg(err, hresp))
+	}
+
+	userList := users.GetUsers()
+	var sweptCount int
+	var sweepErrors []string
+
+	for _, user := range userList {
+		username, ok := user.GetUsernameOk()
+		if !ok || username == nil {
+			continue
+		}
+
+		if !strings.HasPrefix(*username, testUserPrefix) {
+			log.Printf("[INFO] Skipping user (name): %s", *username)
+
+			continue
+		}
+
+		email, ok := user.GetEmailOk()
+		if !ok || email == nil || !isSweepableEmail(*email) {
+			log.Printf("[INFO] Skipping user (email): %s", *username)
+
+			continue
+		}
+
+		id, ok := user.GetIdOk()
+		if !ok || id == nil {
+			log.Printf("[INFO] Skipping user (id): %s", *username)
+
+			continue
+		}
+
+		log.Printf("[INFO] Sweeping user: %s (id: %d)", *username, *id)
+
+		// Delete the user
+		_, hresp, err := client.UsersAPI.DeleteUser(ctx, *id).Execute()
+		if err != nil || hresp.StatusCode != http.StatusOK {
+			errMsg := fmt.Sprintf(
+				"failed to delete user %s (id: %d): %s",
+				*username, *id, errors.ErrMsg(err, hresp),
+			)
+			log.Printf("[ERROR] %s", errMsg)
+			sweepErrors = append(sweepErrors, errMsg)
+
+			continue
+		}
+
+		sweptCount++
+	}
+
+	log.Printf(
+		"[INFO] User sweep completed. Users swept: %d, errors: %d",
+		sweptCount, len(sweepErrors),
+	)
+
+	if len(sweepErrors) > 0 {
+		return fmt.Errorf("%s", strings.Join(sweepErrors, "\n"))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add a sweeper to remove dangling resources resulting from user resource
acceptance tests.

Users whose name begins with `TestAccMorpheusUser` will be eligible for
deletion.

Additionally, to further reduce the chances of accidently deleting system users, the email must
also match one of `foo@testacc.com` or `bar@testacc.com`.

```
2025/09/23 16:41:13 [DEBUG] Running Sweepers for region (all):
2025/09/23 16:41:13 [DEBUG] Running Sweeper (hpe_morpheus_user) in region (all)
2025/09/23 16:41:14 [INFO] Sweeping user: TestAccMorpheusUser-001 (id: 11128)
2025/09/23 16:41:15 [INFO] Sweeping user: TestAccMorpheusUser-002 (id: 11126)
2025/09/23 16:41:15 [INFO] Skipping user (email): TestAccMorpheusUser-003
2025/09/23 16:41:15 [INFO] User sweep completed. Users swept: 2, errors: 0
2025/09/23 16:41:15 [DEBUG] Completed Sweeper (hpe_morpheus_user) in region (all) in 1.371601073s
2025/09/23 16:41:15 Completed Sweepers for region (all) in 1.371684483s
2025/09/23 16:41:15 Sweeper Tests for region (all) ran successfully:
2025/09/23 16:41:15     - hpe_morpheus_user
ok      github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/test/sweep 1.387s
```