### PR TITLE
Add instance sweeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ docs-experimental:
 
 sweep:
 	go test -v ./internal/subproviders/morpheus/test/sweep/... \
-	  -sweep=all -sweep-run=hpe_morpheus_network,hpe_morpheus_user
+	  -sweep=all -sweep-run=hpe_morpheus_instance,hpe_morpheus_network,hpe_morpheus_user

--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -64,6 +64,22 @@ resource "hpe_morpheus_instance" "example" {
 
   tags = [
     {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
       name  = "managed_by"
       value = "terraform"
     }

--- a/internal/subproviders/morpheus/resources/instance/example.tf
+++ b/internal/subproviders/morpheus/resources/instance/example.tf
@@ -44,6 +44,22 @@ resource "hpe_morpheus_instance" "example" {
 
   tags = [
     {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
       name  = "managed_by"
       value = "terraform"
     }

--- a/internal/subproviders/morpheus/resources/instance/example.tf.tmpl
+++ b/internal/subproviders/morpheus/resources/instance/example.tf.tmpl
@@ -44,6 +44,22 @@ resource "hpe_morpheus_instance" "example" {
 
   tags = [
     {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
       name  = "managed_by"
       value = "terraform"
     }

--- a/internal/subproviders/morpheus/test/sweep/instances.go
+++ b/internal/subproviders/morpheus/test/sweep/instances.go
@@ -1,0 +1,143 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+// Package sweep allows deletion of dangling test resources
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/sdk"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
+)
+
+// Instances whose name begins with this string will be eligible for deletion
+const testInstancePrefix = "TestAccMorpheusInstance"
+
+// All of these tags must be present with value "true" for the instance to be deleted
+var requiredSweepTags = []string{
+	"terraform",
+	"acctest",
+	"hpe_morpheus_instance",
+	"sweepable",
+}
+
+func hasRequiredTags(tags []sdk.AddInstance200ResponseAllOfOneOfInstanceTagsInner) bool {
+	if tags == nil {
+		return false
+	}
+
+	tagMap := make(map[string]string)
+	for _, tag := range tags {
+		if name, ok := tag.GetNameOk(); ok && name != nil {
+			if value, ok := tag.GetValueOk(); ok && value != nil {
+				tagMap[*name] = *value
+			}
+		}
+	}
+
+	for _, requiredTag := range requiredSweepTags {
+		if value, exists := tagMap[requiredTag]; !exists || value != "true" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func Instances() {
+	resource.AddTestSweepers(
+		"hpe_morpheus_instance",
+		&resource.Sweeper{
+			Name: "hpe_morpheus_instance",
+			F:    testSweepMorpheusInstances,
+		})
+}
+
+func testSweepMorpheusInstances(_ string) error {
+	ctx := context.Background()
+
+	client, err := NewSweepClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	instances, hresp, err := client.InstancesAPI.ListInstances(ctx).
+		Phrase(testInstancePrefix).Execute()
+	if err != nil || hresp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to list instances: %s", errors.ErrMsg(err, hresp))
+	}
+
+	instanceList := instances.GetInstances()
+	var sweptCount int
+	var sweepErrors []string
+
+	for _, instance := range instanceList {
+		name, ok := instance.GetNameOk()
+		if !ok || name == nil {
+			continue
+		}
+
+		if !strings.HasPrefix(*name, testInstancePrefix) {
+			log.Printf("[INFO] Skipping instance (name): %s", *name)
+
+			continue
+		}
+
+		id, ok := instance.GetIdOk()
+		if !ok || id == nil {
+			log.Printf("[INFO] Skipping instance (id): %s", *name)
+
+			continue
+		}
+
+		// Get instance details to check tags
+		instanceDetail, hresp, err := client.InstancesAPI.GetInstance(ctx, *id).Execute()
+		if err != nil || hresp.StatusCode != http.StatusOK {
+			log.Printf("[INFO] Skipping instance (failed to get details): %s", *name)
+
+			continue
+		}
+
+		inst := instanceDetail.GetInstance()
+		tags, ok := inst.GetTagsOk()
+		if !ok || !hasRequiredTags(tags) {
+			log.Printf("[INFO] Skipping instance (tags): %s", *name)
+
+			continue
+		}
+
+		log.Printf("[INFO] Sweeping instance: %s (id: %d)", *name, *id)
+
+		// Delete the instance
+		_, hresp, err = client.InstancesAPI.DeleteInstance(ctx, *id).Execute()
+		if err != nil || hresp.StatusCode != http.StatusOK {
+			errMsg := fmt.Sprintf(
+				"failed to delete instance %s (id: %d): %s",
+				*name, *id, errors.ErrMsg(err, hresp),
+			)
+			log.Printf("[ERROR] %s", errMsg)
+			sweepErrors = append(sweepErrors, errMsg)
+
+			continue
+		}
+
+		sweptCount++
+	}
+
+	log.Printf(
+		"[INFO] Instance sweep completed. Instances swept: %d, errors: %d",
+		sweptCount, len(sweepErrors),
+	)
+
+	if len(sweepErrors) > 0 {
+		return fmt.Errorf("%s", strings.Join(sweepErrors, "\n"))
+	}
+
+	return nil
+}

--- a/internal/subproviders/morpheus/test/sweep/sweep_test.go
+++ b/internal/subproviders/morpheus/test/sweep/sweep_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func init() {
+	Instances()
 	Networks()
 	Users()
 }


### PR DESCRIPTION
Add ability to Automatically clean up dangling instance resources
after test runs.

We use both instance name and a set of tags to prevent accidental
deletion of non-test related instances.

Instance cleanup is now included when `make sweep` is run.

```
2025/10/10 11:50:47 [DEBUG] Running Sweeper (hpe_morpheus_instance) in region (all)
2025/10/10 11:50:49 [INFO] Skipping instance (tags): TestAccMorpheusInstanceExampleOk-4876698026874336211
2025/10/10 11:50:50 [INFO] Skipping instance (tags): TestAccMorpheusInstanceExampleOk-6628025738902714339
2025/10/10 11:50:51 [INFO] Sweeping instance: TestAccMorpheusInstanceExampleOk-6896228796040585870 (id: 108701)
2025/10/10 11:50:51 [INFO] Instance sweep completed. Instances swept: 1, errors: 0
```