### PR TITLE
sdkv2: Switch to using NotFoundInResponseError

### DIFF
--- a/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
+++ b/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
@@ -414,7 +414,7 @@ func getClusterWorkers(client *morpheus.Client, clusterId int64) ([]morpheus.Clu
 	}
 
 	if workerResp.Workers == nil {
-		return []morpheus.ClusterWorker{}, helpers.NotFoundInResponseError("workerResp.Workers")
+		return []morpheus.ClusterWorker{}, helpers.NotFoundInResponseError("Workers")
 	}
 
 	// Sort the workers by date created to avoid naming problems i.e. worker-1-1
@@ -765,7 +765,7 @@ func resourceClusterMKSVSphereCreate(ctx context.Context, d *schema.ResourceData
 				}
 
 				if hostsResult.Hosts == nil {
-					return clusterResult, clusterStatus, helpers.NotFoundInResponseError("hostsResult.Hosts")
+					return clusterResult, clusterStatus, helpers.NotFoundInResponseError("Hosts")
 				}
 
 				for _, host := range *hostsResult.Hosts {

--- a/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
+++ b/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
@@ -722,7 +722,7 @@ func resourceClusterMKSVSphereCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Cluster == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Cluster"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Cluster"))
 	}
 	cluster := result.Cluster
 	clusterStatus := statusProvisioning
@@ -865,7 +865,7 @@ func resourceClusterMKSVSphereRead(ctx context.Context, d *schema.ResourceData, 
 
 	cluster := result.Cluster
 	if cluster == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Cluster")) // should not happen
+		return diag.FromErr(helpers.NotFoundInResponseError("Cluster")) // should not happen
 	}
 
 	d.SetId(convert.Int64ToString(cluster.ID))
@@ -1313,7 +1313,7 @@ func resourceClusterMKSVSphereDelete(ctx context.Context, d *schema.ResourceData
 			}
 
 			if result.Cluster == nil {
-				return result, "error", helpers.NotFoundInResponseError("result.Cluster")
+				return result, "error", helpers.NotFoundInResponseError("Cluster")
 			}
 
 			cluster := result.Cluster

--- a/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
+++ b/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
@@ -414,7 +414,7 @@ func getClusterWorkers(client *morpheus.Client, clusterId int64) ([]morpheus.Clu
 	}
 
 	if workerResp.Workers == nil {
-		return []morpheus.ClusterWorker{}, helpers.NilPointerError("workerResp.Workers")
+		return []morpheus.ClusterWorker{}, helpers.NotFoundInResponseError("workerResp.Workers")
 	}
 
 	// Sort the workers by date created to avoid naming problems i.e. worker-1-1
@@ -722,7 +722,7 @@ func resourceClusterMKSVSphereCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Cluster == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Cluster"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Cluster"))
 	}
 	cluster := result.Cluster
 	clusterStatus := statusProvisioning
