### PR TITLE
Implement in-place updates for the Image resource

### DIFF
--- a/internal/framework/subproviders/morpheus/convert/convert.go
+++ b/internal/framework/subproviders/morpheus/convert/convert.go
@@ -55,6 +55,25 @@ func SetToStrSlice(set types.Set) ([]string, error) {
 	return items, nil
 }
 
+func SetToSlice[T any](ctx context.Context, set types.Set) ([]T, error) {
+	var items []T
+	for _, elem := range set.Elements() {
+		a, err := ValueToAny(ctx, elem)
+		if err != nil {
+			return nil, err
+		}
+
+		v, ok := a.(T)
+		if !ok {
+			return nil, fmt.Errorf("converting Set to %T not possible, underlying type does not match", items)
+		}
+
+		items = append(items, v)
+	}
+
+	return items, nil
+}
+
 func BoolToType(b *bool) types.Bool {
 	if b == nil {
 		return types.BoolNull()

--- a/internal/framework/subproviders/morpheus/resources/image/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/image/schema_gen.go
@@ -10,11 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -34,20 +31,14 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Auto Join Domain?",
 				MarkdownDescription: "Auto Join Domain?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-				Default: booldefault.StaticBool(false),
+				Default:             booldefault.StaticBool(false),
 			},
 			"cloud_init": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Cloud Init Enabled?",
 				MarkdownDescription: "Cloud Init Enabled?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-				Default: booldefault.StaticBool(false),
+				Default:             booldefault.StaticBool(false),
 			},
 			"config_azure": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
@@ -93,9 +84,6 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Azure Reference Virtual Image Parameters",
 				MarkdownDescription: "Azure Reference Virtual Image Parameters",
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,
@@ -108,34 +96,22 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"external_id": schema.StringAttribute{
 				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"fips_enabled": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "FIPS enabled?",
 				MarkdownDescription: "FIPS enabled?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
 			},
 			"force_customization": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Force Guest Customization?",
 				MarkdownDescription: "Force Guest Customization?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-				Default: booldefault.StaticBool(false),
+				Default:             booldefault.StaticBool(false),
 			},
 			"id": schema.Int64Attribute{
 				Computed: true,
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 			"image_type": schema.StringAttribute{
 				Required:            true,
@@ -150,10 +126,7 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Install Agent?",
 				MarkdownDescription: "Install Agent?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-				Default: booldefault.StaticBool(false),
+				Default:             booldefault.StaticBool(false),
 			},
 			"labels": schema.SetAttribute{
 				ElementType:         types.StringType,
@@ -161,60 +134,39 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Array of label strings, can be used for filtering.",
 				MarkdownDescription: "Array of label strings, can be used for filtering.",
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplace(),
-				},
 			},
 			"min_disk": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Minimal required amount of disk space for provisioning in GB",
 				MarkdownDescription: "Minimal required amount of disk space for provisioning in GB",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 			"min_ram": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Minimal required amount of RAM for provisioning in GB",
 				MarkdownDescription: "Minimal required amount of RAM for provisioning in GB",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required:            true,
 				Description:         "A name for the virtual image",
 				MarkdownDescription: "A name for the virtual image",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"os_type_id": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "ID of the OS Type",
 				MarkdownDescription: "ID of the OS Type",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 			"owner_id": schema.Int64Attribute{
 				Computed:            true,
 				Description:         "ID of the user which created this image",
 				MarkdownDescription: "ID of the user which created this image",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 			"raw_size": schema.Int64Attribute{
 				Computed:            true,
 				Description:         "Size of image in bytes",
 				MarkdownDescription: "Size of image in bytes",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 			"ssh_password_wo": schema.StringAttribute{
 				Optional:            true,
@@ -223,25 +175,18 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "SSH password (Write Only)",
 				PlanModifiers: []planmodifier.String{
 					modifiers.NullableStringUpdateModifier{},
-					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"ssh_password_wo_version": schema.Int64Attribute{
 				Optional:            true,
 				Description:         "SSH password version. Used to determine if ssh_password_wo has been updated.",
 				MarkdownDescription: "SSH password version. Used to determine if ssh_password_wo has been updated.",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
 			},
 			"ssh_username": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "SSH Username",
 				MarkdownDescription: "SSH Username",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"storage_provider_id": schema.Int64Attribute{
 				Optional:            true,
@@ -257,31 +202,19 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Sysprep Enabled?",
 				MarkdownDescription: "Sysprep Enabled?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-				Default: booldefault.StaticBool(false),
+				Default:             booldefault.StaticBool(false),
 			},
 			"system_image": schema.BoolAttribute{
 				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
 			},
 			"tags": schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
 							Required: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.RequiresReplace(),
-							},
 						},
 						"value": schema.StringAttribute{
 							Required: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.RequiresReplace(),
-							},
 						},
 					},
 					CustomType: TagsType{
@@ -294,9 +227,6 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Metadata tags, Array of objects having a name and value",
 				MarkdownDescription: "Metadata tags, Array of objects having a name and value",
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplace(),
-				},
 			},
 			"tenant_ids": schema.SetAttribute{
 				ElementType:         types.Int64Type,
@@ -304,28 +234,19 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "List of tenant IDs",
 				MarkdownDescription: "List of tenant IDs",
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplace(),
-				},
 			},
 			"trial_version": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Trial Version",
 				MarkdownDescription: "Trial Version",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-				Default: booldefault.StaticBool(false),
