### PR TITLE
Bump version of actions/setup-go for all workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,13 +10,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go: [ '1.24.1' ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
       - run: go version
       - run: make build

--- a/.github/workflows/buildexperimental.yaml
+++ b/.github/workflows/buildexperimental.yaml
@@ -10,13 +10,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go: [ '1.24.1' ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
       - run: go version
       - run: make experimental

--- a/.github/workflows/docs-diff.yaml
+++ b/.github/workflows/docs-diff.yaml
@@ -10,14 +10,11 @@ on:
 jobs:
   diff:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go: [ '1.24.1' ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.12.2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,14 +10,11 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go: [ '1.24.1' ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.12.2

--- a/.github/workflows/docsexperimental.yaml
+++ b/.github/workflows/docsexperimental.yaml
@@ -10,14 +10,11 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go: [ '1.24.1' ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.12.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,14 +10,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go: [ '1.24.1' ]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.12.2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # terraform-provider-hpe
+
+Test

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/hpe/terraform-provider-hpe/tools
 
-go 1.24.2
+go 1.24.1
 
 require github.com/hashicorp/terraform-plugin-docs v0.21.0
 


### PR DESCRIPTION
Also removes the matrix strategy options and tells `setup-go` to pick up the Go version from the `go.mod` file
