### PR TITLE
Add datastore sweeper (not enabled)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ docs-experimental:
 
 sweep:
 	go test -v ./internal/subproviders/morpheus/test/sweep/... \
-	  -sweep=all -sweep-run=hpe_morpheus_instance,hpe_morpheus_network,hpe_morpheus_user
+	  -sweep=all -sweep-run=hpe_morpheus_datastore,hpe_morpheus_instance,hpe_morpheus_network,hpe_morpheus_user

--- a/internal/subproviders/morpheus/test/sweep/datastores.go
+++ b/internal/subproviders/morpheus/test/sweep/datastores.go
@@ -1,0 +1,111 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+// Package sweep allows deletion of dangling test resources
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
+)
+
+// Datastores whose name begins with this string will be eligible for deletion
+const (
+	testDatastorePrefix   = "TestAccMorpheusDatastore"
+	enableDatastoreDelete = false
+)
+
+func Datastores() {
+	resource.AddTestSweepers(
+		"hpe_morpheus_datastore",
+		&resource.Sweeper{
+			Name: "hpe_morpheus_datastore",
+			F:    testSweepMorpheusDatastores,
+		})
+}
+
+func testSweepMorpheusDatastores(_ string) error {
+	ctx := context.Background()
+
+	client, err := NewSweepClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	datastores, hresp, err := client.DatastoresAPI.ListDatastores(ctx).
+		Phrase(testDatastorePrefix).Execute()
+	if err != nil {
+		// Handle 404 and 403 as "no matches found" rather than an error
+		if hresp != nil && (hresp.StatusCode == http.StatusNotFound || hresp.StatusCode == http.StatusForbidden) {
+			log.Printf("[INFO] No datastores found matching prefix (status %d): %s", hresp.StatusCode, testDatastorePrefix)
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to list datastores: %s", errors.ErrMsg(err, hresp))
+	}
+	if hresp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to list datastores: %s", errors.ErrMsg(err, hresp))
+	}
+
+	datastoreList := datastores.GetDatastores()
+	var sweptCount int
+	var sweepErrors []string
+
+	for _, datastore := range datastoreList {
+		name, ok := datastore.GetNameOk()
+		if !ok || name == nil {
+			continue
+		}
+
+		if !strings.HasPrefix(*name, testDatastorePrefix) {
+			log.Printf("[INFO] Skipping datastore (name): %s", *name)
+
+			continue
+		}
+
+		id, ok := datastore.GetIdOk()
+		if !ok || id == nil {
+			log.Printf("[INFO] Skipping datastore (id): %s", *name)
+
+			continue
+		}
+
+		// Delete the datastore
+		if enableDatastoreDelete {
+			log.Printf("[INFO] Sweeping datastore: %s (id: %d)", *name, *id)
+			_, hresp, err := client.DatastoresAPI.DeleteDatastores(ctx, *id).Execute()
+			if err != nil || hresp.StatusCode != http.StatusOK {
+				errMsg := fmt.Sprintf(
+					"failed to delete datastore %s (id: %d): %s",
+					*name, *id, errors.ErrMsg(err, hresp),
+				)
+				log.Printf("[ERROR] %s", errMsg)
+				sweepErrors = append(sweepErrors, errMsg)
+
+				continue
+			}
+
+			sweptCount++
+		} else {
+			log.Printf("[INFO] datastore: %s (id: %d): delete disabled", *name, *id)
+		}
+	}
+
+	log.Printf(
+		"[INFO] Datastore sweep completed. Datastores swept: %d, errors: %d",
+		sweptCount, len(sweepErrors),
+	)
+
+	if len(sweepErrors) > 0 {
+		return fmt.Errorf("%s", strings.Join(sweepErrors, "\n"))
+	}
+
+	return nil
+}

--- a/internal/subproviders/morpheus/test/sweep/sweep_test.go
+++ b/internal/subproviders/morpheus/test/sweep/sweep_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func init() {
+	Datastores()
 	Instances()
 	Networks()
 	Users()


### PR DESCRIPTION
Cleanup any stale datastore resources after acceptance tests.

Note: this draft identifies datastores by name only, using the `phrase` query parameter.
When sweeping other resources we rely on two factors, name and, eg, label, to avoid
mistakenly deleting resources. There is no obvious second factor for datastore.
Because of this we initially run the datastore sweep in "disabled" mode. Names of datastores
that would be deleted are printed, but no deletion occurs.
As we gain confidence that the correct datastores are being identified we can
consider enabling deletion.

```
2025/10/10 15:30:08 [DEBUG] Running Sweeper (hpe_morpheus_datastore) in region (all)
2025/10/10 15:30:09 [INFO] No datastores found matching prefix (status 403): TestAccMorpheusDatastore
2025/10/10 15:30:09 [DEBUG] Completed Sweeper (hpe_morpheus_datastore) in region (all) in 878.71409ms
```