### PR TITLE
Cloud: Use SDK function to get the cloud code

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_read.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_read.go
@@ -65,7 +65,7 @@ func getCloudAsState(
 	state.GroupId = convert.Int64ToType(cloud.Groups[0].Id)
 	state.AgentInstallMode = convert.StrToType(cloud.AgentMode)
 	state.AutoRecoverPowerState = convert.BoolToType(cloud.AutoRecoverPowerState)
-	if *cloud.Code != "standard" { // workaround an API bug
+	if cloud.GetCode() != "standard" { // workaround an API bug
 		state.Code = convert.StrToType(cloud.Code)
 	}
 	state.CostingMode = convert.StrToType(cloud.CostingMode.Get())


### PR DESCRIPTION
This PR fixes a possible panic by using an SDK function to avoid referencing a possible null pointer.