+				Default:             booldefault.StaticBool(false),
 			},
 			"uefi": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "UEFI enabled?",
 				MarkdownDescription: "UEFI enabled?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
 			},
 			"url": schema.StringAttribute{
 				Optional:            true,
@@ -340,28 +261,19 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Cloud-Init User Data, a bash script",
 				MarkdownDescription: "Cloud-Init User Data, a bash script",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"virtio_supported": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "VirtIO Drivers Loaded?",
 				MarkdownDescription: "VirtIO Drivers Loaded?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-				Default: booldefault.StaticBool(true),
+				Default:             booldefault.StaticBool(true),
 			},
 			"visibility": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "private or public",
 				MarkdownDescription: "private or public",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"private",
@@ -375,10 +287,7 @@ func ImageResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "VM Tools Installed?",
 				MarkdownDescription: "VM Tools Installed?",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-				Default: booldefault.StaticBool(true),
+				Default:             booldefault.StaticBool(true),
 			},
 		},
 	}

--- a/internal/framework/subproviders/morpheus/resources/image/update.go
+++ b/internal/framework/subproviders/morpheus/resources/image/update.go
@@ -1,14 +1,246 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
-
 package image
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"net/http"
 
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// Update implements resource.Resource.
-func (r *Resource) Update(context.Context, resource.UpdateRequest, *resource.UpdateResponse) {
-	panic("unimplemented")
+func (r *Resource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
+	var plan, state, config ImageModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("creating client failed", err.Error())
+
+		return
+	}
+
+	name := plan.Name.ValueString()
+
+	updateRequest := sdk.NewUpdateVirtualImageRequestWithDefaults()
+	updateImage := sdk.NewUpdateVirtualImageRequestVirtualImageWithDefaults()
+
+	// auto_join_domain
+	if !plan.AutoJoinDomain.IsNull() {
+		updateImage.SetIsAutoJoinDomain(plan.AutoJoinDomain.ValueBool())
+	}
+
+	// cloud_init
+	if !plan.CloudInit.IsNull() {
+		updateImage.SetIsCloudInit(plan.CloudInit.ValueBool())
+	}
+
+	// config_azure
+	// keep unimplemented for now, we can decide in the future if this
+	// should continue being a replace or if we want to support in-place updates
+	// of the Azure image config
+
+	// description
+	// description for whatever reason cannot be updated at the moment
+
+	// fips_enabled
+	if !plan.FipsEnabled.IsNull() {
+		updateImage.SetFipsEnabled(plan.FipsEnabled.ValueBool())
+	}
+
+	// force_customization
+	if !plan.ForceCustomization.IsNull() {
+		updateImage.SetIsForceCustomization(plan.ForceCustomization.ValueBool())
+	}
+
+	// image_type
+	if !plan.ImageType.IsNull() {
+		updateImage.SetImageType(plan.ImageType.ValueString())
+	}
+
+	// install_agent
+	if !plan.InstallAgent.IsNull() {
+		updateImage.SetInstallAgent(plan.InstallAgent.ValueBool())
+	}
+
+	// labels
+	if !plan.Labels.IsNull() {
+		labels, err := convert.SetToStrSlice(plan.Labels)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"update image resource",
+				"image "+name+": failed to parse label: "+err.Error(),
+			)
+
+			return
+		}
+
+		updateImage.SetLabels(labels)
+	}
+
+	// min_disk
+	if !plan.MinDisk.IsNull() {
+		updateImage.SetMinDisk(plan.MinDisk.ValueInt64() * 1024 * 1024 * 1024)
+
+	}
+
+	// min_ram
+	if !plan.MinRam.IsNull() {
+		updateImage.SetMinRamGB(plan.MinRam.ValueInt64())
+	}
+
+	// name
+	if !plan.Name.IsNull() {
+		updateImage.SetName(name)
+	}
+
+	// os_type_id
+	if !plan.OsTypeId.IsNull() {
+		updateImage.SetOsType(plan.OsTypeId.ValueInt64())
+	}
+
+	// ssh_password_wo
+	if !plan.SshPasswordWoVersion.Equal(state.SshPasswordWoVersion) {
+		if config.SshPasswordWo.IsUnknown() {
+			resp.Diagnostics.AddError(
+				"update image resource",
+				fmt.Sprintf("image %s: 'ssh_password_wo_version' changed, "+
+					"but 'ssh_password_wo' is not set", name),
+			)
+
+			return
+		}
+		updateImage.SetSshPassword(config.SshPasswordWo.ValueString())
+	}
+
+	// ssh_username
+	if !plan.SshUsername.IsNull() {
+		updateImage.SetSshUsername(plan.SshUsername.ValueString())
+	}
+
+	// storage_provider_id
+	if !plan.StorageProviderId.IsNull() {
+		storageProvider := sdk.NewAddVirtualImageRequestVirtualImageStorageProviderWithDefaults()
+		storageProvider.SetId(plan.StorageProviderId.ValueInt64())
+
+		updateImage.SetStorageProvider(*storageProvider)
+	}
+
+	// sysprep
+	if !plan.Sysprep.IsNull() {
+		updateImage.SetIsSysprep(plan.Sysprep.ValueBool())
+	}
+
+	// tags
+	tags, diags := convert.FromSetType(ctx, plan.Tags, tagMapper)
+	if diags.HasError() {
+		tflog.Error(ctx, "cannot convert tags")
+		resp.Diagnostics.Append(diags...)
+
+		return
+	}
+	updateImage.SetTags(tags)
+
+	// tenant_ids
+	if !plan.TenantIds.IsNull() {
+		tenantIDs, err := convert.SetToSlice[types.Int64](ctx, plan.TenantIds)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, idVal := range tenantIDs {
+			if !idVal.IsNull() {
+				updateImage.Accounts = append(
+					updateImage.Accounts,
+					idVal.ValueInt64(),
+				)
+			}
+		}
+	}
+
+	// trial_version
+	if !plan.TrialVersion.IsNull() {
+		updateImage.SetTrialVersion(plan.TrialVersion.ValueBool())
+	}
+
+	// uefi
+	if !plan.Uefi.IsNull() {
+		updateImage.SetUefi(plan.Uefi.ValueBool())
+	}
+
+	// url
+	// keep unimplemented for now, we can decide in the future if this
+	// should continue being a replace or if we want to support in-place updates
+	// of the image URL
+
+	// user_data
+	if !plan.UserData.IsNull() {
+		updateImage.SetUserData(plan.UserData.ValueString())
+	}
+
+	// virtio_supported
+	if !plan.VirtioSupported.IsNull() {
+		updateImage.SetVirtioSupported(plan.VirtioSupported.ValueBool())
+	}
+
+	// visibility
+	if !plan.Visibility.IsNull() {
+		updateImage.SetVisibility(plan.Visibility.ValueString())
+	}
+
+	// vm_tools_installed
+	if !plan.VmToolsInstalled.IsNull() {
+		updateImage.SetVmToolsInstalled(plan.VmToolsInstalled.ValueBool())
+	}
+
+	// send the API request here
+	updateRequest.SetVirtualImage(*updateImage)
+	image, httpResp, err := client.LibraryAPI.UpdateVirtualImage(ctx, state.Id.ValueInt64()).
+		UpdateVirtualImageRequest(*updateRequest).
+		Execute()
+	if err != nil || httpResp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError("error updating image", errors.ErrMsg(err, httpResp))
+
+		return
+	}
+	// set the ID value in state
+	plan.Id = convert.Int64ToType(image.GetVirtualImage().Id)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state, diag := getImageAsState(ctx, plan.Id.ValueInt64(), client, plan)
+	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }

