### PR TITLE
Bumping SDK to faciliate new service plan update attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HPE/terraform-provider-hpe
 go 1.24.1
 
 require (
-	github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251006135601-1ee6246027f9
+	github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251007101423-40adab7a3c38
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251006135601-1ee6246027f9 h1:rSZe1QLdew3pqJEo87lNxpjFaJTZsKwzquQAtfP4nJY=
-github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251006135601-1ee6246027f9/go.mod h1:GPkKVeXv0go/+jzI15RDeM0jIskuQRlMydsvQiKT6VY=
+github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251007101423-40adab7a3c38 h1:maqMFoy4df3g/Glzodj/0dktZ4ulb4nW5+hofzvNGII=
+github.com/HewlettPackard/hpe-morpheus-go-sdk v0.0.0-20251007101423-40adab7a3c38/go.mod h1:GPkKVeXv0go/+jzI15RDeM0jIskuQRlMydsvQiKT6VY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=


### PR DESCRIPTION
Bumping to latest SDK to pick up new attributes for service plan updates.
- Ran go get github.com/HewlettPackard/hpe-morpheus-go-sdk@main
- Ran go mod tidy