### PR TITLE
Fix issue with datastore data-source and no resource_permissions

### DIFF
--- a/internal/framework/subproviders/morpheus/datasources/datastore/datasource.go
+++ b/internal/framework/subproviders/morpheus/datasources/datastore/datasource.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/constants"
@@ -316,66 +318,62 @@ func populateCloudDatastoreInformation(
 	}
 
 	// Populate Tenants
+	var tenantsSet types.Set
 	tenants, ok := cloudDatastore.GetTenantsOk()
-	if !ok || tenants == nil {
-		retErr := fmt.Errorf("datastore %d missing tenants in response", id)
+	if ok && tenants != nil {
 
-		return types.SetNull(TenantsType{}), NewResourcePermissionsValueNull(), retErr
-	}
+		var tdiag diag.Diagnostics
+		tenantsSet, tdiag = convert.ToSetType(
+			ctx,
+			tenants,
+			func(
+				in sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerTenantsInner,
+			) TenantsValue {
+				return TenantsValue{
+					Id:    convert.Int64ToType(in.Id),
+					state: attr.ValueStateKnown,
+				}
+			},
+		)
 
-	tenantsSet, tdiag := convert.ToSetType(
-		ctx,
-		tenants,
-		func(
-			in sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerTenantsInner,
-		) TenantsValue {
-			return TenantsValue{
-				Id:    convert.Int64ToType(in.Id),
-				state: attr.ValueStateKnown,
-			}
-		},
-	)
+		if tdiag.HasError() {
+			retErr := fmt.Errorf("datastore %d error in creating tenants set", id)
 
-	if tdiag.HasError() {
-		retErr := fmt.Errorf("datastore %d error in creating tenants set", id)
-
-		return types.SetNull(TenantsType{}), NewResourcePermissionsValueNull(), retErr
+			return types.SetNull(TenantsType{}), NewResourcePermissionsValueNull(), retErr
+		}
 	}
 
 	// Populate ResourcePermissions, we'll only do Groups for now
+	var resourcePermissions ResourcePermissionsValue
 	rp, ok := cloudDatastore.GetResourcePermissionOk()
-	if !ok || rp == nil {
-		retErr := fmt.Errorf("datastore %d missing resource permissions in response", id)
+	if ok && rp != nil {
+		sites, ok := rp.GetSitesOk()
+		if !ok || sites == nil {
+			tflog.Debug(ctx, fmt.Sprintf("datastore %d missing resource permission sites in response", id))
 
-		return tenantsSet, NewResourcePermissionsValueNull(), retErr
+			return tenantsSet, NewResourcePermissionsValueNull(), nil
+		}
+		groupsSet, gdiag := convert.ToSetType(
+			ctx,
+			sites,
+			func(
+				in sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerResourcePermissionSitesInner,
+			) GroupsValue {
+				return GroupsValue{
+					Id:    convert.Int64ToType(in.Id),
+					state: attr.ValueStateKnown,
+				}
+			},
+		)
+
+		if gdiag.HasError() {
+			retErr := fmt.Errorf("datastore %d error in creating groups set", id)
+
+			return tenantsSet, NewResourcePermissionsValueNull(), retErr
+		}
+
+		resourcePermissions, err = populateResourcePermissionsFromApi(ctx, id, groupsSet)
 	}
-
-	sites, ok := rp.GetSitesOk()
-	if !ok || sites == nil {
-		retErr := fmt.Errorf("datastore %d missing resource permission sites in response", id)
-
-		return tenantsSet, NewResourcePermissionsValueNull(), retErr
-	}
-	groupsSet, gdiag := convert.ToSetType(
-		ctx,
-		sites,
-		func(
-			in sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerResourcePermissionSitesInner,
-		) GroupsValue {
-			return GroupsValue{
-				Id:    convert.Int64ToType(in.Id),
-				state: attr.ValueStateKnown,
-			}
-		},
-	)
-
-	if gdiag.HasError() {
-		retErr := fmt.Errorf("datastore %d error in creating groups set", id)
-
-		return tenantsSet, NewResourcePermissionsValueNull(), retErr
-	}
-
-	resourcePermissions, err := populateResourcePermissionsFromApi(ctx, id, groupsSet)
 
 	return tenantsSet, resourcePermissions, err
 }
@@ -402,64 +400,62 @@ func populateClusterDatastoreInformation(
 	}
 
 	// Populate Tenants
+	var tenantsSet types.Set
 	tenants, ok := clusterDatastore.GetTenantsOk()
-	if !ok || tenants == nil {
-		retErr := fmt.Errorf("datastore %d missing tenants in response", id)
+	if ok && tenants != nil {
 
-		return types.SetNull(TenantsType{}), NewResourcePermissionsValueNull(), retErr
-	}
+		var tdiag diag.Diagnostics
+		tenantsSet, tdiag = convert.ToSetType(
+			ctx,
+			tenants,
+			func(
+				in sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerTenantsInner,
+			) TenantsValue {
+				return TenantsValue{
+					Id:    convert.Int64ToType(in.Id),
+					state: attr.ValueStateKnown,
+				}
+			},
+		)
+		if tdiag.HasError() {
+			retErr := fmt.Errorf("datastore %d error in creating tenants set", id)
 
-	tenantsSet, tdiag := convert.ToSetType(
-		ctx,
-		tenants,
-		func(
-			in sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerTenantsInner,
-		) TenantsValue {
-			return TenantsValue{
-				Id:    convert.Int64ToType(in.Id),
-				state: attr.ValueStateKnown,
-			}
-		},
-	)
-	if tdiag.HasError() {
-		retErr := fmt.Errorf("datastore %d error in creating tenants set", id)
-
-		return tenantsSet, NewResourcePermissionsValueNull(), retErr
+			return tenantsSet, NewResourcePermissionsValueNull(), retErr
+		}
 	}
 
 	// Populate ResourcePermissions, we'll only do Groups for now
+	var resourcePermissions ResourcePermissionsValue
 	rp, ok := clusterDatastore.GetResourcePermissionsOk()
-	if !ok || rp == nil {
-		retErr := fmt.Errorf("datastore %d missing resource permissions in response", id)
+	if ok && rp != nil {
 
-		return tenantsSet, NewResourcePermissionsValueNull(), retErr
+		sites, ok := rp.GetSitesOk()
+		if !ok || sites == nil {
+			tflog.Debug(ctx, fmt.Sprintf("datastore %d missing resource permission sites in response", id))
+
+			return tenantsSet, NewResourcePermissionsValueNull(), nil
+		}
+
+		groupsSet, gdiag := convert.ToSetType(
+			ctx,
+			sites,
+			func(
+				in sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerResourcePermissionSitesInner,
+			) GroupsValue {
+				return GroupsValue{
+					Id:    convert.Int64ToType(in.Id),
+					state: attr.ValueStateKnown,
+				}
+			},
+		)
+		if gdiag.HasError() {
+			retErr := fmt.Errorf("datastore %d error in creating groups set", id)
+
+			return tenantsSet, NewResourcePermissionsValueNull(), retErr
+		}
+
+		resourcePermissions, err = populateResourcePermissionsFromApi(ctx, id, groupsSet)
 	}
-	sites, ok := rp.GetSitesOk()
-	if !ok || sites == nil {
-		retErr := fmt.Errorf("datastore %d missing resource permission sites in response", id)
-
-		return tenantsSet, NewResourcePermissionsValueNull(), retErr
-	}
-
-	groupsSet, gdiag := convert.ToSetType(
-		ctx,
-		sites,
-		func(
-			in sdk.ListCloudDatastores200ResponseAllOfDatastoresInnerResourcePermissionSitesInner,
-		) GroupsValue {
-			return GroupsValue{
-				Id:    convert.Int64ToType(in.Id),
-				state: attr.ValueStateKnown,
-			}
-		},
-	)
-	if gdiag.HasError() {
-		retErr := fmt.Errorf("datastore %d error in creating groups set", id)
-
-		return tenantsSet, NewResourcePermissionsValueNull(), retErr
-	}
-
-	resourcePermissions, err := populateResourcePermissionsFromApi(ctx, id, groupsSet)
 
 	return tenantsSet, resourcePermissions, err
 }

--- a/internal/framework/subproviders/morpheus/datasources/datastore/datasource_test.go
+++ b/internal/framework/subproviders/morpheus/datasources/datastore/datasource_test.go
@@ -47,6 +47,31 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 }
 
 func testCheckFns(name string) []resource.TestCheckFunc {
+	checks := testCheckFnsNoResourcePermissions(name)
+	checksResourcePermissions := []resource.TestCheckFunc{
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_datastore.test",
+			"resource_permissions.groups.*",
+			map[string]string{
+				"id": "17830",
+			},
+		),
+		// it seems that adding resource permissions results in the root tenant being added
+		// for our tests with TerraformTester on feature
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_datastore.test",
+			"tenants.*",
+			map[string]string{
+				"id": "1",
+			},
+		),
+	}
+	checks = append(checks, checksResourcePermissions...)
+
+	return checks
+}
+
+func testCheckFnsNoResourcePermissions(name string) []resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(
 			"data.hpe_morpheus_datastore.test",
@@ -65,23 +90,9 @@ func testCheckFns(name string) []resource.TestCheckFunc {
 		),
 		resource.TestCheckTypeSetElemNestedAttrs(
 			"data.hpe_morpheus_datastore.test",
-			"resource_permissions.groups.*",
-			map[string]string{
-				"id": "17830",
-			},
-		),
-		resource.TestCheckTypeSetElemNestedAttrs(
-			"data.hpe_morpheus_datastore.test",
 			"tenants.*",
 			map[string]string{
 				"id": "466",
-			},
-		),
-		resource.TestCheckTypeSetElemNestedAttrs(
-			"data.hpe_morpheus_datastore.test",
-			"tenants.*",
-			map[string]string{
-				"id": "1",
 			},
 		),
 	}
