### PR TITLE
Policy validation

### DIFF
--- a/docs/resources/morpheus_policy.md
+++ b/docs/resources/morpheus_policy.md
@@ -60,6 +60,8 @@ Policies are different rules that can be applied to various Morpheus resources.
 
 ```terraform
 # Approve Delete Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_delete" {
   name                     = "Approve Delete Policy"
   description              = "Require approval before deleting instances"
@@ -81,6 +83,8 @@ resource "hpe_morpheus_policy" "approve_delete" {
 
 ```terraform
 # Approve Provision Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_provision" {
   name                     = "Approve Provision Policy"
   description              = "Require approval before provisioning instances"
@@ -102,6 +106,8 @@ resource "hpe_morpheus_policy" "approve_provision" {
 
 ```terraform
 # Approve Reconfigure Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_reconfigure" {
   name                     = "Approve Reconfigure Policy"
   description              = "Require approval before reconfiguring instances"
@@ -123,6 +129,8 @@ resource "hpe_morpheus_policy" "approve_reconfigure" {
 
 ```terraform
 # Approve Workflow Execute Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_workflow" {
   name                     = "Approve Workflow Execute Policy"
   description              = "Require approval before executing workflows"
@@ -144,6 +152,8 @@ resource "hpe_morpheus_policy" "approve_workflow" {
 
 ```terraform
 # Backup Creation Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "backup_creation" {
   name                     = "Backup Creation Policy"
   description              = "Enforce backup creation for instances"
@@ -169,6 +179,8 @@ Not currently supported
 
 ```terraform
 # Budget Policy - Limits instance costs
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "budget" {
   name                     = "Budget Policy"
   description              = "Limit maximum instance costs"
@@ -192,6 +204,8 @@ resource "hpe_morpheus_policy" "budget" {
 
 ```terraform
 # Cluster Resource Name Policy - Enforces naming conventions for cluster resources
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "cluster_naming" {
   name                     = "Cluster Resource Naming Policy"
   description              = "Enforce naming for cluster resources"
@@ -215,6 +229,8 @@ resource "hpe_morpheus_policy" "cluster_naming" {
 
 ```terraform
 # Cypher Access Policy - Controls access to Cypher secrets
+# Allowed associated_resource_types: User, Global, Role
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "cypher_access" {
   name                     = "Cypher Access Policy"
   description              = "Control Cypher key access permissions"
@@ -241,6 +257,8 @@ resource "hpe_morpheus_policy" "cypher_access" {
 
 ```terraform
 # Delayed Delete Policy - Delays instance deletion
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "delayed_delete" {
   name                     = "Delayed Delete Policy"
   description              = "Delay instance deletion by specified days"
@@ -262,6 +280,8 @@ resource "hpe_morpheus_policy" "delayed_delete" {
 
 ```terraform
 # Expiration Policy - Sets instance expiration and renewal options
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "expiration" {
   name                     = "Expiration Policy"
   description              = "Set instance expiration and renewal policies"
@@ -291,6 +311,8 @@ resource "hpe_morpheus_policy" "expiration" {
 
 ```terraform
 # File Share Storage Quota Policy - Limits file share storage
+# Allowed associated_resource_types: User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "file_share_quota" {
   name                     = "File Share Storage Quota Policy"
   description              = "Limit file share storage usage"
@@ -312,6 +334,8 @@ resource "hpe_morpheus_policy" "file_share_quota" {
 
 ```terraform
 # Hostname Policy - Enforces hostname naming conventions
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "hostname" {
   name                     = "Hostname Policy"
   description              = "Enforce hostname naming conventions"
@@ -334,6 +358,8 @@ resource "hpe_morpheus_policy" "hostname" {
 
 ```terraform
 # Instance Name Policy - Enforces instance naming conventions
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "instance_naming" {
   name                     = "Instance Name Policy"
   description              = "Enforce instance naming conventions"
@@ -357,10 +383,12 @@ resource "hpe_morpheus_policy" "instance_naming" {
 
 ```terraform
 # Instance Networks Policy - Requires specific networks for instances
+# Allowed associated_resource_types: Group, Cloud
+# Tenant specification: NOT allowed (allowOnTenant = false)
 resource "hpe_morpheus_policy" "required_networks" {
   name                     = "Instance Networks Policy"
   description              = "Require specific networks for instances"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 
@@ -378,6 +406,8 @@ resource "hpe_morpheus_policy" "required_networks" {
 
 ```terraform
 # Max Containers Policy - Limits container count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_containers" {
   name                     = "Max Containers Policy"
   description              = "Limit maximum container count"
@@ -399,6 +429,8 @@ resource "hpe_morpheus_policy" "max_containers" {
 
 ```terraform
 # Max Cores Policy - Limits CPU cores
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_cores" {
   name                     = "Max Cores Policy"
   description              = "Limit maximum CPU cores"
@@ -421,6 +453,8 @@ resource "hpe_morpheus_policy" "max_cores" {
 
 ```terraform
 # Max Hosts Policy - Limits host count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_hosts" {
   name                     = "Max Hosts Policy"
   description              = "Limit maximum host count"
@@ -442,6 +476,8 @@ resource "hpe_morpheus_policy" "max_hosts" {
 
 ```terraform
 # Max Load Balancer Pools Policy - Limits load balancer pools
+# Allowed associated_resource_types: Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_pools" {
   name                     = "Max Load Balancer Pools Policy"
   description              = "Limit maximum load balancer pools"
@@ -463,6 +499,8 @@ resource "hpe_morpheus_policy" "max_pools" {
 
 ```terraform
 # Max Memory Policy - Limits memory allocation
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_memory" {
   name                     = "Max Memory Policy"
   description              = "Limit maximum memory allocation"
@@ -485,10 +523,12 @@ resource "hpe_morpheus_policy" "max_memory" {
 
 ```terraform
 # Max Pool Members Policy - Limits pool members
+# Allowed associated_resource_types: Cloud, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_pool_members" {
   name                     = "Max Pool Members Policy"
   description              = "Limit maximum pool members"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 
@@ -506,6 +546,8 @@ resource "hpe_morpheus_policy" "max_pool_members" {
 
 ```terraform
 # Max Snapshots Policy - Limits snapshots per VM
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_snapshots" {
   name                     = "Max Snapshots Policy"
   description              = "Limit maximum snapshots per VM"
@@ -527,6 +569,8 @@ resource "hpe_morpheus_policy" "max_snapshots" {
 
 ```terraform
 # Max Storage Policy - Limits storage allocation
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_storage" {
   name                     = "Max Storage Policy"
   description              = "Limit maximum storage allocation"
@@ -549,10 +593,12 @@ resource "hpe_morpheus_policy" "max_storage" {
 
 ```terraform
 # Max Virtual Servers Policy - Limits virtual server count
+# Allowed associated_resource_types: Cloud, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_virtual_servers" {
   name                     = "Max Virtual Servers Policy"
   description              = "Limit maximum virtual server count"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 
@@ -570,6 +616,8 @@ resource "hpe_morpheus_policy" "max_virtual_servers" {
 
 ```terraform
 # Max VMs Policy - Limits VM count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Network, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_vms" {
   name                     = "Max VMs Policy"
   description              = "Limit maximum VM count"
@@ -591,11 +639,12 @@ resource "hpe_morpheus_policy" "max_vms" {
 
 ```terraform
 # Message of the Day (MOTD) Policy - Displays login messages
+# Allowed associated_resource_types: Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "motd" {
   name                     = "MOTD Policy"
   description              = "Display message of the day on login"
-  associated_resource_type = "User"
-  associated_resource_id   = 9969
+  associated_resource_type = "Global"
   enabled                  = true
 
   policy_type = {
@@ -615,6 +664,8 @@ resource "hpe_morpheus_policy" "motd" {
 
 ```terraform
 # Network Quota Policy - Limits network count
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "network_quota" {
   name                     = "Network Quota Policy"
   description              = "Limit maximum network count"
@@ -636,6 +687,8 @@ resource "hpe_morpheus_policy" "network_quota" {
 
 ```terraform
 # Object Storage Quota Policy - Limits object storage
+# Allowed associated_resource_types: User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "object_storage_quota" {
   name                     = "Object Storage Quota Policy"
   description              = "Limit object storage usage"
@@ -657,6 +710,8 @@ resource "hpe_morpheus_policy" "object_storage_quota" {
 
 ```terraform
 # Power Scheduling Policy - Enforces power schedules
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "power_schedule" {
   name                     = "Power Scheduling Policy"
   description              = "Enforce power schedules for instances"
@@ -680,6 +735,8 @@ resource "hpe_morpheus_policy" "power_schedule" {
 
 ```terraform
 # Router Quota Policy - Limits router count
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "router_quota" {
   name                     = "Router Quota Policy"
   description              = "Limit maximum router count"
@@ -701,6 +758,8 @@ resource "hpe_morpheus_policy" "router_quota" {
 
 ```terraform
 # Shutdown Policy - Auto-shutdown idle instances
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "shutdown" {
   name                     = "Shutdown Policy"
   description              = "Auto-shutdown idle instances"
@@ -730,10 +789,12 @@ resource "hpe_morpheus_policy" "shutdown" {
 
 ```terraform
 # Storage Server Storage Quota Policy - Limits storage on specific storage server
+# Allowed associated_resource_types: Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "storage_server_quota" {
   name                     = "Storage Server Storage Quota Policy"
   description              = "Limit storage usage on specific storage server"
-  associated_resource_type = "User"
+  associated_resource_type = "Global"
   associated_resource_id   = 9969
   enabled                  = true
 
@@ -752,6 +813,8 @@ resource "hpe_morpheus_policy" "storage_server_quota" {
 
 ```terraform
 # Tags Policy - Enforces instance tagging
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "tags" {
   name                     = "Tags Policy"
   description              = "Enforce instance tagging requirements"
@@ -776,6 +839,8 @@ resource "hpe_morpheus_policy" "tags" {
 
 ```terraform
 # User Creation Policy - Controls user creation on instances
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "user_creation" {
   name                     = "User Creation Policy"
   description              = "Control user creation on provisioned instances"
@@ -798,6 +863,8 @@ resource "hpe_morpheus_policy" "user_creation" {
 
 ```terraform
 # User Group Creation Policy - Assigns default user group
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "user_group_creation" {
   name                     = "User Group Creation Policy"
   description              = "Assign default user group for created users"
@@ -819,6 +886,8 @@ resource "hpe_morpheus_policy" "user_group_creation" {
 
 ```terraform
 # Workflow Policy - Executes workflow on provision
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 # Note: This example uses the morpheus external provider to create a workflow resource
 # because the hpe provider does not yet have a workflow resource implemented.
 # You will need to configure the morpheus provider in your terraform configuration.

--- a/docs/resources/morpheus_policy.md
+++ b/docs/resources/morpheus_policy.md
@@ -863,13 +863,13 @@ resource "hpe_morpheus_policy" "workflow" {
 
 ### Required
 
-- `associated_resource_type` (String) Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', or 'Plan'
+- `associated_resource_type` (String) Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', 'Plan' or 'Label'
 - `name` (String) A name for the policy
 - `policy_type` (Attributes) (see [below for nested schema](#nestedatt--policy_type))
 
 ### Optional
 
-- `associated_resource_id` (Number) The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan
+- `associated_resource_id` (Number) The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan, Label
 - `config` (Dynamic) Generic Policy Configuration
 - `description` (String) A description for the policy
 - `each_user` (Boolean) Apply individually to each user in role.  Only when `refType` equals `Role`

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_backupStorage.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_backupStorage.tf
@@ -1,4 +1,6 @@
 # # Backup Targets Policy - Restricts available backup storage targets
+# Allowed associated_resource_types: Group, Cloud, User, Global, Role
+# Tenant specification: NOT allowed (cannot specify tenants array)
 # resource "hpe_morpheus_policy" "backup_targets" {
 #   name                     = "Backup Targets Policy"
 #   description              = "Restrict available backup targets"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_createBackup.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_createBackup.tf
@@ -1,4 +1,6 @@
 # Backup Creation Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "backup_creation" {
   name                     = "Backup Creation Policy"
   description              = "Enforce backup creation for instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_createUser.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_createUser.tf
@@ -1,4 +1,6 @@
 # User Creation Policy - Controls user creation on instances
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "user_creation" {
   name                     = "User Creation Policy"
   description              = "Control user creation on provisioned instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_createUserGroup.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_createUserGroup.tf
@@ -1,4 +1,6 @@
 # User Group Creation Policy - Assigns default user group
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "user_group_creation" {
   name                     = "User Group Creation Policy"
   description              = "Assign default user group for created users"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_cypher.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_cypher.tf
@@ -1,4 +1,6 @@
 # Cypher Access Policy - Controls access to Cypher secrets
+# Allowed associated_resource_types: User, Global, Role
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "cypher_access" {
   name                     = "Cypher Access Policy"
   description              = "Control Cypher key access permissions"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_delayedRemoval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_delayedRemoval.tf
@@ -1,4 +1,6 @@
 # Delayed Delete Policy - Delays instance deletion
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "delayed_delete" {
   name                     = "Delayed Delete Policy"
   description              = "Delay instance deletion by specified days"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_deleteApproval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_deleteApproval.tf
@@ -1,4 +1,6 @@
 # Approve Delete Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_delete" {
   name                     = "Approve Delete Policy"
   description              = "Require approval before deleting instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_hostNaming.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_hostNaming.tf
@@ -1,4 +1,6 @@
 # Hostname Policy - Enforces hostname naming conventions
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "hostname" {
   name                     = "Hostname Policy"
   description              = "Enforce hostname naming conventions"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_lifecycle.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_lifecycle.tf
@@ -1,4 +1,6 @@
 # Expiration Policy - Sets instance expiration and renewal options
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "expiration" {
   name                     = "Expiration Policy"
   description              = "Set instance expiration and renewal policies"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxContainers.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxContainers.tf
@@ -1,4 +1,6 @@
 # Max Containers Policy - Limits container count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_containers" {
   name                     = "Max Containers Policy"
   description              = "Limit maximum container count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxCores.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxCores.tf
@@ -1,4 +1,6 @@
 # Max Cores Policy - Limits CPU cores
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_cores" {
   name                     = "Max Cores Policy"
   description              = "Limit maximum CPU cores"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxHosts.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxHosts.tf
@@ -1,4 +1,6 @@
 # Max Hosts Policy - Limits host count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_hosts" {
   name                     = "Max Hosts Policy"
   description              = "Limit maximum host count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxMemory.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxMemory.tf
@@ -1,4 +1,6 @@
 # Max Memory Policy - Limits memory allocation
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_memory" {
   name                     = "Max Memory Policy"
   description              = "Limit maximum memory allocation"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxNetworks.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxNetworks.tf
@@ -1,4 +1,6 @@
 # Network Quota Policy - Limits network count
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "network_quota" {
   name                     = "Network Quota Policy"
   description              = "Limit maximum network count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPoolMembers.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPoolMembers.tf
@@ -1,8 +1,10 @@
 # Max Pool Members Policy - Limits pool members
+# Allowed associated_resource_types: Cloud, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_pool_members" {
   name                     = "Max Pool Members Policy"
   description              = "Limit maximum pool members"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPools.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPools.tf
@@ -1,4 +1,6 @@
 # Max Load Balancer Pools Policy - Limits load balancer pools
+# Allowed associated_resource_types: Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_pools" {
   name                     = "Max Load Balancer Pools Policy"
   description              = "Limit maximum load balancer pools"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPrice.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPrice.tf
@@ -1,4 +1,6 @@
 # Budget Policy - Limits instance costs
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "budget" {
   name                     = "Budget Policy"
   description              = "Limit maximum instance costs"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxRouters.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxRouters.tf
@@ -1,4 +1,6 @@
 # Router Quota Policy - Limits router count
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "router_quota" {
   name                     = "Router Quota Policy"
   description              = "Limit maximum router count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxSnapshots.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxSnapshots.tf
@@ -1,4 +1,6 @@
 # Max Snapshots Policy - Limits snapshots per VM
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_snapshots" {
   name                     = "Max Snapshots Policy"
   description              = "Limit maximum snapshots per VM"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxStorage.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxStorage.tf
@@ -1,4 +1,6 @@
 # Max Storage Policy - Limits storage allocation
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_storage" {
   name                     = "Max Storage Policy"
   description              = "Limit maximum storage allocation"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxVirtualServers.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxVirtualServers.tf
@@ -1,8 +1,10 @@
 # Max Virtual Servers Policy - Limits virtual server count
+# Allowed associated_resource_types: Cloud, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_virtual_servers" {
   name                     = "Max Virtual Servers Policy"
   description              = "Limit maximum virtual server count"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxVms.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxVms.tf
@@ -1,4 +1,6 @@
 # Max VMs Policy - Limits VM count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Network, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_vms" {
   name                     = "Max VMs Policy"
   description              = "Limit maximum VM count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_motd.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_motd.tf
@@ -1,9 +1,10 @@
 # Message of the Day (MOTD) Policy - Displays login messages
+# Allowed associated_resource_types: Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "motd" {
   name                     = "MOTD Policy"
   description              = "Display message of the day on login"
-  associated_resource_type = "User"
-  associated_resource_id   = 9969
+  associated_resource_type = "Global"
   enabled                  = true
 
   policy_type = {

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_naming.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_naming.tf
@@ -1,4 +1,6 @@
 # Instance Name Policy - Enforces instance naming conventions
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "instance_naming" {
   name                     = "Instance Name Policy"
   description              = "Enforce instance naming conventions"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_powerSchedule.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_powerSchedule.tf
@@ -1,4 +1,6 @@
 # Power Scheduling Policy - Enforces power schedules
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "power_schedule" {
   name                     = "Power Scheduling Policy"
   description              = "Enforce power schedules for instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_provisionApproval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_provisionApproval.tf
@@ -1,4 +1,6 @@
 # Approve Provision Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_provision" {
   name                     = "Approve Provision Policy"
   description              = "Require approval before provisioning instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_reconfigureApproval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_reconfigureApproval.tf
@@ -1,4 +1,6 @@
 # Approve Reconfigure Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_reconfigure" {
   name                     = "Approve Reconfigure Policy"
   description              = "Require approval before reconfiguring instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_requiredNetwork.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_requiredNetwork.tf
@@ -1,8 +1,10 @@
 # Instance Networks Policy - Requires specific networks for instances
+# Allowed associated_resource_types: Group, Cloud
+# Tenant specification: NOT allowed (allowOnTenant = false)
 resource "hpe_morpheus_policy" "required_networks" {
   name                     = "Instance Networks Policy"
   description              = "Require specific networks for instances"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_serverNaming.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_serverNaming.tf
@@ -1,4 +1,6 @@
 # Cluster Resource Name Policy - Enforces naming conventions for cluster resources
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "cluster_naming" {
   name                     = "Cluster Resource Naming Policy"
   description              = "Enforce naming for cluster resources"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_shutdown.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_shutdown.tf
@@ -1,4 +1,6 @@
 # Shutdown Policy - Auto-shutdown idle instances
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "shutdown" {
   name                     = "Shutdown Policy"
   description              = "Auto-shutdown idle instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_storageBucketQuota.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_storageBucketQuota.tf
@@ -1,4 +1,6 @@
 # Object Storage Quota Policy - Limits object storage
+# Allowed associated_resource_types: User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "object_storage_quota" {
   name                     = "Object Storage Quota Policy"
   description              = "Limit object storage usage"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_storageServerQuota.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_storageServerQuota.tf
@@ -1,8 +1,10 @@
 # Storage Server Storage Quota Policy - Limits storage on specific storage server
+# Allowed associated_resource_types: Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "storage_server_quota" {
   name                     = "Storage Server Storage Quota Policy"
   description              = "Limit storage usage on specific storage server"
-  associated_resource_type = "User"
+  associated_resource_type = "Global"
   associated_resource_id   = 9969
   enabled                  = true
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_storageShareQuota.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_storageShareQuota.tf
@@ -1,4 +1,6 @@
 # File Share Storage Quota Policy - Limits file share storage
+# Allowed associated_resource_types: User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "file_share_quota" {
   name                     = "File Share Storage Quota Policy"
   description              = "Limit file share storage usage"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_tags.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_tags.tf
@@ -1,4 +1,6 @@
 # Tags Policy - Enforces instance tagging
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "tags" {
   name                     = "Tags Policy"
   description              = "Enforce instance tagging requirements"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_workflow.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_workflow.tf
@@ -1,4 +1,6 @@
 # Workflow Policy - Executes workflow on provision
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 # Note: This example uses the morpheus external provider to create a workflow resource
 # because the hpe provider does not yet have a workflow resource implemented.
 # You will need to configure the morpheus provider in your terraform configuration.

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_workflowApproval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_workflowApproval.tf
@@ -1,4 +1,6 @@
 # Approve Workflow Execute Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_workflow" {
   name                     = "Approve Workflow Execute Policy"
   description              = "Require approval before executing workflows"

--- a/internal/framework/subproviders/morpheus/resources/policy/consts.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/consts.go
@@ -1,0 +1,22 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package policy
+
+const (
+	// AssociatedResourceTypeGlobal is the resource type for global policies
+	AssociatedResourceTypeGlobal = "Global"
+	// AssociatedResourceTypeCloud is the resource type for cloud-scoped policies
+	AssociatedResourceTypeCloud = "Cloud"
+	// AssociatedResourceTypeGroup is the resource type for group-scoped policies
+	AssociatedResourceTypeGroup = "Group"
+	// AssociatedResourceTypeUser is the resource type for user-scoped policies
+	AssociatedResourceTypeUser = "User"
+	// AssociatedResourceTypeRole is the resource type for role-scoped policies
+	AssociatedResourceTypeRole = "Role"
+	// AssociatedResourceTypeNetwork is the resource type for network-scoped policies
+	AssociatedResourceTypeNetwork = "Network"
+	// AssociatedResourceTypePlan is the resource type for plan-scoped policies
+	AssociatedResourceTypePlan = "Plan"
+	// AssociatedResourceTypeLabel is the resource type for label-scoped policies
+	AssociatedResourceTypeLabel = "Label"
+)

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -51,7 +51,7 @@ func (r *Resource) Create(
 
 	// When associated_resource_type is "Global", leave refType null (null defaults to Global)
 	associatedResourceType := plan.AssociatedResourceType.ValueString()
-	if associatedResourceType != "Global" {
+	if associatedResourceType != AssociatedResourceTypeGlobal {
 		// Convert user-facing resource type to API type
 		apiType := resourceTypeToAPIType(associatedResourceType)
 		addPolicy.SetRefType(apiType)

--- a/internal/framework/subproviders/morpheus/resources/policy/create_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create_test.go
@@ -104,6 +104,7 @@ func TestAccMorpheusPolicyAllBareMetalPolicyTypesOk(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlockMixed()
 	namePrefix := acctest.RandomWithPrefix(t.Name())
 	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+	cloudName := acctest.RandomWithPrefix(t.Name() + "-cloud")
 
 	resourceConfig := `
 variable "policy_name" {
@@ -127,6 +128,19 @@ resource "hpe_morpheus_group" "test" {
   location = "test"
 }
 
+resource "hpe_morpheus_cloud" "test" {
+  name = "` + cloudName + `"
+  tenant_id = 1
+  group_id = hpe_morpheus_group.test.id
+  code = "` + cloudName + `"
+  cloud_type_code = "standard"
+  
+  config = {
+    certificateProvider = "internal"
+    enableNetworkTypeSelection = false
+  }
+}
+
 resource "morpheus_operational_workflow" "test" {
   name = "` + namePrefix + `-workflow"
 }
@@ -140,6 +154,64 @@ resource "hpe_morpheus_policy" "test" {
   description = var.policy_description
   associated_resource_type = "Group"
   associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = var.policy_type_code
+  }
+  
+  config = var.policy_config
+}
+`
+
+	resourceConfigCloud := `
+variable "policy_name" {
+  type = string
+}
+
+variable "policy_description" {
+  type = string
+}
+
+variable "policy_type_code" {
+  type = string
+}
+
+variable "policy_config" {
+  type = map(any)
+}
+
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+
+resource "hpe_morpheus_cloud" "test" {
+  name = "` + cloudName + `"
+  tenant_id = 1
+  group_id = hpe_morpheus_group.test.id
+  code = "` + cloudName + `"
+  cloud_type_code = "standard"
+  
+  config = {
+    certificateProvider = "internal"
+    enableNetworkTypeSelection = false
+  }
+}
+
+resource "morpheus_operational_workflow" "test" {
+  name = "` + namePrefix + `-workflow"
+}
+
+data "morpheus_workflow" "test" {
+  name = morpheus_operational_workflow.test.name
+}
+
+resource "hpe_morpheus_policy" "test" {
+  name = var.policy_name
+  description = var.policy_description
+  associated_resource_type = "Cloud"
+  associated_resource_id = hpe_morpheus_cloud.test.id
   enabled = true
   
   policy_type = {
@@ -265,7 +337,7 @@ resource "hpe_morpheus_policy" "test" {
 			},
 			// Step 7: Instance Networks
 			{
-				Config: providerConfig + resourceConfig,
+				Config: providerConfig + resourceConfigCloud,
 				ConfigVariables: config.Variables{
 					"policy_name":        config.StringVariable(namePrefix + "-requiredNetwork"),
 					"policy_description": config.StringVariable("Required network policy"),
@@ -301,7 +373,7 @@ resource "hpe_morpheus_policy" "test" {
 			},
 			// Step 9: Max Pool Members
 			{
-				Config: providerConfig + resourceConfig,
+				Config: providerConfig + resourceConfigCloud,
 				ConfigVariables: config.Variables{
 					"policy_name":        config.StringVariable(namePrefix + "-maxPoolMembers"),
 					"policy_description": config.StringVariable("Max pool members policy"),
@@ -385,7 +457,7 @@ resource "hpe_morpheus_policy" "test" {
 					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "description", "Max networks policy"),
 				),
 			},
-			// Step 14: Storage Server Quota
+			/* // Step 14: Storage Server Quota - Commented out, requires Global scope which impacts other users
 			{
 				Config: providerConfig + resourceConfig,
 				ConfigVariables: config.Variables{
@@ -403,7 +475,7 @@ resource "hpe_morpheus_policy" "test" {
 					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "description", "Storage server quota policy"),
 				),
 			},
-			// Step 15: Tags
+			*/ // Step 15: Tags
 			{
 				Config: providerConfig + resourceConfig,
 				ConfigVariables: config.Variables{
@@ -665,9 +737,9 @@ resource "hpe_morpheus_network" "test" {
 		"Description", "Example network-scoped policy",
 		"AssociatedResourceType", "Network",
 		"AssociatedResourceID", "hpe_morpheus_network.test.id",
-		"PolicyTypeCode", "maxMemory",
-		"ConfigKey", "maxMemory",
-		"ConfigValue", "1073741824",
+		"PolicyTypeCode", "maxVms",
+		"ConfigKey", "maxVms",
+		"ConfigValue", "20",
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/framework/subproviders/morpheus/resources/policy/read.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/read.go
@@ -75,7 +75,7 @@ func getPolicyAsState(
 		// Convert API type to user-facing resource type
 		state.AssociatedResourceType = types.StringValue(apiTypeToResourceType(apiType))
 	} else {
-		state.AssociatedResourceType = types.StringValue("Global")
+		state.AssociatedResourceType = types.StringValue(AssociatedResourceTypeGlobal)
 	}
 
 	// Set Tenant IDs

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -216,7 +216,16 @@ func (r *Resource) ModifyPlan(
 	}
 
 	// Validate tenants field is only set when allowOnTenant is true
-	if !plan.Tenants.IsNull() && !plan.Tenants.IsUnknown() {
+	// Only validate if tenants is explicitly set in the config (not null and not unknown)
+	// Get the config value to check if it was actually set by the user
+	var config PolicyModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only validate if tenants was explicitly set in the user's config
+	if !config.Tenants.IsNull() && !config.Tenants.IsUnknown() {
 		allowOnTenant := false
 		if allowValue, ok := matchingPolicyType["allowOnTenant"]; ok {
 			if allowBool, ok := allowValue.(bool); ok {

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -17,6 +17,7 @@ var (
 	_ resource.Resource                   = &Resource{}
 	_ resource.ResourceWithImportState    = &Resource{}
 	_ resource.ResourceWithValidateConfig = &Resource{}
+	_ resource.ResourceWithModifyPlan     = &Resource{}
 )
 
 func NewResource() resource.Resource {
@@ -120,4 +121,180 @@ func (r *Resource) ValidateConfig(
 			)
 		}
 	}
+}
+
+// ModifyPlan validates policy type compatibility during the plan phase when the provider is configured
+func (r *Resource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	// Only run validation if we have a plan (not during destroy)
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan PolicyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate policy type is compatible with the associated resource type
+	if plan.PolicyType.IsNull() || plan.PolicyType.IsUnknown() {
+		return
+	}
+
+	policyTypeCode := plan.PolicyType.Code.ValueString()
+	resourceType := plan.AssociatedResourceType.ValueString()
+
+	// Get API client - provider is configured at this point
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		// If we can't get a client, skip validation - will be caught during apply
+		return
+	}
+
+	// Fetch policy types from the API
+	policyTypesResp, httpResp, err := client.OptionsAPI.GetOptionSourceData(ctx, "policyTypes").Execute()
+	if err != nil || httpResp == nil || httpResp.StatusCode != 200 {
+		return
+	}
+
+	// Find the matching policy type
+	var matchingPolicyType map[string]interface{}
+	if policyTypesResp != nil && policyTypesResp.Data != nil {
+		for _, pt := range policyTypesResp.Data {
+			if code, ok := pt["code"].(string); ok && code == policyTypeCode {
+				matchingPolicyType = pt
+				break
+			}
+		}
+	}
+
+	if matchingPolicyType == nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("policy_type").AtName("code"),
+			"Invalid policy type",
+			fmt.Sprintf("Policy type with code '%s' not found", policyTypeCode),
+		)
+		return
+	}
+
+	// Map resource type to the corresponding "allowOn" field
+	var allowFieldName string
+	switch resourceType {
+	case "Global":
+		allowFieldName = "allowOnGlobal"
+	case "Group":
+		allowFieldName = "allowOnSite"
+	case "Cloud":
+		allowFieldName = "allowOnZone"
+	case "User":
+		allowFieldName = "allowOnUser"
+	case "Role":
+		allowFieldName = "allowOnRole"
+	case "Network":
+		allowFieldName = "allowOnNetwork"
+	case "Plan":
+		allowFieldName = "allowOnPlan"
+	case "Label":
+		allowFieldName = "allowOnLabel"
+	default:
+		// Unknown resource type - should not happen due to schema validation
+		resp.Diagnostics.AddAttributeError(
+			path.Root("associated_resource_type"),
+			"Unknown resource type",
+			fmt.Sprintf("Resource type '%s' is not recognized", resourceType),
+		)
+		return
+	}
+
+	// Check if the policy type allows this resource type
+	allowed := false
+	if allowValue, ok := matchingPolicyType[allowFieldName]; ok {
+		if allowBool, ok := allowValue.(bool); ok {
+			allowed = allowBool
+		}
+	}
+
+	// Validate tenants field is only set when allowOnTenant is true
+	if !plan.Tenants.IsNull() && !plan.Tenants.IsUnknown() {
+		allowOnTenant := false
+		if allowValue, ok := matchingPolicyType["allowOnTenant"]; ok {
+			if allowBool, ok := allowValue.(bool); ok {
+				allowOnTenant = allowBool
+			}
+		}
+
+		if !allowOnTenant {
+			policyTypeName := ""
+			if name, ok := matchingPolicyType["name"].(string); ok {
+				policyTypeName = name
+			}
+
+			resp.Diagnostics.AddAttributeError(
+				path.Root("tenants"),
+				"Tenants not supported for this policy type",
+				fmt.Sprintf(
+					"Policy type '%s' (%s) does not support specifying tenants. "+
+						"Remove the tenants attribute or choose a different policy type.",
+					policyTypeName, policyTypeCode,
+				),
+			)
+		}
+	}
+
+	if !allowed {
+		policyTypeName := ""
+		if name, ok := matchingPolicyType["name"].(string); ok {
+			policyTypeName = name
+		}
+
+		// Build a list of allowed scopes for this policy type
+		var allowedScopes []string
+		scopeMapping := map[string]string{
+			"allowOnGlobal":  "Global",
+			"allowOnSite":    "Group",
+			"allowOnZone":    "Cloud",
+			"allowOnUser":    "User",
+			"allowOnRole":    "Role",
+			"allowOnNetwork": "Network",
+			"allowOnPlan":    "Plan",
+			"allowOnLabel":   "Label",
+		}
+
+		for field, scope := range scopeMapping {
+			if val, ok := matchingPolicyType[field].(bool); ok && val {
+				if !contains(allowedScopes, scope) {
+					allowedScopes = append(allowedScopes, scope)
+				}
+			}
+		}
+
+		availableMsg := ""
+		if len(allowedScopes) > 0 {
+			availableMsg = fmt.Sprintf("\n\nThis policy type can be applied to the following resource types: %v", allowedScopes)
+		}
+
+		resp.Diagnostics.AddAttributeError(
+			path.Root("associated_resource_type"),
+			"Incompatible policy type and resource type",
+			fmt.Sprintf(
+				"Policy type '%s' (%s) cannot be applied to resource type '%s'. "+
+					"This policy type does not support the selected scope.%s",
+				policyTypeName, policyTypeCode, resourceType, availableMsg,
+			),
+		)
+	}
+}
+
+// contains checks if a string slice contains a specific string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -141,11 +141,11 @@ func (r *Resource) ModifyPlan(
 	}
 
 	// Validate policy type is compatible with the associated resource type
-	if plan.PolicyType.IsNull() || plan.PolicyType.IsUnknown() {
+	policyTypeCode := plan.PolicyType.Code.ValueString()
+	if plan.PolicyType.Code.IsUnknown() {
 		return
 	}
 
-	policyTypeCode := plan.PolicyType.Code.ValueString()
 	resourceType := plan.AssociatedResourceType.ValueString()
 
 	// Get API client - provider is configured at this point
@@ -202,15 +202,6 @@ func (r *Resource) ModifyPlan(
 		allowFieldName = "allowOnPlan"
 	case AssociatedResourceTypeLabel:
 		allowFieldName = "allowOnLabel"
-	default:
-		// Unknown resource type - should not happen due to schema validation
-		resp.Diagnostics.AddAttributeError(
-			path.Root("associated_resource_type"),
-			"Unknown resource type",
-			fmt.Sprintf("Resource type '%s' is not recognized", resourceType),
-		)
-
-		return
 	}
 
 	// Check if the policy type allows this resource type

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -211,8 +211,11 @@ func (r *Resource) ModifyPlan(
 	}
 
 	// Check if the policy type allows this resource type
+	// Treat Global as always allowed (API may return nil for allowOnGlobal)
 	allowed := false
-	if allowValue, ok := matchingPolicyType[allowFieldName]; ok {
+	if resourceType == "Global" {
+		allowed = true
+	} else if allowValue, ok := matchingPolicyType[allowFieldName]; ok {
 		if allowBool, ok := allowValue.(bool); ok {
 			allowed = allowBool
 		}
@@ -265,7 +268,12 @@ func (r *Resource) ModifyPlan(
 		}
 
 		for field, scope := range scopeMapping {
-			if val, ok := matchingPolicyType[field].(bool); ok && val {
+			// Always treat Global as allowed (API may return nil for allowOnGlobal)
+			if scope == "Global" {
+				if !contains(allowedScopes, scope) {
+					allowedScopes = append(allowedScopes, scope)
+				}
+			} else if val, ok := matchingPolicyType[field].(bool); ok && val {
 				if !contains(allowedScopes, scope) {
 					allowedScopes = append(allowedScopes, scope)
 				}

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -49,9 +49,9 @@ func (r *Resource) Schema(
 // resourceTypeToAPIType converts user-facing resource types to API types
 func resourceTypeToAPIType(resourceType string) string {
 	switch resourceType {
-	case "Cloud":
+	case AssociatedResourceTypeCloud:
 		return "ComputeZone"
-	case "Group":
+	case AssociatedResourceTypeGroup:
 		return "ComputeSite"
 	default:
 		// For other types (User, Role, Network, Plan), pass through as-is
@@ -63,9 +63,9 @@ func resourceTypeToAPIType(resourceType string) string {
 func apiTypeToResourceType(apiType string) string {
 	switch apiType {
 	case "ComputeZone":
-		return "Cloud"
+		return AssociatedResourceTypeCloud
 	case "ComputeSite":
-		return "Group"
+		return AssociatedResourceTypeGroup
 	default:
 		// For other types (User, Role, Network, Plan), pass through as-is
 		return apiType
@@ -91,7 +91,7 @@ func (r *Resource) ValidateConfig(
 	// If associated_resource_type is not "Global", associated_resource_id must be set
 	resourceType := config.AssociatedResourceType.ValueString()
 
-	if resourceType != "Global" {
+	if resourceType != AssociatedResourceTypeGlobal {
 		// Check if associated_resource_id is set
 		if config.AssociatedResourceId.IsNull() {
 			resp.Diagnostics.AddAttributeError(
@@ -108,7 +108,7 @@ func (r *Resource) ValidateConfig(
 
 	// Validate each_user is only set when associated_resource_type is "Role"
 	if !config.EachUser.IsNull() {
-		if resourceType != "Role" {
+		if resourceType != AssociatedResourceTypeRole {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("each_user"),
 				"Invalid attribute combination",
@@ -167,6 +167,7 @@ func (r *Resource) ModifyPlan(
 		for _, pt := range policyTypesResp.Data {
 			if code, ok := pt["code"].(string); ok && code == policyTypeCode {
 				matchingPolicyType = pt
+
 				break
 			}
 		}
@@ -178,27 +179,28 @@ func (r *Resource) ModifyPlan(
 			"Invalid policy type",
 			fmt.Sprintf("Policy type with code '%s' not found", policyTypeCode),
 		)
+
 		return
 	}
 
 	// Map resource type to the corresponding "allowOn" field
 	var allowFieldName string
 	switch resourceType {
-	case "Global":
+	case AssociatedResourceTypeGlobal:
 		allowFieldName = "allowOnGlobal"
-	case "Group":
+	case AssociatedResourceTypeGroup:
 		allowFieldName = "allowOnSite"
-	case "Cloud":
+	case AssociatedResourceTypeCloud:
 		allowFieldName = "allowOnZone"
-	case "User":
+	case AssociatedResourceTypeUser:
 		allowFieldName = "allowOnUser"
-	case "Role":
+	case AssociatedResourceTypeRole:
 		allowFieldName = "allowOnRole"
-	case "Network":
+	case AssociatedResourceTypeNetwork:
 		allowFieldName = "allowOnNetwork"
-	case "Plan":
+	case AssociatedResourceTypePlan:
 		allowFieldName = "allowOnPlan"
-	case "Label":
+	case AssociatedResourceTypeLabel:
 		allowFieldName = "allowOnLabel"
 	default:
 		// Unknown resource type - should not happen due to schema validation
@@ -207,13 +209,14 @@ func (r *Resource) ModifyPlan(
 			"Unknown resource type",
 			fmt.Sprintf("Resource type '%s' is not recognized", resourceType),
 		)
+
 		return
 	}
 
 	// Check if the policy type allows this resource type
 	// Treat Global as always allowed (API may return nil for allowOnGlobal)
 	allowed := false
-	if resourceType == "Global" {
+	if resourceType == AssociatedResourceTypeGlobal {
 		allowed = true
 	} else if allowValue, ok := matchingPolicyType[allowFieldName]; ok {
 		if allowBool, ok := allowValue.(bool); ok {
@@ -257,19 +260,19 @@ func (r *Resource) ModifyPlan(
 		// Build a list of allowed scopes for this policy type
 		var allowedScopes []string
 		scopeMapping := map[string]string{
-			"allowOnGlobal":  "Global",
-			"allowOnSite":    "Group",
-			"allowOnZone":    "Cloud",
-			"allowOnUser":    "User",
-			"allowOnRole":    "Role",
-			"allowOnNetwork": "Network",
-			"allowOnPlan":    "Plan",
-			"allowOnLabel":   "Label",
+			"allowOnGlobal":  AssociatedResourceTypeGlobal,
+			"allowOnSite":    AssociatedResourceTypeGroup,
+			"allowOnZone":    AssociatedResourceTypeCloud,
+			"allowOnUser":    AssociatedResourceTypeUser,
+			"allowOnRole":    AssociatedResourceTypeRole,
+			"allowOnNetwork": AssociatedResourceTypeNetwork,
+			"allowOnPlan":    AssociatedResourceTypePlan,
+			"allowOnLabel":   AssociatedResourceTypeLabel,
 		}
 
 		for field, scope := range scopeMapping {
 			// Always treat Global as allowed (API may return nil for allowOnGlobal)
-			if scope == "Global" {
+			if scope == AssociatedResourceTypeGlobal {
 				if !contains(allowedScopes, scope) {
 					allowedScopes = append(allowedScopes, scope)
 				}
@@ -304,5 +307,6 @@ func contains(slice []string, item string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
@@ -161,3 +161,125 @@ resource "hpe_morpheus_policy" "validation_test" {
 		},
 	})
 }
+
+// Test validation: incompatible policy type and resource type (motd does not support User)
+func TestAccMorpheusPolicyValidationIncompatiblePolicyAndResourceType(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockMixed()
+	name := acctest.RandomWithPrefix(t.Name())
+	roleName := acctest.RandomWithPrefix(t.Name() + "-role")
+	userName := acctest.RandomWithPrefix(t.Name() + "-user")
+
+	resourceConfig := `
+resource "hpe_morpheus_role" "test" {
+  name = "` + roleName + `"
+  role_type = "user"
+}
+
+resource "hpe_morpheus_user" "test" {
+  username = "` + userName + `"
+  email = "` + userName + `@test.com"
+  role_ids = [hpe_morpheus_role.test.id]
+  password_wo = "TestPassword123!"
+}
+
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "User"
+  associated_resource_id = hpe_morpheus_user.test.id
+  
+  policy_type = {
+    code = "motd"
+  }
+  
+  config = {
+    enabled = true
+    message = "Test message"
+    fullPage = false
+    title = "MOTD"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"morpheus": {
+				Source:            "gomorpheus/morpheus",
+				VersionConstraint: "0.13.2",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("Incompatible policy type and resource type"),
+			},
+		},
+	})
+}
+
+// Test validation: tenants not supported for policy type
+func TestAccMorpheusPolicyValidationTenantsNotSupported(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+	cloudName := acctest.RandomWithPrefix(t.Name() + "-cloud")
+
+	resourceConfig := `
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+
+resource "hpe_morpheus_cloud" "test" {
+  name = "` + cloudName + `"
+  tenant_id = 1
+  group_id = hpe_morpheus_group.test.id
+  code = "` + cloudName + `"
+  cloud_type_code = "standard"
+  
+  config = {
+    certificateProvider = "internal"
+    enableNetworkTypeSelection = false
+  }
+}
+
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Cloud"
+  associated_resource_id = hpe_morpheus_cloud.test.id
+  tenants = [1]
+  
+  policy_type = {
+    code = "requiredNetwork"
+  }
+  
+  config = {
+    requiredNetworks = [1]
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("Tenants not supported for this policy type"),
+			},
+		},
+	})
+}

--- a/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
@@ -27,21 +27,21 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 			"associated_resource_id": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan",
-				MarkdownDescription: "The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan",
+				Description:         "The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan, Label",
+				MarkdownDescription: "The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan, Label",
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},
 			},
 			"associated_resource_type": schema.StringAttribute{
 				Required:            true,
-				Description:         "Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', or 'Plan'",
-				MarkdownDescription: "Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', or 'Plan'",
+				Description:         "Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', 'Plan' or 'Label'",
+				MarkdownDescription: "Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', 'Plan' or 'Label'",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("Global", "Group", "Cloud", "User", "Role", "Network", "Plan"),
+					stringvalidator.OneOf("Global", "Group", "Cloud", "User", "Role", "Network", "Plan", "Label"),
 				},
 			},
 			"cloud": schema.SingleNestedAttribute{


### PR DESCRIPTION
Adding validation for policy so that the ability to specify the `associated_resource_type` to a certain type and the ability to specify `tenants` is checked at plan time.
- Added Label associated resource type
- Implemented checks in ModifyPlan interface
- Implemented consts to fix linting
- Updated example Terraform configs to include acceptable associated_resource_types for each policyType.
- Updated acceptance tests to avoid using invalid associated_resource_types and added two new validation acceptance tests.