### PR TITLE
hpe_morpheus_datastore commit 3

### DIFF
--- a/internal/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -1,0 +1,216 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+//go:build experimental
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+)
+
+const (
+	cloudRefType   = "ComputeZone"
+	clusterRefType = "ComputeServerGroup"
+
+	associatedResourceTypeCluster = "Cluster"
+	associatedResourceTypeCloud   = "Cloud"
+)
+
+var (
+	CreateTargetStatuses = []string{
+		"provisioned",
+	}
+
+	CreateErrorStatuses = []string{
+		"failed",
+		"warning",
+	}
+)
+
+func checkStatusDone(status string, targetStatuses []string, errorStatuses []string) error {
+	switch {
+	case slices.Contains(errorStatuses, status):
+		return backoff.Permanent(errors.New("reached error status: " + status))
+	case slices.Contains(targetStatuses, status):
+		return nil
+	default:
+		return backoff.RetryAfter(5)
+	}
+}
+
+func (r *Resource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
+	var plan, cfg DatastoreModel
+
+	tflog.Info(ctx, "creating datastore")
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		tflog.Info(ctx, "error getting plan")
+		return
+	}
+
+	// Read configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
+	if resp.Diagnostics.HasError() {
+		tflog.Info(ctx, "error getting config")
+		return
+	}
+
+	name := plan.Name.ValueString()
+	datastoreType := plan.DatastoreType
+	associatedResourceType := plan.AssociatedResourceType.ValueString()
+	associatedResourceId := plan.AssociatedResourceId.ValueInt64()
+
+	var config DatastoreModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create a Morpheus API client
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"create cloud resource",
+			"cloud "+name+": failed to create client: "+err.Error(),
+		)
+
+		return
+	}
+
+	var id int64
+	switch associatedResourceType {
+	case associatedResourceTypeCloud:
+		id = datastoreCreateDatastore(
+			ctx,
+			datastoreType,
+			associatedResourceType, name,
+			associatedResourceId,
+			client,
+			plan,
+			resp,
+		)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	case associatedResourceTypeCluster:
+		id = datastoreCreateCluster(
+			ctx,
+			datastoreType,
+			name,
+			associatedResourceId,
+			client,
+			plan,
+			resp,
+		)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	default:
+		resp.Diagnostics.AddError(
+			"create datastore resource",
+			"datastore "+name+": invalid associated_resource_type "+associatedResourceType+", must be 'Cloud' or 'Cluster'",
+		)
+		return
+	}
+
+	// Set the resource ID
+	plan.Id = types.Int64Value(id)
+
+	// write id as soon as possible
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Wait for the datastore to be ready
+	waitForReady := func() (*sdk.GetDatastores200Response, error) {
+		response, hresp, err := client.DatastoresAPI.GetDatastores(ctx, plan.Id.ValueInt64()).Execute()
+		if err != nil || hresp.StatusCode != http.StatusOK {
+			return nil, backoff.Permanent(err)
+		}
+
+		status := response.GetDatastore().Status
+
+		return response, checkStatusDone(
+			status,
+			CreateTargetStatuses,
+			CreateErrorStatuses,
+		)
+	}
+
+	if r, err := backoff.Retry(
+		ctx,
+		waitForReady,
+		backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)),
+		backoff.WithMaxElapsedTime(5*time.Minute),
+	); err != nil {
+		var status string
+
+		if r != nil {
+			status = r.GetDatastore().Status
+		}
+
+		resp.Diagnostics.AddError(
+			"create datastore resource",
+			fmt.Sprintf(
+				"datastore %d: provisioning failed current status is: %v",
+				plan.Id.ValueInt64(),
+				status,
+			),
+		)
+	}
+
+	state, pdiags := getDatastoreAsState(ctx, plan.Id.ValueInt64(), plan, client)
+	if pdiags.HasError() {
+		resp.Diagnostics.Append(pdiags...)
+		resp.Diagnostics.AddError(
+			"create datastore resource",
+			fmt.Sprintf("datastore %d: failed to read from api", plan.Id.ValueInt64()),
+		)
+
+		return
+	}
+
+	// TODO reenable this when we add datastore_update.go
+	/*
+		// For now, we need to call update to set resourcePermission and tenantPermissions
+		// because the API does not set these on create, even if provided.
+		state, pdiags = updateDatastoreFunc(ctx, plan.Id.ValueInt64(), plan, state, client)
+		if pdiags.HasError() {
+			resp.Diagnostics.Append(pdiags...)
+			resp.Diagnostics.AddError(
+				"create datastore resource",
+				fmt.Sprintf("datastore %d: failed to update", plan.Id.ValueInt64()),
+			)
+
+			return
+		}
+
+	*/
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+}

--- a/internal/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -12,12 +12,10 @@ import (
 	"slices"
 	"time"
 
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 	"github.com/cenkalti/backoff/v5"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-
-	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
 )
 
 const (
@@ -57,19 +55,15 @@ func (r *Resource) Create(
 ) {
 	var plan, cfg DatastoreModel
 
-	tflog.Info(ctx, "creating datastore")
-
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
-		tflog.Info(ctx, "error getting plan")
 		return
 	}
 
 	// Read configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
 	if resp.Diagnostics.HasError() {
-		tflog.Info(ctx, "error getting config")
 		return
 	}
 
@@ -88,7 +82,7 @@ func (r *Resource) Create(
 	client, err := r.NewClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"create cloud resource",
+			"create datastore resource",
 			"cloud "+name+": failed to create client: "+err.Error(),
 		)
 
@@ -180,9 +174,13 @@ func (r *Resource) Create(
 		)
 	}
 
