### PR TITLE
Adding Instance Networks Policy Type to Policy

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/policy/create_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create_test.go
@@ -265,7 +265,25 @@ resource "hpe_morpheus_policy" "test" {
 					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "description", "Naming policy"),
 				),
 			},
-			// Step 7: TODO: Add requiredNetwork policy type to OpenAPI spec
+			// Step 7: Instance Networks
+			{
+				Config: providerConfig + resourceConfig,
+				ConfigVariables: config.Variables{
+					"policy_name":        config.StringVariable(namePrefix + "-requiredNetwork"),
+					"policy_description": config.StringVariable("Required network policy"),
+					"policy_type_code":   config.StringVariable("requiredNetwork"),
+					"policy_config": config.ObjectVariable(map[string]config.Variable{
+						"requiredNetworks": config.ListVariable(
+							config.IntegerVariable(1),
+						),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-requiredNetwork"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "requiredNetwork"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "description", "Required network policy"),
+				),
+			},
 			// Step 8: Max Memory
 			{
 				Config: providerConfig + resourceConfig,

--- a/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
@@ -163,6 +163,7 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 								"maxNetworks",
 								"storageBucketQuota",
 								"powerSchedule",
+								"requiredNetwork",
 								"maxRouters",
 								"shutdown",
 								"storageServerQuota",


### PR DESCRIPTION
Adding Instance Networks Policy Type to Policy. Included an acceptance test as it is a priority BM resource.
- Updated schema_gen.go to include `requiredNetwork` in the policy type enum.
- Updated create_test.go to add an acceptance test for the new policy type.