### PR TITLE
Instance changes: network_interfaces and remove layout_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 In this release (v0.4.0) we have added the following resource functionality:
 
 - hpe_morpheus_image Update functionality has been added
+- hpe_morpheus_instance supports multiple networks and child virtual networks
 
 ## New known issues
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Morpheus API SSL cert checking is enabled by default in this provider.
 ## Morpheus
 
 This provider can be used to manage Morpheus resources.  Support will grow over time.  See below for
-release notes for the current version (v0.3.0).
+release notes for the current version (v0.4.0).
 
 ### Authentication
 
@@ -49,7 +49,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.3.0"
+      version = "= 0.4.0"
     }
   }
 }
@@ -73,7 +73,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.3.0"
+      version = "= 0.4.0"
     }
   }
 }
@@ -96,7 +96,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.3.0"
+      version = "= 0.4.0"
     }
   }
 }
@@ -132,6 +132,7 @@ will be evaluated at run-time.  Examples of these are shown in the documentation
 In this release (v0.4.0) we have added the following resource functionality:
 
 - hpe_morpheus_image Update functionality has been added
+- hpe_morpheus_instance supports multiple networks and child virtual networks
 
 ### New known issues
 
@@ -149,7 +150,6 @@ In this release (v0.4.0) we have added the following resource functionality:
   and that the share is accessible before creating.
 - hpe_morpheus_datastore delete is not guaranteed to succeed.  AlletraMP HVM datastores will delete but NFS datastores
   may fail to delete.  Always delete VMs and other resources using the datastore before deleting the datastore itself.
-- hpe_morpheus_instance only supports 1 network
 - hpe_morpheus_instance in Morpheus versions prior to 8.0.11 requires that the `root` volume is the first entry in
   the `volumes` block list
 - hpe_morpheus_datastore data-source if a datastore with the specified name cannot be found (i.e. the corresponding

--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -13,13 +13,23 @@ Morpheus oversees its entire lifecycle, from initial provisioning to scaling,
 monitoring, and eventual decommissioning.
 
 -> Currently only HVM instances are supported.<br>
-Only one network interface is supported at this time.<br>
 `ip_mode` must be set to avoid a forced replace on update - this will be addresses in a future release.<br>
 With Morpheus versions prior to 8.0.11, make sure the root volume is the first defined.<br>
 The addition and removal of volumes is not supported during updates.<br>
 Updates fail when removing optional fields.<br>
 Updates fail when removing `evars`.<br>
 These will be addressed in a future release.
+
+-> When an instance is created, it is marked as "ready" before DHCP has assigned IP addresses to all
+`network_interfaces` and any `child_virtual_networks`.  A `terraform plan` will report that no changes
+will be made.  Eventually, when all IP addresses have been assigned (this can be seen in the UI) a
+`terraform apply` will report that no changes have been made but will update the state-file to include
+the missing IP addresses.
+
+-> We have removed `layout_size` from the Schema.  For technical reasons we have decided to only allow
+the creation of one VM per instance.  When executing terraform an error will be raised stating that
+`layout_size` is unsupported.  It is safe to remove the attribute from HCL, a `plan` will show no changes
+to infrastructure after removal and on the next `apply` the attribute will be removed from the state-file.
 
 ## Example Usage
 
@@ -38,7 +48,6 @@ resource "hpe_morpheus_instance" "example" {
   cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
   layout_id        = 5385                                 # Single KVM VM
   instance_type_id = 9                  # (HVM) mvm-cluster
-  layout_size      = 1
 
   group_id = 1
   plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
@@ -121,7 +130,6 @@ The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" ca
 - `config` (Dynamic) Configuration object. Settings vary by type.
 - `evars` (Attributes Set) Environment Variables, an array of objects that have name and value. (see [below for nested schema](#nestedatt--evars))
 - `instance_context` (String) Environment
-- `layout_size` (Number) Apply a multiply factor of containers/vms within the instance.
 - `ports` (Attributes Set) The ports parameter is for port configuration.
 
 The layout may have default ports, which are defined in node types, that are always configured. This parameter will be for additional custom ports to be opened. (see [below for nested schema](#nestedatt--ports))
@@ -138,10 +146,38 @@ The layout may have default ports, which are defined in node types, that are alw
 
 Optional:
 
+- `child_virtual_networks` (Attributes List) The child_virtual_networks parameter is for network configuration of child virtual networks
+
+The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" can be used to see which options are available. (see [below for nested schema](#nestedatt--network_interfaces--child_virtual_networks))
 - `ip_address` (String) The ip address. Not applicable when using DHCP or IP Pools.
 - `ip_mode` (String) The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.
-- `network_group_id` (Number) id of the network group to be used.
-- `network_id` (Number) id of the network to be used.
+- `ip_pool` (Number) id of the ip pool to be used with this network
+- `network_group_id` (Number) id of the network group to be used. Cannot be used with 'network_id', will be used instead of 'network_id'
+- `network_id` (Number) id of the network to be used.  This cannot be used with 'network_group_id'
+- `network_type_id` (Number) The id of the type of network interface
+
+Read-Only:
+
+- `name` (String) The name of the interface, e.g. 'eth0', 'eth1'
+- `primary_interface` (Boolean) Is this interface the 'primary interface'?
+
+<a id="nestedatt--network_interfaces--child_virtual_networks"></a>
+### Nested Schema for `network_interfaces.child_virtual_networks`
+
+Optional:
+
+- `ip_address` (String) The ip address. Not applicable when using DHCP or IP Pools.
+- `ip_mode` (String) The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.
+- `ip_pool` (Number) id of the ip pool to be used with this network
+- `network_group_id` (Number) id of the network group to be used. Cannot be used with 'network_id', will be used instead of 'network_id'
+- `network_id` (Number) id of the network to be used.  This cannot be used with 'network_group_id'
+- `network_type_id` (Number) The id of the type of network interface
+
+Read-Only:
+
+- `name` (String) The name of the interface, e.g. 'eth0', 'eth1'
+- `primary_interface` (Boolean) Is this interface the 'primary interface'?
+
 
 
 <a id="nestedatt--evars"></a>

--- a/examples/provider/morpheus/provider-accesstoken.tf
+++ b/examples/provider/morpheus/provider-accesstoken.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.3.0"
+      version = "= 0.4.0"
     }
   }
 }

--- a/examples/provider/morpheus/provider-insecure.tf
+++ b/examples/provider/morpheus/provider-insecure.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.3.0"
+      version = "= 0.4.0"
     }
   }
 }

--- a/examples/provider/morpheus/provider-unamepasswd.tf
+++ b/examples/provider/morpheus/provider-unamepasswd.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.3.0"
+      version = "= 0.4.0"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4bb578ba
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.1.0
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.2.0
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4bb578ba/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.1.0 h1:JxHOVtOmKRkYnYfF0zbD+V5Wk9nvHx/Q/eqz5sfFi98=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.1.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.2.0 h1:I6hT05BSo5dowGZNU7s7CvgOiDlY/o91ygFNVkWbx9k=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.2.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=

