### PR TITLE
Add sdkv2 data source: hpe_morpheus_cloud_type

### DIFF
--- a/examples/data-sources/morpheus_cloud_type/data-source.tf
+++ b/examples/data-sources/morpheus_cloud_type/data-source.tf
@@ -1,0 +1,3 @@
+data "hpe_morpheus_cloud_type" "canonical_maas_cloud" {
+  name = "MaaS"
+}

--- a/internal/sdkv2/morpheus/datasources/cloud/cloud_type.go
+++ b/internal/sdkv2/morpheus/datasources/cloud/cloud_type.go
@@ -1,0 +1,112 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package cloud
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/helpers"
+
+	morpheus "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
+)
+
+func DataSourceCloudType() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Morpheus cloud type data source.",
+		ReadContext: dataSourceCloudTypeRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of the Morpheus cloud type",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func dataSourceCloudTypeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var client *morpheus.Client
+	if v, ok := meta.(*morpheus.Client); ok {
+		client = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
+	}
+
+	var diags diag.Diagnostics
+
+	var name string
+	if v, ok := d.Get("name").(string); ok {
+		name = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("name", d.Get("name")))
+	}
+
+	var resp *morpheus.Response
+	var err error
+
+	resp, err = client.Execute(&morpheus.Request{
+		Method: "GET",
+		QueryParams: map[string]string{
+			"name": name,
+		},
+		Path:   "/api/appliance-settings/zone-types",
+		Result: &CloudTypes{},
+	})
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("API 404: %s - %v", resp, err)
+
+			return nil
+		}
+
+		log.Printf("API FAILURE: %s - %v", resp, err)
+
+		return diag.FromErr(err)
+	}
+	log.Printf("API RESPONSE: %s", resp)
+
+	if resp.Result == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
+	}
+
+	var cloudType *CloudTypes
+	if v, ok := resp.Result.(*CloudTypes); ok {
+		cloudType = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
+	}
+
+	if cloudType.ZoneTypes == nil {
+		return diag.Errorf("cloud type not found in response data.")
+	}
+
+	for _, cType := range cloudType.ZoneTypes {
+		if cType.Name == name {
+			d.SetId(convert.Int64ToString(cType.ID))
+			d.Set("name", cType.Name)
+		}
+	}
+
+	return diags
+}
+
+type CloudTypes struct {
+	ZoneTypes []CloudType       `json:"zoneTypes"`
+	Message   string            `json:"msg"`
+	Errors    map[string]string `json:"errors"`
+}
+
+type CloudType struct {
+	ID      int64  `json:"id"`
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}

--- a/templates/data-sources/morpheus_cloud_type.md.tmpl
+++ b/templates/data-sources/morpheus_cloud_type.md.tmpl
@@ -1,0 +1,15 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{tffile "examples/data-sources/morpheus_cloud_type/data-source.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Adds the hpe_morpheus_cloud_type data source.

Type assertions have been made safe.

Adds the doc templates.

Generated docs and provider registration will come in a follow-up PR.
