### PR TITLE
Add sdkv2 data source: hpe_morpheus_integration

### DIFF
--- a/examples/data-sources/morpheus_integration/data-source.tf
+++ b/examples/data-sources/morpheus_integration/data-source.tf
@@ -1,0 +1,3 @@
+data "hpe_morpheus_integration" "tf_example_integration" {
+  name = "ansible dev"
+}

--- a/internal/sdkv2/morpheus/datasources/integration/integration.go
+++ b/internal/sdkv2/morpheus/datasources/integration/integration.go
@@ -1,0 +1,106 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package integration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	morpheus "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
+
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/helpers"
+)
+
+func DataSourceIntegration() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Morpheus integration data source.",
+		ReadContext: dataSourceIntegrationRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+				Computed:      true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Description:   "The name of the integration",
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+			},
+		},
+	}
+}
+
+func dataSourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var client *morpheus.Client
+	if v, ok := meta.(*morpheus.Client); ok {
+		client = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
+	}
+
+	var diags diag.Diagnostics
+
+	var name string
+	if v, ok := d.Get("name").(string); ok {
+		name = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("name", d.Get("name")))
+	}
+
+	var id int
+	if v, ok := d.Get("id").(int); ok {
+		id = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("id", d.Get("id")))
+	}
+
+	var resp *morpheus.Response
+	var err error
+	if id == 0 && name != "" {
+		resp, err = client.FindIntegrationByName(name)
+	} else if id != 0 {
+		resp, err = client.GetIntegration(int64(id), &morpheus.Request{})
+	} else {
+		return diag.Errorf("Integration cannot be read without name or id")
+	}
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("API 404: %s - %v", resp, err)
+
+			return nil
+		}
+
+		log.Printf("API FAILURE: %s - %v", resp, err)
+
+		return diag.FromErr(err)
+	}
+	log.Printf("API RESPONSE: %s", resp)
+
+	if resp.Result == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
+	}
+
+	var result *morpheus.GetIntegrationResult
+	if v, ok := resp.Result.(*morpheus.GetIntegrationResult); ok {
+		result = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
+	}
+
+	if result.Integration == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Integration"))
+	}
+
+	integration := result.Integration
+	d.SetId(convert.Int64ToString(integration.ID))
+	d.Set("name", integration.Name)
+
+	return diags
+}

--- a/templates/data-sources/morpheus_integration.md.tmpl
+++ b/templates/data-sources/morpheus_integration.md.tmpl
@@ -1,0 +1,15 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{tffile "examples/data-sources/morpheus_integration/data-source.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Adds the hpe_morpheus_integration data source.

Type assertions have been made safe.

Adds the doc templates.

Generated docs and provider registration will come in a follow-up PR.

Note: This functionally captures what the `morpheus_chef_server` data source does, as that data source reports all chef integrations.
Chef integrations can be found by name by using the `morpheus_integration` data source, so `morpheus_chef_server` shall not be ported.
Furthermore, `morpheus_chef_server` only gives information about `name` and `id`, which `morpheus_integration` does.
