### PR TITLE
Sdkv2: Append read diagnostics in create method

### DIFF
--- a/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
+++ b/internal/sdkv2/morpheus/resources/cluster/resource_cluster_mks_vsphere.go
@@ -803,7 +803,7 @@ func resourceClusterMKSVSphereCreate(ctx context.Context, d *schema.ResourceData
 
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(cluster.ID))
-	resourceClusterMKSVSphereRead(ctx, d, meta)
+	diags = append(diags, resourceClusterMKSVSphereRead(ctx, d, meta)...)
 
 	// Fail the cluster deployment if the cluster status is in a failed state
 	if clusterStatus == statusFailed {

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
@@ -146,6 +146,9 @@ func resourceIdentitySourceActiveDirectoryCreate(
 	d *schema.ResourceData,
 	meta interface{},
 ) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -275,7 +278,9 @@ func resourceIdentitySourceActiveDirectoryCreate(
 		return diag.FromErr(helpers.TypeAssertFailError("tenant_id", d.Get("tenant_id")))
 	}
 
-	return resourceIdentitySourceActiveDirectoryRead(ctx, d, meta)
+	resourceIdentitySourceActiveDirectoryRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceIdentitySourceActiveDirectoryRead(

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
@@ -146,9 +146,6 @@ func resourceIdentitySourceActiveDirectoryCreate(
 	d *schema.ResourceData,
 	meta interface{},
 ) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -278,9 +275,7 @@ func resourceIdentitySourceActiveDirectoryCreate(
 		return diag.FromErr(helpers.TypeAssertFailError("tenant_id", d.Get("tenant_id")))
 	}
 
-	resourceIdentitySourceActiveDirectoryRead(ctx, d, meta)
-
-	return diags
+	return resourceIdentitySourceActiveDirectoryRead(ctx, d, meta)
 }
 
 func resourceIdentitySourceActiveDirectoryRead(

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_active_directory.go
@@ -278,7 +278,7 @@ func resourceIdentitySourceActiveDirectoryCreate(
 		return diag.FromErr(helpers.TypeAssertFailError("tenant_id", d.Get("tenant_id")))
 	}
 
-	resourceIdentitySourceActiveDirectoryRead(ctx, d, meta)
+	diags = append(diags, resourceIdentitySourceActiveDirectoryRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
@@ -150,9 +150,6 @@ func ResourceIdentitySourceSAML() *schema.Resource {
 }
 
 func resourceIdentitySourceSAMLCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -318,9 +315,7 @@ func resourceIdentitySourceSAMLCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(helpers.TypeAssertFailError("tenant_id", d.Get("tenant_id")))
 	}
 
-	resourceIdentitySourceSAMLRead(ctx, d, meta)
-
-	return diags
+	return resourceIdentitySourceSAMLRead(ctx, d, meta)
 }
 
 func resourceIdentitySourceSAMLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
@@ -150,6 +150,9 @@ func ResourceIdentitySourceSAML() *schema.Resource {
 }
 
 func resourceIdentitySourceSAMLCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -315,7 +318,9 @@ func resourceIdentitySourceSAMLCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(helpers.TypeAssertFailError("tenant_id", d.Get("tenant_id")))
 	}
 
-	return resourceIdentitySourceSAMLRead(ctx, d, meta)
+	resourceIdentitySourceSAMLRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceIdentitySourceSAMLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
+++ b/internal/sdkv2/morpheus/resources/identitysource/resource_identity_source_saml.go
@@ -318,7 +318,7 @@ func resourceIdentitySourceSAMLCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(helpers.TypeAssertFailError("tenant_id", d.Get("tenant_id")))
 	}
 