--- a/internal/framework/subproviders/morpheus/resources/instance/example.tf
+++ b/internal/framework/subproviders/morpheus/resources/instance/example.tf
@@ -12,7 +12,6 @@ resource "hpe_morpheus_instance" "example" {
   cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
   layout_id        = 5385                                 # Single KVM VM
   instance_type_id = 9                  # (HVM) mvm-cluster
-  layout_size      = 1
 
   group_id = 1
   plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512

--- a/internal/framework/subproviders/morpheus/resources/instance/example.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/instance/example.tf.tmpl
@@ -12,7 +12,6 @@ resource "hpe_morpheus_instance" "example" {
   cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
   layout_id        = 5385                                 # Single KVM VM
   instance_type_id = {{.InstanceType}}                  # (HVM) mvm-cluster
-  layout_size      = 1
 
   group_id = 1
   plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512

--- a/internal/framework/subproviders/morpheus/resources/instance/instance.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance.go
@@ -222,80 +222,55 @@ func getInstanceAsState(
 	// layout_id
 	state.LayoutId = convert.Int64ToType(instance.Layout.Id)
 
-	// layout_size
-	state.LayoutSize = convert.Int64ToType(instance.Config.LayoutSize)
-
 	// name
 	state.Name = convert.StrToType(instance.Name)
 
 	// network_interfaces
-	// interfaces, d := convert.ToSetType(
-	// 	ctx,
-	// 	resp.GetInstance().Interfaces,
-	// 	func(
-	// 		in sdk.AddInstance200ResponseAllOfOneOfInstanceInterfacesInner,
-	// 	) NetworkInterfacesValue {
-	// 		v := NetworkInterfacesValue{}
-	// 		v.IpAddress = convert.StrToType(in.IpAddress)
-	// 		v.IpMode = convert.StrToType(in.IpMode)
-	//
-	// 		if in.Network.Group != nil {
-	// 			groupID := int64(in.Network.GetGroup())
-	// 			v.NetworkGroupId = types.Int64Value(groupID)
-	// 		}
-	//
-	// 		v.NetworkId = convert.Int64ToType(in.Network.Id)
-	//
-	// 		v.state = attr.ValueStateKnown
-	//
-	// 		return v
-	// 	},
-	// )
-	// diags.Append(d...)
-	// state.NetworkInterfaces = interfaces
+	// We are going to read network interface information from containerDetails.server.interfaces
+	// Note that, at present, all network IP addresses will not be available to us when we reach
+	// this stage on instance creation, we will have enough in the state-file that a plan will
+	// be a no-op, and that when all IP addresses are available (this can be seen in the UI) an
+	// apply will update the state-file with the IP addresses etc.
+	subIntfMap, isSubIntf, serverIntfsMap, serverInterfaces := getAllServerInterfaces(instance)
 
-	// TODO: find a way to make sure each slice matches up correctly
-	if len(resp.GetInstance().Interfaces) == len(resp.GetInstance().ConnectionInfo) {
-		var ifaces []NetworkInterfacesValue
+	var ifaces []NetworkInterfacesValue
 
-		for _, iface := range resp.GetInstance().Interfaces {
-			ifaceVal := NetworkInterfacesValue{}
-
-			ifaceVal.IpAddress = convert.StrToType(iface.IpAddress)
-			ifaceVal.IpMode = convert.StrToType(iface.IpMode)
-
-			if iface.Network.Group != nil {
-				groupID := int64(iface.Network.GetGroup())
-				ifaceVal.NetworkGroupId = types.Int64Value(groupID)
-			}
-
-			ifaceVal.NetworkId = convert.Int64ToType(iface.Network.Id)
-
-			ifaceVal.state = attr.ValueStateKnown
-
-			ifaces = append(ifaces, ifaceVal)
+	for _, iface := range serverInterfaces {
+		// Skip sub-interfaces
+		if _, ok := isSubIntf[*iface.Id]; ok {
+			continue
 		}
+		ifaceVal := NetworkInterfacesValue{}
 
-		var newIfaces []NetworkInterfacesValue
-
-		for i, conn := range resp.GetInstance().ConnectionInfo {
-			iface := ifaces[i]
-			iface.IpAddress = convert.StrToType(conn.Ip)
-
-			newIfaces = append(newIfaces, iface)
+		ifaceVal.IpAddress = convert.StrToType(iface.IpAddress)
+		ifaceVal.IpMode = convert.StrToType(iface.IpMode)
+		ifaceVal.NetworkGroupId = types.Int64Null()
+		if group, ok := iface.GetNetworkGroupOk(); ok {
+			ifaceVal.NetworkGroupId = convert.Int64ToType(group.Id)
 		}
+		ifaceVal.NetworkId = convert.Int64ToType(iface.Network.Id)
+		ifaceVal.Name = convert.StrToType(iface.Name)
+		ifaceVal.PrimaryInterface = convert.BoolToType(iface.PrimaryInterface)
 
-		networkInterfacesSet, d := types.ListValueFrom(ctx, NetworkInterfacesValue{}.Type(ctx), newIfaces)
-		diags.Append(d...)
+		childInterfaces, childD := getChildNetworks(ctx, iface.Id, subIntfMap, serverIntfsMap)
+		diags.Append(childD...)
+		ifaceVal.ChildVirtualNetworks = childInterfaces
 
-		if diags.HasError() {
-			tflog.Error(ctx, "cannot convert network interfaces")
+		ifaceVal.state = attr.ValueStateKnown
 
-			return state, diags
-		}
-
-		state.NetworkInterfaces = networkInterfacesSet
+		ifaces = append(ifaces, ifaceVal)
 	}
+
+	networkInterfacesSet, d := types.ListValueFrom(ctx, NetworkInterfacesValue{}.Type(ctx), ifaces)
+	diags.Append(d...)
+
+	if diags.HasError() {
+		tflog.Error(ctx, "cannot convert network interfaces")
+
+		return state, diags
+	}
+
+	state.NetworkInterfaces = networkInterfacesSet
 
 	// plan_id
 	state.PlanId = convert.Int64ToType(instance.Plan.Id)
@@ -378,6 +353,123 @@ func getInstanceAsState(
 	state.Volumes = volumes
 
 	return state, diags
+}
+
+// Process the set of interfaces in an instance
+// This function takes an "instance" input and returns the following:
+//   - a map of interface-ids with a list of the ids of any sub-interfaces
+//   - a map of interface-ids with a boolean saying if they are sub-interfaces
+//   - a map of interface-ids with the corresponding interface information
+//   - a list of the interfaces, which should (hopefully) be in the same order as those specified
+//     in network_interfaces
+func getAllServerInterfaces(
+	instance sdk.AddInstance200ResponseAllOfOneOfInstance,
+) (map[int64][]int64, map[int64]bool,
+	map[int64]sdk.InstanceContainerServerInterfacesInner1, []sdk.InstanceContainerServerInterfacesInner1,
+) {
+	subIntfsMap := make(map[int64][]int64)
+	isSubIntf := make(map[int64]bool)
+	serverIntfsMap := make(map[int64]sdk.InstanceContainerServerInterfacesInner1)
+	serverIntfsList := make([]sdk.InstanceContainerServerInterfacesInner1, 0)
+
+	// First clean-up the server interface list
+	// The list of interfaces is malleable, and changes after the instance has been created and returned
+	// to us for reading.  In early stages the interface "name" (eth0, eth1 etc) will have repeated
+	// entries.
+	// Key here is the "UniqueId".  If an interface doesn't have a value for that or for Network then all
+	// it has is an IP address that will be assigned to the interface with the same name (eth0, eth1, etc)
+	for _, container := range instance.ContainerDetails {
+		server, _ := container.GetServerOk()
+		serverIntfList, _ := server.GetInterfacesOk()
+		serverIntfsNameMap := make(map[string][]sdk.InstanceContainerServerInterfacesInner1)
+		for _, serverIntf := range serverIntfList {
+			serverIntfsNameMap[*serverIntf.Name] = append(serverIntfsNameMap[*serverIntf.Name], serverIntf)
+		}
+
+		for _, v := range serverIntfsNameMap {
+			if len(v) == 1 {
+				serverIntfsList = append(serverIntfsList, v[0])
+
+				continue
+			}
+
+			// Hopefully there will only be two entries in the other lists
+			// What we are going to do here is use the entry that has Network information
+			// as the base of the cumulative interface, and then hunt through the rest for
+			// an ip-address
+			var cumulativeIntf sdk.InstanceContainerServerInterfacesInner1
+			var ipAddress *string
+			for _, serverIntf := range v {
+				if _, ok := serverIntf.GetNetworkOk(); ok {
+					cumulativeIntf = serverIntf
+
+					break
+				}
+			}
+			for _, serverIntf := range v {
+				if ip, ok := serverIntf.GetIpAddressOk(); ok {
+					ipAddress = ip
+
+					break
+				}
+			}
+
+			cumulativeIntf.IpAddress = ipAddress
+			serverIntfsList = append(serverIntfsList, cumulativeIntf)
+		}
+	}
+
+	// Build the maps that we're going to return
+	for _, serverInterface := range serverIntfsList {
+		serverIntfsMap[serverInterface.GetId()] = serverInterface
+		if subIntfs, ok := serverInterface.GetInterfacesOk(); ok {
+			intfList := make([]int64, 0)
+			for _, subIntf := range subIntfs {
+				intfList = append(intfList, subIntf.GetId())
+				isSubIntf[subIntf.GetId()] = true
+			}
+			if len(intfList) > 0 {
+				subIntfsMap[serverInterface.GetId()] = intfList
+			}
+		}
+	}
+
+	return subIntfsMap, isSubIntf, serverIntfsMap, serverIntfsList
+}
+
+// Get the child virtual network interface values
+func getChildNetworks(
+	ctx context.Context,
+	id *int64,
+	subIntfMap map[int64][]int64,
+	serverIntfsMap map[int64]sdk.InstanceContainerServerInterfacesInner1,
+) (basetypes.ListValue, diag.Diagnostics) {
+	if id == nil {
+		return basetypes.NewListNull(ChildVirtualNetworksType{}), nil
+	}
+
+	if len(subIntfMap[*id]) == 0 {
+		return basetypes.NewListNull(ChildVirtualNetworksType{}), nil
+	}
+
+	children := make([]ChildVirtualNetworksValue, 0)
+	for _, subIntf := range subIntfMap[*id] {
+		ifaceVal := ChildVirtualNetworksValue{}
+		iface := serverIntfsMap[subIntf]
+		ifaceVal.IpAddress = convert.StrToType(iface.IpAddress)
+		ifaceVal.IpMode = convert.StrToType(iface.IpMode)
+		ifaceVal.NetworkGroupId = types.Int64Null()
+		if group, ok := iface.GetNetworkGroupOk(); ok {
+			ifaceVal.NetworkGroupId = convert.Int64ToType(group.Id)
+		}
+		ifaceVal.NetworkId = convert.Int64ToType(iface.Network.Id)
+		ifaceVal.Name = convert.StrToType(iface.Name)
+		ifaceVal.PrimaryInterface = convert.BoolToType(iface.PrimaryInterface)
+		ifaceVal.state = attr.ValueStateKnown
+		children = append(children, ifaceVal)
+	}
+
+	return types.ListValueFrom(ctx, ChildVirtualNetworksValue{}.Type(ctx), children)
 }
 
 func getInstanceTypeCode(
@@ -532,11 +624,6 @@ func (g *Resource) Create(
 		)
 	}
 
-	// layout_size
-	if !plan.LayoutSize.IsNull() {
-		reqInstance.SetLayoutSize(plan.LayoutSize.ValueInt64())
-	}
-
 	// name
 	if !plan.Name.IsNull() {
 		reqInstance.Instance.SetName(plan.Name.ValueString())
@@ -546,7 +633,7 @@ func (g *Resource) Create(
 	networkInterfaces, diags := convert.FromListType(
 		ctx,
 		plan.NetworkInterfaces,
-		networkInterfaceMapper,
+		networkInterfaceMapper(ctx),
 	)
 	if diags.HasError() {
 		tflog.Error(ctx, "cannot convert network interfaces")

--- a/internal/framework/subproviders/morpheus/resources/instance/mappings.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/mappings.go
@@ -1,9 +1,14 @@
 package instance
 
 import (
+	"context"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 )
 
 // Map Terraform volume value into an API request struct
@@ -52,8 +57,50 @@ func volumeMapper(
 
 // Map Terraform network interface value into an API request struct
 func networkInterfaceMapper(
-	in NetworkInterfacesValue,
-) sdk.AddCatalogItemTypeRequestCatalogItemTypeOneOfConfigNetworkInterfacesInner {
+	ctx context.Context,
+) func(in NetworkInterfacesValue) sdk.InstancesNetworkInterfaces {
+	return func(in NetworkInterfacesValue) sdk.InstancesNetworkInterfaces {
+		var id string
+		if !in.NetworkGroupId.IsNull() {
+			id = "networkGroup-" + in.NetworkGroupId.String()
+		}
+
+		if !in.NetworkId.IsNull() {
+			id = in.NetworkId.String()
+		}
+
+		ipPool := sdk.NewInstancesNetworkInterfacesNetworkPoolWithDefaults()
+		if !in.IpPool.IsNull() {
+			ipPool.SetId(in.IpPool.ValueInt64())
+		}
+
+		childNetworkInterfaces, diags := convert.FromListType(
+			ctx,
+			in.ChildVirtualNetworks,
+			childNetworkInterfaceMapper,
+		)
+		if diags.HasError() {
+			tflog.Error(ctx, "cannot convert child virtual network interfaces")
+		}
+
+		return sdk.InstancesNetworkInterfaces{
+			Network: sdk.
+				InstancesNetworkInterfacesNetwork{
+				Id:   id,
+				Pool: ipPool,
+			},
+			IpMode:                 in.IpMode.ValueStringPointer(),
+			IpAddress:              in.IpAddress.ValueStringPointer(),
+			NetworkInterfaceTypeId: in.NetworkTypeId.ValueInt64Pointer(),
+			NetworkInterfaces:      childNetworkInterfaces,
+		}
+	}
+}
+
+// Map Child Virtual Network interface if it exists
+func childNetworkInterfaceMapper(
+	in ChildVirtualNetworksValue,
+) sdk.InstancesNetworkInterfacesNetworkInterfacesInner {
 	var id string
 	if !in.NetworkGroupId.IsNull() {
 		id = "networkGroup-" + in.NetworkGroupId.String()
@@ -63,13 +110,19 @@ func networkInterfaceMapper(
 		id = in.NetworkId.String()
 	}
 
-	return sdk.AddCatalogItemTypeRequestCatalogItemTypeOneOfConfigNetworkInterfacesInner{
-		Network: sdk.
-			AddCatalogItemTypeRequestCatalogItemTypeOneOfConfigNetworkInterfacesInnerNetwork{
-			Id: id,
+	ipPool := sdk.NewInstancesNetworkInterfacesNetworkPoolWithDefaults()
+	if !in.IpPool.IsNull() {
+		ipPool.SetId(in.IpPool.ValueInt64())
+	}
+
+	return sdk.InstancesNetworkInterfacesNetworkInterfacesInner{
+		Network: sdk.InstancesNetworkInterfacesNetwork{
+			Id:   id,
+			Pool: ipPool,
 		},
-		IpMode:    in.IpMode.ValueStringPointer(),
-		IpAddress: in.IpAddress.ValueStringPointer(),
+		IpMode:                 in.IpMode.ValueStringPointer(),
+		IpAddress:              in.IpAddress.ValueStringPointer(),
+		NetworkInterfaceTypeId: in.NetworkTypeId.ValueInt64Pointer(),
 	}
 }
 

--- a/internal/framework/subproviders/morpheus/resources/instance/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/resource_test.go
@@ -126,7 +126,6 @@ func TestAccMorpheusInstanceUpdateName(t *testing.T) {
 						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
 						layout_id          = 5385
 						instance_type_id   = 9
-						layout_size        = 1
 
 						group_id           = 1
 						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
@@ -188,7 +187,6 @@ func TestAccMorpheusInstanceUpdateName(t *testing.T) {
 						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
 						layout_id          = 5385
 						instance_type_id   = 9
-						layout_size        = 1
 
 						group_id           = 1
 						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
@@ -269,7 +267,6 @@ func TestAccMorpheusInstanceUpdateInstanceContext(t *testing.T) {
 						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
 						layout_id          = 5385
 						instance_type_id   = 9
-						layout_size        = 1
 
 						group_id           = 1
 						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
@@ -331,7 +328,6 @@ func TestAccMorpheusInstanceUpdateInstanceContext(t *testing.T) {
 						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
 						layout_id          = 5385
 						instance_type_id   = 9
-						layout_size        = 1
 
 						group_id           = 1
 						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
@@ -412,7 +408,6 @@ func TestAccMorpheusInstanceUpdateTags(t *testing.T) {
 						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
 						layout_id          = 5385
 						instance_type_id   = 9
-						layout_size        = 1
 
 						group_id           = 1
 						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
@@ -474,7 +469,6 @@ func TestAccMorpheusInstanceUpdateTags(t *testing.T) {
 						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
 						layout_id          = 5385
 						instance_type_id   = 9
-						layout_size        = 1
 
 						group_id           = 1
 						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id

--- a/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
@@ -5,15 +5,12 @@ package instance
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/morpheusvalidators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -23,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -96,13 +94,6 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The layout id for the instance type that you want to provision. i.e. single process or cluster",
 				MarkdownDescription: "The layout id for the instance type that you want to provision. i.e. single process or cluster",
 			},
-			"layout_size": schema.Int64Attribute{
-				Optional:            true,
-				Computed:            true,
-				Description:         "Apply a multiply factor of containers/vms within the instance.",
-				MarkdownDescription: "Apply a multiply factor of containers/vms within the instance.",
-				Default:             int64default.StaticInt64(1),
-			},
 			"name": schema.StringAttribute{
 				Required:            true,
 				Description:         "Name of the instance to be created.",
@@ -111,6 +102,91 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 			"network_interfaces": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"child_virtual_networks": schema.ListNestedAttribute{
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"ip_address": schema.StringAttribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "The ip address. Not applicable when using DHCP or IP Pools.",
+										MarkdownDescription: "The ip address. Not applicable when using DHCP or IP Pools.",
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"ip_mode": schema.StringAttribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.",
+										MarkdownDescription: "The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.",
+										Validators: []validator.String{
+											stringvalidator.OneOf("static", "dhcp"),
+										},
+									},
+									"ip_pool": schema.Int64Attribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "id of the ip pool to be used with this network",
+										MarkdownDescription: "id of the ip pool to be used with this network",
+										Validators: []validator.Int64{
+											int64validator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("ip_address"),
+											}...),
+										},
+									},
+									"name": schema.StringAttribute{
+										Computed:            true,
+										Description:         "The name of the interface, e.g. 'eth0', 'eth1'",
+										MarkdownDescription: "The name of the interface, e.g. 'eth0', 'eth1'",
+									},
+									"network_group_id": schema.Int64Attribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "id of the network group to be used. Cannot be used with 'network_id', will be used instead of 'network_id'\n",
+										MarkdownDescription: "id of the network group to be used. Cannot be used with 'network_id', will be used instead of 'network_id'\n",
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
+										Validators: []validator.Int64{
+											int64validator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("network_id"),
+											}...),
+										},
+									},
+									"network_id": schema.Int64Attribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "id of the network to be used.  This cannot be used with 'network_group_id'",
+										MarkdownDescription: "id of the network to be used.  This cannot be used with 'network_group_id'",
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
+									},
+									"network_type_id": schema.Int64Attribute{
+										Optional:            true,
+										Computed:            true,
+										Description:         "The id of the type of network interface",
+										MarkdownDescription: "The id of the type of network interface",
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
+									},
+									"primary_interface": schema.BoolAttribute{
+										Computed:            true,
+										Description:         "Is this interface the 'primary interface'?",
+										MarkdownDescription: "Is this interface the 'primary interface'?",
+									},
+								},
+								CustomType: ChildVirtualNetworksType{
+									ObjectType: types.ObjectType{
+										AttrTypes: ChildVirtualNetworksValue{}.AttributeTypes(ctx),
+									},
+								},
+							},
+							Optional:            true,
+							Description:         "The child_virtual_networks parameter is for network configuration of child virtual networks\n\nThe Options API \"/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10\" can be used to see which options are available.\n",
+							MarkdownDescription: "The child_virtual_networks parameter is for network configuration of child virtual networks\n\nThe Options API \"/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10\" can be used to see which options are available.\n",
+						},
 						"ip_address": schema.StringAttribute{
 							Optional:            true,
 							Computed:            true,
@@ -126,34 +202,61 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 							Description:         "The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.",
 							MarkdownDescription: "The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.",
 							Validators: []validator.String{
-								stringvalidator.OneOf(
-									"static",
-									"dhcp",
-								),
+								stringvalidator.OneOf("static", "dhcp"),
 							},
+						},
+						"ip_pool": schema.Int64Attribute{
+							Optional:            true,
+							Computed:            true,
+							Description:         "id of the ip pool to be used with this network",
+							MarkdownDescription: "id of the ip pool to be used with this network",
+							Validators: []validator.Int64{
+								int64validator.ConflictsWith(path.Expressions{
+									path.MatchRelative().AtParent().AtName("ip_address"),
+								}...),
+							},
+						},
+						"name": schema.StringAttribute{
+							Computed:            true,
+							Description:         "The name of the interface, e.g. 'eth0', 'eth1'",
+							MarkdownDescription: "The name of the interface, e.g. 'eth0', 'eth1'",
 						},
 						"network_group_id": schema.Int64Attribute{
 							Optional:            true,
 							Computed:            true,
-							Description:         "id of the network group to be used.",
-							MarkdownDescription: "id of the network group to be used.",
-							Validators: []validator.Int64{
-								int64validator.ConflictsWith(path.Expressions{
-									path.MatchRoot("network_id"),
-								}...),
-							},
+							Description:         "id of the network group to be used. Cannot be used with 'network_id', will be used instead of 'network_id'\n",
+							MarkdownDescription: "id of the network group to be used. Cannot be used with 'network_id', will be used instead of 'network_id'\n",
 							PlanModifiers: []planmodifier.Int64{
 								int64planmodifier.UseStateForUnknown(),
+							},
+							Validators: []validator.Int64{
+								int64validator.ConflictsWith(path.Expressions{
+									path.MatchRelative().AtParent().AtName("network_id"),
+								}...),
 							},
 						},
 						"network_id": schema.Int64Attribute{
 							Optional:            true,
 							Computed:            true,
-							Description:         "id of the network to be used.",
-							MarkdownDescription: "id of the network to be used.",
+							Description:         "id of the network to be used.  This cannot be used with 'network_group_id'",
+							MarkdownDescription: "id of the network to be used.  This cannot be used with 'network_group_id'",
 							PlanModifiers: []planmodifier.Int64{
 								int64planmodifier.UseStateForUnknown(),
 							},
+						},
+						"network_type_id": schema.Int64Attribute{
+							Optional:            true,
+							Computed:            true,
+							Description:         "The id of the type of network interface",
+							MarkdownDescription: "The id of the type of network interface",
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
+						},
+						"primary_interface": schema.BoolAttribute{
+							Computed:            true,
+							Description:         "Is this interface the 'primary interface'?",
+							MarkdownDescription: "Is this interface the 'primary interface'?",
 						},
 					},
 					CustomType: NetworkInterfacesType{
@@ -339,7 +442,6 @@ type InstanceModel struct {
 	InstanceContext   types.String  `tfsdk:"instance_context"`
 	InstanceTypeId    types.Int64   `tfsdk:"instance_type_id"`
 	LayoutId          types.Int64   `tfsdk:"layout_id"`
-	LayoutSize        types.Int64   `tfsdk:"layout_size"`
 	Name              types.String  `tfsdk:"name"`
 	NetworkInterfaces types.List    `tfsdk:"network_interfaces"`
 	PlanId            types.Int64   `tfsdk:"plan_id"`
@@ -582,12 +684,14 @@ func (t EvarsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (at
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
+
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
 		if err != nil {
 			return nil, err
 		}
@@ -626,6 +730,7 @@ func (v EvarsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals := make(map[string]tftypes.Value, 2)
 
 		val, err = v.Name.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -633,6 +738,7 @@ func (v EvarsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals["name"] = val
 
 		val, err = v.Value.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -765,6 +871,24 @@ func (t NetworkInterfacesType) ValueFromObject(ctx context.Context, in basetypes
 
 	attributes := in.Attributes()
 
+	childVirtualNetworksAttribute, ok := attributes["child_virtual_networks"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`child_virtual_networks is missing from object`)
+
+		return nil, diags
+	}
+
+	childVirtualNetworksVal, ok := childVirtualNetworksAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`child_virtual_networks expected to be basetypes.ListValue, was: %T`, childVirtualNetworksAttribute))
+	}
+
 	ipAddressAttribute, ok := attributes["ip_address"]
 
 	if !ok {
@@ -799,6 +923,42 @@ func (t NetworkInterfacesType) ValueFromObject(ctx context.Context, in basetypes
 		diags.AddError(
 			"Attribute Wrong Type",
 			fmt.Sprintf(`ip_mode expected to be basetypes.StringValue, was: %T`, ipModeAttribute))
+	}
+
+	ipPoolAttribute, ok := attributes["ip_pool"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`ip_pool is missing from object`)
+
+		return nil, diags
+	}
+
+	ipPoolVal, ok := ipPoolAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`ip_pool expected to be basetypes.Int64Value, was: %T`, ipPoolAttribute))
+	}
+
+	nameAttribute, ok := attributes["name"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`name is missing from object`)
+
+		return nil, diags
+	}
+
+	nameVal, ok := nameAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`name expected to be basetypes.StringValue, was: %T`, nameAttribute))
 	}
 
 	networkGroupIdAttribute, ok := attributes["network_group_id"]
@@ -837,16 +997,57 @@ func (t NetworkInterfacesType) ValueFromObject(ctx context.Context, in basetypes
 			fmt.Sprintf(`network_id expected to be basetypes.Int64Value, was: %T`, networkIdAttribute))
 	}
 
+	networkTypeIdAttribute, ok := attributes["network_type_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`network_type_id is missing from object`)
+
+		return nil, diags
+	}
+
+	networkTypeIdVal, ok := networkTypeIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`network_type_id expected to be basetypes.Int64Value, was: %T`, networkTypeIdAttribute))
+	}
+
+	primaryInterfaceAttribute, ok := attributes["primary_interface"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`primary_interface is missing from object`)
+
+		return nil, diags
+	}
+
+	primaryInterfaceVal, ok := primaryInterfaceAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`primary_interface expected to be basetypes.BoolValue, was: %T`, primaryInterfaceAttribute))
+	}
+
 	if diags.HasError() {
 		return nil, diags
 	}
 
 	return NetworkInterfacesValue{
-		IpAddress:      ipAddressVal,
-		IpMode:         ipModeVal,
-		NetworkGroupId: networkGroupIdVal,
-		NetworkId:      networkIdVal,
-		state:          attr.ValueStateKnown,
+		ChildVirtualNetworks: childVirtualNetworksVal,
+		IpAddress:            ipAddressVal,
+		IpMode:               ipModeVal,
+		IpPool:               ipPoolVal,
+		Name:                 nameVal,
+		NetworkGroupId:       networkGroupIdVal,
+		NetworkId:            networkIdVal,
+		NetworkTypeId:        networkTypeIdVal,
+		PrimaryInterface:     primaryInterfaceVal,
+		state:                attr.ValueStateKnown,
 	}, diags
 }
 
