### PR TITLE
Allow null child_virtual_networks

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -30,6 +30,11 @@ the creation of one VM per instance.  When executing terraform an error will be 
 `layout_size` is unsupported.  It is safe to remove the attribute from HCL, a `plan` will show no changes
 to infrastructure after removal and on the next `apply` the attribute will be removed from the state-file.
 
+-> Beware when importing an instance where DHCP has been enabled: if the experimental `plan` functionality
+to generate HCL (flag `-generate-config-out`) is being used the resulting HCL will contain IP addresses for
+each of the interfaces. Remove these IP addresses from the generated HCL *before* executing `terraform apply`
+to import the instance. Otherwise the import will result in the instance being destroyed.
+
 ## Example Usage
 
 ```terraform
@@ -144,7 +149,8 @@ The layout may have default ports, which are defined in node types, that are alw
 
 Optional:
 
-- `child_virtual_networks` (Attributes List) The child_virtual_networks parameter is for network configuration of child virtual networks
+- `child_virtual_networks` (Attributes List) The child_virtual_networks parameter is for network configuration of child virtual networks.  Note that this list
+cannot be empty, it can either not be specified in HCL or if specified must contain at least one element
 
 The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" can be used to see which options are available. (see [below for nested schema](#nestedatt--network_interfaces--child_virtual_networks))
 - `ip_address` (String) The ip address. Not applicable when using DHCP or IP Pools.

--- a/internal/framework/subproviders/morpheus/resources/instance/instance.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance.go
@@ -445,11 +445,11 @@ func getChildNetworks(
 	serverIntfsMap map[int64]sdk.InstanceContainerServerInterfacesInner1,
 ) (basetypes.ListValue, diag.Diagnostics) {
 	if id == nil {
-		return basetypes.NewListNull(ChildVirtualNetworksType{}), nil
+		return types.ListNull(ChildVirtualNetworksValue{}.Type(ctx)), nil
 	}
 
 	if len(subIntfMap[*id]) == 0 {
-		return basetypes.NewListNull(ChildVirtualNetworksType{}), nil
+		return types.ListNull(ChildVirtualNetworksValue{}.Type(ctx)), nil
 	}
 
 	children := make([]ChildVirtualNetworksValue, 0)
@@ -774,7 +774,7 @@ func (g *Resource) Delete(
 		return
 	}
 
-	deleteReq := client.InstancesAPI.DeleteInstance(ctx, id.ValueInt64())
+	deleteReq := client.InstancesAPI.DeleteInstance(ctx, id.ValueInt64()).Force("on")
 	_, hresp, err := deleteReq.Execute()
 	if err != nil || hresp.StatusCode != http.StatusOK {
 		resp.Diagnostics.AddError(

--- a/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/morpheusvalidators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -186,8 +187,11 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 								},
 							},
 							Optional:            true,
-							Description:         "The child_virtual_networks parameter is for network configuration of child virtual networks\n\nThe Options API \"/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10\" can be used to see which options are available.\n",
-							MarkdownDescription: "The child_virtual_networks parameter is for network configuration of child virtual networks\n\nThe Options API \"/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10\" can be used to see which options are available.\n",
+							Description:         "The child_virtual_networks parameter is for network configuration of child virtual networks.  Note that this list\ncannot be empty, it can either not be specified in HCL or if specified must contain at least one element\n\nThe Options API \"/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10\" can be used to see which options are available.\n",
+							MarkdownDescription: "The child_virtual_networks parameter is for network configuration of child virtual networks.  Note that this list\ncannot be empty, it can either not be specified in HCL or if specified must contain at least one element\n\nThe Options API \"/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10\" can be used to see which options are available.\n",
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+							},
 						},
 						"ip_address": schema.StringAttribute{
 							Optional:            true,

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -30,6 +30,11 @@ the creation of one VM per instance.  When executing terraform an error will be 
 `layout_size` is unsupported.  It is safe to remove the attribute from HCL, a `plan` will show no changes
 to infrastructure after removal and on the next `apply` the attribute will be removed from the state-file.
 
+-> Beware when importing an instance where DHCP has been enabled: if the experimental `plan` functionality
+to generate HCL (flag `-generate-config-out`) is being used the resulting HCL will contain IP addresses for
+each of the interfaces. Remove these IP addresses from the generated HCL *before* executing `terraform apply`
+to import the instance. Otherwise the import will result in the instance being destroyed.
+
 ## Example Usage
 
 {{ tffile "internal/framework/subproviders/morpheus/resources/instance/example.tf" }}


### PR DESCRIPTION
In this PR we make the following changes:
- we add a listvalidator to the Schema for child_virtual_networks to make sure that the list is either null or contains at least 1 element, in other words we don't allow empty lists
- we update getChildNetworks() to return a null list with the correct type if there aren't any child networks for an interface
- we update the interface docs:
  - to warn that child_virtual_networks must have at least one element
  - to warn about importing instances where the HCL is autogenerated, if using DHCP the "ip_addresses" must be removed from the HCL before "apply" is run
- we add "force=on" to instance delete to force delete