### PR TITLE
Add cloud sweeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ docs-experimental:
 
 sweep:
 	go test -v ./internal/subproviders/morpheus/test/sweep/... \
-	  -sweep=all -sweep-run=hpe_morpheus_datastore,hpe_morpheus_instance,hpe_morpheus_network,hpe_morpheus_user
+	  -sweep=all -sweep-run=hpe_morpheus_cloud,hpe_morpheus_datastore,hpe_morpheus_instance,hpe_morpheus_network,hpe_morpheus_user

--- a/docs/resources/morpheus_cloud.md
+++ b/docs/resources/morpheus_cloud.md
@@ -25,7 +25,7 @@ resource "hpe_morpheus_cloud" "example" {
 
   code             = "aCode"
   external_id      = "aCode"
-  labels           = ["aLabel1", "aLabel2"]
+  labels           = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "aLabel1", "aLabel2"]
   data_center_name = "aDatacenter"
   enabled          = true
   location         = "somewhere"
@@ -59,7 +59,7 @@ resource "hpe_morpheus_cloud" "example" {
   group_id  = 1
 
   code             = "aCode"
-  labels           = ["aLabel1", "aLabel2"]
+  labels           = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "aLabel1", "aLabel2"]
   enabled          = true
   location         = "somewhere"
   visibility       = "public"

--- a/internal/subproviders/morpheus/resources/cloud/cloud_test.go
+++ b/internal/subproviders/morpheus/resources/cloud/cloud_test.go
@@ -40,7 +40,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (
 }
 
 // Tests that our example file template used for docs is a valid config