@@ -913,6 +1114,24 @@ func NewNetworkInterfacesValue(attributeTypes map[string]attr.Type, attributes m
 		return NewNetworkInterfacesValueUnknown(), diags
 	}
 
+	childVirtualNetworksAttribute, ok := attributes["child_virtual_networks"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`child_virtual_networks is missing from object`)
+
+		return NewNetworkInterfacesValueUnknown(), diags
+	}
+
+	childVirtualNetworksVal, ok := childVirtualNetworksAttribute.(basetypes.ListValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`child_virtual_networks expected to be basetypes.ListValue, was: %T`, childVirtualNetworksAttribute))
+	}
+
 	ipAddressAttribute, ok := attributes["ip_address"]
 
 	if !ok {
@@ -947,6 +1166,42 @@ func NewNetworkInterfacesValue(attributeTypes map[string]attr.Type, attributes m
 		diags.AddError(
 			"Attribute Wrong Type",
 			fmt.Sprintf(`ip_mode expected to be basetypes.StringValue, was: %T`, ipModeAttribute))
+	}
+
+	ipPoolAttribute, ok := attributes["ip_pool"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`ip_pool is missing from object`)
+
+		return NewNetworkInterfacesValueUnknown(), diags
+	}
+
+	ipPoolVal, ok := ipPoolAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`ip_pool expected to be basetypes.Int64Value, was: %T`, ipPoolAttribute))
+	}
+
+	nameAttribute, ok := attributes["name"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`name is missing from object`)
+
+		return NewNetworkInterfacesValueUnknown(), diags
+	}
+
+	nameVal, ok := nameAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`name expected to be basetypes.StringValue, was: %T`, nameAttribute))
 	}
 
 	networkGroupIdAttribute, ok := attributes["network_group_id"]