-	resourceIdentitySourceSAMLRead(ctx, d, meta)
+	diags = append(diags, resourceIdentitySourceSAMLRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/job/resource_job_task.go
+++ b/internal/sdkv2/morpheus/resources/job/resource_job_task.go
@@ -129,9 +129,6 @@ func resourceJobTaskCreate(ctx context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
 	}
 
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	job := make(map[string]any)
 
 	var name string
@@ -283,9 +280,7 @@ func resourceJobTaskCreate(ctx context.Context, d *schema.ResourceData, meta any
 	// Successfully created resource, now set id
 	d.SetId(jobId)
 
-	resourceJobTaskRead(ctx, d, meta)
-
-	return diags
+	return resourceJobTaskRead(ctx, d, meta)
 }
 
 func resourceJobTaskRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/job/resource_job_task.go
+++ b/internal/sdkv2/morpheus/resources/job/resource_job_task.go
@@ -129,6 +129,9 @@ func resourceJobTaskCreate(ctx context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
 	}
 
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	job := make(map[string]any)
 
 	var name string
@@ -280,7 +283,9 @@ func resourceJobTaskCreate(ctx context.Context, d *schema.ResourceData, meta any
 	// Successfully created resource, now set id
 	d.SetId(jobId)
 
-	return resourceJobTaskRead(ctx, d, meta)
+	resourceJobTaskRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceJobTaskRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/job/resource_job_task.go
+++ b/internal/sdkv2/morpheus/resources/job/resource_job_task.go
@@ -283,7 +283,7 @@ func resourceJobTaskCreate(ctx context.Context, d *schema.ResourceData, meta any
 	// Successfully created resource, now set id
 	d.SetId(jobId)
 
-	resourceJobTaskRead(ctx, d, meta)
+	diags = append(diags, resourceJobTaskRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/job/resource_job_workflow.go
+++ b/internal/sdkv2/morpheus/resources/job/resource_job_workflow.go
@@ -120,6 +120,9 @@ func ResourceJobWorkflow() *schema.Resource {
 func resourceJobWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*morpheus.Client)
 
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	job := make(map[string]any)
 
 	var name string
@@ -284,7 +287,9 @@ func resourceJobWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(jobResult.ID))
 
-	return resourceJobWorkflowRead(ctx, d, meta)
+	resourceJobWorkflowRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceJobWorkflowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/job/resource_job_workflow.go
+++ b/internal/sdkv2/morpheus/resources/job/resource_job_workflow.go
@@ -120,9 +120,6 @@ func ResourceJobWorkflow() *schema.Resource {
 func resourceJobWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*morpheus.Client)
 
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	job := make(map[string]any)
 
 	var name string
@@ -287,9 +284,7 @@ func resourceJobWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(jobResult.ID))
 
-	resourceJobWorkflowRead(ctx, d, meta)
-
-	return diags
+	return resourceJobWorkflowRead(ctx, d, meta)
 }
 
 func resourceJobWorkflowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/job/resource_job_workflow.go
+++ b/internal/sdkv2/morpheus/resources/job/resource_job_workflow.go
@@ -287,7 +287,7 @@ func resourceJobWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(jobResult.ID))
 
-	resourceJobWorkflowRead(ctx, d, meta)
+	diags = append(diags, resourceJobWorkflowRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
@@ -115,6 +115,9 @@ func ResourceTaskAnsiblePlaybook() *schema.Resource {
 }
 
 func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -277,7 +280,9 @@ func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskAnsiblePlaybookRead(ctx, d, meta)
+	resourceTaskAnsiblePlaybookRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskAnsiblePlaybookRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
@@ -115,9 +115,6 @@ func ResourceTaskAnsiblePlaybook() *schema.Resource {
 }
 
 func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -280,9 +277,7 @@ func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskAnsiblePlaybookRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskAnsiblePlaybookRead(ctx, d, meta)
 }
 
 func resourceTaskAnsiblePlaybookRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_playbook.go
@@ -280,7 +280,7 @@ func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskAnsiblePlaybookRead(ctx, d, meta)
+	diags = append(diags, resourceTaskAnsiblePlaybookRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
@@ -125,6 +125,9 @@ func ResourceTaskAnsibleTower() *schema.Resource {
 }
 
 func resourceTaskAnsibleTowerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -300,7 +303,9 @@ func resourceTaskAnsibleTowerCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskAnsibleTowerRead(ctx, d, meta)
+	resourceTaskAnsibleTowerRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskAnsibleTowerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
@@ -125,9 +125,6 @@ func ResourceTaskAnsibleTower() *schema.Resource {
 }
 
 func resourceTaskAnsibleTowerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -303,9 +300,7 @@ func resourceTaskAnsibleTowerCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskAnsibleTowerRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskAnsibleTowerRead(ctx, d, meta)
 }
 
 func resourceTaskAnsibleTowerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ansible_tower.go
