### PR TITLE
Add new Image Create status

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/image/image.go
+++ b/internal/framework/subproviders/morpheus/resources/image/image.go
@@ -19,12 +19,14 @@ var (
 	// Converting
 	// Downloading
 	// Failed
+	// Error
 	CreateTargetStatuses = []string{
 		"Active",
 	}
 
 	CreateErrorStatuses = []string{
 		"Failed",
+		"Error",
 	}
 )
 


### PR DESCRIPTION
Image can enter an `Error` state when a download from a URL fails.
