### PR TITLE
Fix failing acceptance tests

### DIFF
--- a/docs/resources/morpheus_image.md
+++ b/docs/resources/morpheus_image.md
@@ -28,10 +28,10 @@ resource "hpe_morpheus_image" "example_image" {
     labels = ["terraform-image"]
     image_type = "qcow2"
     url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2"
-    storage_provider_id = 1
+    storage_provider_id = 196
     auto_join_domain = true
     cloud_init = true
-    os_type_id = 116
+    os_type_id = 75
     ssh_username = "alpine"
     min_ram = 1
     min_disk = 20

--- a/internal/framework/subproviders/morpheus/resources/image/example.tf
+++ b/internal/framework/subproviders/morpheus/resources/image/example.tf
@@ -4,10 +4,10 @@ resource "hpe_morpheus_image" "example_image" {
     labels = ["terraform-image"]
     image_type = "qcow2"
     url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2"
-    storage_provider_id = 1
+    storage_provider_id = 196
     auto_join_domain = true
     cloud_init = true
-    os_type_id = 116
+    os_type_id = 75
     ssh_username = "alpine"
     min_ram = 1
     min_disk = 20

--- a/internal/framework/subproviders/morpheus/resources/image/example.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/image/example.tf.tmpl
@@ -4,10 +4,10 @@ resource "hpe_morpheus_image" "example_image" {
     labels = ["terraform-image"]
     image_type = "qcow2"
     url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2"
-    storage_provider_id = 1
+    storage_provider_id = 196
     auto_join_domain = true
     cloud_init = true
-    os_type_id = 116
+    os_type_id = 75
     ssh_username = "alpine"
     min_ram = 1
     min_disk = 20

--- a/internal/framework/subproviders/morpheus/resources/network/create_test.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create_test.go
@@ -160,7 +160,7 @@ func TestAccMorpheusNetworkResourceCreateAllAttrsOk(t *testing.T) {
 	uniqueName := acctest.RandomWithPrefix(t.Name())
 
 	// Path to example configuration files
-	examplePath := "../../../../../examples/resources/hpe_morpheus_network/azure"
+	examplePath := "../../../../../../examples/resources/hpe_morpheus_network/azure"
 
 	// Read the resource.tf file from disk
 	resourceContent, err := os.ReadFile(filepath.Join(examplePath, "resource.tf"))
@@ -265,7 +265,7 @@ func TestAccMorpheusNetworkResourceCreateHostConfig(t *testing.T) {
 	uniqueName := acctest.RandomWithPrefix(t.Name())
 
 	// Path to example configuration files
-	examplePath := "../../../../../examples/resources/hpe_morpheus_network/host"
+	examplePath := "../../../../../../examples/resources/hpe_morpheus_network/host"
 
 	// Read the resource.tf file from disk
 	resourceContent, err := os.ReadFile(filepath.Join(examplePath, "resource.tf"))
@@ -340,7 +340,7 @@ func TestAccMorpheusNetworkResourceCreateAWSExample(t *testing.T) {
 	uniqueName := acctest.RandomWithPrefix(t.Name())
 
 	// Path to example configuration files
-	examplePath := "../../../../../examples/resources/hpe_morpheus_network"
+	examplePath := "../../../../../../examples/resources/hpe_morpheus_network"
 
 	// Read the resource.tf file from disk
 	resourceContent, err := os.ReadFile(filepath.Join(examplePath, "resource.tf"))
@@ -441,7 +441,7 @@ func TestAccMorpheusNetworkResourceCreateGcp(t *testing.T) {
 	uniqueName := acctest.RandomWithPrefix(t.Name())
 
 	// Path to example configuration files
-	examplePath := "../../../../../examples/resources/hpe_morpheus_network/gcp"
+	examplePath := "../../../../../../examples/resources/hpe_morpheus_network/gcp"
 
 	// Read the resource.tf file from disk
 	resourceContent, err := os.ReadFile(filepath.Join(examplePath, "resource.tf"))
@@ -547,7 +547,7 @@ func TestAccMorpheusNetworkResourceCreateOVSPortGroup(t *testing.T) {
 	uniqueName := acctest.RandomWithPrefix(t.Name())
 
 	// Path to example configuration files
-	examplePath := "../../../../../examples/resources/hpe_morpheus_network/ovs_port_group"
+	examplePath := "../../../../../../examples/resources/hpe_morpheus_network/ovs_port_group"
 
 	// Read the resource.tf file from disk
 	resourceContent, err := os.ReadFile(filepath.Join(examplePath, "resource.tf"))

--- a/internal/framework/subproviders/morpheus/resources/user/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/user/resource_test.go
@@ -83,7 +83,7 @@ func TestAccMorpheusUserExample(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	path := "../../../../../examples/resources/hpe_morpheus_user/resource.tf"
+	path := "../../../../../../examples/resources/hpe_morpheus_user/resource.tf"
 	exampleConfig, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("Error reading example config: %v", err)


### PR DESCRIPTION
Image:
- `storage_provider_id` and `os_type_id` needed to be adjusted for the test system

Network/User:
- Example path needed to be adjusted