@@ -303,7 +303,7 @@ func resourceTaskAnsibleTowerCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskAnsibleTowerRead(ctx, d, meta)
+	diags = append(diags, resourceTaskAnsibleTowerRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
@@ -306,7 +306,7 @@ func resourceTaskChefBootstrapCreate(ctx context.Context, d *schema.ResourceData
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskChefBootstrapRead(ctx, d, meta)
+	diags = append(diags, resourceTaskChefBootstrapRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
@@ -133,9 +133,6 @@ func ResourceTaskChefBootstrap() *schema.Resource {
 }
 
 func resourceTaskChefBootstrapCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -306,9 +303,7 @@ func resourceTaskChefBootstrapCreate(ctx context.Context, d *schema.ResourceData
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskChefBootstrapRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskChefBootstrapRead(ctx, d, meta)
 }
 
 func resourceTaskChefBootstrapRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_chef_bootstrap.go
@@ -133,6 +133,9 @@ func ResourceTaskChefBootstrap() *schema.Resource {
 }
 
 func resourceTaskChefBootstrapCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -303,7 +306,9 @@ func resourceTaskChefBootstrapCreate(ctx context.Context, d *schema.ResourceData
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskChefBootstrapRead(ctx, d, meta)
+	resourceTaskChefBootstrapRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskChefBootstrapRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_email.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_email.go
@@ -135,6 +135,9 @@ func ResourceTaskEmail() *schema.Resource {
 }
 
 func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -329,7 +332,9 @@ func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta a
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskEmailRead(ctx, d, meta)
+	resourceTaskEmailRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskEmailRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_email.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_email.go
@@ -135,9 +135,6 @@ func ResourceTaskEmail() *schema.Resource {
 }
 
 func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -332,9 +329,7 @@ func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta a
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskEmailRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskEmailRead(ctx, d, meta)
 }
 
 func resourceTaskEmailRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_email.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_email.go
@@ -332,7 +332,7 @@ func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta a
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskEmailRead(ctx, d, meta)
+	diags = append(diags, resourceTaskEmailRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
@@ -126,6 +126,9 @@ func ResourceTaskGroovyScript() *schema.Resource {
 }
 
 func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -287,7 +290,9 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskGroovyScriptRead(ctx, d, meta)
+	resourceTaskGroovyScriptRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskGroovyScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
@@ -126,9 +126,6 @@ func ResourceTaskGroovyScript() *schema.Resource {
 }
 
 func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -290,9 +287,7 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskGroovyScriptRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskGroovyScriptRead(ctx, d, meta)
 }
 
 func resourceTaskGroovyScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
@@ -290,7 +290,7 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskGroovyScriptRead(ctx, d, meta)
+	diags = append(diags, resourceTaskGroovyScriptRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
@@ -100,9 +100,6 @@ func ResourceTaskJavaScript() *schema.Resource {
 }
 
 func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -227,9 +224,7 @@ func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(convert.Int64ToString(task.ID))
 	log.Printf("Task ID: %s", convert.Int64ToString(task.ID))
 
-	resourceTaskJavaScriptRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskJavaScriptRead(ctx, d, meta)
 }
 
 func resourceTaskJavaScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
@@ -100,6 +100,9 @@ func ResourceTaskJavaScript() *schema.Resource {
 }
 
 func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -224,7 +227,9 @@ func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(convert.Int64ToString(task.ID))
 	log.Printf("Task ID: %s", convert.Int64ToString(task.ID))
 
-	return resourceTaskJavaScriptRead(ctx, d, meta)
+	resourceTaskJavaScriptRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskJavaScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_javascript.go
@@ -227,7 +227,7 @@ func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(convert.Int64ToString(task.ID))
 	log.Printf("Task ID: %s", convert.Int64ToString(task.ID))
 
-	resourceTaskJavaScriptRead(ctx, d, meta)
+	diags = append(diags, resourceTaskJavaScriptRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
@@ -112,6 +112,9 @@ func ResourceTaskLibraryScript() *schema.Resource {
 }
 
 func resourceTaskLibraryScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -265,7 +268,9 @@ func resourceTaskLibraryScriptCreate(ctx context.Context, d *schema.ResourceData
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskLibraryScriptRead(ctx, d, meta)
+	resourceTaskLibraryScriptRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskLibraryScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
@@ -112,9 +112,6 @@ func ResourceTaskLibraryScript() *schema.Resource {
 }
 
 func resourceTaskLibraryScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -268,9 +265,7 @@ func resourceTaskLibraryScriptCreate(ctx context.Context, d *schema.ResourceData
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskLibraryScriptRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskLibraryScriptRead(ctx, d, meta)
 }
 
 func resourceTaskLibraryScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_script.go
@@ -268,7 +268,7 @@ func resourceTaskLibraryScriptCreate(ctx context.Context, d *schema.ResourceData
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskLibraryScriptRead(ctx, d, meta)
+	diags = append(diags, resourceTaskLibraryScriptRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
@@ -112,9 +112,6 @@ func ResourceTaskLibraryTemplate() *schema.Resource {
 }
 
 func resourceTaskLibraryTemplateCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -268,9 +265,7 @@ func resourceTaskLibraryTemplateCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskLibraryTemplateRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskLibraryTemplateRead(ctx, d, meta)
 }
 
 func resourceTaskLibraryTemplateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
@@ -112,6 +112,9 @@ func ResourceTaskLibraryTemplate() *schema.Resource {
 }
 
 func resourceTaskLibraryTemplateCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -265,7 +268,9 @@ func resourceTaskLibraryTemplateCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskLibraryTemplateRead(ctx, d, meta)
+	resourceTaskLibraryTemplateRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskLibraryTemplateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_library_template.go
@@ -268,7 +268,7 @@ func resourceTaskLibraryTemplateCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskLibraryTemplateRead(ctx, d, meta)
+	diags = append(diags, resourceTaskLibraryTemplateRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
@@ -89,9 +89,6 @@ func ResourceTaskNestedWorkflow() *schema.Resource {
 }
 
 func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -215,9 +212,7 @@ func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceDat
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskNestedWorkflowRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskNestedWorkflowRead(ctx, d, meta)
 }
 
 func resourceTaskNestedWorkflowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
@@ -215,7 +215,7 @@ func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceDat
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskNestedWorkflowRead(ctx, d, meta)
+	diags = append(diags, resourceTaskNestedWorkflowRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_nested_workflow.go
@@ -89,6 +89,9 @@ func ResourceTaskNestedWorkflow() *schema.Resource {
 }
 
 func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -212,7 +215,9 @@ func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceDat
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskNestedWorkflowRead(ctx, d, meta)
+	resourceTaskNestedWorkflowRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskNestedWorkflowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
@@ -171,9 +171,6 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 }
 
 func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -398,9 +395,7 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 	d.SetId(convert.Int64ToString(task.ID))
 	log.Printf("Task ID: %s", convert.Int64ToString(task.ID))
 
-	resourceTaskPowerShellScriptRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskPowerShellScriptRead(ctx, d, meta)
 }
 
 func resourceTaskPowerShellScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
@@ -171,6 +171,9 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 }
 
 func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -395,7 +398,9 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 	d.SetId(convert.Int64ToString(task.ID))
 	log.Printf("Task ID: %s", convert.Int64ToString(task.ID))
 
-	return resourceTaskPowerShellScriptRead(ctx, d, meta)
+	resourceTaskPowerShellScriptRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskPowerShellScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
@@ -398,7 +398,7 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 	d.SetId(convert.Int64ToString(task.ID))
 	log.Printf("Task ID: %s", convert.Int64ToString(task.ID))
 
-	resourceTaskPowerShellScriptRead(ctx, d, meta)
+	diags = append(diags, resourceTaskPowerShellScriptRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
@@ -334,7 +334,7 @@ func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskPythonScriptRead(ctx, d, meta)
+	diags = append(diags, resourceTaskPythonScriptRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
@@ -143,6 +143,9 @@ func ResourceTaskPythonScript() *schema.Resource {
 }
 
 func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -331,7 +334,9 @@ func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskPythonScriptRead(ctx, d, meta)
+	resourceTaskPythonScriptRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskPythonScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
@@ -143,9 +143,6 @@ func ResourceTaskPythonScript() *schema.Resource {
 }
 
 func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -334,9 +331,7 @@ func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData,
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskPythonScriptRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskPythonScriptRead(ctx, d, meta)
 }
 
 func resourceTaskPythonScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
@@ -184,7 +184,7 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskRestartRead(ctx, d, meta)
+	diags = append(diags, resourceTaskRestartRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
@@ -77,6 +77,9 @@ func ResourceTaskRestart() *schema.Resource {
 }
 
 func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -181,7 +184,9 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskRestartRead(ctx, d, meta)
+	resourceTaskRestartRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskRestartRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_restart.go
@@ -77,9 +77,6 @@ func ResourceTaskRestart() *schema.Resource {
 }
 
 func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -184,9 +181,7 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskRestartRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskRestartRead(ctx, d, meta)
 }
 
 func resourceTaskRestartRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
@@ -283,7 +283,7 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskRubyScriptRead(ctx, d, meta)
+	diags = append(diags, resourceTaskRubyScriptRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
@@ -119,6 +119,9 @@ func ResourceTaskRubyScript() *schema.Resource {
 }
 
 func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -280,7 +283,9 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskRubyScriptRead(ctx, d, meta)
+	resourceTaskRubyScriptRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskRubyScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
@@ -119,9 +119,6 @@ func ResourceTaskRubyScript() *schema.Resource {
 }
 
 func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -283,9 +280,7 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskRubyScriptRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskRubyScriptRead(ctx, d, meta)
 }
 
 func resourceTaskRubyScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
@@ -432,7 +432,7 @@ func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, 
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskShellScriptRead(ctx, d, meta)
+	diags = append(diags, resourceTaskShellScriptRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
@@ -194,9 +194,6 @@ func ResourceTaskShellScript() *schema.Resource {
 }
 
 func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -432,9 +429,7 @@ func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, 
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskShellScriptRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskShellScriptRead(ctx, d, meta)
 }
 
 func resourceTaskShellScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
@@ -194,6 +194,9 @@ func ResourceTaskShellScript() *schema.Resource {
 }
 
 func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -429,7 +432,9 @@ func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, 
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskShellScriptRead(ctx, d, meta)
+	resourceTaskShellScriptRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskShellScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
@@ -254,7 +254,7 @@ func resourceTaskVroCreate(ctx context.Context, d *schema.ResourceData, meta any
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskVroRead(ctx, d, meta)
+	diags = append(diags, resourceTaskVroRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
@@ -105,9 +105,6 @@ func ResourceTaskVro() *schema.Resource {
 }
 
 func resourceTaskVroCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -254,9 +251,7 @@ func resourceTaskVroCreate(ctx context.Context, d *schema.ResourceData, meta any
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskVroRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskVroRead(ctx, d, meta)
 }
 
 func resourceTaskVroRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_vro.go
@@ -105,6 +105,9 @@ func ResourceTaskVro() *schema.Resource {
 }
 
 func resourceTaskVroCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -251,7 +254,9 @@ func resourceTaskVroCreate(ctx context.Context, d *schema.ResourceData, meta any
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskVroRead(ctx, d, meta)
+	resourceTaskVroRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskVroRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
@@ -93,9 +93,6 @@ func ResourceTaskWriteAttributes() *schema.Resource {
 }
 
 func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -212,9 +209,7 @@ func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskWriteAttributesRead(ctx, d, meta)
-
-	return diags
+	return resourceTaskWriteAttributesRead(ctx, d, meta)
 }
 
 func resourceTaskWriteAttributesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
@@ -93,6 +93,9 @@ func ResourceTaskWriteAttributes() *schema.Resource {
 }
 
 func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -209,7 +212,9 @@ func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	return resourceTaskWriteAttributesRead(ctx, d, meta)
+	resourceTaskWriteAttributesRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceTaskWriteAttributesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_write_attributes.go
@@ -212,7 +212,7 @@ func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(task.ID))
 
-	resourceTaskWriteAttributesRead(ctx, d, meta)
+	diags = append(diags, resourceTaskWriteAttributesRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
+++ b/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
@@ -68,9 +68,6 @@ func resourceWikiPageCreate(ctx context.Context, d *schema.ResourceData, meta an
 		return diag.FromErr(helpers.TypeAssertFailError("meta", meta))
 	}
 
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	wikiPage := make(map[string]any)
 
 	var name string
@@ -123,9 +120,7 @@ func resourceWikiPageCreate(ctx context.Context, d *schema.ResourceData, meta an
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(wikiPageResult.ID))
 
-	resourceWikiPageRead(ctx, d, meta)
-
-	return diags
+	return resourceWikiPageRead(ctx, d, meta)
 }
 
 func resourceWikiPageRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
+++ b/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
@@ -123,7 +123,7 @@ func resourceWikiPageCreate(ctx context.Context, d *schema.ResourceData, meta an
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(wikiPageResult.ID))
 
-	resourceWikiPageRead(ctx, d, meta)
+	diags = append(diags, resourceWikiPageRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
+++ b/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
@@ -68,6 +68,9 @@ func resourceWikiPageCreate(ctx context.Context, d *schema.ResourceData, meta an
 		return diag.FromErr(helpers.TypeAssertFailError("meta", meta))
 	}
 
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	wikiPage := make(map[string]any)
 
 	var name string
@@ -120,7 +123,9 @@ func resourceWikiPageCreate(ctx context.Context, d *schema.ResourceData, meta an
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(wikiPageResult.ID))
 
-	return resourceWikiPageRead(ctx, d, meta)
+	resourceWikiPageRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceWikiPageRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_catalog_item.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_catalog_item.go
@@ -371,7 +371,7 @@ func resourceWorkflowCatalogItemCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(catalogItemResult.ID))
 
-	resourceWorkflowCatalogItemRead(ctx, d, meta)
+	diags = append(diags, resourceWorkflowCatalogItemRead(ctx, d, meta)...)
 
 	return diags
 }

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_catalog_item.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_catalog_item.go
@@ -161,9 +161,6 @@ func resourceWorkflowCatalogItemCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
 	}
 
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-
 	catalogItem := make(map[string]any)
 
 	var name string
@@ -371,9 +368,7 @@ func resourceWorkflowCatalogItemCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(catalogItemResult.ID))
 
-	resourceWorkflowCatalogItemRead(ctx, d, meta)
-
-	return diags
+	return resourceWorkflowCatalogItemRead(ctx, d, meta)
 }
 
 func resourceWorkflowCatalogItemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_catalog_item.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_catalog_item.go
@@ -161,6 +161,9 @@ func resourceWorkflowCatalogItemCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
 	}
 
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
 	catalogItem := make(map[string]any)
 
 	var name string
@@ -368,7 +371,9 @@ func resourceWorkflowCatalogItemCreate(ctx context.Context, d *schema.ResourceDa
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(catalogItemResult.ID))
 
-	return resourceWorkflowCatalogItemRead(ctx, d, meta)
+	resourceWorkflowCatalogItemRead(ctx, d, meta)
+
+	return diags
 }
 
 func resourceWorkflowCatalogItemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {


### PR DESCRIPTION
Previously any diagnostics returned from the call to Read were not being propagated correctly; this fixes that.