### PR TITLE
Rearrange naming of sdkv2 identity sources to match established patterns

### DIFF
--- a/docs/resources/morpheus_identity_source_active_directory.md
+++ b/docs/resources/morpheus_identity_source_active_directory.md
@@ -1,17 +1,17 @@
 ---
-page_title: "hpe_morpheus_active_directory_identity_source Resource - terraform-provider-hpe"
+page_title: "hpe_morpheus_identity_source_active_directory Resource - terraform-provider-hpe"
 subcategory: "morpheus"
 description: |-
   Provides an active directory identity source resource
 ---
-# hpe_morpheus_active_directory_identity_source (Resource)
+# hpe_morpheus_identity_source_active_directory (Resource)
 
 Provides an active directory identity source resource
 
 ## Example Usage
 
 ```terraform
-resource "hpe_morpheus_active_directory_identity_source" "addemo" {
+resource "hpe_morpheus_identity_source_active_directory" "addemo" {
   tenant_id               = 1
   name                    = "addemo"
   description             = "TF example AD identity source"
@@ -74,5 +74,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import hpe_morpheus_active_directory_identity_source.tf_example_active_directory_identity_source 1
+terraform import hpe_morpheus_identity_source_active_directory.tf_example_identity_source_active_directory 1
 ```

--- a/docs/resources/morpheus_identity_source_saml.md
+++ b/docs/resources/morpheus_identity_source_saml.md
@@ -1,17 +1,17 @@
 ---
-page_title: "hpe_morpheus_saml_identity_source Resource - terraform-provider-hpe"
+page_title: "hpe_morpheus_identity_source_saml Resource - terraform-provider-hpe"
 subcategory: "morpheus"
 description: |-
   Provides a saml identity source resource
 ---
-# hpe_morpheus_saml_identity_source (Resource)
+# hpe_morpheus_identity_source_saml (Resource)
 
 Provides a saml identity source resource
 
 ## Example Usage
 
 ```terraform
-resource "hpe_morpheus_saml_identity_source" "samldemo" {
+resource "hpe_morpheus_identity_source_saml" "samldemo" {
   tenant_id                      = 1
   name                           = "samldemo"
   description                    = "TF example SAML identity source"
@@ -84,5 +84,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import hpe_morpheus_saml_identity_source.tf_example_saml_identity_source 1
+terraform import hpe_morpheus_identity_source_saml.tf_example_identity_source_saml 1
 ```

--- a/examples/resources/hpe_morpheus_active_directory_identity_source/import.sh
+++ b/examples/resources/hpe_morpheus_active_directory_identity_source/import.sh
@@ -1,1 +1,0 @@
-terraform import hpe_morpheus_active_directory_identity_source.tf_example_active_directory_identity_source 1

--- a/examples/resources/hpe_morpheus_identity_source_active_directory/import.sh
+++ b/examples/resources/hpe_morpheus_identity_source_active_directory/import.sh
@@ -1,0 +1,1 @@
+terraform import hpe_morpheus_identity_source_active_directory.tf_example_identity_source_active_directory 1

