### PR TITLE
Bumping SDK to faciliate user access attribute update.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HPE/terraform-provider-hpe
 go 1.24.1
 
 require (
-	github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250919151946-3abcc4685d7e
+	github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251001122913-1f822867c74d
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250919151946-3abcc4685d7e h1:zOnwp8cLJ8QCvFY5waSsdLZ8Rm4itwFGWJtubO0oqfw=
-github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20250919151946-3abcc4685d7e/go.mod h1:GPkKVeXv0go/+jzI15RDeM0jIskuQRlMydsvQiKT6VY=
+github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251001122913-1f822867c74d h1:cnu8K+tIPjIAA25UgnMMZzUv9qWsnirpJGMNy1i/Yk4=
+github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251001122913-1f822867c74d/go.mod h1:GPkKVeXv0go/+jzI15RDeM0jIskuQRlMydsvQiKT6VY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=


### PR DESCRIPTION
Bumping SDK to the latest version on the main branch as user attribute types used in the user datasource implementation were added.
- Ran go get github.com/HewlettPackard/hpe-morpheus-go-sdk@main
- Ran go mod tidy