--- a/internal/framework/subproviders/morpheus/resources/image/update.go
+++ b/internal/framework/subproviders/morpheus/resources/image/update.go
@@ -6,12 +6,14 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
-	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
-	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
 )
 
 func (r *Resource) Update(
@@ -104,7 +106,6 @@ func (r *Resource) Update(
 	// min_disk
 	if !plan.MinDisk.IsNull() {
 		updateImage.SetMinDisk(plan.MinDisk.ValueInt64() * 1024 * 1024 * 1024)
-
 	}
 
 	// min_ram

--- a/internal/framework/subproviders/morpheus/resources/image/update_test.go
+++ b/internal/framework/subproviders/morpheus/resources/image/update_test.go
@@ -1,0 +1,309 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package image_test
+
+import (
+	"testing"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+var storageProvider = "196"
+
+func TestAccMorpheusImageUpdate(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_image.example",
+			"name",
+			name+"2",
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(
+		checks...,
+	)
+
+	checkReplace := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction("hpe_morpheus_image.example", plancheck.ResourceActionReplace),
+		},
+	}
+
+	// this check verifies that the resource is going to be updated in place
+	checkInPlaceUpdate := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction("hpe_morpheus_image.example", plancheck.ResourceActionUpdate),
+		},
+	}
+
+	osType := "75"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `"
+						description = "this is a test image"
+						labels = ["terraform-image"]
+						image_type = "qcow2"
+						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2"
+						storage_provider_id = ` + storageProvider + `
+						install_agent = false
+						cloud_init = false
+						os_type_id = ` + osType + `
+						min_ram = 2
+						uefi = false
+						min_disk = 25
+						trial_version = false
+						ssh_username = "test-user"
+						user_data = trimspace(
+						<<-EOT
+						#!/bin/sh
+						apk add --no-cache bash
+						EOT
+						)
+						tags = [
+						{
+							name = "test-tag"
+							value = "true"
+						}
+						]
+						virtio_supported = false
+						visibility = "private"
+					}`,
+				PlanOnly: false,
+			},
+			// change fields which don't require a replace
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `2"
+						description = "this is a test image" # requires replace
+						labels = ["terraform-image", "terraform-test"]
+						image_type = "qcow2" # requires replace
+						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2" # requires replace
+						storage_provider_id = ` + storageProvider + ` # requires replace
+						install_agent = true
+						cloud_init = true
+						os_type_id = ` + osType + `
+						min_ram = 1
+						uefi = true
+						min_disk = 20
+						trial_version = true
+						ssh_username = "test-user2"
+						user_data = trimspace(
+						<<-EOT
+						#!/bin/sh
+						apk add --no-cache bash go
+						EOT
+						)
+						tags = [
+							{
+								name = "test-tag"
+								value = "true"
+							},
+							{
+								name = "test-tag2"
+								value = "false"
+							}
+						]
+						virtio_supported = true
+						visibility = "public"
+					}`,
+				Check:            checkFn,
+				PlanOnly:         false,
+				ConfigPlanChecks: checkInPlaceUpdate,
+			},
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `2"
+						description = "this is a test image" # requires replace
+						image_type = "qcow2" # requires replace
+						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2" # requires replace
+						storage_provider_id = ` + storageProvider + ` # requires replace
+					}`,
+				Check:              checkFn,
+				ExpectNonEmptyPlan: true,
+				PlanOnly:           false,
+				ConfigPlanChecks:   checkInPlaceUpdate,
+			},
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `2"
+						description = "this is a test image" # requires replace
+						image_type = "qcow2" # requires replace
+						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2" # requires replace
+						storage_provider_id = ` + storageProvider + ` # requires replace
+						ssh_password_wo = "this-is-a-test-password2"
+						ssh_password_wo_version = 1
+					}`,
+				Check:              checkFn,
+				ExpectNonEmptyPlan: true,
+				PlanOnly:           false,
+				ConfigPlanChecks:   checkInPlaceUpdate,
+			},
+			// change description to force a replace
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `2"
+						description = "this is a test image2" # requires replace
+						labels = ["terraform-image", "terraform-test"]
+						image_type = "qcow2" # requires replace
+						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2" # requires replace
+						storage_provider_id = ` + storageProvider + ` # requires replace
+						install_agent = true
+						cloud_init = true
+						os_type_id = ` + osType + `
+						min_ram = 1
+						uefi = true
+						min_disk = 20
+						trial_version = true
+						ssh_username = "test-user2"
+						user_data = trimspace(
+						<<-EOT
+						#!/bin/sh
+						apk add --no-cache bash go
+						EOT
+						)
+						tags = [
+						{
+							name = "test-tag"
+							value = "true"
+						}
+						]
+						virtio_supported = true
+						visibility = "public"
+					}`,
+				Check:            checkFn,
+				PlanOnly:         false,
+				ConfigPlanChecks: checkReplace,
+			},
+		},
+	})
+}
+
+func TestAccMorpheusImageUpdatePassword(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_image.example",
+			"name",
+			name,
+		),
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_image.example",
+			"ssh_password_wo",
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(
+		checks...,
+	)
+	// no changes in plan
+	checkNoOp := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction("hpe_morpheus_image.example", plancheck.ResourceActionNoop),
+		},
+	}
+
+	// this check verifies that the resource is going to be updated in place
+	checkInPlaceUpdate := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction("hpe_morpheus_image.example", plancheck.ResourceActionUpdate),
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `"
+						description = "this is a test image" # requires replace
+						image_type = "qcow2" # requires replace
+						storage_provider_id = ` + storageProvider + ` # requires replace
+						ssh_password_wo = "this-is-a-test-password"
+						ssh_password_wo_version = 1
+					}`,
+				Check:    checkFn,
+				PlanOnly: false,
+			},
+			// changing the password without bumping the `wo_version` should not
+			// change the password
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `"
+						description = "this is a test image" # requires replace
+						image_type = "qcow2" # requires replace
+						storage_provider_id = ` + storageProvider + ` # requires replace
+						ssh_password_wo = "this-is-a-test-password2"
+						ssh_password_wo_version = 1
+					}`,
+				Check:            checkFn,
+				ConfigPlanChecks: checkNoOp,
+				PlanOnly:         false,
+			},
+			// removing the password field should not cause any changes
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `"
+						description = "this is a test image" # requires replace
+						image_type = "qcow2" # requires replace
+						storage_provider_id = ` + storageProvider + ` # requires replace
+						ssh_password_wo_version = 1
+					}`,
+				Check:            checkFn,
+				ConfigPlanChecks: checkNoOp,
+				PlanOnly:         false,
+			},
+			// bumping the password version and changing the password attribute
+			// should trigger an in place update
+			{
+				Config: providerConfig + `
+					resource "hpe_morpheus_image" "example" {
+						name = "` + name + `"
+						description = "this is a test image" # requires replace
+						image_type = "qcow2" # requires replace
+						storage_provider_id = ` + storageProvider + ` # requires replace
+						ssh_password_wo = "this-is-a-test-password2"
+						ssh_password_wo_version = 2
+					}`,
+				Check:            checkFn,
+				PlanOnly:         false,
+				ConfigPlanChecks: checkInPlaceUpdate,
+			},
+		},
+	})
+}

