### PR TITLE
Add a builder function for reporting type assertion errors

### DIFF
--- a/internal/sdkv2/morpheus/helpers/errors.go
+++ b/internal/sdkv2/morpheus/helpers/errors.go
@@ -1,4 +1,4 @@
-package sdkv2err
+package helpers
 
 import (
 	"fmt"

--- a/internal/sdkv2/morpheus/sdkv2err/errors.go
+++ b/internal/sdkv2/morpheus/sdkv2err/errors.go
@@ -1,0 +1,13 @@
+package sdkv2err
+
+import (
+	"fmt"
+)
+
+// TypeAssertFail builds an error for reporting a failed type assertion.
+// It is useful for working with sdkv2 as it relies heavily on type
+// assertions to pull information from state and plan.
+// k is the key or name of the object being type asserted, v is its value.
+func TypeAssertFail(k string, v any) error {
+	return fmt.Errorf("%s: Type assertion failed for value: %v (type: %T)", k, v, v)
+}


### PR DESCRIPTION
Adds a builder function to help with constructing errors for reporting failed type assertions.

This is useful as we will aim to make the legacy provider code more type safe as we port it.

We can use this to return a diagnostic wrapping an error whenever we hit a failed assertion and avoid the provider panicking. 