### PR TITLE
Change instance volumes to a list

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -121,7 +121,7 @@ The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" ca
 The layout may have default ports, which are defined in node types, that are always configured. This parameter will be for additional custom ports to be opened. (see [below for nested schema](#nestedatt--ports))
 - `tags` (Attributes Set) Metadata tags, Array of objects having a name and value. (see [below for nested schema](#nestedatt--tags))
 - `task_set_id` (Number) The Workflow ID to execute.
-- `volumes` (Attributes Set) Logical Volume configuration to create additional LVs at provision time (see [below for nested schema](#nestedatt--volumes))
+- `volumes` (Attributes List) Logical Volume configuration to create additional LVs at provision time (see [below for nested schema](#nestedatt--volumes))
 
 ### Read-Only
 

--- a/internal/subproviders/morpheus/resources/instance/instance.go
+++ b/internal/subproviders/morpheus/resources/instance/instance.go
@@ -254,6 +254,11 @@ func getInstanceAsState(
 	diags.Append(d...)
 	state.NetworkInterfaces = interfaces
 
+	// var ifs []NetworkInterfacesValue
+	// for _, i := range resp.GetInstance().Interfaces {
+	//
+	// }
+
 	// plan_id
 	state.PlanId = convert.Int64ToType(instance.Plan.Id)
 
@@ -303,7 +308,7 @@ func getInstanceAsState(
 		},
 	)
 
-	volumes, d := convert.ToSetType(
+	volumes, d := convert.ToListType(
 		ctx,
 		apiVolumes,
 		func(
@@ -556,7 +561,7 @@ func (g *Resource) Create(
 	}
 
 	// volumes
-	volumes, diags := convert.FromSetType(ctx, plan.Volumes, volumeMapper)
+	volumes, diags := convert.FromListType(ctx, plan.Volumes, volumeMapper)
 	if diags.HasError() {
 		tflog.Error(ctx, "cannot convert volumes")
 		resp.Diagnostics.Append(diags...)

--- a/internal/subproviders/morpheus/resources/instance/schema_gen.go
+++ b/internal/subproviders/morpheus/resources/instance/schema_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -224,7 +225,7 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The Workflow ID to execute.",
 				MarkdownDescription: "The Workflow ID to execute.",
 			},
-			"volumes": schema.SetNestedAttribute{
+			"volumes": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"controller_mount_point": schema.StringAttribute{
@@ -302,8 +303,8 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Logical Volume configuration to create additional LVs at provision time",
 				MarkdownDescription: "Logical Volume configuration to create additional LVs at provision time",
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplaceIf(func(_ context.Context, req planmodifier.SetRequest, resp *setplanmodifier.RequiresReplaceIfFuncResponse) {
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplaceIf(func(_ context.Context, req planmodifier.ListRequest, resp *listplanmodifier.RequiresReplaceIfFuncResponse) {
 						if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
 							return
 						}
@@ -333,7 +334,7 @@ type InstanceModel struct {
 	Ports             types.Set     `tfsdk:"ports"`
 	Tags              types.Set     `tfsdk:"tags"`
 	TaskSetId         types.Int64   `tfsdk:"task_set_id"`
-	Volumes           types.Set     `tfsdk:"volumes"`
+	Volumes           types.List    `tfsdk:"volumes"`
 }
 
 var _ basetypes.ObjectTypable = EvarsType{}

--- a/internal/subproviders/morpheus/resources/instance/update.go
+++ b/internal/subproviders/morpheus/resources/instance/update.go
@@ -101,7 +101,7 @@ func (g *Resource) Update(
 	if len(state.Volumes.Elements()) != len(plan.Volumes.Elements()) {
 		resizing = true
 
-		volumes, diags := convert.FromSetType(ctx, plan.Volumes, volumeMapper)
+		volumes, diags := convert.FromListType(ctx, plan.Volumes, volumeMapper)
 		if diags.HasError() {
 			tflog.Error(ctx, "cannot convert volumes")
 			resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
This PR works around a bug in 8.0.10 which uses the first volume definition as the root volume even it `root_volume` is set to false.
