### PR TITLE
Add error helpers for empty slices and nil pointers

### DIFF
--- a/internal/sdkv2/morpheus/helpers/errors.go
+++ b/internal/sdkv2/morpheus/helpers/errors.go
@@ -11,3 +11,20 @@ import (
 func TypeAssertFail(k string, v any) error {
 	return fmt.Errorf("%s: Type assertion failed for value: %v (type: %T)", k, v, v)
 }
+
+// EmptySliceAccess builds an error for reporting an attempt to access
+// an element from an empty slice.
+// It is useful for working with the legacy provider code as it often attempts
+// to access the 0th index of a slice without checking its length first.
+// k is the key or name of the slice being accessed.
+func EmptySlice(k string) error {
+	return fmt.Errorf("%s: Slice is empty", k)
+}
+
+// NilPointer builds an error for reporting a nil pointer dereference.
+// It is useful for working with the legacy provider code as it often
+// dereferences pointers without checking for nil first.
+// k is the key or name of the pointer being dereferenced.
+func NilPointer(k string) error {
+	return fmt.Errorf("%s: Pointer is nil", k)
+}

--- a/internal/sdkv2/morpheus/helpers/errors.go
+++ b/internal/sdkv2/morpheus/helpers/errors.go
@@ -17,7 +17,7 @@ func TypeAssertFail(k string, v any) error {
 // It is useful for working with the legacy provider code as it often attempts
 // to access the 0th index of a slice without checking its length first.
 // k is the key or name of the slice being accessed.
-func EmptySlice(k string) error {
+func EmptySliceError(k string) error {
 	return fmt.Errorf("%s: Slice is empty", k)
 }
 
@@ -25,6 +25,6 @@ func EmptySlice(k string) error {
 // It is useful for working with the legacy provider code as it often
 // dereferences pointers without checking for nil first.
 // k is the key or name of the pointer being dereferenced.
-func NilPointer(k string) error {
+func NilPointerError(k string) error {
 	return fmt.Errorf("%s: Pointer is nil", k)
 }

--- a/internal/sdkv2/morpheus/helpers/errors.go
+++ b/internal/sdkv2/morpheus/helpers/errors.go
@@ -8,7 +8,7 @@ import (
 // It is useful for working with sdkv2 as it relies heavily on type
 // assertions to pull information from state and plan.
 // k is the key or name of the object being type asserted, v is its value.
-func TypeAssertFail(k string, v any) error {
+func TypeAssertFailError(k string, v any) error {
 	return fmt.Errorf("%s: Type assertion failed for value: %v (type: %T)", k, v, v)
 }
 


### PR DESCRIPTION
Adds two new error helpers for reporting when a slice is empty and for when a pointer is nil.

These are two common occurrences in the legacy provider code that we need to defensively program against as we port resources.

Drive-by: Rename `TypeAssertFail` to `TypeAssertFailError`