### PR TITLE
Improve and fix legacy client constructor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HPE/terraform-provider-hpe
 go 1.24.1
 
 require (
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4bb578ba
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251030151041-d8412f6d2741
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.0.0-20251023150927-415f8c7cd80b
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4bb578ba h1:bp92Ge78ab+lf3B1icgUPWHNUNotlVl1f2TrYtMqA7s=
-github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4bb578ba/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251030151041-d8412f6d2741 h1:JJFmku1AlESTbZTcCmkvnLYR9DMH7s6sVj4a+Z2DEjQ=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251030151041-d8412f6d2741/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.0.0-20251023150927-415f8c7cd80b h1:YUuOJqX6y1/kovlUD7DqNKFSB91CUJSolAq+PnSZ9q0=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.0.0-20251023150927-415f8c7cd80b/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/internal/sdkv2/morpheus/config.go
+++ b/internal/sdkv2/morpheus/config.go
@@ -3,11 +3,14 @@
 package morpheus
 
 import (
+	"context"
 	"os"
 
 	sdklegacy "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/client"
 )
 
 // Config is the configuration structure used to instantiate the Morpheus
@@ -31,26 +34,16 @@ func (c *Config) Client() (*sdklegacy.Client, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	if c.client == nil {
-
-		var client *sdklegacy.Client
-		if !c.Insecure {
-			// default: secure
-			client = sdklegacy.NewClient(
-				c.Url,
-				sdklegacy.SkipLogin(), // required for custom auth transport
-				sdklegacy.WithDebug(debug),
-			)
-		} else {
-			// insecure
-			client = sdklegacy.NewClient(
-				c.Url,
-				sdklegacy.SkipLogin(), // required for custom auth transport
-				sdklegacy.WithDebug(debug),
-				sdklegacy.Insecure(),
-			)
-		}
-
-		c.client = client
+		c.client = client.NewLegacyClient(
+			context.Background(),
+			c.Url,
+			c.Username,
+			c.Password,
+			c.AccessToken,
+			sdklegacy.SkipLogin(),
+			sdklegacy.WithDebug(debug),
+			sdklegacy.WithInsecure(c.Insecure),
+		)
 	}
 
 	return c.client, diags


### PR DESCRIPTION
Bumps version of legacy sdk to latest so we can take advantage of the `WithInsecure()` option.

Fixes the client constructor (it was previously using the `NewClient()` from the legacy SDK, not our wrapper in the provider).
