### PR TITLE
Add sdkv2 data source: hpe_morpheus_blueprint

### DIFF
--- a/examples/data-sources/morpheus_blueprint/data-source.tf
+++ b/examples/data-sources/morpheus_blueprint/data-source.tf
@@ -1,0 +1,3 @@
+data "hpe_morpheus_blueprint" "example_blueprint" {
+  name = "TF Example Blueprint"
+}

--- a/internal/sdkv2/morpheus/datasources/blueprint/blueprint.go
+++ b/internal/sdkv2/morpheus/datasources/blueprint/blueprint.go
@@ -1,0 +1,109 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package blueprint
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/convert"
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/helpers"
+
+	morpheus "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
+)
+
+func DataSourceBlueprint() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Morpheus blueprint data source.",
+		ReadContext: dataSourceBlueprintRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:          schema.TypeInt,
+				Description:   "The ID of the blueprint",
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+				Computed:      true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Description:   "The name of the blueprint",
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+			},
+		},
+	}
+}
+
+func dataSourceBlueprintRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var client *morpheus.Client
+	if v, ok := meta.(*morpheus.Client); ok {
+		client = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("client", meta))
+	}
+
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
+	var name string
+	if v, ok := d.Get("name").(string); ok {
+		name = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("name", d.Get("name")))
+	}
+
+	var id int
+	if v, ok := d.Get("id").(int); ok {
+		id = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("id", d.Get("id")))
+	}
+
+	// lookup by name if we do not have an id yet
+	var resp *morpheus.Response
+	var err error
+	if id == 0 && name != "" {
+		resp, err = client.FindBlueprintByName(name)
+	} else if id != 0 {
+		resp, err = client.GetBlueprint(int64(id), &morpheus.Request{})
+	} else {
+		return diag.Errorf("Blueprint cannot be read without name or id")
+	}
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Printf("API 404: %s - %v", resp, err)
+
+			return nil
+		}
+
+		log.Printf("API FAILURE: %s - %v", resp, err)
+
+		return diag.FromErr(err)
+	}
+	log.Printf("API RESPONSE: %s", resp)
+
+	if resp.Result == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
+	}
+
+	var result *morpheus.GetBlueprintResult
+	if v, ok := resp.Result.(*morpheus.GetBlueprintResult); ok {
+		result = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
+	}
+
+	if result.Blueprint == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Blueprint"))
+	}
+
+	blueprint := result.Blueprint
+	d.SetId(convert.Int64ToString(blueprint.ID))
+	d.Set("name", blueprint.Name)
+
+	return diags
+}

--- a/templates/data-sources/morpheus_blueprint.md.tmpl
+++ b/templates/data-sources/morpheus_blueprint.md.tmpl
@@ -1,0 +1,15 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{tffile "examples/data-sources/morpheus_blueprint/data-source.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Adds the hpe_morpheus_blueprint data source.

Type assertions have been made safe.

Adds the doc templates.

Generated docs and provider registration will come in a follow-up PR.
