### PR TITLE
Switch to using official golangci-lint action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,22 +2,25 @@
 
 name: Lint
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   push:
     branches:
       - main
   pull_request:
 jobs:
-  lint:
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go: [ '1.24.1' ]
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
-      - run: go version
-      - run: make linter
-      - run: make lint
+          go-version: '1.24.1'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1


### PR DESCRIPTION
This should hopefully make the lint workflow a bit faster.