### PR TITLE
Remove cloud_type_id

### DIFF
--- a/docs/resources/morpheus_cloud.md
+++ b/docs/resources/morpheus_cloud.md
@@ -71,7 +71,6 @@ resource "hpe_morpheus_cloud" "example" {
 - `appliance_url` (String) The URL used by workloads provisioned in the cloud for interacting with the Morpheus appliance.
 - `auto_recover_power_state` (Boolean) Automatically Power on VMs
 - `cloud_type_code` (String) Cloud (zone) type code
-- `cloud_type_id` (Number) Cloud (zone) type id
 - `code` (String) Optional code for use with policies
 - `config` (Dynamic) Generic Cloud Configuration
 - `config_hvm` (Attributes) HVM Cloud (see [below for nested schema](#nestedatt--config_hvm))

--- a/docs/resources/morpheus_user.md
+++ b/docs/resources/morpheus_user.md
@@ -43,19 +43,17 @@ resource "hpe_morpheus_user" "example" {
 
 ### Optional
 
-> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
-
 - `first_name` (String) User's first name (optional)
 - `last_name` (String) User's last name (optional)
 - `linux_key_pair_id` (Number) Linux key pair id (optional)
-- `linux_password_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Linux password (Write Only)
+- `linux_password_wo` (String) Linux password (Write Only)
 - `linux_password_wo_version` (Number) Linux password version. Used to determine if linux_password_wo has been updated.
 - `linux_username` (String) Linux username
-- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Password to apply to the user (Write Only)
+- `password_wo` (String, Sensitive) Password to apply to the user (Write Only)
 - `password_wo_version` (Number) Password version. Used to determine if password_wo has been updated.
 - `receive_notifications` (Boolean) Receive Notifications?
 - `tenant_id` (Number) Tenant Id (accountId) create user in a sub tenant account instead of your own. Changing this attribute forces a deletion and recreation.
-- `windows_password_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Windows password (Write Only)
+- `windows_password_wo` (String) Windows password (Write Only)
 - `windows_password_wo_version` (Number) Windows password version. Used to determine if windows_password_wo has been updated.
 - `windows_username` (String) Windows username
 

--- a/internal/subproviders/morpheus/resources/cloud/schema_gen.go
+++ b/internal/subproviders/morpheus/resources/cloud/schema_gen.go
@@ -5,12 +5,9 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -19,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -55,14 +53,6 @@ func CloudResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				Description:         "Cloud (zone) type code",
 				MarkdownDescription: "Cloud (zone) type code",
-				Validators: []validator.String{
-					stringvalidator.ConflictsWith(path.Expressions{path.MatchRoot("cloud_type_id")}...),
-				},
-			},
-			"cloud_type_id": schema.Int64Attribute{
-				Optional:            true,
-				Description:         "Cloud (zone) type id",
-				MarkdownDescription: "Cloud (zone) type id",
 			},
 			"code": schema.StringAttribute{
 				Optional:            true,
@@ -224,7 +214,6 @@ type CloudModel struct {
 	ApplianceUrl          types.String   `tfsdk:"appliance_url"`
 	AutoRecoverPowerState types.Bool     `tfsdk:"auto_recover_power_state"`
 	CloudTypeCode         types.String   `tfsdk:"cloud_type_code"`
-	CloudTypeId           types.Int64    `tfsdk:"cloud_type_id"`
 	Code                  types.String   `tfsdk:"code"`
 	Config                types.Dynamic  `tfsdk:"config"`
 	ConfigHvm             ConfigHvmValue `tfsdk:"config_hvm"`
@@ -478,12 +467,14 @@ func (t ConfigHvmType) ValueFromTerraform(ctx context.Context, in tftypes.Value)
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
+
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
 		if err != nil {
 			return nil, err
 		}
@@ -522,6 +513,7 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals := make(map[string]tftypes.Value, 2)
 
 		val, err = v.CertificateProvider.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -529,6 +521,7 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["certificate_provider"] = val
 
 		val, err = v.EnableNetworkTypeSelection.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}


### PR DESCRIPTION
This PR removes the cloud_type_id from the cloud resource spec.

It's handier to not have it due to validation problems