--- a/internal/framework/subproviders/morpheus/resources/image/update_test.go
+++ b/internal/framework/subproviders/morpheus/resources/image/update_test.go
@@ -5,13 +5,18 @@ package image_test
 import (
 	"testing"
 
-	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
 )
 
-var storageProvider = "196"
+var (
+	storageProvider = "196"
+	// nolint: lll
+	url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2"
+)
 
 func TestAccMorpheusImageUpdate(t *testing.T) {
 	defer testhelpers.RecordResult(t)
@@ -39,14 +44,20 @@ func TestAccMorpheusImageUpdate(t *testing.T) {
 
 	checkReplace := resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{
-			plancheck.ExpectResourceAction("hpe_morpheus_image.example", plancheck.ResourceActionReplace),
+			plancheck.ExpectResourceAction(
+				"hpe_morpheus_image.example",
+				plancheck.ResourceActionReplace,
+			),
 		},
 	}
 
 	// this check verifies that the resource is going to be updated in place
 	checkInPlaceUpdate := resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{
-			plancheck.ExpectResourceAction("hpe_morpheus_image.example", plancheck.ResourceActionUpdate),
+			plancheck.ExpectResourceAction(
+				"hpe_morpheus_image.example",
+				plancheck.ResourceActionUpdate,
+			),
 		},
 	}
 
