### PR TITLE
Make service_plan cores_per_socket required

### DIFF
--- a/docs/resources/morpheus_service_plan.md
+++ b/docs/resources/morpheus_service_plan.md
@@ -23,6 +23,7 @@ resource "hpe_morpheus_service_plan" "example_service_plan" {
   max_storage = 536870912
   provision_type_code = "arm"
   custom_max_storage = true
+  cores_per_socket = 1
   config_ranges = {
     min_storage = 268435456
     max_storage = 536870912
@@ -36,6 +37,7 @@ resource "hpe_morpheus_service_plan" "example_service_plan" {
 ### Required
 
 - `code` (String) Service plan code, must be unique
+- `cores_per_socket` (Number) Number of cores per CPU
 - `max_memory` (Number) Max memory size in bytes
 - `max_storage` (Number) Max storage size in bytes
 - `name` (String) Service plan name
@@ -45,7 +47,6 @@ resource "hpe_morpheus_service_plan" "example_service_plan" {
 
 - `add_volumes` (Boolean) Can be used to enable / disable ability to add volumes
 - `config_ranges` (Attributes) The min and max ranges that instances using this service plan must conform to. (see [below for nested schema](#nestedatt--config_ranges))
-- `cores_per_socket` (Number) Number of cores per CPU
 - `custom_cores` (Boolean) Can be used to enable / disable customizable cores
 - `custom_cpu` (Boolean) Can be used to enable / disable customizable cpu
 - `custom_max_memory` (Boolean) Can be used to enable / disable customizable memory.

--- a/internal/framework/subproviders/morpheus/resources/serviceplan/example.tf
+++ b/internal/framework/subproviders/morpheus/resources/serviceplan/example.tf
@@ -6,6 +6,7 @@ resource "hpe_morpheus_service_plan" "example_service_plan" {
   max_storage = 536870912
   provision_type_code = "arm"
   custom_max_storage = true
+  cores_per_socket = 1
   config_ranges = {
     min_storage = 268435456
     max_storage = 536870912

--- a/internal/framework/subproviders/morpheus/resources/serviceplan/example.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/serviceplan/example.tf.tmpl
@@ -6,6 +6,7 @@ resource "hpe_morpheus_service_plan" "example_service_plan" {
   max_storage = {{.MaxStorage}}
   provision_type_code = "{{.ProvisionTypeCode}}"
   custom_max_storage = {{.CustomMaxStorage}}
+  cores_per_socket = {{.CoresPerSocket}}
   config_ranges = {
     min_storage = {{.ConfigRangesMinStorage}}
     max_storage = {{.ConfigRangesMaxStorage}}

--- a/internal/framework/subproviders/morpheus/resources/serviceplan/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/serviceplan/resource_test.go
@@ -1,6 +1,6 @@
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
-//go:generate go run ../../../../../../cmd/render example.tf.tmpl Name "ExampleServicePlan" Code "exampleserviceplan" MaxMemory "4294967296" MaxStorage "536870912"  ProvisionTypeCode "arm" CustomMaxStorage "true" ConfigRangesMinStorage "268435456" ConfigRangesMaxStorage "536870912" SortOrder "10000"
+//go:generate go run ../../../../../../cmd/render example.tf.tmpl Name "ExampleServicePlan" Code "exampleserviceplan" MaxMemory "4294967296" MaxStorage "536870912"  ProvisionTypeCode "arm" CustomMaxStorage "true" ConfigRangesMinStorage "268435456" ConfigRangesMaxStorage "536870912" SortOrder "10000" CoresPerSocket "1"
 
 package serviceplan_test
 
@@ -56,6 +56,7 @@ resource "hpe_morpheus_service_plan" "example_required" {
   max_memory             = 4294967296
   sort_order             = 10000
   max_storage            = 0
+  cores_per_socket       = 1
 	provision_type_code    = "arm"
 }
 	`
@@ -90,6 +91,11 @@ resource "hpe_morpheus_service_plan" "example_required" {
 			"hpe_morpheus_service_plan.example_required",
 			"sort_order",
 			"10000",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_required",
+			"cores_per_socket",
+			"1",
 		),
 	}
 
@@ -369,6 +375,7 @@ func TestAccMorpheusServicePlanExampleOk(t *testing.T) {
 		"MaxStorage", "536870912",
 		"ProvisionTypeCode", "arm",
 		"CustomMaxStorage", "true",
+		"CoresPerSocket", "1",
 		"ConfigRangesMinStorage", "268435456",
 		"ConfigRangesMaxStorage", "536870912")
 	if err != nil {
@@ -405,6 +412,11 @@ func TestAccMorpheusServicePlanExampleOk(t *testing.T) {
 			"hpe_morpheus_service_plan.example_service_plan",
 			"custom_max_storage",
 			"true",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_service_plan.example_service_plan",
+			"cores_per_socket",
+			"1",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_service_plan.example_service_plan",

--- a/internal/framework/subproviders/morpheus/resources/serviceplan/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/serviceplan/schema_gen.go
@@ -111,8 +111,7 @@ func ServicePlanResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "The min and max ranges that instances using this service plan must conform to.",
 			},
 			"cores_per_socket": schema.Int64Attribute{
-				Optional:            true,
-				Computed:            true,
+				Required:            true,
 				Description:         "Number of cores per CPU",
 				MarkdownDescription: "Number of cores per CPU",
 				PlanModifiers: []planmodifier.Int64{


### PR DESCRIPTION
An issue was raised by a customer against the legacy Morpheus provider to the effect that service_plan cores_per_socket should be required. We're applying the fix here and not in the legacy provider.