### PR TITLE
Add sdkv2 data source: hpe_morpheus_budget

### DIFF
--- a/examples/data-sources/morpheus_budget/data-source.tf
+++ b/examples/data-sources/morpheus_budget/data-source.tf
@@ -1,0 +1,3 @@
+data "hpe_morpheus_budget" "example" {
+  name = "example budget"
+}

--- a/internal/sdkv2/morpheus/datasources/costing/budget.go
+++ b/internal/sdkv2/morpheus/datasources/costing/budget.go
@@ -1,0 +1,105 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package costing
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	morpheus "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
+
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/helpers"
+)
+
+func DataSourceBudget() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Morpheus budget data source.",
+		ReadContext: dataSourceBudgetRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+				Computed:      true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Description:   "The name of the Morpheus budget.",
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+			},
+		},
+	}
+}
+
+func dataSourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var client *morpheus.Client
+	if v, ok := meta.(*morpheus.Client); ok {
+		client = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
+	}
+
+	var diags diag.Diagnostics
+
+	var name string
+	if v, ok := d.Get("name").(string); ok {
+		name = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("name", d.Get("name")))
+	}
+
+	var id int
+	if v, ok := d.Get("id").(int); ok {
+		id = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("id", d.Get("id")))
+	}
+
+	var resp *morpheus.Response
+	var err error
+	if id == 0 && name != "" {
+		resp, err = client.FindBudgetByName(name)
+	} else if id != 0 {
+		resp, err = client.GetBudget(int64(id), &morpheus.Request{})
+	} else {
+		return diag.Errorf("Budget cannot be read without name or id")
+	}
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("API 404: %s - %v", resp, err)
+
+			return nil
+		}
+
+		log.Printf("API FAILURE: %s - %v", resp, err)
+
+		return diag.FromErr(err)
+	}
+	log.Printf("API RESPONSE: %s", resp)
+
+	if resp.Result == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
+	}
+
+	var result *morpheus.GetBudgetResult
+	if v, ok := resp.Result.(*morpheus.GetBudgetResult); ok {
+		result = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
+	}
+
+	if result.Budget == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Budget"))
+	}
+
+	budget := result.Budget
+	d.SetId(convert.Int64ToString(budget.ID))
+	d.Set("name", budget.Name)
+
+	return diags
+}

--- a/templates/data-sources/morpheus_budget.md.tmpl
+++ b/templates/data-sources/morpheus_budget.md.tmpl
@@ -1,0 +1,15 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{tffile "examples/data-sources/morpheus_budget/data-source.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Adds the hpe_morpheus_budget data source.

Type assertions have been made safe.

Adds the doc templates.

Generated docs and provider registration will come in a follow-up PR.