@@ -62,7 +73,7 @@ func TestAccMorpheusImageUpdate(t *testing.T) {
 						description = "this is a test image"
 						labels = ["terraform-image"]
 						image_type = "qcow2"
-						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2"
+						url = "` + url + `"
 						storage_provider_id = ` + storageProvider + `
 						install_agent = false
 						cloud_init = false
@@ -97,7 +108,7 @@ func TestAccMorpheusImageUpdate(t *testing.T) {
 						description = "this is a test image" # requires replace
 						labels = ["terraform-image", "terraform-test"]
 						image_type = "qcow2" # requires replace
-						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2" # requires replace
+						url = "` + url + `" # requires replace
 						storage_provider_id = ` + storageProvider + ` # requires replace
 						install_agent = true
 						cloud_init = true
@@ -136,7 +147,7 @@ func TestAccMorpheusImageUpdate(t *testing.T) {
 						name = "` + name + `2"
 						description = "this is a test image" # requires replace
 						image_type = "qcow2" # requires replace
-						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2" # requires replace
+						url = "` + url + `" # requires replace
 						storage_provider_id = ` + storageProvider + ` # requires replace
 					}`,
 				Check:              checkFn,
@@ -150,7 +161,7 @@ func TestAccMorpheusImageUpdate(t *testing.T) {
 						name = "` + name + `2"
 						description = "this is a test image" # requires replace
 						image_type = "qcow2" # requires replace
-						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2" # requires replace
+						url = "` + url + `" # requires replace
 						storage_provider_id = ` + storageProvider + ` # requires replace
 						ssh_password_wo = "this-is-a-test-password2"
 						ssh_password_wo_version = 1
@@ -168,7 +179,7 @@ func TestAccMorpheusImageUpdate(t *testing.T) {
 						description = "this is a test image2" # requires replace
 						labels = ["terraform-image", "terraform-test"]
 						image_type = "qcow2" # requires replace
-						url = "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.2-x86_64-bios-cloudinit-r0.qcow2" # requires replace
+						url = "` + url + `" # requires replace
 						storage_provider_id = ` + storageProvider + ` # requires replace
 						install_agent = true
 						cloud_init = true
@@ -231,14 +242,20 @@ func TestAccMorpheusImageUpdatePassword(t *testing.T) {
 	// no changes in plan
 	checkNoOp := resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{
-			plancheck.ExpectResourceAction("hpe_morpheus_image.example", plancheck.ResourceActionNoop),
+			plancheck.ExpectResourceAction(
+				"hpe_morpheus_image.example",
+				plancheck.ResourceActionNoop,
+			),
 		},
 	}
 
 	// this check verifies that the resource is going to be updated in place
 	checkInPlaceUpdate := resource.ConfigPlanChecks{
 		PreApply: []plancheck.PlanCheck{
-			plancheck.ExpectResourceAction("hpe_morpheus_image.example", plancheck.ResourceActionUpdate),
+			plancheck.ExpectResourceAction(
+				"hpe_morpheus_image.example",
+				plancheck.ResourceActionUpdate,
+			),
 		},
 	}
 


### PR DESCRIPTION
Adds in-place updating for most attributes in the Image resource.

`url` and `config_azure` will continue to require a replace as those fields may require extra logic to ensure
correct updating of the underlying image.

`description` requires a replace due to the API not supporting description updates at the moment.
