### PR TITLE
Remove USE_FORCE env-var

### DIFF
--- a/internal/sdkv2/morpheus/helpers/morpheus.go
+++ b/internal/sdkv2/morpheus/helpers/morpheus.go
@@ -1,9 +1,0 @@
-package helpers
-
-import (
-	"os"
-)
-
-// global stuff here
-
-var UseForce = (os.Getenv("USE_FORCE") == "true")

--- a/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
+++ b/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
@@ -1,3 +1,5 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
 package cluster
 
 import (
@@ -1275,9 +1277,7 @@ func resourceClusterMKSVSphereDelete(ctx context.Context, d *schema.ResourceData
 			"removeResources": "on",
 		},
 	}
-	if helpers.UseForce {
-		req.QueryParams["force"] = "true"
-	}
+	req.QueryParams["force"] = "true"
 	resp, err := client.DeleteCluster(convert.StringToInt64(id), req)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {


### PR DESCRIPTION
It is only used in morpheus_cluster_mks.  Instead we always add "force=true" as a query parameter on DELETE.