### PR TITLE
Add sdkv2 data source: hpe_morpheus_groups

### DIFF
--- a/examples/data-sources/morpheus_groups/data-source.tf
+++ b/examples/data-sources/morpheus_groups/data-source.tf
@@ -1,0 +1,12 @@
+data "hpe_morpheus_groups" "terraform_test" {
+  sort_ascending = false
+  filter {
+    name   = "name"
+    values = ["^tf*"]
+  }
+
+  filter {
+    name   = "location"
+    values = ["denver"]
+  }
+}

--- a/internal/sdkv2/morpheus/datasources/group/groups.go
+++ b/internal/sdkv2/morpheus/datasources/group/groups.go
@@ -1,0 +1,227 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package group
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	morpheus "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
+
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/helpers"
+)
+
+func DataSourceGroups() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Morpheus groups data source.",
+		ReadContext: dataSourceGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"sort_ascending": {
+				Type:        schema.TypeBool,
+				Description: "Whether to sort the IDs in ascending order. Defaults to true",
+				Default:     true,
+				Optional:    true,
+			},
+			"filter": {
+				Type:        schema.TypeSet,
+				Description: "Custom filter block as described below.",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "The name of the filter. Filter names are case-sensitive. Valid names are (name, location)",
+							Required:    true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{"name", "location"},
+								false,
+							),
+						},
+						"values": {
+							Type: schema.TypeSet,
+							Description: "The filter values. Filter values are case-sensitive. " +
+								"Filters values support the use of Golang regex and can be tested at https://regex101.com/",
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var client *morpheus.Client
+	if v, ok := meta.(*morpheus.Client); ok {
+		client = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
+	}
+
+	var diags diag.Diagnostics
+
+	var resp *morpheus.Response
+	var err error
+	var sortOrder string
+	var locations []string
+	var names []string
+
+	var filterSet *schema.Set
+	if v, ok := d.Get("filter").(*schema.Set); ok {
+		filterSet = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("filter", d.Get("filter")))
+	}
+
+	if filterSet != nil && len(filterSet.List()) > 0 {
+		filters := filterSet.List()
+		for _, filter := range filters {
+			var test map[string]any
+			if v, ok := filter.(map[string]any); ok {
+				test = v
+			} else {
+				return diag.FromErr(helpers.TypeAssertFailError("filter", filter))
+			}
+
+			var filterName string
+			if v, ok := test["name"].(string); ok {
+				filterName = v
+			} else {
+				return diag.FromErr(helpers.TypeAssertFailError("name", test["name"]))
+			}
+
+			var valuesSet *schema.Set
+			if v, ok := test["values"].(*schema.Set); ok {
+				valuesSet = v
+			} else {
+				return diag.FromErr(helpers.TypeAssertFailError("values", test["values"]))
+			}
+
+			if filterName == "location" {
+				if valuesSet != nil {
+					for _, item := range valuesSet.List() {
+						var location string
+						if v, ok := item.(string); ok {
+							location = v
+						} else {
+							return diag.FromErr(helpers.TypeAssertFailError("location", item))
+						}
+						locations = append(locations, location)
+					}
+				}
+			}
+
+			if filterName == "name" {
+				if valuesSet != nil {
+					for _, item := range valuesSet.List() {
+						var name string
+						if v, ok := item.(string); ok {
+							name = v
+						} else {
+							return diag.FromErr(helpers.TypeAssertFailError("name", item))
+						}
+						names = append(names, name)
+					}
+				}
+			}
+		}
+	}
+
+	if len(locations) == 0 {
+		locations = append(locations, "$")
+	}
+
+	if len(names) == 0 {
+		names = append(names, "$")
+	}
+
+	var sortAscending bool
+	if v, ok := d.Get("sort_ascending").(bool); ok {
+		sortAscending = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("sort_ascending", d.Get("sort_ascending")))
+	}
+
+	if sortAscending {
+		sortOrder = "asc"
+	} else {
+		sortOrder = "desc"
+	}
+
+	resp, err = client.ListGroups(&morpheus.Request{
+		QueryParams: map[string]string{
+			"max":       "50",
+			"sort":      "id",
+			"direction": sortOrder,
+		},
+	})
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("API 404: %s - %v", resp, err)
+
+			return nil
+		}
+
+		log.Printf("API FAILURE: %s - %v", resp, err)
+
+		return diag.FromErr(err)
+	}
+	log.Printf("API RESPONSE: %s", resp)
+
+	if resp.Result == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
+	}
+
+	var result *morpheus.ListGroupsResult
+	if v, ok := resp.Result.(*morpheus.ListGroupsResult); ok {
+		result = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
+	}
+
+	if result.Groups == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Groups"))
+	}
+
+	groups := result.Groups
+
+	var groupIDs []string
+	if groups != nil {
+		for _, group := range *groups {
+			if regexCheck(locations, group.Location) && regexCheck(names, group.Name) {
+				groupIDs = append(groupIDs, convert.Int64ToString(group.ID))
+			}
+		}
+	}
+
+	d.SetId("1")
+	d.Set("ids", groupIDs)
+
+	return diags
+}
+
+func regexCheck(s []string, str string) bool {
+	var status int
+	for _, v := range s {
+		match, _ := regexp.MatchString(v, str)
+		if match {
+			status = status + 1
+		}
+	}
+
+	return status > 0
+}

--- a/templates/data-sources/morpheus_groups.md.tmpl
+++ b/templates/data-sources/morpheus_groups.md.tmpl
@@ -1,0 +1,15 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{tffile "examples/data-sources/morpheus_groups/data-source.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Adds the hpe_morpheus_groups data source.

Type assertions have been made safe.

Adds the doc templates.

Generated docs and provider registration will come in a follow-up PR.
