### PR TITLE
policy resource: basic boilerplate

### DIFF
--- a/internal/subproviders/morpheus/resources/policy/import.go
+++ b/internal/subproviders/morpheus/resources/policy/import.go
@@ -1,0 +1,32 @@
+//go:build experimental
+
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package policy
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func (r *Resource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"import policy resource",
+			"provided import ID '"+req.ID+"' is invalid (non-number)",
+		)
+
+		return
+	}
+
+	diags := resp.State.SetAttribute(ctx, path.Root("id"), id)
+	resp.Diagnostics.Append(diags...)
+}

--- a/internal/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/subproviders/morpheus/resources/policy/resource.go
@@ -1,0 +1,46 @@
+//go:build experimental
+
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+// policy provides the package for hpe_morpheus_policy
+package policy
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/configure"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var (
+	_ resource.Resource                = &Resource{}
+	_ resource.ResourceWithImportState = &Resource{}
+)
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+// Resource defines the resource implementation.
+type Resource struct {
+	configure.ResourceWithMorpheusConfigure
+	resource.Resource
+}
+
+func (r *Resource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_morpheus_policy"
+}
+
+func (r *Resource) Schema(
+	ctx context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
+	resp.Schema = PolicyResourceSchema(ctx)
+}

--- a/internal/subproviders/morpheus/resources_experimental.go
+++ b/internal/subproviders/morpheus/resources_experimental.go
@@ -24,6 +24,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/resources/group"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/resources/instance"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/resources/network"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/resources/policy"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/resources/role"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/resources/serviceplan"
 	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/resources/user"
@@ -35,11 +36,12 @@ func (s SubProvider) GetResources(
 	resources := []func() resource.Resource{
 		cloud.NewResource,
 		group.NewResource,
+		instance.NewResource,
+		network.NewResource,
+		policy.NewResource,
 		role.NewResource,
 		serviceplan.NewResource,
 		user.NewResource,
-		network.NewResource,
-		instance.NewResource,
 	}
 
 	return resources


### PR DESCRIPTION
Add some initial boiler plate for the policy resource.

This allows us to compile a `hpe_morpheus_policy` resource into an
experimental provider. Import can be called, but will not work until `Read()` is
implemented.