--- a/examples/resources/hpe_morpheus_identity_source_active_directory/resource.tf
+++ b/examples/resources/hpe_morpheus_identity_source_active_directory/resource.tf
@@ -1,4 +1,4 @@
-resource "hpe_morpheus_active_directory_identity_source" "addemo" {
+resource "hpe_morpheus_identity_source_active_directory" "addemo" {
   tenant_id               = 1
   name                    = "addemo"
   description             = "TF example AD identity source"

--- a/examples/resources/hpe_morpheus_identity_source_saml/import.sh
+++ b/examples/resources/hpe_morpheus_identity_source_saml/import.sh
@@ -1,0 +1,1 @@
+terraform import hpe_morpheus_identity_source_saml.tf_example_identity_source_saml 1

--- a/examples/resources/hpe_morpheus_identity_source_saml/resource.tf
+++ b/examples/resources/hpe_morpheus_identity_source_saml/resource.tf
@@ -1,4 +1,4 @@
-resource "hpe_morpheus_saml_identity_source" "samldemo" {
+resource "hpe_morpheus_identity_source_saml" "samldemo" {
   tenant_id                      = 1
   name                           = "samldemo"
   description                    = "TF example SAML identity source"

--- a/examples/resources/hpe_morpheus_saml_identity_source/import.sh
+++ b/examples/resources/hpe_morpheus_saml_identity_source/import.sh
@@ -1,1 +1,0 @@
-terraform import hpe_morpheus_saml_identity_source.tf_example_saml_identity_source 1

--- a/internal/sdkv2/morpheus/provider.go
+++ b/internal/sdkv2/morpheus/provider.go
@@ -17,9 +17,9 @@ func Provider() *schema.Provider {
 		Schema: providerSchema(),
 
 		ResourcesMap: map[string]*schema.Resource{
-			"hpe_morpheus_active_directory_identity_source": identitysource.ResourceActiveDirectoryIdentitySource(),
-			"hpe_morpheus_saml_identity_source":             identitysource.ResourceSAMLIdentitySource(),
 			"hpe_morpheus_cluster_mks_vsphere":              cluster.ResourceClusterMKSVSphere(),
+			"hpe_morpheus_identity_source_active_directory": identitysource.ResourceIdentitySourceActiveDirectory(),
+			"hpe_morpheus_identity_source_saml":             identitysource.ResourceIdentitySourceSAML(),
 		},
 		DataSourcesMap:       map[string]*schema.Resource{},
 		ConfigureContextFunc: providerConfigure,

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
@@ -16,13 +16,13 @@ import (
 )
 
 //nolint:lll
-func ResourceActiveDirectoryIdentitySource() *schema.Resource {
+func ResourceIdentitySourceActiveDirectory() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Provides an active directory identity source resource",
-		CreateContext: resourceActiveDirectoryIdentitySourceCreate,
-		ReadContext:   resourceActiveDirectoryIdentitySourceRead,
-		UpdateContext: resourceActiveDirectoryIdentitySourceUpdate,
-		DeleteContext: resourceActiveDirectoryIdentitySourceDelete,
+		CreateContext: resourceIdentitySourceActiveDirectoryCreate,
+		ReadContext:   resourceIdentitySourceActiveDirectoryRead,
+		UpdateContext: resourceIdentitySourceActiveDirectoryUpdate,
+		DeleteContext: resourceIdentitySourceActiveDirectoryDelete,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -141,7 +141,7 @@ func ResourceActiveDirectoryIdentitySource() *schema.Resource {
 	}
 }
 
-func resourceActiveDirectoryIdentitySourceCreate(
+func resourceIdentitySourceActiveDirectoryCreate(
 	ctx context.Context,
 	d *schema.ResourceData,
 	meta interface{},
@@ -278,12 +278,12 @@ func resourceActiveDirectoryIdentitySourceCreate(
 		return diag.FromErr(helpers.TypeAssertFailError("tenant_id", d.Get("tenant_id")))
 	}
 
-	resourceActiveDirectoryIdentitySourceRead(ctx, d, meta)
+	resourceIdentitySourceActiveDirectoryRead(ctx, d, meta)
 
 	return diags
 }
 
-func resourceActiveDirectoryIdentitySourceRead(
+func resourceIdentitySourceActiveDirectoryRead(
 	ctx context.Context,
 	d *schema.ResourceData,
 	meta interface{},
@@ -377,7 +377,7 @@ func resourceActiveDirectoryIdentitySourceRead(
 	return diags
 }
 
-func resourceActiveDirectoryIdentitySourceUpdate(
+func resourceIdentitySourceActiveDirectoryUpdate(
 	ctx context.Context,
 	d *schema.ResourceData,
 	meta interface{},
@@ -518,10 +518,10 @@ func resourceActiveDirectoryIdentitySourceUpdate(
 	// err, it should not have changed though..
 	d.SetId(convert.Int64ToString(identitySourceResult.ID))
 
-	return resourceActiveDirectoryIdentitySourceRead(ctx, d, meta)
+	return resourceIdentitySourceActiveDirectoryRead(ctx, d, meta)
 }
 
-func resourceActiveDirectoryIdentitySourceDelete(
+func resourceIdentitySourceActiveDirectoryDelete(
 	ctx context.Context,
 	d *schema.ResourceData,
 	meta interface{},

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
@@ -14,13 +14,13 @@ import (
 )
 
 //nolint:lll
-func ResourceSAMLIdentitySource() *schema.Resource {
+func ResourceIdentitySourceSAML() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Provides a saml identity source resource",
-		CreateContext: resourceSAMLIdentitySourceCreate,
-		ReadContext:   resourceSAMLIdentitySourceRead,
-		UpdateContext: resourceSAMLIdentitySourceUpdate,
-		DeleteContext: resourceSAMLIdentitySourceDelete,
+		CreateContext: resourceIdentitySourceSAMLCreate,
+		ReadContext:   resourceIdentitySourceSAMLRead,
+		UpdateContext: resourceIdentitySourceSAMLUpdate,
+		DeleteContext: resourceIdentitySourceSAMLDelete,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -149,7 +149,7 @@ func ResourceSAMLIdentitySource() *schema.Resource {
 	}
 }
 
-func resourceSAMLIdentitySourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceIdentitySourceSAMLCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
@@ -318,12 +318,12 @@ func resourceSAMLIdentitySourceCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(helpers.TypeAssertFailError("tenant_id", d.Get("tenant_id")))
 	}
 
-	resourceSAMLIdentitySourceRead(ctx, d, meta)
+	resourceIdentitySourceSAMLRead(ctx, d, meta)
 
 	return diags
 }
 
-func resourceSAMLIdentitySourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceIdentitySourceSAMLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
@@ -420,7 +420,7 @@ func resourceSAMLIdentitySourceRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceSAMLIdentitySourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceIdentitySourceSAMLUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -593,10 +593,10 @@ func resourceSAMLIdentitySourceUpdate(ctx context.Context, d *schema.ResourceDat
 	// err, it should not have changed though..
 	d.SetId(convert.Int64ToString(identitySourceResult.ID))
 
-	return resourceSAMLIdentitySourceRead(ctx, d, meta)
+	return resourceIdentitySourceSAMLRead(ctx, d, meta)
 }
 
-func resourceSAMLIdentitySourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceIdentitySourceSAMLDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 

--- a/templates/resources/morpheus_identity_source_active_directory.md.tmpl
+++ b/templates/resources/morpheus_identity_source_active_directory.md.tmpl
@@ -10,7 +10,7 @@ description: |-
 
 ## Example Usage
 
-{{tffile "examples/resources/hpe_morpheus_active_directory_identity_source/resource.tf"}}
+{{tffile "examples/resources/hpe_morpheus_identity_source_active_directory/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
 
@@ -18,4 +18,4 @@ description: |-
 
 Import is supported using the following syntax:
 
-{{codefile "shell" "examples/resources/hpe_morpheus_active_directory_identity_source/import.sh" }}
+{{codefile "shell" "examples/resources/hpe_morpheus_identity_source_active_directory/import.sh" }}

--- a/templates/resources/morpheus_identity_source_saml.md.tmpl
+++ b/templates/resources/morpheus_identity_source_saml.md.tmpl
@@ -10,7 +10,7 @@ description: |-
 
 ## Example Usage
 
-{{tffile "examples/resources/hpe_morpheus_saml_identity_source/resource.tf"}}
+{{tffile "examples/resources/hpe_morpheus_identity_source_saml/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
 
@@ -18,4 +18,4 @@ description: |-
 
 Import is supported using the following syntax:
 
-{{codefile "shell" "examples/resources/hpe_morpheus_saml_identity_source/import.sh" }}
+{{codefile "shell" "examples/resources/hpe_morpheus_identity_source_saml/import.sh" }}


### PR DESCRIPTION
Renaming these in the format `hpe_morpheus_identity_source_{type}` for consistency with other resources.