### PR TITLE
Add sdkv2 data source: hpe_morpheus_contact

### DIFF
--- a/examples/data-sources/morpheus_contact/data-source.tf
+++ b/examples/data-sources/morpheus_contact/data-source.tf
@@ -1,0 +1,3 @@
+data "hpe_morpheus_contact" "example" {
+  name = "example contact"
+}

--- a/internal/sdkv2/morpheus/datasources/contact/contact.go
+++ b/internal/sdkv2/morpheus/datasources/contact/contact.go
@@ -1,0 +1,108 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package contact
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	morpheus "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
+
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/helpers"
+)
+
+func DataSourceContact() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Morpheus contact data source.",
+		ReadContext: dataSourceContactRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+				Computed:      true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Description:   "The name of the Morpheus contact.",
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+			},
+		},
+	}
+}
+
+func dataSourceContactRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var client *morpheus.Client
+	if v, ok := meta.(*morpheus.Client); ok {
+		client = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
+	}
+
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
+	var name string
+	if v, ok := d.Get("name").(string); ok {
+		name = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("name", d.Get("name")))
+	}
+
+	var id int
+	if v, ok := d.Get("id").(int); ok {
+		id = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("id", d.Get("id")))
+	}
+
+	// lookup by name if we do not have an id yet
+	var resp *morpheus.Response
+	var err error
+	if id == 0 && name != "" {
+		resp, err = client.FindContactByName(name)
+	} else if id != 0 {
+		resp, err = client.GetContact(int64(id), &morpheus.Request{})
+	} else {
+		return diag.Errorf("Contact cannot be read without name or id")
+	}
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("API 404: %s - %v", resp, err)
+
+			return nil
+		} else {
+			log.Printf("API FAILURE: %s - %v", resp, err)
+
+			return diag.FromErr(err)
+		}
+	}
+	log.Printf("API RESPONSE: %s", resp)
+
+	// store resource data
+	var result *morpheus.GetContactResult
+	if v, ok := resp.Result.(*morpheus.GetContactResult); ok {
+		result = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("GetContactResult", resp.Result))
+	}
+
+	if result == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("GetContactResult"))
+	}
+
+	contact := result.Contact
+	if contact == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Contact"))
+	}
+
+	d.SetId(convert.Int64ToString(contact.ID))
+	d.Set("name", contact.Name)
+
+	return diags
+}

--- a/templates/data-sources/morpheus_contact.md.tmpl
+++ b/templates/data-sources/morpheus_contact.md.tmpl
@@ -1,0 +1,15 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{tffile "examples/data-sources/morpheus_contact/data-source.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Adds the hpe_morpheus_contact data source.

Type assertions have been made safe.

Adds the doc templates.

Generated docs and provider registration will come in a follow-up PR.
