### PR TITLE
Fix image resource SSH password

### DIFF
--- a/docs/resources/morpheus_image.md
+++ b/docs/resources/morpheus_image.md
@@ -70,8 +70,6 @@ resource "hpe_morpheus_image" "example_image" {
 - `min_disk` (Number) Minimal required amount of disk space for provisioning in GB
 - `min_ram` (Number) Minimal required amount of RAM for provisioning in GB
 - `os_type_id` (Number) ID of the OS Type
-- `ssh_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) SSH key (Write Only)
-- `ssh_key_wo_version` (Number) SSH key version. Used to determine if ssh_key_wo has been updated.
 - `ssh_password_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) SSH password (Write Only)
 - `ssh_password_wo_version` (Number) SSH password version. Used to determine if ssh_password_wo has been updated.
 - `ssh_username` (String) SSH Username

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -22,9 +22,14 @@ import (
 
 // Create implements resource.Resource.
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan ImageModel
+	var plan, config ImageModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -127,14 +132,9 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		reqImage.VirtualImage.SetOsType(plan.OsTypeId.ValueInt64())
 	}
 
-	// ssh_key
-	if !plan.SshKeyWo.IsNull() && !plan.SshKeyWo.IsUnknown() {
-		reqImage.VirtualImage.SetSshKey(plan.SshKeyWo.ValueString())
-	}
-
-	// ssh_password
-	if !plan.SshPasswordWo.IsNull() && !plan.SshPasswordWo.IsUnknown() {
-		reqImage.VirtualImage.SetSshPassword(plan.SshPasswordWo.ValueString())
+	// ssh_password_wo
+	if !config.SshPasswordWo.IsNull() && !config.SshPasswordWo.IsUnknown() {
+		reqImage.VirtualImage.SetSshPassword(config.SshPasswordWo.ValueString())
 	}
 
 	// ssh_username

--- a/internal/framework/subproviders/morpheus/resources/image/read.go
+++ b/internal/framework/subproviders/morpheus/resources/image/read.go
@@ -114,9 +114,6 @@ func getImageAsState(
 	// ssh_username
 	state.SshUsername = convert.StrToType(image.SshUsername.Get())
 
-	// ssh_key_wo_version
-	state.SshKeyWoVersion = plan.SshKeyWoVersion
-
 	// ssh_password_wo_version
 	state.SshPasswordWoVersion = plan.SshPasswordWoVersion
 

--- a/internal/framework/subproviders/morpheus/resources/image/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/image/schema_gen.go
@@ -5,12 +5,10 @@ package image
 import (
 	"context"
 	"fmt"
-	"strings"
-
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -23,8 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"strings"
 
-	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/modifiers"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 func ImageResourceSchema(ctx context.Context) schema.Schema {
@@ -217,24 +216,6 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 					int64planmodifier.RequiresReplace(),
 				},
 			},
-			"ssh_key_wo": schema.StringAttribute{
-				Optional:            true,
-				WriteOnly:           true,
-				Description:         "SSH key (Write Only)",
-				MarkdownDescription: "SSH key (Write Only)",
-				PlanModifiers: []planmodifier.String{
-					modifiers.NullableStringUpdateModifier{},
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"ssh_key_wo_version": schema.Int64Attribute{
-				Optional:            true,
-				Description:         "SSH key version. Used to determine if ssh_key_wo has been updated.",
-				MarkdownDescription: "SSH key version. Used to determine if ssh_key_wo has been updated.",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
-			},
 			"ssh_password_wo": schema.StringAttribute{
 				Optional:            true,
 				WriteOnly:           true,
@@ -421,8 +402,6 @@ type ImageModel struct {
 	OsTypeId             types.Int64      `tfsdk:"os_type_id"`
 	OwnerId              types.Int64      `tfsdk:"owner_id"`
 	RawSize              types.Int64      `tfsdk:"raw_size"`
-	SshKeyWo             types.String     `tfsdk:"ssh_key_wo"`
-	SshKeyWoVersion      types.Int64      `tfsdk:"ssh_key_wo_version"`
 	SshPasswordWo        types.String     `tfsdk:"ssh_password_wo"`
 	SshPasswordWoVersion types.Int64      `tfsdk:"ssh_password_wo_version"`
 	SshUsername          types.String     `tfsdk:"ssh_username"`


### PR DESCRIPTION
The `ssh_password_wo` attribute is not available in the plan as it's a write only value. This means we need to read the value from the config directly.
Also removes SSH key attribute as it cannot be set.
