### PR TITLE
Use state values for Visibility and Active on Update

### DIFF
--- a/internal/subproviders/morpheus/resources/datastore/datastore_update.go
+++ b/internal/subproviders/morpheus/resources/datastore/datastore_update.go
@@ -36,11 +36,25 @@ func updateDatastore(
 	updateDatastore := sdk.NewUpdateCloudDatastoresRequestDatastoreWithDefaults()
 	updateDatastore.AdditionalProperties = make(map[string]any)
 
-	if !plan.Visibility.IsNull() {
+	// If the plan has unknown value for Visibility, use the state values
+	// We can't use a PlanModifier for this since we call updateDatastore during Create
+	// and Update, and in Create the state is not available since it hasn't been
+	// written-out yet
+	switch plan.Visibility.IsUnknown() {
+	case true:
+		updateDatastore.SetVisibility(state.Visibility.ValueString())
+	case false:
 		updateDatastore.SetVisibility(plan.Visibility.ValueString())
 	}
 
-	if !plan.Active.IsNull() {
+	// If the plan has unknown value for Active, use the state values
+	// We can't use a PlanModifier for this since we call updateDatastore during Create
+	// and Update, and in Create the state is not available since it hasn't been
+	// written-out yet
+	switch plan.Active.IsUnknown() {
+	case true:
+		updateDatastore.SetActive(state.Active.ValueBool())
+	case false:
 		updateDatastore.SetActive(plan.Active.ValueBool())
 	}
 


### PR DESCRIPTION
If they aren't set in the config.  Vivek found an issue where the PUT
would return a 500 on the Update call during Create if Visiblity and 
Active hadn't been set in the config.  On debugging the issue is that 
if those values aren't set in the config then Morpheus sets them for 
you. We can't use a PlanModifier (UseStateForUnknown) since that 
requires that the State exists and is written out, which isn't the case 
on Create.  So we add code to use the State values for both - which 
are set to those returned by the API - if the values are Unknown in 
the Plan, i.e. not set by the user.

Note that When we Create we need to run an Update directly afterward
to set the resourcePermissions and tenants.
