### PR TITLE
Update attribute_compare to work with ObjectValues that are empty

### DIFF
--- a/internal/utils/attribute_compare.go
+++ b/internal/utils/attribute_compare.go
@@ -111,12 +111,19 @@ func CheckPlanAttributeAgainstAPIAttribute(
 	}
 
 	// Check the keys in the planAttribute against fromApiMap
-	planAttrs := planObject.Attributes()
-	// Build map of keys in planAttrs
 	planKeys := make(map[string]struct{})
-	for k := range planAttrs {
-		planKeys[k] = struct{}{}
+	switch attrs := planObject.Attributes(); {
+	case len(attrs) == 0:
+		planAttrTypes := planObject.AttributeTypes(context.Background())
+		for k := range planAttrTypes {
+			planKeys[k] = struct{}{}
+		}
+	default:
+		for k := range attrs {
+			planKeys[k] = struct{}{}
+		}
 	}
+
 	// Build map of keys in fromApiMap
 	fromApiKeys := make(map[string]struct{})
 	for k := range fromApiMap {


### PR DESCRIPTION
When importing certain datastores, the Config block returned by the API has extra information over that specified by the user.  However in import the plan is empty and thus the keys used in the ObjectValue cannot be determined from the Attributes.  To get around these situations we extract the AttributeTypes when ObjectValue is empty and use this to construct the map of keys.  This means that the keys which can be set by the user are extracted from the Config block returned by the API.