### PR TITLE
Adding Sweeper to TestMain in Policy

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
@@ -8,6 +8,7 @@
 package policy_test
 
 import (
+	"log"
 	"os"
 	"regexp"
 	"testing"
@@ -24,6 +25,12 @@ import (
 
 func TestMain(m *testing.M) {
 	code := m.Run()
+
+	// Run sweep after tests complete
+	if err := sweepPolicies(); err != nil {
+		log.Printf("[ERROR] Failed to sweep policies: %v", err)
+	}
+
 	testhelpers.WriteMergedResults()
 	os.Exit(code)
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/sweep_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/sweep_test.go
@@ -1,0 +1,93 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package policy_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	morpheuserrors "github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/test/sweep"
+)
+
+// Policies whose name begins with this string will be eligible for deletion
+const testPolicyPrefix = "TestAccMorpheusPolicy"
+
+// sweepPolicies cleans up test policies after tests complete
+func sweepPolicies() error {
+	ctx := context.Background()
+
+	client, err := sweep.NewSweepClient(ctx)
+	if err != nil {
+		// If we can't create a client (e.g., env vars not set), just log and continue
+		log.Printf("[INFO] Cannot create sweep client, skipping policy sweep: %v", err)
+		return nil
+	}
+
+	policies, hresp, err := client.PoliciesAPI.ListPolicies(ctx).
+		Phrase(testPolicyPrefix).Execute()
+	if err != nil {
+		// Handle 404 and 403 as "no matches found" rather than an error
+		if hresp != nil && (hresp.StatusCode == http.StatusNotFound || hresp.StatusCode == http.StatusForbidden) {
+			log.Printf("[INFO] No policies found matching prefix (status %d): %s", hresp.StatusCode, testPolicyPrefix)
+			return nil
+		}
+
+		return fmt.Errorf("failed to list policies: %s", morpheuserrors.ErrMsg(err, hresp))
+	}
+	if hresp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to list policies: %s", morpheuserrors.ErrMsg(err, hresp))
+	}
+
+	policyList := policies.GetPolicies()
+	var sweptCount int
+	var sweepErrors []string
+
+	for _, policy := range policyList {
+		name, ok := policy.GetNameOk()
+		if !ok || name == nil {
+			continue
+		}
+
+		if !strings.HasPrefix(*name, testPolicyPrefix) {
+			log.Printf("[INFO] Skipping policy (name): %s", *name)
+			continue
+		}
+
+		id, ok := policy.GetIdOk()
+		if !ok || id == nil {
+			log.Printf("[INFO] Skipping policy (id): %s", *name)
+			continue
+		}
+
+		log.Printf("[INFO] Sweeping policy: %s (id: %d)", *name, *id)
+
+		// Delete the policy
+		_, hresp, err := client.PoliciesAPI.RemovePolicies(ctx, *id).Execute()
+		if err != nil || hresp.StatusCode != http.StatusOK {
+			errMsg := fmt.Sprintf(
+				"failed to delete policy %s (id: %d): %s",
+				*name, *id, morpheuserrors.ErrMsg(err, hresp),
+			)
+			log.Printf("[ERROR] %s", errMsg)
+			sweepErrors = append(sweepErrors, errMsg)
+			continue
+		}
+
+		sweptCount++
+	}
+
+	log.Printf(
+		"[INFO] Policy sweep completed. Policies swept: %d, errors: %d",
+		sweptCount, len(sweepErrors),
+	)
+
+	if len(sweepErrors) > 0 {
+		return fmt.Errorf("%s", strings.Join(sweepErrors, "\n"))
+	}
+
+	return nil
+}

--- a/internal/framework/subproviders/morpheus/resources/policy/sweep_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/sweep_test.go
@@ -24,6 +24,7 @@ func sweepPolicies() error {
 	if err != nil {
 		// If we can't create a client (e.g., env vars not set), just log and continue
 		log.Printf("[INFO] Cannot create sweep client, skipping policy sweep: %v", err)
+
 		return nil
 	}
 
@@ -33,6 +34,7 @@ func sweepPolicies() error {
 		// Handle 404 and 403 as "no matches found" rather than an error
 		if hresp != nil && (hresp.StatusCode == http.StatusNotFound || hresp.StatusCode == http.StatusForbidden) {
 			log.Printf("[INFO] No policies found matching prefix (status %d): %s", hresp.StatusCode, testPolicyPrefix)
+
 			return nil
 		}
 
@@ -54,12 +56,14 @@ func sweepPolicies() error {
 
 		if !strings.HasPrefix(*name, testPolicyPrefix) {
 			log.Printf("[INFO] Skipping policy (name): %s", *name)
+
 			continue
 		}
 
 		id, ok := policy.GetIdOk()
 		if !ok || id == nil {
 			log.Printf("[INFO] Skipping policy (id): %s", *name)
+
 			continue
 		}
 
@@ -74,6 +78,7 @@ func sweepPolicies() error {
 			)
 			log.Printf("[ERROR] %s", errMsg)
 			sweepErrors = append(sweepErrors, errMsg)
+
 			continue
 		}
 


### PR DESCRIPTION
Adding a sweeper function to the TestMain for the Policy resource. This is probably the simplest approach to sweeper functionality - with some overhead if another resource acceptance test uses a policy they will likely have to call the sweeper manually (for policy this is unlikely - but might be worth considering if other resources adopt this pattern.)
- Added sweeper in sweeper_test.go
- Included sweeper call in TestMain in resource_test.go