-func TestAccMorpheusCloudExampleOk(t *testing.T) {
+func TestAccMorpheusCloudResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if testing.Short() {
@@ -77,7 +77,27 @@ func TestAccMorpheusCloudExampleOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_cloud.example",
 			"labels.#",
-			"2",
+			"6",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"terraform",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"acctest",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"hpe_morpheus_cloud",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"sweepable",
 		),
 		resource.TestCheckTypeSetElemAttr(
 			"hpe_morpheus_cloud.example",
@@ -188,7 +208,7 @@ func TestAccMorpheusCloudExampleOk(t *testing.T) {
 }
 
 // Tests that our example file template used for docs is a valid config
-func TestAccMorpheusCloudExampleGenericOk(t *testing.T) {
+func TestAccMorpheusCloudResourceExampleGenericOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if testing.Short() {
@@ -230,7 +250,27 @@ func TestAccMorpheusCloudExampleGenericOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_cloud.example",
 			"labels.#",
-			"2",
+			"6",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"terraform",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"acctest",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"hpe_morpheus_cloud",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"sweepable",
 		),
 		resource.TestCheckTypeSetElemAttr(
 			"hpe_morpheus_cloud.example",
@@ -342,7 +382,7 @@ func TestAccMorpheusCloudExampleGenericOk(t *testing.T) {
 	})
 }
 
-func TestAccMorpheusCloudUpdate(t *testing.T) {
+func TestAccMorpheusCloudResourceUpdate(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if testing.Short() {
@@ -369,7 +409,27 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_cloud.example",
 			"labels.#",
-			"2",
+			"6",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"terraform",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"acctest",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"hpe_morpheus_cloud",
+		),
+		resource.TestCheckTypeSetElemAttr(
+			"hpe_morpheus_cloud.example",
+			"labels.*",
+			"sweepable",
 		),
 		resource.TestCheckTypeSetElemAttr(
 			"hpe_morpheus_cloud.example",
@@ -474,7 +534,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -506,7 +566,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -538,7 +598,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -570,7 +630,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "changed"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -602,7 +662,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "changed"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -634,7 +694,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "cloudInit"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -666,7 +726,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://changed.com"
 						auto_recover_power_state = true
@@ -698,7 +758,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = false
@@ -730,7 +790,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -762,7 +822,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -794,7 +854,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -826,7 +886,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -858,7 +918,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -890,7 +950,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -922,7 +982,10 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2", "Label3"]
+						labels = [
+							"terraform", "acctest", "hpe_morpheus_cloud", "sweepable",
+							"Label1", "Label2", "Label3"
+						]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -946,7 +1009,27 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 						resource.TestCheckResourceAttr(
 							"hpe_morpheus_cloud.example",
 							"labels.#",
-							"3",
+							"7",
+						),
+						resource.TestCheckTypeSetElemAttr(
+							"hpe_morpheus_cloud.example",
+							"labels.*",
+							"terraform",
+						),
+						resource.TestCheckTypeSetElemAttr(
+							"hpe_morpheus_cloud.example",
+							"labels.*",
+							"acctest",
+						),
+						resource.TestCheckTypeSetElemAttr(
+							"hpe_morpheus_cloud.example",
+							"labels.*",
+							"hpe_morpheus_cloud",
+						),
+						resource.TestCheckTypeSetElemAttr(
+							"hpe_morpheus_cloud.example",
+							"labels.*",
+							"sweepable",
 						),
 						resource.TestCheckTypeSetElemAttr(
 							"hpe_morpheus_cloud.example",
@@ -977,7 +1060,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -1009,7 +1092,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -1041,7 +1124,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -1073,7 +1156,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -1105,7 +1188,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 
 						code                     = "` + code + `"
 						external_id              = "` + code + `"
-						labels                   = ["Label1", "Label2"]
+						labels                   = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "Label1", "Label2"]
 						agent_install_mode       = "ssh"
 						appliance_url            = "https://somewhere.com"
 						auto_recover_power_state = true
@@ -1131,7 +1214,7 @@ func TestAccMorpheusCloudUpdate(t *testing.T) {
 	})
 }
 
-func TestAccMorpheusCloudValidationOneOf(t *testing.T) {
+func TestAccMorpheusCloudResourceValidationOneOf(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	t.Parallel()
@@ -1215,7 +1298,7 @@ func TestAccMorpheusCloudValidationOneOf(t *testing.T) {
 	})
 }
 
-func TestAccMorpheusCloudValidationRequiredAttrs(t *testing.T) {
+func TestAccMorpheusCloudResourceValidationRequiredAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	t.Parallel()

--- a/internal/subproviders/morpheus/resources/cloud/example.tf
+++ b/internal/subproviders/morpheus/resources/cloud/example.tf
@@ -5,7 +5,7 @@ resource "hpe_morpheus_cloud" "example" {
 
   code             = "aCode"
   external_id      = "aCode"
-  labels           = ["aLabel1", "aLabel2"]
+  labels           = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "aLabel1", "aLabel2"]
   data_center_name = "aDatacenter"
   enabled          = true
   location         = "somewhere"

--- a/internal/subproviders/morpheus/resources/cloud/example.tf.tmpl
+++ b/internal/subproviders/morpheus/resources/cloud/example.tf.tmpl
@@ -5,7 +5,7 @@ resource "hpe_morpheus_cloud" "example" {
 
   code             = "{{.Code}}"
   external_id      = "{{.Code}}"
-  labels           = ["{{.Label}}1", "{{.Label}}2"]
+  labels           = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "{{.Label}}1", "{{.Label}}2"]
   data_center_name = "aDatacenter"
   enabled          = true
   location         = "somewhere"

--- a/internal/subproviders/morpheus/resources/cloud/example_generic.tf
+++ b/internal/subproviders/morpheus/resources/cloud/example_generic.tf
@@ -4,7 +4,7 @@ resource "hpe_morpheus_cloud" "example" {
   group_id  = 1
 
   code             = "aCode"
-  labels           = ["aLabel1", "aLabel2"]
+  labels           = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "aLabel1", "aLabel2"]
   enabled          = true
   location         = "somewhere"
   visibility       = "public"

--- a/internal/subproviders/morpheus/resources/cloud/example_generic.tf.tmpl
+++ b/internal/subproviders/morpheus/resources/cloud/example_generic.tf.tmpl
@@ -4,7 +4,7 @@ resource "hpe_morpheus_cloud" "example" {
   group_id  = 1
 
   code             = "{{.Code}}"
-  labels           = ["{{.Label}}1", "{{.Label}}2"]
+  labels           = ["terraform", "acctest", "hpe_morpheus_cloud", "sweepable", "{{.Label}}1", "{{.Label}}2"]
   enabled          = true
   location         = "somewhere"
   visibility       = "public"

--- a/internal/subproviders/morpheus/test/sweep/clouds.go
+++ b/internal/subproviders/morpheus/test/sweep/clouds.go
@@ -1,0 +1,142 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+// Package sweep allows deletion of dangling test resources
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/subproviders/morpheus/errors"
+)
+
+// Clouds whose name begins with this string will be eligible for deletion
+const testCloudPrefix = "TestAccMorpheusCloud"
+
+// All of these labels must be present for the cloud to be deleted
+var requiredCloudSweepLabels = []string{
+	"terraform",
+	"acctest",
+	"hpe_morpheus_cloud",
+	"sweepable",
+}
+
+func hasRequiredCloudLabels(labels []string) bool {
+	if labels == nil {
+		return false
+	}
+
+	labelMap := make(map[string]bool)
+	for _, label := range labels {
+		labelMap[label] = true
+	}
+
+	for _, requiredLabel := range requiredCloudSweepLabels {
+		if !labelMap[requiredLabel] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func Clouds() {
+	resource.AddTestSweepers(
+		"hpe_morpheus_cloud",
+		&resource.Sweeper{
+			Name: "hpe_morpheus_cloud",
+			F:    testSweepMorpheusClouds,
+		})
+}
+
+func testSweepMorpheusClouds(_ string) error {
+	ctx := context.Background()
+
+	client, err := NewSweepClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	clouds, hresp, err := client.CloudsAPI.ListClouds(ctx).
+		Phrase(testCloudPrefix).Execute()
+	if err != nil {
+		// Handle 404 and 403 as "no matches found" rather than an error
+		if hresp != nil && (hresp.StatusCode == http.StatusNotFound ||
+			hresp.StatusCode == http.StatusForbidden) {
+			log.Printf(
+				"[INFO] No clouds found matching prefix (status %d): %s",
+				hresp.StatusCode, testCloudPrefix,
+			)
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to list clouds: %s", errors.ErrMsg(err, hresp))
+	}
+	if hresp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to list clouds: %s", errors.ErrMsg(err, hresp))
+	}
+
+	cloudList := clouds.GetZones()
+	var sweptCount int
+	var sweepErrors []string
+
+	for _, cloud := range cloudList {
+		name, ok := cloud.GetNameOk()
+		if !ok || name == nil {
+			continue
+		}
+
+		if strings.HasPrefix(*name, testCloudPrefix) {
+			labels, ok := cloud.GetLabelsOk()
+			if !ok || !hasRequiredCloudLabels(labels) {
+				log.Printf("[INFO] Skipping cloud (labels): %s", *name)
+
+				continue
+			}
+
+			id, ok := cloud.GetIdOk()
+			if !ok || id == nil {
+				log.Printf("[INFO] Skipping cloud (id): %s", *name)
+
+				continue
+			}
+
+			log.Printf("[INFO] Sweeping cloud: %s (id: %d)", *name, *id)
+
+			// Delete the cloud
+			_, hresp, err := client.CloudsAPI.RemoveClouds(ctx, *id).
+				Force(true).Execute()
+			if err != nil || hresp.StatusCode != http.StatusOK {
+				errMsg := fmt.Sprintf(
+					"failed to delete cloud %s (id: %d): %s",
+					*name, *id, errors.ErrMsg(err, hresp),
+				)
+				log.Printf("[ERROR] %s", errMsg)
+				sweepErrors = append(sweepErrors, errMsg)
+
+				continue
+			}
+
+			sweptCount++
+		} else {
+			log.Printf("[INFO] Skipping cloud (name): %s", *name)
+		}
+	}
+
+	log.Printf(
+		"[INFO] Cloud sweep completed. Clouds swept: %d, errors: %d",
+		sweptCount, len(sweepErrors),
+	)
+
+	if len(sweepErrors) > 0 {
+		return fmt.Errorf("%s", strings.Join(sweepErrors, "\n"))
+	}
+
+	return nil
+}

--- a/internal/subproviders/morpheus/test/sweep/sweep_test.go
+++ b/internal/subproviders/morpheus/test/sweep/sweep_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func init() {
+	Clouds()
 	Datastores()
 	Instances()
 	Networks()


### PR DESCRIPTION
Remove any stray clouds created as part of the cloud resource acceptance tests.

Tee off both name and labels (use labels to guard against accidental deletion).

```
2025/10/14 12:21:51 [DEBUG] Running Sweeper (hpe_morpheus_cloud) in region (all)
2025/10/14 12:21:52 [INFO] Skipping cloud (labels): TestAccMorpheusCloudXXX
2025/10/14 12:21:52 [INFO] Cloud sweep completed. Clouds swept: 0, errors: 0
```