@@ -765,7 +765,7 @@ func resourceClusterMKSVSphereCreate(ctx context.Context, d *schema.ResourceData
 				}
 
 				if hostsResult.Hosts == nil {
-					return clusterResult, clusterStatus, helpers.NilPointerError("hostsResult.Hosts")
+					return clusterResult, clusterStatus, helpers.NotFoundInResponseError("hostsResult.Hosts")
 				}
 
 				for _, host := range *hostsResult.Hosts {
@@ -865,7 +865,7 @@ func resourceClusterMKSVSphereRead(ctx context.Context, d *schema.ResourceData, 
 
 	cluster := result.Cluster
 	if cluster == nil {
-		return diag.Errorf("Cluster not found in response data.") // should not happen
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Cluster")) // should not happen
 	}
 
 	d.SetId(convert.Int64ToString(cluster.ID))
@@ -1313,7 +1313,7 @@ func resourceClusterMKSVSphereDelete(ctx context.Context, d *schema.ResourceData
 			}
 
 			if result.Cluster == nil {
-				return result, "error", helpers.NilPointerError("result.Cluster")
+				return result, "error", helpers.NotFoundInResponseError("result.Cluster")
 			}
 
 			cluster := result.Cluster

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
@@ -342,7 +342,7 @@ func resourceIdentitySourceActiveDirectoryRead(
 
 	identitySource := result.IdentitySource
 	if identitySource == nil {
-		return diag.Errorf("Identity source not found in response")
+		return diag.FromErr(helpers.NotFoundInResponseError("result.IdentitySource"))
 	}
 
 	d.SetId(convert.Int64ToString(identitySource.ID))
@@ -511,7 +511,7 @@ func resourceIdentitySourceActiveDirectoryUpdate(
 
 	identitySourceResult := result.IdentitySource
 	if identitySourceResult == nil {
-		return diag.Errorf("Identity source not found in response")
+		return diag.FromErr(helpers.NotFoundInResponseError("result.IdentitySource"))
 	}
 
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
@@ -342,7 +342,7 @@ func resourceIdentitySourceActiveDirectoryRead(
 
 	identitySource := result.IdentitySource
 	if identitySource == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.IdentitySource"))
+		return diag.FromErr(helpers.NotFoundInResponseError("IdentitySource"))
 	}
 
 	d.SetId(convert.Int64ToString(identitySource.ID))
@@ -511,7 +511,7 @@ func resourceIdentitySourceActiveDirectoryUpdate(
 
 	identitySourceResult := result.IdentitySource
 	if identitySourceResult == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.IdentitySource"))
+		return diag.FromErr(helpers.NotFoundInResponseError("IdentitySource"))
 	}
 
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
@@ -379,7 +379,7 @@ func resourceIdentitySourceSAMLRead(ctx context.Context, d *schema.ResourceData,
 
 	identitySource := result.IdentitySource
 	if identitySource == nil {
-		return diag.Errorf("Identity source not found in response")
+		return diag.FromErr(helpers.NotFoundInResponseError("result.IdentitySource"))
 	}
 
 	d.SetId(convert.Int64ToString(identitySource.ID))
@@ -586,7 +586,7 @@ func resourceIdentitySourceSAMLUpdate(ctx context.Context, d *schema.ResourceDat
 
 	identitySourceResult := result.IdentitySource
 	if identitySourceResult == nil {
-		return diag.Errorf("Identity source not found in response")
+		return diag.FromErr(helpers.NotFoundInResponseError("result.IdentitySource"))
 	}
 
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
@@ -379,7 +379,7 @@ func resourceIdentitySourceSAMLRead(ctx context.Context, d *schema.ResourceData,
 
 	identitySource := result.IdentitySource
 	if identitySource == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.IdentitySource"))
+		return diag.FromErr(helpers.NotFoundInResponseError("IdentitySource"))
 	}
 
 	d.SetId(convert.Int64ToString(identitySource.ID))
@@ -586,7 +586,7 @@ func resourceIdentitySourceSAMLUpdate(ctx context.Context, d *schema.ResourceDat
 
 	identitySourceResult := result.IdentitySource
 	if identitySourceResult == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.IdentitySource"))
+		return diag.FromErr(helpers.NotFoundInResponseError("IdentitySource"))
 	}
 
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
@@ -274,7 +274,7 @@ func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -341,7 +341,7 @@ func resourceTaskAnsiblePlaybookRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	ansiblePlaybookTask := result.Task
 	d.SetId(convert.Int64ToString(ansiblePlaybookTask.ID))
@@ -522,7 +522,7 @@ func resourceTaskAnsiblePlaybookUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	ansiblePlaybookTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
@@ -274,7 +274,7 @@ func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -341,7 +341,7 @@ func resourceTaskAnsiblePlaybookRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	ansiblePlaybookTask := result.Task
 	d.SetId(convert.Int64ToString(ansiblePlaybookTask.ID))
@@ -522,7 +522,7 @@ func resourceTaskAnsiblePlaybookUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	ansiblePlaybookTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
@@ -297,7 +297,7 @@ func resourceTaskAnsibleTowerCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -364,7 +364,7 @@ func resourceTaskAnsibleTowerRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	ansibleTowerTask := result.Task
 
@@ -577,7 +577,7 @@ func resourceTaskAnsibleTowerUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	ansibleTowerTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
@@ -297,7 +297,7 @@ func resourceTaskAnsibleTowerCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -364,7 +364,7 @@ func resourceTaskAnsibleTowerRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	ansibleTowerTask := result.Task
 
@@ -577,7 +577,7 @@ func resourceTaskAnsibleTowerUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	ansibleTowerTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
@@ -300,7 +300,7 @@ func resourceTaskChefBootstrapCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -367,7 +367,7 @@ func resourceTaskChefBootstrapRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	chefBootstrapTask := result.Task
 	d.SetId(convert.Int64ToString(chefBootstrapTask.ID))
@@ -561,7 +561,7 @@ func resourceTaskChefBootstrapUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	chefBootstrapTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
@@ -300,7 +300,7 @@ func resourceTaskChefBootstrapCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -367,7 +367,7 @@ func resourceTaskChefBootstrapRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	chefBootstrapTask := result.Task
 	d.SetId(convert.Int64ToString(chefBootstrapTask.ID))
@@ -561,7 +561,7 @@ func resourceTaskChefBootstrapUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	chefBootstrapTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_email.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_email.go
@@ -326,7 +326,7 @@ func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -393,7 +393,7 @@ func resourceTaskEmailRead(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	emailTask := result.Task
 	d.SetId(convert.Int64ToString(emailTask.ID))
@@ -615,7 +615,7 @@ func resourceTaskEmailUpdate(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	emailTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_email.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_email.go
@@ -326,7 +326,7 @@ func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -393,7 +393,7 @@ func resourceTaskEmailRead(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	emailTask := result.Task
 	d.SetId(convert.Int64ToString(emailTask.ID))
@@ -615,7 +615,7 @@ func resourceTaskEmailUpdate(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	emailTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
@@ -284,7 +284,7 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -351,7 +351,7 @@ func resourceTaskGroovyScriptRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	groovyScriptTask := result.Task
 	d.SetId(convert.Int64ToString(groovyScriptTask.ID))
@@ -530,7 +530,7 @@ func resourceTaskGroovyScriptUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	groovyScriptTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
@@ -284,7 +284,7 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -351,7 +351,7 @@ func resourceTaskGroovyScriptRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	groovyScriptTask := result.Task
 	d.SetId(convert.Int64ToString(groovyScriptTask.ID))
@@ -530,7 +530,7 @@ func resourceTaskGroovyScriptUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	groovyScriptTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
@@ -220,7 +220,7 @@ func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -288,7 +288,7 @@ func resourceTaskJavaScriptRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	javascriptTask := result.Task
 	d.SetId(convert.Int64ToString(javascriptTask.ID))
@@ -425,7 +425,7 @@ func resourceTaskJavaScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	writeAttributesTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
@@ -220,7 +220,7 @@ func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -288,7 +288,7 @@ func resourceTaskJavaScriptRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	javascriptTask := result.Task
 	d.SetId(convert.Int64ToString(javascriptTask.ID))
@@ -425,7 +425,7 @@ func resourceTaskJavaScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	writeAttributesTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
@@ -262,7 +262,7 @@ func resourceTaskLibraryScriptCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -329,7 +329,7 @@ func resourceTaskLibraryScriptRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	libraryScriptTask := result.Task
 	d.SetId(convert.Int64ToString(libraryScriptTask.ID))
@@ -500,7 +500,7 @@ func resourceTaskLibraryScriptUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	libraryScriptTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
@@ -262,7 +262,7 @@ func resourceTaskLibraryScriptCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -329,7 +329,7 @@ func resourceTaskLibraryScriptRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	libraryScriptTask := result.Task
 	d.SetId(convert.Int64ToString(libraryScriptTask.ID))
@@ -500,7 +500,7 @@ func resourceTaskLibraryScriptUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	libraryScriptTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
@@ -262,7 +262,7 @@ func resourceTaskLibraryTemplateCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -329,7 +329,7 @@ func resourceTaskLibraryTemplateRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	libraryTemplateTask := result.Task
 	d.SetId(convert.Int64ToString(libraryTemplateTask.ID))
@@ -499,7 +499,7 @@ func resourceTaskLibraryTemplateUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	libraryTemplateTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
@@ -262,7 +262,7 @@ func resourceTaskLibraryTemplateCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -329,7 +329,7 @@ func resourceTaskLibraryTemplateRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	libraryTemplateTask := result.Task
 	d.SetId(convert.Int64ToString(libraryTemplateTask.ID))
@@ -499,7 +499,7 @@ func resourceTaskLibraryTemplateUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	libraryTemplateTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
@@ -209,7 +209,7 @@ func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -276,7 +276,7 @@ func resourceTaskNestedWorkflowRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	nestedWorkflowTask := result.Task
 	d.SetId(convert.Int64ToString(nestedWorkflowTask.ID))
@@ -413,7 +413,7 @@ func resourceTaskNestedWorkflowUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	nestedWorkflowTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
@@ -209,7 +209,7 @@ func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -276,7 +276,7 @@ func resourceTaskNestedWorkflowRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	nestedWorkflowTask := result.Task
 	d.SetId(convert.Int64ToString(nestedWorkflowTask.ID))
@@ -413,7 +413,7 @@ func resourceTaskNestedWorkflowUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	nestedWorkflowTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
@@ -391,7 +391,7 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -459,7 +459,7 @@ func resourceTaskPowerShellScriptRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	powerShellScriptTask := result.Task
 	d.SetId(convert.Int64ToString(powerShellScriptTask.ID))
@@ -691,7 +691,7 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
@@ -391,7 +391,7 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -459,7 +459,7 @@ func resourceTaskPowerShellScriptRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	powerShellScriptTask := result.Task
 	d.SetId(convert.Int64ToString(powerShellScriptTask.ID))
@@ -691,7 +691,7 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
@@ -328,7 +328,7 @@ func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -389,7 +389,7 @@ func resourceTaskPythonScriptRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	pythonScriptTask := result.Task
 	d.SetId(convert.Int64ToString(pythonScriptTask.ID))
@@ -483,7 +483,7 @@ func resourceTaskPythonScriptUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	pythonScriptTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
@@ -328,7 +328,7 @@ func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -389,7 +389,7 @@ func resourceTaskPythonScriptRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	pythonScriptTask := result.Task
 	d.SetId(convert.Int64ToString(pythonScriptTask.ID))
@@ -483,7 +483,7 @@ func resourceTaskPythonScriptUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	pythonScriptTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
@@ -178,7 +178,7 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -245,7 +245,7 @@ func resourceTaskRestartRead(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	restartTask := result.Task
 	d.SetId(convert.Int64ToString(restartTask.ID))
@@ -361,7 +361,7 @@ func resourceTaskRestartUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	restartTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
@@ -178,7 +178,7 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -245,7 +245,7 @@ func resourceTaskRestartRead(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	restartTask := result.Task
 	d.SetId(convert.Int64ToString(restartTask.ID))
@@ -361,7 +361,7 @@ func resourceTaskRestartUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	restartTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
@@ -277,7 +277,7 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -344,7 +344,7 @@ func resourceTaskRubyScriptRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	rubyScriptTask := result.Task
 	d.SetId(convert.Int64ToString(rubyScriptTask.ID))
@@ -523,7 +523,7 @@ func resourceTaskRubyScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	rubyScriptTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
@@ -277,7 +277,7 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -344,7 +344,7 @@ func resourceTaskRubyScriptRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	rubyScriptTask := result.Task
 	d.SetId(convert.Int64ToString(rubyScriptTask.ID))
@@ -523,7 +523,7 @@ func resourceTaskRubyScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	rubyScriptTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
@@ -425,7 +425,7 @@ func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 
 	task := result.Task
@@ -493,7 +493,7 @@ func resourceTaskShellScriptRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 
 	shellScriptTask := result.Task
@@ -760,7 +760,7 @@ func resourceTaskShellScriptUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 
 	shellScriptTask := result.Task

--- a/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
@@ -425,7 +425,7 @@ func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 
 	task := result.Task
@@ -493,7 +493,7 @@ func resourceTaskShellScriptRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 
 	shellScriptTask := result.Task
@@ -760,7 +760,7 @@ func resourceTaskShellScriptUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 
 	shellScriptTask := result.Task

--- a/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
@@ -248,7 +248,7 @@ func resourceTaskVroCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -315,7 +315,7 @@ func resourceTaskVroRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	workflowTask := result.Task
 
@@ -480,7 +480,7 @@ func resourceTaskVroUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 	vroTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
@@ -248,7 +248,7 @@ func resourceTaskVroCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	task := result.Task
 	// Successfully created resource, now set id
@@ -315,7 +315,7 @@ func resourceTaskVroRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	workflowTask := result.Task
 
@@ -480,7 +480,7 @@ func resourceTaskVroUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("result.Task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("result.Task"))
 	}
 	vroTask := result.Task
 	// Successfully updated resource, now set id

--- a/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
@@ -205,7 +205,7 @@ func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("task"))
 	}
 
 	task := result.Task
@@ -273,7 +273,7 @@ func resourceTaskWriteAttributesRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("task"))
 	}
 
 	writeAttributesTask := result.Task
@@ -403,7 +403,7 @@ func resourceTaskWriteAttributesUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NilPointerError("task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("task"))
 	}
 
 	writeAttributesTask := result.Task

--- a/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
@@ -205,7 +205,7 @@ func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 
 	task := result.Task
@@ -273,7 +273,7 @@ func resourceTaskWriteAttributesRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 
 	writeAttributesTask := result.Task
@@ -403,7 +403,7 @@ func resourceTaskWriteAttributesUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if result.Task == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("task"))
+		return diag.FromErr(helpers.NotFoundInResponseError("Task"))
 	}
 
 	writeAttributesTask := result.Task


### PR DESCRIPTION
Switches to using NotFoundInResponseError for nil checks on pointers to objects in sdkv2 `result` objects.