### PR TITLE
Add a basic dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should create PRs for Go packages which may need updating.
Primary goal of this action is to automate the creation of PRs for SDK updates.