@@ -985,16 +1240,57 @@ func NewNetworkInterfacesValue(attributeTypes map[string]attr.Type, attributes m
 			fmt.Sprintf(`network_id expected to be basetypes.Int64Value, was: %T`, networkIdAttribute))
 	}
 
+	networkTypeIdAttribute, ok := attributes["network_type_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`network_type_id is missing from object`)
+
+		return NewNetworkInterfacesValueUnknown(), diags
+	}
+
+	networkTypeIdVal, ok := networkTypeIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`network_type_id expected to be basetypes.Int64Value, was: %T`, networkTypeIdAttribute))
+	}
+
+	primaryInterfaceAttribute, ok := attributes["primary_interface"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`primary_interface is missing from object`)
+
+		return NewNetworkInterfacesValueUnknown(), diags
+	}
+
+	primaryInterfaceVal, ok := primaryInterfaceAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`primary_interface expected to be basetypes.BoolValue, was: %T`, primaryInterfaceAttribute))
+	}
+
 	if diags.HasError() {
 		return NewNetworkInterfacesValueUnknown(), diags
 	}
 
 	return NetworkInterfacesValue{
-		IpAddress:      ipAddressVal,
-		IpMode:         ipModeVal,
-		NetworkGroupId: networkGroupIdVal,
-		NetworkId:      networkIdVal,
-		state:          attr.ValueStateKnown,
+		ChildVirtualNetworks: childVirtualNetworksVal,
+		IpAddress:            ipAddressVal,
+		IpMode:               ipModeVal,
+		IpPool:               ipPoolVal,
+		Name:                 nameVal,
+		NetworkGroupId:       networkGroupIdVal,
+		NetworkId:            networkIdVal,
+		NetworkTypeId:        networkTypeIdVal,
+		PrimaryInterface:     primaryInterfaceVal,
+		state:                attr.ValueStateKnown,
 	}, diags
 }
 