-	state, pdiags := getDatastoreAsState(ctx, plan.Id.ValueInt64(), plan, client)
-	if pdiags.HasError() {
-		resp.Diagnostics.Append(pdiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state, gdiags := getDatastoreAsState(ctx, plan.Id.ValueInt64(), plan, client)
+	if gdiags.HasError() {
+		resp.Diagnostics.Append(gdiags...)
 		resp.Diagnostics.AddError(
 			"create datastore resource",
 			fmt.Sprintf("datastore %d: failed to read from api", plan.Id.ValueInt64()),

--- a/internal/subproviders/morpheus/resources/datastore/datastore_create_cluster.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_create_cluster.go
@@ -20,6 +20,8 @@ var (
 	resourcePermissionsFuncCluster = sdk.NewSaveClusterDatastoreRequestDatastoreResourcePermissionsWithDefaults
 	permissionsSitesFuncCluster    = sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults
 	datastoreTypeFuncCluster       = sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults
+	nfsConfigFuncCluster           = sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOfWithDefaults
+	alletrampHvmConfigFuncCluster  = sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOf2WithDefaults
 )
 
 func datastoreCreateCluster(ctx context.Context,
@@ -48,7 +50,7 @@ func datastoreCreateCluster(ctx context.Context,
 	createConfig := datastoreCreate.GetConfig()
 	switch {
 	case !plan.ConfigNfs.IsNull() && !plan.ConfigNfs.IsUnknown():
-		nfsConfig := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOfWithDefaults()
+		nfsConfig := nfsConfigFuncCluster()
 
 		if !plan.ConfigNfs.SourceHostname.IsNull() {
 			nfsConfig.SetSourceHostname(plan.ConfigNfs.SourceHostname.ValueString())
@@ -65,7 +67,7 @@ func datastoreCreateCluster(ctx context.Context,
 		createConfig.SaveClusterDatastoreRequestDatastoreConfigAnyOf = nfsConfig
 
 	case !plan.ConfigAlletrampHvm.IsNull() && !plan.ConfigAlletrampHvm.IsUnknown():
-		alletrampHvmConfig := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOf2WithDefaults()
+		alletrampHvmConfig := alletrampHvmConfigFuncCluster()
 
 		if !plan.ConfigAlletrampHvm.EnableRansomware.IsUnknown() {
 			alletrampHvmConfig.SetEnableRansomware(plan.ConfigAlletrampHvm.EnableRansomware.ValueBool())
@@ -150,7 +152,6 @@ func datastoreCreateCluster(ctx context.Context,
 			return 0
 		}
 
-		// tenantPermissions := sdk.NewSaveDatastoreRequestDatastoreTenantPermissionsWithDefaults()
 		var tenantPermissions []sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerTenantsInner
 		for _, tenantsValue := range tenantsValues {
 			tenantPermission := tenantsFuncCluster()

--- a/internal/subproviders/morpheus/resources/datastore/datastore_create_cluster.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_create_cluster.go
@@ -1,0 +1,246 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+//go:build experimental
+
+package datastore
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
+	hpeErrors "github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
+)
+
+var (
+	tenantsFuncCluster             = sdk.NewListCloudDatastores200ResponseAllOfDatastoresInnerTenantsInnerWithDefaults
+	resourcePermissionsFuncCluster = sdk.NewSaveClusterDatastoreRequestDatastoreResourcePermissionsWithDefaults
+	permissionsSitesFuncCluster    = sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults
+	datastoreTypeFuncCluster       = sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults
+)
+
+func datastoreCreateCluster(ctx context.Context,
+	datastoreType DatastoreTypeValue,
+	name string,
+	associatedResourceId int64,
+	client *sdk.APIClient,
+	plan DatastoreModel,
+	resp *resource.CreateResponse,
+) int64 {
+	// datastoreCreate is used by the SDK to create the datastore
+	datastoreCreate := sdk.NewSaveClusterDatastoreRequestDatastoreWithDefaults()
+
+	// Set the required fields
+	datastoreCreate.SetName(name)
+
+	// Set the type
+	datastoreTypeForRequest := datastoreTypeFuncCluster()
+	datastoreTypeForRequest.SetId(datastoreType.Id.ValueInt64())
+	datastoreCreate.SetDatastoreType(*datastoreTypeForRequest)
+
+	// Set the config.  As far as I can tell you need a config object, even if empty.
+	// The config can be one of several types, handled below.
+	// If none of the specific types are set, then use the generic config map.
+	// The specific types are mutually exclusive.
+	createConfig := datastoreCreate.GetConfig()
+	switch {
+	case !plan.ConfigNfs.IsNull() && !plan.ConfigNfs.IsUnknown():
+		nfsConfig := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOfWithDefaults()
+
+		if !plan.ConfigNfs.SourceHostname.IsNull() {
+			nfsConfig.SetSourceHostname(plan.ConfigNfs.SourceHostname.ValueString())
+		}
+
+		if !plan.ConfigNfs.SourceDirPath.IsNull() {
+			nfsConfig.SetSourceDirPath(plan.ConfigNfs.SourceDirPath.ValueString())
+		}
+
+		if !plan.ConfigNfs.SourceVersion.IsNull() {
+			nfsConfig.SetSourceVersion(plan.ConfigNfs.SourceVersion.ValueString())
+		}
+
+		createConfig.SaveClusterDatastoreRequestDatastoreConfigAnyOf = nfsConfig
+
+	case !plan.ConfigAlletrampHvm.IsNull() && !plan.ConfigAlletrampHvm.IsUnknown():
+		alletrampHvmConfig := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOf2WithDefaults()
+
+		if !plan.ConfigAlletrampHvm.EnableRansomware.IsUnknown() {
+			alletrampHvmConfig.SetEnableRansomware(plan.ConfigAlletrampHvm.EnableRansomware.ValueBool())
+		}
+
+		if !plan.ConfigAlletrampHvm.ProtocolType.IsNull() {
+			alletrampHvmConfig.SetProtocolType(plan.ConfigAlletrampHvm.ProtocolType.ValueString())
+		}
+
+		createConfig.SaveClusterDatastoreRequestDatastoreConfigAnyOf2 = alletrampHvmConfig
+
+		// removing for now
+		/*
+			case !plan.ConfigGfs2.IsNull() && !plan.ConfigGfs2.IsUnknown():
+				gfs2Config := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOf1WithDefaults()
+
+				if !plan.ConfigGfs2.BlockDevice.IsNull() {
+					gfs2Config.SetBlockDevice(plan.ConfigGfs2.BlockDevice.ValueString())
+				}
+
+				if !plan.ConfigGfs2.AllowReformat.IsUnknown() {
+					gfs2Config.SetAllowReformat(plan.ConfigGfs2.AllowReformat.ValueBool())
+				}
+
+				createConfig.SaveClusterDatastoreRequestDatastoreConfigAnyOf1 = gfs2Config
+
+		*/
+
+	case !plan.Config.IsNull() && !plan.Config.IsUnknown():
+		configValue := plan.Config.UnderlyingValue()
+		configMap, err := convert.ValueToAny(ctx, configValue)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"create cluster datastore resource",
+				"datastore "+name+": failed to convert config: "+
+					err.Error(),
+			)
+
+			return 0
+		}
+
+		configDataMap, ok := configMap.(map[string]any)
+		if ok {
+			createConfig.MapmapOfStringAny = &configDataMap
+		} else {
+			resp.Diagnostics.AddError(
+				"create cluster datastore resource",
+				"datastore "+name+": config must be a valid object/map",
+			)
+
+			return 0
+		}
+
+	}
+
+	datastoreCreate.SetConfig(createConfig)
+
+	// Optional fields
+	if !plan.StorageServer.IsNull() && !plan.StorageServer.IsUnknown() {
+		storageServerConfig := sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults()
+		storageServerConfig.SetId(plan.StorageServer.Id.ValueInt64())
+		datastoreCreate.SetStorageServer(*storageServerConfig)
+	}
+
+	if !plan.Visibility.IsNull() && !plan.Visibility.IsUnknown() {
+		datastoreCreate.SetVisibility(plan.Visibility.ValueString())
+	}
+
+	if !plan.Active.IsNull() && !plan.Active.IsUnknown() {
+		datastoreCreate.SetActive(plan.Active.ValueBool())
+	}
+
+	if !plan.DefaultStore.IsNull() && !plan.DefaultStore.IsUnknown() {
+		datastoreCreate.SetDefaultStore(plan.DefaultStore.ValueBool())
+	}
+
+	if !plan.Tenants.IsNull() && !plan.Tenants.IsUnknown() {
+		var tenantsValues []TenantsValue
+		diags := plan.Tenants.ElementsAs(ctx, &tenantsValues, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return 0
+		}
+
+		// tenantPermissions := sdk.NewSaveDatastoreRequestDatastoreTenantPermissionsWithDefaults()
+		var tenantPermissions []sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerTenantsInner
+		for _, tenantsValue := range tenantsValues {
+			tenantPermission := tenantsFuncCluster()
+			tenantPermission.SetId(tenantsValue.Id.ValueInt64())
+			tenantPermissions = append(tenantPermissions, *tenantPermission)
+		}
+		datastoreCreate.SetTenants(tenantPermissions)
+	}
+
+	if !plan.ResourcePermissions.IsNull() && !plan.ResourcePermissions.IsUnknown() {
+		resourcePermissions := resourcePermissionsFuncCluster()
+		resourcePermissions.SetAllGroups(plan.ResourcePermissions.AllGroups.ValueBool())
+		resourcePermissions.SetDefaultStore(plan.ResourcePermissions.DefaultStore.ValueBool())
+		resourcePermissions.SetCanManage(plan.ResourcePermissions.CanManage.ValueBool())
+		resourcePermissions.SetAll(plan.ResourcePermissions.All.ValueBool())
+		if !plan.ResourcePermissions.Groups.IsNull() && !plan.ResourcePermissions.Groups.IsUnknown() {
+			var groupsValues []GroupsValue
+			diags := plan.ResourcePermissions.Groups.ElementsAs(ctx, &groupsValues, false)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return 0
+			}
+
+			sites := []sdk.GetAlerts200ResponseAllOfChecksInnerAccount{}
+			for _, groupsValue := range groupsValues {
+				site := permissionsSitesFuncCluster()
+				site.SetId(groupsValue.Id.ValueInt64())
+				sites = append(sites, *site)
+			}
+
+			resourcePermissions.SetSites(sites)
+		}
+
+		// nolint:duplicate
+		if !plan.ResourcePermissions.Plans.IsNull() && !plan.ResourcePermissions.Plans.IsUnknown() {
+			var plansValues []PlansValue
+			diags := plan.ResourcePermissions.Plans.ElementsAs(ctx, &plansValues, false)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return 0
+			}
+
+			var plans []permissionsPlans
+			for _, plansValue := range plansValues {
+				planItem := permissionsPlansFunc()
+				planItem.SetId(plansValue.Id.ValueInt64())
+				planItem.SetCode(plansValue.Code.ValueString())
+				planItem.SetName(plansValue.Name.ValueString())
+				plans = append(plans, *planItem)
+			}
+
+			resourcePermissions.SetPlans(plans)
+		}
+
+		datastoreCreate.SetResourcePermissions(*resourcePermissions)
+	}
+
+	// Call API
+	datastoreRequest := sdk.NewSaveClusterDatastoreRequestWithDefaults()
+	datastoreRequest.SetDatastore(*datastoreCreate)
+
+	response, hresp, err := client.ClustersAPI.SaveClusterDatastore(ctx, int32(associatedResourceId)).
+		SaveClusterDatastoreRequest(*datastoreRequest).Execute()
+	if response == nil || err != nil || hresp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"create cluster datastore resource",
+			"datastore "+name+" POST failed: "+hpeErrors.ErrMsg(err, hresp),
+		)
+
+		return 0
+	}
+
+	datastore, ok := response.GetDatastoreOk()
+	if !ok {
+		resp.Diagnostics.AddError(
+			"create cluster datastore resource",
+			"datastore "+name+": could not get datastore from response",
+		)
+
+		return 0
+	}
+	id, ok := datastore.GetIdOk()
+	if !ok || id == nil {
+		resp.Diagnostics.AddError(
+			"create cluster datastore resource",
+			"datastore "+name+": could not get id",
+		)
+
+		return 0
+	}
+
+	return *id
+}

--- a/internal/subproviders/morpheus/resources/datastore/datastore_create_datastore.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_create_datastore.go
@@ -1,0 +1,262 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+//go:build experimental
+
+package datastore
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
+	hpeErrors "github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
+)
+
+var (
+	permissionsFunc      = sdk.NewSaveClusterDatastoreRequestDatastoreResourcePermissionsWithDefaults
+	permissionsPlansFunc = sdk.NewListBackupSettings200ResponseBackupSettingsDefaultScheduleWithDefaults
+	permissionsSitesFunc = sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults
+	tenantsFunc          = sdk.NewSaveDatastoreRequestDatastoreTenantPermissionsWithDefaults
+)
+
+type (
+	permissionsPlans = sdk.ListBackupSettings200ResponseBackupSettingsDefaultSchedule
+	permissionsSites = sdk.GetAlerts200ResponseAllOfChecksInnerAccount
+)
+
+func datastoreCreateDatastore(ctx context.Context,
+	datastoreType DatastoreTypeValue,
+	associatedResourceType, name string,
+	associatedResourceId int64,
+	client *sdk.APIClient,
+	plan DatastoreModel,
+	resp *resource.CreateResponse,
+) int64 {
+	// datastoreCreate is used by the SDK to create the datastore
+	datastoreCreate := sdk.NewSaveDatastoreRequestDatastoreWithDefaults()
+
+	// Set the required fields
+	datastoreCreate.SetName(name)
+	datastoreCreate.SetDatastoreType(datastoreType.Code.ValueString())
+	// Set the associated resource - this is refType for the API
+	switch associatedResourceType {
+	case associatedResourceTypeCloud:
+		datastoreCreate.SetRefType(cloudRefType)
+		// TODO allow the following when API has been fixed
+	//case associatedResourceTypeCluster:
+	//	datastoreCreate.SetRefType(clusterRefType)
+	default:
+		resp.Diagnostics.AddError(
+			"create datastore resource",
+			"datastore "+name+": invalid associated_resource_type "+associatedResourceType+", must be 'Cloud' or 'Cluster'",
+		)
+	}
+	datastoreCreate.SetRefId(associatedResourceId)
+
+	// Set the config.  As far as I can tell you need a config object, even if empty.
+	// The config can be one of several types, handled below.
+	// If none of the specific types are set, then use the generic config map.
+	// The specific types are mutually exclusive.
+	createConfig := datastoreCreate.GetConfig()
+	switch {
+	case !plan.ConfigNfs.IsNull() && !plan.ConfigNfs.IsUnknown():
+		nfsConfig := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOfWithDefaults()
+
+		if !plan.ConfigNfs.SourceHostname.IsNull() {
+			nfsConfig.SetSourceHostname(plan.ConfigNfs.SourceHostname.ValueString())
+		}
+
+		if !plan.ConfigNfs.SourceDirPath.IsNull() {
+			nfsConfig.SetSourceDirPath(plan.ConfigNfs.SourceDirPath.ValueString())
+		}
+
+		if !plan.ConfigNfs.SourceVersion.IsNull() {
+			nfsConfig.SetSourceVersion(plan.ConfigNfs.SourceVersion.ValueString())
+		}
+
+		createConfig.SaveClusterDatastoreRequestDatastoreConfigAnyOf = nfsConfig
+	case !plan.ConfigAlletrampHvm.IsNull() && !plan.ConfigAlletrampHvm.IsUnknown():
+		alletrampHvmConfig := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOf2WithDefaults()
+
+		if !plan.ConfigAlletrampHvm.EnableRansomware.IsUnknown() {
+			alletrampHvmConfig.SetEnableRansomware(plan.ConfigAlletrampHvm.EnableRansomware.ValueBool())
+		}
+
+		if !plan.ConfigAlletrampHvm.ProtocolType.IsNull() {
+			alletrampHvmConfig.SetProtocolType(plan.ConfigAlletrampHvm.ProtocolType.ValueString())
+		}
+
+		createConfig.SaveClusterDatastoreRequestDatastoreConfigAnyOf2 = alletrampHvmConfig
+
+		// removing for now
+		/*
+			case !plan.ConfigGfs2.IsNull() && !plan.ConfigGfs2.IsUnknown():
+				gfs2Config := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOf1WithDefaults()
+
+				if !plan.ConfigGfs2.BlockDevice.IsNull() {
+					gfs2Config.SetBlockDevice(plan.ConfigGfs2.BlockDevice.ValueString())
+				}
+
+				if !plan.ConfigGfs2.AllowReformat.IsUnknown() {
+					gfs2Config.SetAllowReformat(plan.ConfigGfs2.AllowReformat.ValueBool())
+				}
+
+				createConfig.SaveClusterDatastoreRequestDatastoreConfigAnyOf1 = gfs2Config
+
+		*/
+
+	case !plan.Config.IsNull() && !plan.Config.IsUnknown():
+		configValue := plan.Config.UnderlyingValue()
+		configMap, err := convert.ValueToAny(ctx, configValue)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"create datastore resource",
+				"datastore "+name+": failed to convert config: "+
+					err.Error(),
+			)
+
+			return 0
+		}
+
+		configDataMap, ok := configMap.(map[string]any)
+		if ok {
+			createConfig.MapmapOfStringAny = &configDataMap
+		} else {
+			resp.Diagnostics.AddError(
+				"create datastore resource",
+				"datastore "+name+": config must be a valid object/map",
+			)
+
+			return 0
+		}
+
+	}
+
+	datastoreCreate.SetConfig(createConfig)
+
+	// Optional fields
+	if !plan.StorageServer.IsNull() && !plan.StorageServer.IsUnknown() {
+		storageServerConfig := sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults()
+		storageServerConfig.SetId(plan.StorageServer.Id.ValueInt64())
+		datastoreCreate.SetStorageServer(*storageServerConfig)
+	}
+
+	if !plan.Visibility.IsNull() && !plan.Visibility.IsUnknown() {
+		datastoreCreate.SetVisibility(plan.Visibility.ValueString())
+	}
+
+	if !plan.Active.IsNull() && !plan.Active.IsUnknown() {
+		datastoreCreate.SetActive(plan.Active.ValueBool())
+	}
+
+	if !plan.DefaultStore.IsNull() && !plan.DefaultStore.IsUnknown() {
+		datastoreCreate.SetDefaultStore(plan.DefaultStore.ValueBool())
+	}
+
+	if !plan.Tenants.IsNull() && !plan.Tenants.IsUnknown() {
+		var tenantsValues []TenantsValue
+		diags := plan.Tenants.ElementsAs(ctx, &tenantsValues, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return 0
+		}
+
+		// tenantPermissions := sdk.NewSaveDatastoreRequestDatastoreTenantPermissionsWithDefaults()
+		tenantPermissions := tenantsFunc()
+		var accounts []sdk.GetAlerts200ResponseAllOfChecksInnerAccount
+		for _, tenantsValue := range tenantsValues {
+			account := sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults()
+			account.SetId(tenantsValue.Id.ValueInt64())
+			accounts = append(accounts, *account)
+		}
+		tenantPermissions.Accounts = accounts
+		datastoreCreate.SetTenantPermissions(*tenantPermissions)
+	}
+
+	if !plan.ResourcePermissions.IsNull() && !plan.ResourcePermissions.IsUnknown() {
+		resourcePermissions := permissionsFunc()
+		resourcePermissions.SetAllGroups(plan.ResourcePermissions.AllGroups.ValueBool())
+		resourcePermissions.SetDefaultStore(plan.ResourcePermissions.DefaultStore.ValueBool())
+		resourcePermissions.SetCanManage(plan.ResourcePermissions.CanManage.ValueBool())
+		resourcePermissions.SetAll(plan.ResourcePermissions.All.ValueBool())
+
+		if !plan.ResourcePermissions.Groups.IsNull() && !plan.ResourcePermissions.Groups.IsUnknown() {
+			var groupsValues []GroupsValue
+			diags := plan.ResourcePermissions.Groups.ElementsAs(ctx, &groupsValues, false)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return 0
+			}
+
+			var sites []permissionsSites
+			for _, groupsValue := range groupsValues {
+				site := permissionsSitesFunc()
+				site.SetId(groupsValue.Id.ValueInt64())
+				sites = append(sites, *site)
+			}
+
+			resourcePermissions.SetSites(sites)
+		}
+
+		// nolint:duplicate
+		if !plan.ResourcePermissions.Plans.IsNull() && !plan.ResourcePermissions.Plans.IsUnknown() {
+			var plansValues []PlansValue
+			diags := plan.ResourcePermissions.Plans.ElementsAs(ctx, &plansValues, false)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return 0
+			}
+
+			var plans []permissionsPlans
+			for _, plansValue := range plansValues {
+				planItem := permissionsPlansFunc()
+				planItem.SetId(plansValue.Id.ValueInt64())
+				planItem.SetCode(plansValue.Code.ValueString())
+				planItem.SetName(plansValue.Name.ValueString())
+				plans = append(plans, *planItem)
+			}
+
+			resourcePermissions.SetPlans(plans)
+		}
+
+		datastoreCreate.SetResourcePermissions(*resourcePermissions)
+	}
+
+	// Call API
+	datastoreRequest := sdk.NewSaveDatastoreRequestWithDefaults()
+	datastoreRequest.SetDatastore(*datastoreCreate)
+
+	response, hresp, err := client.DatastoresAPI.SaveDatastore(ctx).SaveDatastoreRequest(*datastoreRequest).Execute()
+	if response == nil || err != nil || hresp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"create datastore resource",
+			"datastore "+name+" POST failed: "+hpeErrors.ErrMsg(err, hresp),
+		)
+
+		return 0
+	}
+
+	datastore, ok := response.GetDatastoreOk()
+	if !ok {
+		resp.Diagnostics.AddError(
+			"create datastore resource",
+			"datastore "+name+": could not get datastore from response",
+		)
+
+		return 0
+	}
+	id, ok := datastore.GetIdOk()
+	if !ok || id == nil {
+		resp.Diagnostics.AddError(
+			"create datastore resource",
+			"datastore "+name+": could not get id",
+		)
+
+		return 0
+	}
+
+	return *id
+}

