### PR TITLE
Add release note about token regeneration issues with u/p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ We have fixed the following issues:
 
 ## New known issues
 
+- We have seen an issue with authentication for an existing user when using username/password.  The issue manifests
+  as "500" errors on authentication which will not go away on retry.  It is under investigation.  To work around
+  this issue please generate an `access_token` from the Morpheus UI (for the `morph-api` Client for example) and use
+  that instead of username/password.
 - hpe_morpheus_datastore when creating a datastore of type NFS the creation will silently fail if the NFS server is not reachable or the share is not accessible.
   The datastore will remain in a `provisioning` state indefinitely. Ensure the Morpheus appliance can reach the NFS server
   and that the share is accessible before creating.

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,6 +142,10 @@ We have fixed the following issues:
 
 ### New known issues
 
+- We have seen an issue with authentication for an existing user when using username/password.  The issue manifests
+  as "500" errors on authentication which will not go away on retry.  It is under investigation.  To work around
+  this issue please generate an `access_token` from the Morpheus UI (for the `morph-api` Client for example) and use
+  that instead of username/password.
 - hpe_morpheus_datastore when creating a datastore of type NFS the creation will silently fail if the NFS server is not reachable or the share is not accessible.
   The datastore will remain in a `provisioning` state indefinitely. Ensure the Morpheus appliance can reach the NFS server
   and that the share is accessible before creating.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -83,6 +83,10 @@ We have fixed the following issues:
 
 ### New known issues
 
+- We have seen an issue with authentication for an existing user when using username/password.  The issue manifests
+  as "500" errors on authentication which will not go away on retry.  It is under investigation.  To work around
+  this issue please generate an `access_token` from the Morpheus UI (for the `morph-api` Client for example) and use
+  that instead of username/password.
 - hpe_morpheus_datastore when creating a datastore of type NFS the creation will silently fail if the NFS server is not reachable or the share is not accessible.
   The datastore will remain in a `provisioning` state indefinitely. Ensure the Morpheus appliance can reach the NFS server
   and that the share is accessible before creating.


### PR DESCRIPTION
We've seen an issue with "Terraform Tester" on "feature" where token refreshing with username/password seems to fail.  This issue is still under investigation.  In the meantime we're going to add a release note about it.  The workaround is to generate a long-lived token and use that instead.