@@ -1041,12 +1337,14 @@ func (t NetworkInterfacesType) ValueFromTerraform(ctx context.Context, in tftype
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
+
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
 		if err != nil {
 			return nil, err
 		}
@@ -1064,31 +1362,52 @@ func (t NetworkInterfacesType) ValueType(ctx context.Context) attr.Value {
 var _ basetypes.ObjectValuable = NetworkInterfacesValue{}
 
 type NetworkInterfacesValue struct {
-	IpAddress      basetypes.StringValue `tfsdk:"ip_address"`
-	IpMode         basetypes.StringValue `tfsdk:"ip_mode"`
-	NetworkGroupId basetypes.Int64Value  `tfsdk:"network_group_id"`
-	NetworkId      basetypes.Int64Value  `tfsdk:"network_id"`
-	state          attr.ValueState
+	ChildVirtualNetworks basetypes.ListValue   `tfsdk:"child_virtual_networks"`
+	IpAddress            basetypes.StringValue `tfsdk:"ip_address"`
+	IpMode               basetypes.StringValue `tfsdk:"ip_mode"`
+	IpPool               basetypes.Int64Value  `tfsdk:"ip_pool"`
+	Name                 basetypes.StringValue `tfsdk:"name"`
+	NetworkGroupId       basetypes.Int64Value  `tfsdk:"network_group_id"`
+	NetworkId            basetypes.Int64Value  `tfsdk:"network_id"`
+	NetworkTypeId        basetypes.Int64Value  `tfsdk:"network_type_id"`
+	PrimaryInterface     basetypes.BoolValue   `tfsdk:"primary_interface"`
+	state                attr.ValueState
 }
 
 func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 4)
+	attrTypes := make(map[string]tftypes.Type, 9)
 
 	var val tftypes.Value
 	var err error
 
+	attrTypes["child_virtual_networks"] = basetypes.ListType{
+		ElemType: ChildVirtualNetworksValue{}.Type(ctx),
+	}.TerraformType(ctx)
 	attrTypes["ip_address"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["ip_mode"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["ip_pool"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["name"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["network_group_id"] = basetypes.Int64Type{}.TerraformType(ctx)
 	attrTypes["network_id"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["network_type_id"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["primary_interface"] = basetypes.BoolType{}.TerraformType(ctx)
 
 	objectType := tftypes.Object{AttributeTypes: attrTypes}
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 4)
+		vals := make(map[string]tftypes.Value, 9)
+
+		val, err = v.ChildVirtualNetworks.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["child_virtual_networks"] = val
 
 		val, err = v.IpAddress.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1096,13 +1415,31 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["ip_address"] = val
 
 		val, err = v.IpMode.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
 
 		vals["ip_mode"] = val
 
+		val, err = v.IpPool.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["ip_pool"] = val
+
+		val, err = v.Name.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["name"] = val
+
 		val, err = v.NetworkGroupId.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1110,11 +1447,28 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["network_group_id"] = val
 
 		val, err = v.NetworkId.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
 
 		vals["network_id"] = val
+
+		val, err = v.NetworkTypeId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["network_type_id"] = val
+
+		val, err = v.PrimaryInterface.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["primary_interface"] = val
 
 		if err := tftypes.ValidateValue(objectType, vals); err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
@@ -1145,11 +1499,47 @@ func (v NetworkInterfacesValue) String() string {
 func (v NetworkInterfacesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	childVirtualNetworksVal := types.ListValueMust(
+		ChildVirtualNetworksType{
+			basetypes.ObjectType{
+				AttrTypes: ChildVirtualNetworksValue{}.AttributeTypes(ctx),
+			},
+		},
+		v.ChildVirtualNetworks.Elements(),
+	)
+
+	if v.ChildVirtualNetworks.IsNull() {
+		childVirtualNetworksVal = types.ListNull(
+			ChildVirtualNetworksType{
+				basetypes.ObjectType{
+					AttrTypes: ChildVirtualNetworksValue{}.AttributeTypes(ctx),
+				},
+			},
+		)
+	}
+
+	if v.ChildVirtualNetworks.IsUnknown() {
+		childVirtualNetworksVal = types.ListUnknown(
+			ChildVirtualNetworksType{
+				basetypes.ObjectType{
+					AttrTypes: ChildVirtualNetworksValue{}.AttributeTypes(ctx),
+				},
+			},
+		)
+	}
+
 	attributeTypes := map[string]attr.Type{
-		"ip_address":       basetypes.StringType{},
-		"ip_mode":          basetypes.StringType{},
-		"network_group_id": basetypes.Int64Type{},
-		"network_id":       basetypes.Int64Type{},
+		"child_virtual_networks": basetypes.ListType{
+			ElemType: ChildVirtualNetworksValue{}.Type(ctx),
+		},
+		"ip_address":        basetypes.StringType{},
+		"ip_mode":           basetypes.StringType{},
+		"ip_pool":           basetypes.Int64Type{},
+		"name":              basetypes.StringType{},
+		"network_group_id":  basetypes.Int64Type{},
+		"network_id":        basetypes.Int64Type{},
+		"network_type_id":   basetypes.Int64Type{},
+		"primary_interface": basetypes.BoolType{},
 	}
 
 	if v.IsNull() {
@@ -1163,10 +1553,15 @@ func (v NetworkInterfacesValue) ToObjectValue(ctx context.Context) (basetypes.Ob
 	objVal, diags := types.ObjectValue(
 		attributeTypes,
 		map[string]attr.Value{
-			"ip_address":       v.IpAddress,
-			"ip_mode":          v.IpMode,
-			"network_group_id": v.NetworkGroupId,
-			"network_id":       v.NetworkId,
+			"child_virtual_networks": childVirtualNetworksVal,
+			"ip_address":             v.IpAddress,
+			"ip_mode":                v.IpMode,
+			"ip_pool":                v.IpPool,
+			"name":                   v.Name,
+			"network_group_id":       v.NetworkGroupId,
+			"network_id":             v.NetworkId,
+			"network_type_id":        v.NetworkTypeId,
+			"primary_interface":      v.PrimaryInterface,
 		})
 
 	return objVal, diags
@@ -1174,6 +1569,730 @@ func (v NetworkInterfacesValue) ToObjectValue(ctx context.Context) (basetypes.Ob
 
 func (v NetworkInterfacesValue) Equal(o attr.Value) bool {
 	other, ok := o.(NetworkInterfacesValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.ChildVirtualNetworks.Equal(other.ChildVirtualNetworks) {
+		return false
+	}
+
+	if !v.IpAddress.Equal(other.IpAddress) {
+		return false
+	}
+
+	if !v.IpMode.Equal(other.IpMode) {
+		return false
+	}
+
+	if !v.IpPool.Equal(other.IpPool) {
+		return false
+	}
+
+	if !v.Name.Equal(other.Name) {
+		return false
+	}
+
+	if !v.NetworkGroupId.Equal(other.NetworkGroupId) {
+		return false
+	}
+
+	if !v.NetworkId.Equal(other.NetworkId) {
+		return false
+	}
+
+	if !v.NetworkTypeId.Equal(other.NetworkTypeId) {
+		return false
+	}
+
+	if !v.PrimaryInterface.Equal(other.PrimaryInterface) {
+		return false
+	}
+
+	return true
+}
+
+func (v NetworkInterfacesValue) Type(ctx context.Context) attr.Type {
+	return NetworkInterfacesType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v NetworkInterfacesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"child_virtual_networks": basetypes.ListType{
+			ElemType: ChildVirtualNetworksValue{}.Type(ctx),
+		},
+		"ip_address":        basetypes.StringType{},
+		"ip_mode":           basetypes.StringType{},
+		"ip_pool":           basetypes.Int64Type{},
+		"name":              basetypes.StringType{},
+		"network_group_id":  basetypes.Int64Type{},
+		"network_id":        basetypes.Int64Type{},
+		"network_type_id":   basetypes.Int64Type{},
+		"primary_interface": basetypes.BoolType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ChildVirtualNetworksType{}
+
+type ChildVirtualNetworksType struct {
+	basetypes.ObjectType
+}
+
+func (t ChildVirtualNetworksType) Equal(o attr.Type) bool {
+	other, ok := o.(ChildVirtualNetworksType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ChildVirtualNetworksType) String() string {
+	return "ChildVirtualNetworksType"
+}
+
+func (t ChildVirtualNetworksType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewChildVirtualNetworksValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewChildVirtualNetworksValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	ipAddressAttribute, ok := attributes["ip_address"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`ip_address is missing from object`)
+
+		return nil, diags
+	}
+
+	ipAddressVal, ok := ipAddressAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`ip_address expected to be basetypes.StringValue, was: %T`, ipAddressAttribute))
+	}
+
+	ipModeAttribute, ok := attributes["ip_mode"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`ip_mode is missing from object`)
+
+		return nil, diags
+	}
+
+	ipModeVal, ok := ipModeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`ip_mode expected to be basetypes.StringValue, was: %T`, ipModeAttribute))
+	}
+
+	ipPoolAttribute, ok := attributes["ip_pool"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`ip_pool is missing from object`)
+
+		return nil, diags
+	}
+
+	ipPoolVal, ok := ipPoolAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`ip_pool expected to be basetypes.Int64Value, was: %T`, ipPoolAttribute))
+	}
+
+	nameAttribute, ok := attributes["name"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`name is missing from object`)
+
+		return nil, diags
+	}
+
+	nameVal, ok := nameAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`name expected to be basetypes.StringValue, was: %T`, nameAttribute))
+	}
+
+	networkGroupIdAttribute, ok := attributes["network_group_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`network_group_id is missing from object`)
+
+		return nil, diags
+	}
+
+	networkGroupIdVal, ok := networkGroupIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`network_group_id expected to be basetypes.Int64Value, was: %T`, networkGroupIdAttribute))
+	}
+
+	networkIdAttribute, ok := attributes["network_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`network_id is missing from object`)
+
+		return nil, diags
+	}
+
+	networkIdVal, ok := networkIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`network_id expected to be basetypes.Int64Value, was: %T`, networkIdAttribute))
+	}
+
+	networkTypeIdAttribute, ok := attributes["network_type_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`network_type_id is missing from object`)
+
+		return nil, diags
+	}
+
+	networkTypeIdVal, ok := networkTypeIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`network_type_id expected to be basetypes.Int64Value, was: %T`, networkTypeIdAttribute))
+	}
+
+	primaryInterfaceAttribute, ok := attributes["primary_interface"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`primary_interface is missing from object`)
+
+		return nil, diags
+	}
+
+	primaryInterfaceVal, ok := primaryInterfaceAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`primary_interface expected to be basetypes.BoolValue, was: %T`, primaryInterfaceAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ChildVirtualNetworksValue{
+		IpAddress:        ipAddressVal,
+		IpMode:           ipModeVal,
+		IpPool:           ipPoolVal,
+		Name:             nameVal,
+		NetworkGroupId:   networkGroupIdVal,
+		NetworkId:        networkIdVal,
+		NetworkTypeId:    networkTypeIdVal,
+		PrimaryInterface: primaryInterfaceVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewChildVirtualNetworksValueNull() ChildVirtualNetworksValue {
+	return ChildVirtualNetworksValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewChildVirtualNetworksValueUnknown() ChildVirtualNetworksValue {
+	return ChildVirtualNetworksValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewChildVirtualNetworksValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ChildVirtualNetworksValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ChildVirtualNetworksValue Attribute Value",
+				"While creating a ChildVirtualNetworksValue value, a missing attribute value was detected. "+
+					"A ChildVirtualNetworksValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ChildVirtualNetworksValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ChildVirtualNetworksValue Attribute Type",
+				"While creating a ChildVirtualNetworksValue value, an invalid attribute value was detected. "+
+					"A ChildVirtualNetworksValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ChildVirtualNetworksValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ChildVirtualNetworksValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ChildVirtualNetworksValue Attribute Value",
+				"While creating a ChildVirtualNetworksValue value, an extra attribute value was detected. "+
+					"A ChildVirtualNetworksValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ChildVirtualNetworksValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	ipAddressAttribute, ok := attributes["ip_address"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`ip_address is missing from object`)
+
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	ipAddressVal, ok := ipAddressAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`ip_address expected to be basetypes.StringValue, was: %T`, ipAddressAttribute))
+	}
+
+	ipModeAttribute, ok := attributes["ip_mode"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`ip_mode is missing from object`)
+
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	ipModeVal, ok := ipModeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`ip_mode expected to be basetypes.StringValue, was: %T`, ipModeAttribute))
+	}
+
+	ipPoolAttribute, ok := attributes["ip_pool"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`ip_pool is missing from object`)
+
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	ipPoolVal, ok := ipPoolAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`ip_pool expected to be basetypes.Int64Value, was: %T`, ipPoolAttribute))
+	}
+
+	nameAttribute, ok := attributes["name"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`name is missing from object`)
+
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	nameVal, ok := nameAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`name expected to be basetypes.StringValue, was: %T`, nameAttribute))
+	}
+
+	networkGroupIdAttribute, ok := attributes["network_group_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`network_group_id is missing from object`)
+
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	networkGroupIdVal, ok := networkGroupIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`network_group_id expected to be basetypes.Int64Value, was: %T`, networkGroupIdAttribute))
+	}
+
+	networkIdAttribute, ok := attributes["network_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`network_id is missing from object`)
+
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	networkIdVal, ok := networkIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`network_id expected to be basetypes.Int64Value, was: %T`, networkIdAttribute))
+	}
+
+	networkTypeIdAttribute, ok := attributes["network_type_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`network_type_id is missing from object`)
+
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	networkTypeIdVal, ok := networkTypeIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`network_type_id expected to be basetypes.Int64Value, was: %T`, networkTypeIdAttribute))
+	}
+
+	primaryInterfaceAttribute, ok := attributes["primary_interface"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`primary_interface is missing from object`)
+
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	primaryInterfaceVal, ok := primaryInterfaceAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`primary_interface expected to be basetypes.BoolValue, was: %T`, primaryInterfaceAttribute))
+	}
+
+	if diags.HasError() {
+		return NewChildVirtualNetworksValueUnknown(), diags
+	}
+
+	return ChildVirtualNetworksValue{
+		IpAddress:        ipAddressVal,
+		IpMode:           ipModeVal,
+		IpPool:           ipPoolVal,
+		Name:             nameVal,
+		NetworkGroupId:   networkGroupIdVal,
+		NetworkId:        networkIdVal,
+		NetworkTypeId:    networkTypeIdVal,
+		PrimaryInterface: primaryInterfaceVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewChildVirtualNetworksValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ChildVirtualNetworksValue {
+	object, diags := NewChildVirtualNetworksValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewChildVirtualNetworksValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ChildVirtualNetworksType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewChildVirtualNetworksValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewChildVirtualNetworksValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewChildVirtualNetworksValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewChildVirtualNetworksValueMust(ChildVirtualNetworksValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ChildVirtualNetworksType) ValueType(ctx context.Context) attr.Value {
+	return ChildVirtualNetworksValue{}
+}
+
+var _ basetypes.ObjectValuable = ChildVirtualNetworksValue{}
+
+type ChildVirtualNetworksValue struct {
+	IpAddress        basetypes.StringValue `tfsdk:"ip_address"`
+	IpMode           basetypes.StringValue `tfsdk:"ip_mode"`
+	IpPool           basetypes.Int64Value  `tfsdk:"ip_pool"`
+	Name             basetypes.StringValue `tfsdk:"name"`
+	NetworkGroupId   basetypes.Int64Value  `tfsdk:"network_group_id"`
+	NetworkId        basetypes.Int64Value  `tfsdk:"network_id"`
+	NetworkTypeId    basetypes.Int64Value  `tfsdk:"network_type_id"`
+	PrimaryInterface basetypes.BoolValue   `tfsdk:"primary_interface"`
+	state            attr.ValueState
+}
+
+func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 8)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["ip_address"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["ip_mode"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["ip_pool"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["name"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["network_group_id"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["network_id"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["network_type_id"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["primary_interface"] = basetypes.BoolType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 8)
+
+		val, err = v.IpAddress.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["ip_address"] = val
+
+		val, err = v.IpMode.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["ip_mode"] = val
+
+		val, err = v.IpPool.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["ip_pool"] = val
+
+		val, err = v.Name.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["name"] = val
+
+		val, err = v.NetworkGroupId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["network_group_id"] = val
+
+		val, err = v.NetworkId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["network_id"] = val
+
+		val, err = v.NetworkTypeId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["network_type_id"] = val
+
+		val, err = v.PrimaryInterface.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["primary_interface"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ChildVirtualNetworksValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ChildVirtualNetworksValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ChildVirtualNetworksValue) String() string {
+	return "ChildVirtualNetworksValue"
+}
+
+func (v ChildVirtualNetworksValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"ip_address":        basetypes.StringType{},
+		"ip_mode":           basetypes.StringType{},
+		"ip_pool":           basetypes.Int64Type{},
+		"name":              basetypes.StringType{},
+		"network_group_id":  basetypes.Int64Type{},
+		"network_id":        basetypes.Int64Type{},
+		"network_type_id":   basetypes.Int64Type{},
+		"primary_interface": basetypes.BoolType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"ip_address":        v.IpAddress,
+			"ip_mode":           v.IpMode,
+			"ip_pool":           v.IpPool,
+			"name":              v.Name,
+			"network_group_id":  v.NetworkGroupId,
+			"network_id":        v.NetworkId,
+			"network_type_id":   v.NetworkTypeId,
+			"primary_interface": v.PrimaryInterface,
+		})
+
+	return objVal, diags
+}
+
+func (v ChildVirtualNetworksValue) Equal(o attr.Value) bool {
+	other, ok := o.(ChildVirtualNetworksValue)
 
 	if !ok {
 		return false
@@ -1195,6 +2314,14 @@ func (v NetworkInterfacesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.IpPool.Equal(other.IpPool) {
+		return false
+	}
+
+	if !v.Name.Equal(other.Name) {
+		return false
+	}
+
 	if !v.NetworkGroupId.Equal(other.NetworkGroupId) {
 		return false
 	}
@@ -1203,23 +2330,35 @@ func (v NetworkInterfacesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.NetworkTypeId.Equal(other.NetworkTypeId) {
+		return false
+	}
+
+	if !v.PrimaryInterface.Equal(other.PrimaryInterface) {
+		return false
+	}
+
 	return true
 }
 
-func (v NetworkInterfacesValue) Type(ctx context.Context) attr.Type {
-	return NetworkInterfacesType{
+func (v ChildVirtualNetworksValue) Type(ctx context.Context) attr.Type {
+	return ChildVirtualNetworksType{
 		basetypes.ObjectType{
 			AttrTypes: v.AttributeTypes(ctx),
 		},
 	}
 }
 
-func (v NetworkInterfacesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+func (v ChildVirtualNetworksValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
-		"ip_address":       basetypes.StringType{},
-		"ip_mode":          basetypes.StringType{},
-		"network_group_id": basetypes.Int64Type{},
-		"network_id":       basetypes.Int64Type{},
+		"ip_address":        basetypes.StringType{},
+		"ip_mode":           basetypes.StringType{},
+		"ip_pool":           basetypes.Int64Type{},
+		"name":              basetypes.StringType{},
+		"network_group_id":  basetypes.Int64Type{},
+		"network_id":        basetypes.Int64Type{},
+		"network_type_id":   basetypes.Int64Type{},
+		"primary_interface": basetypes.BoolType{},
 	}
 }
 
@@ -1494,12 +2633,14 @@ func (t PortsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (at
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
+
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
 		if err != nil {
 			return nil, err
 		}
@@ -1540,6 +2681,7 @@ func (v PortsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals := make(map[string]tftypes.Value, 3)
 
 		val, err = v.LoadBalancerProtocol.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1547,6 +2689,7 @@ func (v PortsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals["load_balancer_protocol"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1554,6 +2697,7 @@ func (v PortsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals["name"] = val
 
 		val, err = v.Port.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1893,12 +3037,14 @@ func (t TagsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (att
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
+
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
 		if err != nil {
 			return nil, err
 		}
@@ -1937,6 +3083,7 @@ func (v TagsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) 
 		vals := make(map[string]tftypes.Value, 2)
 
 		val, err = v.Name.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1944,6 +3091,7 @@ func (v TagsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) 
 		vals["name"] = val
 
 		val, err = v.Value.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2542,12 +3690,14 @@ func (t VolumesType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
+
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
 		if err != nil {
 			return nil, err
 		}
@@ -2600,6 +3750,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals := make(map[string]tftypes.Value, 9)
 
 		val, err = v.ControllerMountPoint.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2607,6 +3758,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["controller_mount_point"] = val
 
 		val, err = v.DatastoreAutoSelection.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2614,6 +3766,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["datastore_auto_selection"] = val
 
 		val, err = v.DatastoreId.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2621,6 +3774,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["datastore_id"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2628,6 +3782,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["id"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2635,6 +3790,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["name"] = val
 
 		val, err = v.RootVolume.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2642,6 +3798,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["root_volume"] = val
 
 		val, err = v.Size.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2649,6 +3806,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["size"] = val
 
 		val, err = v.SizeId.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2656,6 +3814,7 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["size_id"] = val
 
 		val, err = v.StorageTypeId.ToTerraformValue(ctx)
+
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}

--- a/internal/framework/subproviders/morpheus/resources/instance/update.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/update.go
@@ -121,7 +121,7 @@ func (g *Resource) Update(
 		networkInterfaces, diags := convert.FromListType(
 			ctx,
 			plan.NetworkInterfaces,
-			networkInterfaceMapper,
+			networkInterfaceMapper(ctx),
 		)
 		if diags.HasError() {
 			tflog.Error(ctx, "cannot convert network interfaces")

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -25,7 +25,7 @@ Morpheus API SSL cert checking is enabled by default in this provider.
 ## Morpheus
 
 This provider can be used to manage Morpheus resources.  Support will grow over time.  See below for
-release notes for the current version (v0.3.0).
+release notes for the current version (v0.4.0).
 
 ### Authentication
 
@@ -73,6 +73,7 @@ will be evaluated at run-time.  Examples of these are shown in the documentation
 In this release (v0.4.0) we have added the following resource functionality:
 
 - hpe_morpheus_image Update functionality has been added
+- hpe_morpheus_instance supports multiple networks and child virtual networks
 
 ### New known issues
 
@@ -90,7 +91,6 @@ In this release (v0.4.0) we have added the following resource functionality:
   and that the share is accessible before creating.
 - hpe_morpheus_datastore delete is not guaranteed to succeed.  AlletraMP HVM datastores will delete but NFS datastores
   may fail to delete.  Always delete VMs and other resources using the datastore before deleting the datastore itself.
-- hpe_morpheus_instance only supports 1 network
 - hpe_morpheus_instance in Morpheus versions prior to 8.0.11 requires that the `root` volume is the first entry in
   the `volumes` block list
 - hpe_morpheus_datastore data-source if a datastore with the specified name cannot be found (i.e. the corresponding

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -13,13 +13,23 @@ Morpheus oversees its entire lifecycle, from initial provisioning to scaling,
 monitoring, and eventual decommissioning.
 
 -> Currently only HVM instances are supported.<br>
-Only one network interface is supported at this time.<br>
 `ip_mode` must be set to avoid a forced replace on update - this will be addresses in a future release.<br>
 With Morpheus versions prior to 8.0.11, make sure the root volume is the first defined.<br>
 The addition and removal of volumes is not supported during updates.<br>
 Updates fail when removing optional fields.<br>
 Updates fail when removing `evars`.<br>
 These will be addressed in a future release.
+
+-> When an instance is created, it is marked as "ready" before DHCP has assigned IP addresses to all
+`network_interfaces` and any `child_virtual_networks`.  A `terraform plan` will report that no changes
+will be made.  Eventually, when all IP addresses have been assigned (this can be seen in the UI) a
+`terraform apply` will report that no changes have been made but will update the state-file to include
+the missing IP addresses.
+
+-> We have removed `layout_size` from the Schema.  For technical reasons we have decided to only allow
+the creation of one VM per instance.  When executing terraform an error will be raised stating that
+`layout_size` is unsupported.  It is safe to remove the attribute from HCL, a `plan` will show no changes
+to infrastructure after removal and on the next `apply` the attribute will be removed from the state-file.
 
 ## Example Usage
 


### PR DESCRIPTION
In this PR we make two sets of changes to "hpe_morpheus_instance".
- We remove "layout_size" since we are not going to support the creation of multiple VMs in an instance.  The issue is that we have no good way of storing information on the additional VMs in state, for example the extra "network_interfaces" (with different IP addresses).  Fixing this might be possible but would definitely require a lot of thought. Instead we've made the decision to allow allow creation of one VM per instance

The other set of changes are related to "network_interfaces":
- We add "ip_pool" which is the ID of the ip pool to use with an interface
- We add "network_type_id"
- We allow the creation of "child_virtual_networks" for each "network_interface"
- We allow the creation of multiple "network_interfaces"

The code changes:
- We change networkInterfaceMapper() to be a closure that accepts "ctx". This is so that we can convert "child_network_interfaces" into a list of sub "network_interfaces" to attach to the outer "network_interface"
- We add childNetworkInterfaceMapper() to convert "child_network_interfaces"
- We add getAllServerInterfaces() to process containerDetails.server.interfaces, this allows us to determine IP addresses for the specified HCL "network_interfaces" and the "child_virtual_networks"
- We add getChildNetworks() to get "child_virtual_networks" for each "network_interface"

Testing changes:
- We remove "layout_size" from the acceptance tests

Docs changes:
- We update the release notes
- We add a couple of sigil notes to the docs for hpe_morpheus_instance
- We update the "provider" examples to refer to version 0.4.0
- We update "index.md.tmpl" tp refer to version 0.4.0