@@ -124,6 +135,45 @@ func TestAccMorpheusFindDatastoreById(t *testing.T) {
 			{
 				Config: providerConfig + datastoreResouceConfig + dataSourceConfig,
 				Check:  resource.ComposeAggregateTestCheckFunc(testCheckFns(name)...),
+			},
+		},
+	})
+}
+
+func TestAccMorpheusFindDatastoreNoResourcePermissionsById(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	name := acctest.RandomWithPrefix(t.Name())
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	datastoreResouceConfig, err := testhelpers.RenderExample(t, "example_alletramp_hvm_no_resource_permissions.tf.tmpl",
+		"Name", name,
+		"AssociatedResourceID", "6032",
+		"StorageServerID", "1489",
+		"TenantID", "466",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataSourceConfig, err := testhelpers.RenderExample(t,
+		"example-id.tf.tmpl", "Id", "hpe_morpheus_datastore.example.id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + datastoreResouceConfig + dataSourceConfig,
+				Check:  resource.ComposeAggregateTestCheckFunc(testCheckFnsNoResourcePermissions(name)...),
 			},
 		},
 	})

--- a/internal/framework/subproviders/morpheus/datasources/datastore/example_alletramp_hvm_no_resource_permissions.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/datasources/datastore/example_alletramp_hvm_no_resource_permissions.tf.tmpl
@@ -1,0 +1,26 @@
+resource "hpe_morpheus_datastore" "example" {
+  name = "{{.Name}}"
+  datastore_type = {
+    id   = 8
+    code = "hpedatastore-alletra-mp"
+  }
+  associated_resource_type = "Cluster"
+  visibility               = "private"
+  active                   = true
+  associated_resource_id   = {{.AssociatedResourceID}}
+
+  config_alletramp_hvm = {
+    protocol_type     = "iSCSI"
+    enable_ransomware = false
+  }
+
+  storage_server = {
+    id = {{.StorageServerID}}
+  }
+
+  tenants = [
+    {
+      id = {{.TenantID}}
+    }
+  ]
+}


### PR DESCRIPTION
The datastore data-source failed erroneously when no resource_permissions were specified on creation of the datastore resource.  This PR fixes that issue.  We add an acceptance test for this scenario.