--- a/internal/subproviders/morpheus/resources/datastore/datastore_create_datastore.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_create_datastore.go
@@ -16,10 +16,13 @@ import (
 )
 
 var (
-	permissionsFunc      = sdk.NewSaveClusterDatastoreRequestDatastoreResourcePermissionsWithDefaults
-	permissionsPlansFunc = sdk.NewListBackupSettings200ResponseBackupSettingsDefaultScheduleWithDefaults
-	permissionsSitesFunc = sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults
-	tenantsFunc          = sdk.NewSaveDatastoreRequestDatastoreTenantPermissionsWithDefaults
+	permissionsFunc        = sdk.NewSaveClusterDatastoreRequestDatastoreResourcePermissionsWithDefaults
+	permissionsPlansFunc   = sdk.NewListBackupSettings200ResponseBackupSettingsDefaultScheduleWithDefaults
+	permissionsSitesFunc   = sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults
+	tenantsFunc            = sdk.NewSaveDatastoreRequestDatastoreTenantPermissionsWithDefaults
+	nfsConfigFunc          = sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOfWithDefaults
+	alletrampHvmConfigFunc = sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOf2WithDefaults
+	storageServerFunc      = sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults
 )
 
 type (
@@ -63,7 +66,7 @@ func datastoreCreateDatastore(ctx context.Context,
 	createConfig := datastoreCreate.GetConfig()
 	switch {
 	case !plan.ConfigNfs.IsNull() && !plan.ConfigNfs.IsUnknown():
-		nfsConfig := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOfWithDefaults()
+		nfsConfig := nfsConfigFunc()
 
 		if !plan.ConfigNfs.SourceHostname.IsNull() {
 			nfsConfig.SetSourceHostname(plan.ConfigNfs.SourceHostname.ValueString())
@@ -79,7 +82,7 @@ func datastoreCreateDatastore(ctx context.Context,
 
 		createConfig.SaveClusterDatastoreRequestDatastoreConfigAnyOf = nfsConfig
 	case !plan.ConfigAlletrampHvm.IsNull() && !plan.ConfigAlletrampHvm.IsUnknown():
-		alletrampHvmConfig := sdk.NewSaveClusterDatastoreRequestDatastoreConfigAnyOf2WithDefaults()
+		alletrampHvmConfig := alletrampHvmConfigFunc()
 
 		if !plan.ConfigAlletrampHvm.EnableRansomware.IsUnknown() {
 			alletrampHvmConfig.SetEnableRansomware(plan.ConfigAlletrampHvm.EnableRansomware.ValueBool())
@@ -139,7 +142,7 @@ func datastoreCreateDatastore(ctx context.Context,
 
 	// Optional fields
 	if !plan.StorageServer.IsNull() && !plan.StorageServer.IsUnknown() {
-		storageServerConfig := sdk.NewGetAlerts200ResponseAllOfChecksInnerAccountWithDefaults()
+		storageServerConfig := storageServerFunc()
 		storageServerConfig.SetId(plan.StorageServer.Id.ValueInt64())
 		datastoreCreate.SetStorageServer(*storageServerConfig)
 	}
@@ -164,7 +167,6 @@ func datastoreCreateDatastore(ctx context.Context,
 			return 0
 		}
 
-		// tenantPermissions := sdk.NewSaveDatastoreRequestDatastoreTenantPermissionsWithDefaults()
 		tenantPermissions := tenantsFunc()
 		var accounts []sdk.GetAlerts200ResponseAllOfChecksInnerAccount
 		for _, tenantsValue := range tenantsValues {

--- a/internal/subproviders/morpheus/resources/datastore/datastore_read.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_read.go
@@ -223,7 +223,6 @@ func getDatastoreAsState(
 	state.Tenants = plan.Tenants
 
 	// Set StorageServer to that returned by the API
-	state.StorageServer = NewStorageServerValueNull()
 	if server, ok := datastore.GetStorageServerOk(); ok && server != nil {
 		storageServer := StorageServerValue{}
 		storageServer.Id = convert.Int64ToType(server.Id)
@@ -363,7 +362,7 @@ func (r *Resource) Read(
 	client, err := r.NewClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"read cloud resource",
+			"read datastore resource",
 			"new client call failed with "+err.Error(),
 		)
 
@@ -384,7 +383,4 @@ func (r *Resource) Read(
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }

--- a/internal/subproviders/morpheus/resources/datastore/datastore_read.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_read.go
@@ -1,0 +1,390 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+//go:build experimental
+
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/utils"
+)
+
+const (
+	nfsDatastoreCode = "libvirt-netfs-nfs"
+	alletraMPHVMCode = "hpedatastore-alletra-mp"
+	// gfs2DatastoreCode = "libvirt-dir-gfs2"
+)
+
+// TODO: when implementing the datasource, note that Config can be empty.  If it is then there won't be a DatastoreType.
+// populate datastore resource model with current API values
+func getDatastoreAsState(
+	ctx context.Context,
+	id int64,
+	plan DatastoreModel,
+	client *sdk.APIClient,
+) (DatastoreModel, diag.Diagnostics) {
+	var state DatastoreModel
+	var diags diag.Diagnostics
+
+	d, hresp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
+	if err != nil || d == nil || hresp.StatusCode != http.StatusOK {
+		diags.AddError(
+			"populate datastore resource",
+			fmt.Sprintf("datastore %d GET failed: ", id)+errors.ErrMsg(err, hresp),
+		)
+
+		return state, diags
+	}
+
+	datastore, ok := d.GetDatastoreOk()
+	if !ok || datastore == nil {
+		diags.AddError(
+			"populate datastore resource",
+			fmt.Sprintf("datastore %d not found in response", id),
+		)
+
+		return state, diags
+	}
+
+	state.Name = convert.StrToType(&datastore.Name)
+	state.AssociatedResourceId = convert.Int64ToType(datastore.RefId)
+
+	// Set DatastoreType, we get the code and id back from the API
+	datastoreType, ok := datastore.GetDatastoreTypeOk()
+	if !ok || datastoreType == nil {
+		diags.AddError(
+			"populate datastore resource",
+			fmt.Sprintf("datastore %d missing datastore type in response", id),
+		)
+
+		return state, diags
+	}
+	datastoreTypeValue := DatastoreTypeValue{}
+	datastoreTypeValue.Id = convert.Int64ToType(&datastoreType.Id)
+	datastoreTypeValue.Code = convert.StrToType(&datastoreType.Code)
+	datastoreTypeValue.state = attr.ValueStateKnown
+	state.DatastoreType = datastoreTypeValue
+
+	// Set AssociatedResourceType based on RefType
+	refType, ok := datastore.GetRefTypeOk()
+	if !ok || refType == nil {
+		diags.AddError(
+			"populate datastore resource",
+			fmt.Sprintf("datastore %d missing ref type in response", id),
+		)
+
+		return state, diags
+	}
+	switch *refType {
+	case cloudRefType:
+		state.AssociatedResourceType = types.StringValue(associatedResourceTypeCloud)
+	case clusterRefType:
+		state.AssociatedResourceType = types.StringValue(associatedResourceTypeCluster)
+	default:
+		diags.AddError(
+			"populate datastore resource",
+			fmt.Sprintf("datastore %d has invalid ref type '%s' in response", id, *refType),
+		)
+
+		return state, diags
+	}
+
+	// Populate Config
+	switch datastoreType.GetCode() {
+	case nfsDatastoreCode:
+		// Check returned config against plan
+		keysMap := map[string]string{
+			"source_dir_path": "sourceDirPath",
+			"source_hostname": "sourceHostname"}
+		_, pdiags := utils.CheckPlanAttributeAgainstAPIAttribute(ctx, plan.ConfigNfs, datastore.Config, keysMap)
+		diags = append(diags, pdiags...)
+
+		var configNfsValue ConfigNfsValue
+		for k, v := range datastore.Config {
+			switch k {
+			case "sourceDirPath":
+				str := v.(string)
+				configNfsValue.SourceDirPath = convert.StrToType(&str)
+			case "sourceHostname":
+				str := v.(string)
+				configNfsValue.SourceHostname = convert.StrToType(&str)
+			}
+		}
+		if !plan.ConfigNfs.SourceVersion.IsNull() && !plan.ConfigNfs.SourceVersion.IsUnknown() {
+			// If the user has set a value in the plan, but the API hasn't returned one,
+			// use the plan value
+			configNfsValue.SourceVersion = plan.ConfigNfs.SourceVersion
+		}
+		configNfsValue.state = attr.ValueStateKnown
+
+		state.ConfigNfs = configNfsValue
+
+	case alletraMPHVMCode:
+		// Check returned config against plan
+		keysMap := map[string]string{
+			"enable_ransomware": "enableRansomware",
+			"protocol_type":     "protocolType"}
+		keysFromMap, pdiags := utils.CheckPlanAttributeAgainstAPIAttribute(
+			ctx, plan.ConfigAlletrampHvm, datastore.Config, keysMap)
+		diags = append(diags, pdiags...)
+
+		var configAlletraMPHVM ConfigAlletrampHvmValue
+		for k, v := range datastore.Config {
+			switch k {
+			case "enableRansomware":
+				b := v.(bool)
+				configAlletraMPHVM.EnableRansomware = convert.BoolToType(&b)
+			case "protocolType":
+				str := v.(string)
+				configAlletraMPHVM.ProtocolType = convert.StrToType(&str)
+			}
+		}
+		configAlletraMPHVM.state = attr.ValueStateKnown
+		state.ConfigAlletrampHvm = configAlletraMPHVM
+
+		configFromAPI, pdiags := createConfigFromApiDynamic(ctx, id, datastore.Config, keysFromMap)
+		diags = append(diags, pdiags...)
+		if diags.HasError() {
+			return state, diags
+		}
+
+		state.ConfigFromApi = configFromAPI
+
+	// removing for now
+	/*
+		case gfs2DatastoreCode:
+			// Check returned config against plan
+			keysMap := map[string]string{
+				"block_device": "blockDevice"}
+			_, pdiags := utils.CheckPlanAttributeAgainstAPIAttribute(ctx, plan.ConfigGfs2, datastore.Config, keysMap)
+			diags = append(diags, pdiags...)
+
+			var configGfs2 ConfigGfs2Value
+			for k, v := range datastore.Config {
+				switch k {
+				case "blockDevice":
+					str := v.(string)
+					configGfs2.BlockDevice = convert.StrToType(&str)
+				}
+			}
+			configGfs2.state = attr.ValueStateKnown
+			state.ConfigGfs2 = configGfs2
+
+	*/
+
+	default:
+		// Dynamic config for unknown types
+		// Note that some plugins return information not set by the user, so we need to filter those out
+		// and store them in config_from_api
+		keysFromMap, pdiags := utils.CheckPlanAttributeAgainstAPIAttribute(ctx, plan.Config, datastore.Config, nil)
+		diags = append(diags, pdiags...)
+		apiConfigForConfig := datastore.Config
+		for k, _ := range keysFromMap {
+			if _, ok := datastore.Config[k]; ok {
+				delete(apiConfigForConfig, k)
+			}
+		}
+
+		configDynamic, err := convert.MapToDynamic(ctx, apiConfigForConfig)
+		if err != nil {
+			diags.AddError(
+				"populate datastore resource",
+				fmt.Sprintf("datastore %d: failed to convert config to dynamic config: %s", id, err.Error()),
+			)
+
+			return state, diags
+		}
+		state.Config = configDynamic
+
+		configFromApi, pdiags := createConfigFromApiDynamic(ctx, id, datastore.Config, keysFromMap)
+		diags = append(diags, pdiags...)
+		if diags.HasError() {
+			return state, diags
+		}
+
+		state.ConfigFromApi = configFromApi
+	}
+
+	// Set state to values from plan where the API doesn't return them
+	state.ResourcePermissions = plan.ResourcePermissions
+	state.Tenants = plan.Tenants
+
+	// Set StorageServer to that returned by the API
+	state.StorageServer = NewStorageServerValueNull()
+	if server, ok := datastore.GetStorageServerOk(); ok && server != nil {
+		storageServer := StorageServerValue{}
+		storageServer.Id = convert.Int64ToType(server.Id)
+		storageServer.state = attr.ValueStateKnown
+		state.StorageServer = storageServer
+	}
+
+	state.Visibility = convert.StrToType(datastore.Visibility)
+	state.Active = convert.BoolToType(datastore.Active)
+	state.DefaultStore = convert.BoolToType(datastore.DefaultStore)
+
+	state.Type = convert.StrToType(&datastore.Type)
+	state.Id = convert.Int64ToType(&datastore.Id)
+	state.StorageSize = convert.Int64ToType(datastore.StorageSize.Get())
+	state.DrsEnabled = convert.BoolToType(datastore.DrsEnabled)
+	state.AllowWrite = convert.BoolToType(datastore.AllowWrite)
+	state.Online = convert.BoolToType(datastore.Online)
+	state.AllowRead = convert.BoolToType(datastore.AllowRead)
+	state.AllowProvision = convert.BoolToType(datastore.AllowProvision)
+	state.HeartBeatTarget = convert.BoolToType(datastore.HeartBeatTarget)
+	state.ExternalId = convert.StrToType(datastore.ExternalId)
+	state.ExternalPath = convert.StrToType(datastore.ExternalPath)
+	state.ExternalType = convert.StrToType(datastore.ExternalType)
+	state.FreeSpace = convert.Int64ToType(datastore.FreeSpace.Get())
+	state.StorageSize = convert.Int64ToType(datastore.StorageSize.Get())
+	state.Code = convert.StrToType(datastore.Code.Get())
+	state.Status = convert.StrToType(&datastore.Status)
+	state.StatusMessage = convert.StrToType(datastore.StatusMessage)
+
+	state.Cloud = NewCloudValueNull()
+	if cloudId, ok := datastore.Zone.GetIdOk(); ok && cloudId != nil {
+		cloud := CloudValue{}
+		cloud.Id = convert.Int64ToType(cloudId)
+		cloud.state = attr.ValueStateKnown
+		state.Cloud = cloud
+	}
+
+	state.ResourcePool = NewResourcePoolValueNull()
+	if poolId, ok := datastore.ZonePool.GetIdOk(); ok && poolId != nil {
+		resourcePool := ResourcePoolValue{}
+		resourcePool.Id = convert.Int64ToType(poolId)
+		resourcePool.state = attr.ValueStateKnown
+		state.ResourcePool = resourcePool
+	}
+
+	state.Owner = NewOwnerValueNull()
+	if ownerId, ok := datastore.Owner.GetIdOk(); ok && ownerId != nil {
+		owner := OwnerValue{}
+		owner.Id = convert.Int64ToType(ownerId)
+		owner.state = attr.ValueStateKnown
+		state.Owner = owner
+	}
+
+	state.Locations = basetypes.NewSetNull(LocationsValue{}.Type(ctx))
+	if locations, ok := datastore.GetLocationsOk(); ok && locations != nil {
+		locationsSet, d := convert.ToSetType(
+			ctx,
+			locations,
+			func(
+				in sdk.ListDatastores200ResponseAllOfDatastoresInnerLocationsInner,
+			) LocationsValue {
+				return LocationsValue{
+					RefId:         convert.Int64ToType(in.RefId),
+					RefType:       convert.StrToType(in.RefType),
+					Status:        convert.StrToType(in.Status),
+					StatusMessage: convert.StrToType(in.StatusMessage),
+					state:         attr.ValueStateKnown,
+				}
+			},
+		)
+		diags = append(diags, d...)
+		state.Locations = locationsSet
+	}
+
+	state.Datastores = basetypes.NewSetNull(DatastoresValue{}.Type(ctx))
+	if datastores, ok := datastore.GetDatastoresOk(); ok && datastores != nil {
+		datastoresSet, d := convert.ToSetType(
+			ctx,
+			datastores,
+			func(
+				in sdk.ListDatastores200ResponseAllOfDatastoresInnerDatastoresInner,
+			) DatastoresValue {
+				id64 := int64(*in.Id)
+				return DatastoresValue{
+					Id:    convert.Int64ToType(&id64),
+					Name:  convert.StrToType(in.Name),
+					state: attr.ValueStateKnown,
+				}
+			},
+		)
+		diags = append(diags, d...)
+		state.Datastores = datastoresSet
+	}
+
+	return state, diags
+}
+
+func createConfigFromApiDynamic(
+	ctx context.Context,
+	id int64,
+	config, keysFromMap map[string]any,
+) (types.Dynamic, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	// We get more information back from the API, we put this in config_from_api
+	apiConfigForConfigApi := make(map[string]any)
+	for k, _ := range keysFromMap {
+		if _, ok := config[k]; ok {
+			apiConfigForConfigApi[k] = config[k]
+		}
+	}
+
+	configFromApi, err := convert.MapToDynamic(ctx, apiConfigForConfigApi)
+	if err != nil {
+		diags.AddError(
+			"populate datastore resource",
+			fmt.Sprintf("datastore %d: failed to convert config_from_api to dynamic config: %s", id, err.Error()),
+		)
+
+		return types.DynamicNull(), diags
+	}
+
+	return configFromApi, diags
+}
+
+func (r *Resource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
+	var plan DatastoreModel
+
+	diags := req.State.Get(ctx, &plan)
+	if diags.HasError() {
+		return
+	}
+
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"read cloud resource",
+			"new client call failed with "+err.Error(),
+		)
+
+		return
+	}
+
+	id := plan.Id.ValueInt64()
+
+	state, pdiags := getDatastoreAsState(ctx, id, plan, client)
+	if pdiags.HasError() {
+		resp.Diagnostics.Append(pdiags...)
+		resp.Diagnostics.AddError(
+			"read datastore resource",
+			fmt.Sprintf("datastore %d: failed to read from api", id),
+		)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}


### PR DESCRIPTION
In this PR we add:
- datastore_create.go
- datastore_create_cluster.go which is called for cluster datastores
- datastore_create_datastore.go which is called for cloud datastores and
  which we hope to switch to eventually for cluster datastores
- datastore_read.go

