### PR TITLE
Adding static schema for policy resource 

### DIFF
--- a/docs/resources/morpheus_policy.md
+++ b/docs/resources/morpheus_policy.md
@@ -60,6 +60,8 @@ Policies are different rules that can be applied to various Morpheus resources.
 
 ```terraform
 # Approve Delete Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_delete" {
   name                     = "Approve Delete Policy"
   description              = "Require approval before deleting instances"
@@ -81,6 +83,8 @@ resource "hpe_morpheus_policy" "approve_delete" {
 
 ```terraform
 # Approve Provision Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_provision" {
   name                     = "Approve Provision Policy"
   description              = "Require approval before provisioning instances"
@@ -102,6 +106,8 @@ resource "hpe_morpheus_policy" "approve_provision" {
 
 ```terraform
 # Approve Reconfigure Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_reconfigure" {
   name                     = "Approve Reconfigure Policy"
   description              = "Require approval before reconfiguring instances"
@@ -123,6 +129,8 @@ resource "hpe_morpheus_policy" "approve_reconfigure" {
 
 ```terraform
 # Approve Workflow Execute Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_workflow" {
   name                     = "Approve Workflow Execute Policy"
   description              = "Require approval before executing workflows"
@@ -144,6 +152,8 @@ resource "hpe_morpheus_policy" "approve_workflow" {
 
 ```terraform
 # Backup Creation Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "backup_creation" {
   name                     = "Backup Creation Policy"
   description              = "Enforce backup creation for instances"
@@ -169,6 +179,8 @@ Not currently supported
 
 ```terraform
 # Budget Policy - Limits instance costs
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "budget" {
   name                     = "Budget Policy"
   description              = "Limit maximum instance costs"
@@ -192,6 +204,8 @@ resource "hpe_morpheus_policy" "budget" {
 
 ```terraform
 # Cluster Resource Name Policy - Enforces naming conventions for cluster resources
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "cluster_naming" {
   name                     = "Cluster Resource Naming Policy"
   description              = "Enforce naming for cluster resources"
@@ -215,6 +229,8 @@ resource "hpe_morpheus_policy" "cluster_naming" {
 
 ```terraform
 # Cypher Access Policy - Controls access to Cypher secrets
+# Allowed associated_resource_types: User, Global, Role
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "cypher_access" {
   name                     = "Cypher Access Policy"
   description              = "Control Cypher key access permissions"
@@ -241,6 +257,8 @@ resource "hpe_morpheus_policy" "cypher_access" {
 
 ```terraform
 # Delayed Delete Policy - Delays instance deletion
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "delayed_delete" {
   name                     = "Delayed Delete Policy"
   description              = "Delay instance deletion by specified days"
@@ -262,6 +280,8 @@ resource "hpe_morpheus_policy" "delayed_delete" {
 
 ```terraform
 # Expiration Policy - Sets instance expiration and renewal options
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "expiration" {
   name                     = "Expiration Policy"
   description              = "Set instance expiration and renewal policies"
@@ -291,6 +311,8 @@ resource "hpe_morpheus_policy" "expiration" {
 
 ```terraform
 # File Share Storage Quota Policy - Limits file share storage
+# Allowed associated_resource_types: User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "file_share_quota" {
   name                     = "File Share Storage Quota Policy"
   description              = "Limit file share storage usage"
@@ -312,6 +334,8 @@ resource "hpe_morpheus_policy" "file_share_quota" {
 
 ```terraform
 # Hostname Policy - Enforces hostname naming conventions
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "hostname" {
   name                     = "Hostname Policy"
   description              = "Enforce hostname naming conventions"
@@ -334,6 +358,8 @@ resource "hpe_morpheus_policy" "hostname" {
 
 ```terraform
 # Instance Name Policy - Enforces instance naming conventions
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "instance_naming" {
   name                     = "Instance Name Policy"
   description              = "Enforce instance naming conventions"
@@ -357,10 +383,12 @@ resource "hpe_morpheus_policy" "instance_naming" {
 
 ```terraform
 # Instance Networks Policy - Requires specific networks for instances
+# Allowed associated_resource_types: Group, Cloud
+# Tenant specification: NOT allowed (allowOnTenant = false)
 resource "hpe_morpheus_policy" "required_networks" {
   name                     = "Instance Networks Policy"
   description              = "Require specific networks for instances"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 
@@ -378,6 +406,8 @@ resource "hpe_morpheus_policy" "required_networks" {
 
 ```terraform
 # Max Containers Policy - Limits container count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_containers" {
   name                     = "Max Containers Policy"
   description              = "Limit maximum container count"
@@ -399,6 +429,8 @@ resource "hpe_morpheus_policy" "max_containers" {
 
 ```terraform
 # Max Cores Policy - Limits CPU cores
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_cores" {
   name                     = "Max Cores Policy"
   description              = "Limit maximum CPU cores"
@@ -421,6 +453,8 @@ resource "hpe_morpheus_policy" "max_cores" {
 
 ```terraform
 # Max Hosts Policy - Limits host count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_hosts" {
   name                     = "Max Hosts Policy"
   description              = "Limit maximum host count"
@@ -442,6 +476,8 @@ resource "hpe_morpheus_policy" "max_hosts" {
 
 ```terraform
 # Max Load Balancer Pools Policy - Limits load balancer pools
+# Allowed associated_resource_types: Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_pools" {
   name                     = "Max Load Balancer Pools Policy"
   description              = "Limit maximum load balancer pools"
@@ -463,6 +499,8 @@ resource "hpe_morpheus_policy" "max_pools" {
 
 ```terraform
 # Max Memory Policy - Limits memory allocation
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_memory" {
   name                     = "Max Memory Policy"
   description              = "Limit maximum memory allocation"
@@ -485,10 +523,12 @@ resource "hpe_morpheus_policy" "max_memory" {
 
 ```terraform
 # Max Pool Members Policy - Limits pool members
+# Allowed associated_resource_types: Cloud, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_pool_members" {
   name                     = "Max Pool Members Policy"
   description              = "Limit maximum pool members"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 
@@ -506,6 +546,8 @@ resource "hpe_morpheus_policy" "max_pool_members" {
 
 ```terraform
 # Max Snapshots Policy - Limits snapshots per VM
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_snapshots" {
   name                     = "Max Snapshots Policy"
   description              = "Limit maximum snapshots per VM"
@@ -527,6 +569,8 @@ resource "hpe_morpheus_policy" "max_snapshots" {
 
 ```terraform
 # Max Storage Policy - Limits storage allocation
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_storage" {
   name                     = "Max Storage Policy"
   description              = "Limit maximum storage allocation"
@@ -549,10 +593,12 @@ resource "hpe_morpheus_policy" "max_storage" {
 
 ```terraform
 # Max Virtual Servers Policy - Limits virtual server count
+# Allowed associated_resource_types: Cloud, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_virtual_servers" {
   name                     = "Max Virtual Servers Policy"
   description              = "Limit maximum virtual server count"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 
@@ -570,6 +616,8 @@ resource "hpe_morpheus_policy" "max_virtual_servers" {
 
 ```terraform
 # Max VMs Policy - Limits VM count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Network, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_vms" {
   name                     = "Max VMs Policy"
   description              = "Limit maximum VM count"
@@ -591,11 +639,12 @@ resource "hpe_morpheus_policy" "max_vms" {
 
 ```terraform
 # Message of the Day (MOTD) Policy - Displays login messages
+# Allowed associated_resource_types: Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "motd" {
   name                     = "MOTD Policy"
   description              = "Display message of the day on login"
-  associated_resource_type = "User"
-  associated_resource_id   = 9969
+  associated_resource_type = "Global"
   enabled                  = true
 
   policy_type = {
@@ -615,6 +664,8 @@ resource "hpe_morpheus_policy" "motd" {
 
 ```terraform
 # Network Quota Policy - Limits network count
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "network_quota" {
   name                     = "Network Quota Policy"
   description              = "Limit maximum network count"
@@ -636,6 +687,8 @@ resource "hpe_morpheus_policy" "network_quota" {
 
 ```terraform
 # Object Storage Quota Policy - Limits object storage
+# Allowed associated_resource_types: User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "object_storage_quota" {
   name                     = "Object Storage Quota Policy"
   description              = "Limit object storage usage"
@@ -657,6 +710,8 @@ resource "hpe_morpheus_policy" "object_storage_quota" {
 
 ```terraform
 # Power Scheduling Policy - Enforces power schedules
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "power_schedule" {
   name                     = "Power Scheduling Policy"
   description              = "Enforce power schedules for instances"
@@ -680,6 +735,8 @@ resource "hpe_morpheus_policy" "power_schedule" {
 
 ```terraform
 # Router Quota Policy - Limits router count
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "router_quota" {
   name                     = "Router Quota Policy"
   description              = "Limit maximum router count"
@@ -701,6 +758,8 @@ resource "hpe_morpheus_policy" "router_quota" {
 
 ```terraform
 # Shutdown Policy - Auto-shutdown idle instances
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "shutdown" {
   name                     = "Shutdown Policy"
   description              = "Auto-shutdown idle instances"
@@ -730,10 +789,12 @@ resource "hpe_morpheus_policy" "shutdown" {
 
 ```terraform
 # Storage Server Storage Quota Policy - Limits storage on specific storage server
+# Allowed associated_resource_types: Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "storage_server_quota" {
   name                     = "Storage Server Storage Quota Policy"
   description              = "Limit storage usage on specific storage server"
-  associated_resource_type = "User"
+  associated_resource_type = "Global"
   associated_resource_id   = 9969
   enabled                  = true
 
@@ -752,6 +813,8 @@ resource "hpe_morpheus_policy" "storage_server_quota" {
 
 ```terraform
 # Tags Policy - Enforces instance tagging
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "tags" {
   name                     = "Tags Policy"
   description              = "Enforce instance tagging requirements"
@@ -776,6 +839,8 @@ resource "hpe_morpheus_policy" "tags" {
 
 ```terraform
 # User Creation Policy - Controls user creation on instances
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "user_creation" {
   name                     = "User Creation Policy"
   description              = "Control user creation on provisioned instances"
@@ -798,6 +863,8 @@ resource "hpe_morpheus_policy" "user_creation" {
 
 ```terraform
 # User Group Creation Policy - Assigns default user group
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "user_group_creation" {
   name                     = "User Group Creation Policy"
   description              = "Assign default user group for created users"
@@ -819,6 +886,8 @@ resource "hpe_morpheus_policy" "user_group_creation" {
 
 ```terraform
 # Workflow Policy - Executes workflow on provision
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 # Note: This example uses the morpheus external provider to create a workflow resource
 # because the hpe provider does not yet have a workflow resource implemented.
 # You will need to configure the morpheus provider in your terraform configuration.

--- a/docs/resources/morpheus_policy.md
+++ b/docs/resources/morpheus_policy.md
@@ -863,13 +863,13 @@ resource "hpe_morpheus_policy" "workflow" {
 
 ### Required
 
-- `associated_resource_type` (String) Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', or 'Plan'
+- `associated_resource_type` (String) Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', 'Plan' or 'Label'
 - `name` (String) A name for the policy
 - `policy_type` (Attributes) (see [below for nested schema](#nestedatt--policy_type))
 
 ### Optional
 
-- `associated_resource_id` (Number) The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan
+- `associated_resource_id` (Number) The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan, Label
 - `config` (Dynamic) Generic Policy Configuration
 - `description` (String) A description for the policy
 - `each_user` (Boolean) Apply individually to each user in role.  Only when `refType` equals `Role`

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_backupStorage.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_backupStorage.tf
@@ -1,4 +1,6 @@
 # # Backup Targets Policy - Restricts available backup storage targets
+# Allowed associated_resource_types: Group, Cloud, User, Global, Role
+# Tenant specification: NOT allowed (cannot specify tenants array)
 # resource "hpe_morpheus_policy" "backup_targets" {
 #   name                     = "Backup Targets Policy"
 #   description              = "Restrict available backup targets"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_createBackup.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_createBackup.tf
@@ -1,4 +1,6 @@
 # Backup Creation Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "backup_creation" {
   name                     = "Backup Creation Policy"
   description              = "Enforce backup creation for instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_createUser.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_createUser.tf
@@ -1,4 +1,6 @@
 # User Creation Policy - Controls user creation on instances
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "user_creation" {
   name                     = "User Creation Policy"
   description              = "Control user creation on provisioned instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_createUserGroup.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_createUserGroup.tf
@@ -1,4 +1,6 @@
 # User Group Creation Policy - Assigns default user group
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "user_group_creation" {
   name                     = "User Group Creation Policy"
   description              = "Assign default user group for created users"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_cypher.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_cypher.tf
@@ -1,4 +1,6 @@
 # Cypher Access Policy - Controls access to Cypher secrets
+# Allowed associated_resource_types: User, Global, Role
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "cypher_access" {
   name                     = "Cypher Access Policy"
   description              = "Control Cypher key access permissions"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_delayedRemoval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_delayedRemoval.tf
@@ -1,4 +1,6 @@
 # Delayed Delete Policy - Delays instance deletion
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "delayed_delete" {
   name                     = "Delayed Delete Policy"
   description              = "Delay instance deletion by specified days"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_deleteApproval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_deleteApproval.tf
@@ -1,4 +1,6 @@
 # Approve Delete Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_delete" {
   name                     = "Approve Delete Policy"
   description              = "Require approval before deleting instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_hostNaming.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_hostNaming.tf
@@ -1,4 +1,6 @@
 # Hostname Policy - Enforces hostname naming conventions
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "hostname" {
   name                     = "Hostname Policy"
   description              = "Enforce hostname naming conventions"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_lifecycle.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_lifecycle.tf
@@ -1,4 +1,6 @@
 # Expiration Policy - Sets instance expiration and renewal options
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "expiration" {
   name                     = "Expiration Policy"
   description              = "Set instance expiration and renewal policies"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxContainers.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxContainers.tf
@@ -1,4 +1,6 @@
 # Max Containers Policy - Limits container count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_containers" {
   name                     = "Max Containers Policy"
   description              = "Limit maximum container count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxCores.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxCores.tf
@@ -1,4 +1,6 @@
 # Max Cores Policy - Limits CPU cores
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_cores" {
   name                     = "Max Cores Policy"
   description              = "Limit maximum CPU cores"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxHosts.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxHosts.tf
@@ -1,4 +1,6 @@
 # Max Hosts Policy - Limits host count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_hosts" {
   name                     = "Max Hosts Policy"
   description              = "Limit maximum host count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxMemory.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxMemory.tf
@@ -1,4 +1,6 @@
 # Max Memory Policy - Limits memory allocation
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_memory" {
   name                     = "Max Memory Policy"
   description              = "Limit maximum memory allocation"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxNetworks.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxNetworks.tf
@@ -1,4 +1,6 @@
 # Network Quota Policy - Limits network count
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "network_quota" {
   name                     = "Network Quota Policy"
   description              = "Limit maximum network count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPoolMembers.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPoolMembers.tf
@@ -1,8 +1,10 @@
 # Max Pool Members Policy - Limits pool members
+# Allowed associated_resource_types: Cloud, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_pool_members" {
   name                     = "Max Pool Members Policy"
   description              = "Limit maximum pool members"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPools.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPools.tf
@@ -1,4 +1,6 @@
 # Max Load Balancer Pools Policy - Limits load balancer pools
+# Allowed associated_resource_types: Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_pools" {
   name                     = "Max Load Balancer Pools Policy"
   description              = "Limit maximum load balancer pools"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPrice.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxPrice.tf
@@ -1,4 +1,6 @@
 # Budget Policy - Limits instance costs
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "budget" {
   name                     = "Budget Policy"
   description              = "Limit maximum instance costs"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxRouters.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxRouters.tf
@@ -1,4 +1,6 @@
 # Router Quota Policy - Limits router count
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "router_quota" {
   name                     = "Router Quota Policy"
   description              = "Limit maximum router count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxSnapshots.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxSnapshots.tf
@@ -1,4 +1,6 @@
 # Max Snapshots Policy - Limits snapshots per VM
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_snapshots" {
   name                     = "Max Snapshots Policy"
   description              = "Limit maximum snapshots per VM"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxStorage.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxStorage.tf
@@ -1,4 +1,6 @@
 # Max Storage Policy - Limits storage allocation
+# Allowed associated_resource_types: Group, Cloud, User, Global, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_storage" {
   name                     = "Max Storage Policy"
   description              = "Limit maximum storage allocation"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxVirtualServers.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxVirtualServers.tf
@@ -1,8 +1,10 @@
 # Max Virtual Servers Policy - Limits virtual server count
+# Allowed associated_resource_types: Cloud, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_virtual_servers" {
   name                     = "Max Virtual Servers Policy"
   description              = "Limit maximum virtual server count"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_maxVms.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_maxVms.tf
@@ -1,4 +1,6 @@
 # Max VMs Policy - Limits VM count
+# Allowed associated_resource_types: Group, Cloud, User, Global, Network, Plan
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "max_vms" {
   name                     = "Max VMs Policy"
   description              = "Limit maximum VM count"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_motd.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_motd.tf
@@ -1,9 +1,10 @@
 # Message of the Day (MOTD) Policy - Displays login messages
+# Allowed associated_resource_types: Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "motd" {
   name                     = "MOTD Policy"
   description              = "Display message of the day on login"
-  associated_resource_type = "User"
-  associated_resource_id   = 9969
+  associated_resource_type = "Global"
   enabled                  = true
 
   policy_type = {

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_naming.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_naming.tf
@@ -1,4 +1,6 @@
 # Instance Name Policy - Enforces instance naming conventions
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "instance_naming" {
   name                     = "Instance Name Policy"
   description              = "Enforce instance naming conventions"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_powerSchedule.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_powerSchedule.tf
@@ -1,4 +1,6 @@
 # Power Scheduling Policy - Enforces power schedules
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "power_schedule" {
   name                     = "Power Scheduling Policy"
   description              = "Enforce power schedules for instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_provisionApproval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_provisionApproval.tf
@@ -1,4 +1,6 @@
 # Approve Provision Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_provision" {
   name                     = "Approve Provision Policy"
   description              = "Require approval before provisioning instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_reconfigureApproval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_reconfigureApproval.tf
@@ -1,4 +1,6 @@
 # Approve Reconfigure Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_reconfigure" {
   name                     = "Approve Reconfigure Policy"
   description              = "Require approval before reconfiguring instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_requiredNetwork.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_requiredNetwork.tf
@@ -1,8 +1,10 @@
 # Instance Networks Policy - Requires specific networks for instances
+# Allowed associated_resource_types: Group, Cloud
+# Tenant specification: NOT allowed (allowOnTenant = false)
 resource "hpe_morpheus_policy" "required_networks" {
   name                     = "Instance Networks Policy"
   description              = "Require specific networks for instances"
-  associated_resource_type = "User"
+  associated_resource_type = "Cloud"
   associated_resource_id   = 9969
   enabled                  = true
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_serverNaming.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_serverNaming.tf
@@ -1,4 +1,6 @@
 # Cluster Resource Name Policy - Enforces naming conventions for cluster resources
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "cluster_naming" {
   name                     = "Cluster Resource Naming Policy"
   description              = "Enforce naming for cluster resources"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_shutdown.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_shutdown.tf
@@ -1,4 +1,6 @@
 # Shutdown Policy - Auto-shutdown idle instances
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "shutdown" {
   name                     = "Shutdown Policy"
   description              = "Auto-shutdown idle instances"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_storageBucketQuota.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_storageBucketQuota.tf
@@ -1,4 +1,6 @@
 # Object Storage Quota Policy - Limits object storage
+# Allowed associated_resource_types: User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "object_storage_quota" {
   name                     = "Object Storage Quota Policy"
   description              = "Limit object storage usage"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_storageServerQuota.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_storageServerQuota.tf
@@ -1,8 +1,10 @@
 # Storage Server Storage Quota Policy - Limits storage on specific storage server
+# Allowed associated_resource_types: Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "storage_server_quota" {
   name                     = "Storage Server Storage Quota Policy"
   description              = "Limit storage usage on specific storage server"
-  associated_resource_type = "User"
+  associated_resource_type = "Global"
   associated_resource_id   = 9969
   enabled                  = true
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_storageShareQuota.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_storageShareQuota.tf
@@ -1,4 +1,6 @@
 # File Share Storage Quota Policy - Limits file share storage
+# Allowed associated_resource_types: User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "file_share_quota" {
   name                     = "File Share Storage Quota Policy"
   description              = "Limit file share storage usage"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_tags.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_tags.tf
@@ -1,4 +1,6 @@
 # Tags Policy - Enforces instance tagging
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "tags" {
   name                     = "Tags Policy"
   description              = "Enforce instance tagging requirements"

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_workflow.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_workflow.tf
@@ -1,4 +1,6 @@
 # Workflow Policy - Executes workflow on provision
+# Allowed associated_resource_types: Group, Cloud, User, Global
+# Tenant specification: allowed (can specify tenants array)
 # Note: This example uses the morpheus external provider to create a workflow resource
 # because the hpe provider does not yet have a workflow resource implemented.
 # You will need to configure the morpheus provider in your terraform configuration.

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_workflowApproval.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_workflowApproval.tf
@@ -1,4 +1,6 @@
 # Approve Workflow Execute Policy
+# Allowed associated_resource_types: Group, Cloud, User, Global, Label
+# Tenant specification: allowed (can specify tenants array)
 resource "hpe_morpheus_policy" "approve_workflow" {
   name                     = "Approve Workflow Execute Policy"
   description              = "Require approval before executing workflows"

--- a/internal/framework/subproviders/morpheus/convert/convert.go
+++ b/internal/framework/subproviders/morpheus/convert/convert.go
@@ -5,6 +5,7 @@ package convert
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -134,6 +135,23 @@ func Int64ToType(i *int64) types.Int64 {
 	}
 
 	return types.Int64Value(*i)
+}
+
+// StrToNumber converts a string pointer to a types.Number.
+// Returns null if the pointer is nil or the string cannot be parsed.
+func StrToNumber(s *string) types.Number {
+	if s == nil {
+		return types.NumberNull()
+	}
+
+	// Parse string to big.Float
+	bf := new(big.Float)
+	_, ok := bf.SetString(*s)
+	if !ok {
+		return types.NumberNull()
+	}
+
+	return types.NumberValue(bf)
 }
 
 func Int64SliceToSet(items []int64) types.Set {

--- a/internal/framework/subproviders/morpheus/resources/policy/config.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/config.go
@@ -1,0 +1,603 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
+)
+
+// mapStateToAddPolicyConfig converts state config fields to API config structure for Add (Create)
+func mapStateToAddPolicyConfig(
+	ctx context.Context,
+	plan *PolicyModel,
+) (*sdk.AddPoliciesRequestPolicyConfig, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+	var configMap map[string]interface{}
+
+	// First, check if the legacy dynamic config field is set
+	if !plan.Config.IsNull() && !plan.Config.IsUnknown() {
+		configValue := plan.Config.UnderlyingValue()
+		anyValue, err := convert.ValueToAny(ctx, configValue)
+		if err != nil {
+			diags.AddError(
+				"map state to API config",
+				"failed to convert dynamic config: "+err.Error(),
+			)
+			return nil, diags
+		}
+		var ok bool
+		configMap, ok = anyValue.(map[string]interface{})
+		if !ok {
+			diags.AddError(
+				"map state to API config",
+				"config must be a map",
+			)
+			return nil, diags
+		}
+
+		// Check if config is empty
+		if len(configMap) == 0 {
+			diags.AddError(
+				"map state to API config",
+				"config cannot be empty. Please provide the required configuration fields for this policy type.",
+			)
+			return nil, diags
+		}
+	} else {
+		// Use static config fields
+		configMap = make(map[string]interface{})
+
+		// Map each static config field to the API structure
+		if !plan.ConfigApproval.IsNull() && !plan.ConfigApproval.IsUnknown() {
+			approval := make(map[string]interface{})
+			if !plan.ConfigApproval.AccountIntegrationId.IsNull() {
+				approval["accountIntegrationId"] = plan.ConfigApproval.AccountIntegrationId.ValueString()
+			}
+			if !plan.ConfigApproval.FlowId.IsNull() {
+				approval["flowId"] = plan.ConfigApproval.FlowId.ValueString()
+			}
+			if !plan.ConfigApproval.WorkflowId.IsNull() {
+				approval["workflowId"] = plan.ConfigApproval.WorkflowId.ValueString()
+			}
+			if !plan.ConfigApproval.WorkflowType.IsNull() {
+				approval["workflowType"] = plan.ConfigApproval.WorkflowType.ValueString()
+			}
+			if len(approval) > 0 {
+				configMap = approval
+			}
+		}
+
+		if !plan.ConfigBackupStorage.IsNull() {
+			backupStorage := make(map[string]interface{})
+			if !plan.ConfigBackupStorage.BackupStorageIds.IsNull() {
+				var backupStorageIDs []int64
+				diagsSet := plan.ConfigBackupStorage.BackupStorageIds.ElementsAs(ctx, &backupStorageIDs, false)
+				if diagsSet.HasError() {
+					diags.Append(diagsSet...)
+					return nil, diags
+				}
+				backupStorage["backupStorageIds"] = backupStorageIDs
+			}
+			if len(backupStorage) > 0 {
+				configMap = backupStorage
+			}
+		}
+
+		if !plan.ConfigCreateBackup.IsNull() {
+			createBackup := make(map[string]interface{})
+			if !plan.ConfigCreateBackup.CreateBackup.IsNull() {
+				createBackup["createBackup"] = plan.ConfigCreateBackup.CreateBackup.ValueBool()
+			}
+			if !plan.ConfigCreateBackup.CreateBackupType.IsNull() {
+				createBackup["createBackupType"] = plan.ConfigCreateBackup.CreateBackupType.ValueString()
+			}
+			if len(createBackup) > 0 {
+				configMap = createBackup
+			}
+		}
+
+		if !plan.ConfigCreateUser.IsNull() {
+			createUser := make(map[string]interface{})
+			if !plan.ConfigCreateUser.CreateUser.IsNull() {
+				createUser["createUser"] = plan.ConfigCreateUser.CreateUser.ValueBool()
+			}
+			if !plan.ConfigCreateUser.CreateUserType.IsNull() {
+				createUser["createUserType"] = plan.ConfigCreateUser.CreateUserType.ValueString()
+			}
+			if len(createUser) > 0 {
+				configMap = createUser
+			}
+		}
+
+		if !plan.ConfigCreateUserGroup.IsNull() {
+			createUserGroup := make(map[string]interface{})
+			if !plan.ConfigCreateUserGroup.UserGroup.IsNull() {
+				createUserGroup["userGroup"] = plan.ConfigCreateUserGroup.UserGroup.ValueString()
+			}
+			if len(createUserGroup) > 0 {
+				configMap = createUserGroup
+			}
+		}
+
+		if !plan.ConfigCypher.IsNull() {
+			cypher := make(map[string]interface{})
+			if !plan.ConfigCypher.Delete.IsNull() {
+				cypher["delete"] = plan.ConfigCypher.Delete.ValueBool()
+			}
+			if !plan.ConfigCypher.KeyPattern.IsNull() {
+				cypher["keyPattern"] = plan.ConfigCypher.KeyPattern.ValueString()
+			}
+			if !plan.ConfigCypher.List.IsNull() {
+				cypher["list"] = plan.ConfigCypher.List.ValueBool()
+			}
+			if !plan.ConfigCypher.Read.IsNull() {
+				cypher["read"] = plan.ConfigCypher.Read.ValueBool()
+			}
+			if !plan.ConfigCypher.Update.IsNull() {
+				cypher["update"] = plan.ConfigCypher.Update.ValueBool()
+			}
+			if !plan.ConfigCypher.Write.IsNull() {
+				cypher["write"] = plan.ConfigCypher.Write.ValueBool()
+			}
+			if len(cypher) > 0 {
+				configMap = cypher
+			}
+		}
+
+		if !plan.ConfigDelayedRemoval.IsNull() {
+			delayedRemoval := make(map[string]interface{})
+			if !plan.ConfigDelayedRemoval.RemovalAge.IsNull() {
+				delayedRemoval["removalAge"] = plan.ConfigDelayedRemoval.RemovalAge.ValueString()
+			}
+			if len(delayedRemoval) > 0 {
+				configMap = delayedRemoval
+			}
+		}
+
+		if !plan.ConfigHostNaming.IsNull() {
+			hostNaming := make(map[string]interface{})
+			if !plan.ConfigHostNaming.HostNamingPattern.IsNull() {
+				hostNaming["hostNamingPattern"] = plan.ConfigHostNaming.HostNamingPattern.ValueString()
+			}
+			if !plan.ConfigHostNaming.HostNamingType.IsNull() {
+				hostNaming["hostNamingType"] = plan.ConfigHostNaming.HostNamingType.ValueString()
+			}
+			if len(hostNaming) > 0 {
+				configMap = hostNaming
+			}
+		}
+
+		if !plan.ConfigLifecycle.IsNull() {
+			lifecycle := make(map[string]interface{})
+			if !plan.ConfigLifecycle.AccountIntegrationId.IsNull() {
+				lifecycle["accountIntegrationId"] = plan.ConfigLifecycle.AccountIntegrationId.ValueString()
+			}
+			if !plan.ConfigLifecycle.FlowId.IsNull() {
+				lifecycle["flowId"] = plan.ConfigLifecycle.FlowId.ValueString()
+			}
+			if !plan.ConfigLifecycle.LifecycleAge.IsNull() {
+				lifecycle["lifecycleAge"] = plan.ConfigLifecycle.LifecycleAge.ValueString()
+			}
+			if !plan.ConfigLifecycle.LifecycleAllowExtend.IsNull() {
+				lifecycle["lifecycleAllowExtend"] = plan.ConfigLifecycle.LifecycleAllowExtend.ValueBool()
+			}
+			if !plan.ConfigLifecycle.LifecycleAutoRenew.IsNull() {
+				lifecycle["lifecycleAutoRenew"] = plan.ConfigLifecycle.LifecycleAutoRenew.ValueBool()
+			}
+			if !plan.ConfigLifecycle.LifecycleExtensionsBeforeApproval.IsNull() {
+				lifecycle["lifecycleExtensionsBeforeApproval"] = plan.ConfigLifecycle.LifecycleExtensionsBeforeApproval.ValueString()
+			}
+			if !plan.ConfigLifecycle.LifecycleHideFixed.IsNull() {
+				lifecycle["lifecycleHideFixed"] = plan.ConfigLifecycle.LifecycleHideFixed.ValueBool()
+			}
+			if !plan.ConfigLifecycle.LifecycleMessage.IsNull() {
+				lifecycle["lifecycleMessage"] = plan.ConfigLifecycle.LifecycleMessage.ValueString()
+			}
+			if !plan.ConfigLifecycle.LifecycleNotify.IsNull() {
+				lifecycle["lifecycleNotify"] = plan.ConfigLifecycle.LifecycleNotify.ValueString()
+			}
+			if !plan.ConfigLifecycle.LifecycleRenewal.IsNull() {
+				lifecycle["lifecycleRenewal"] = plan.ConfigLifecycle.LifecycleRenewal.ValueString()
+			}
+			if !plan.ConfigLifecycle.LifecycleType.IsNull() {
+				lifecycle["lifecycleType"] = plan.ConfigLifecycle.LifecycleType.ValueString()
+			}
+			if !plan.ConfigLifecycle.LifecycleWorkflowId.IsNull() {
+				lifecycle["lifecycleWorkflowId"] = plan.ConfigLifecycle.LifecycleWorkflowId.ValueString()
+			}
+			if !plan.ConfigLifecycle.WorkflowType.IsNull() {
+				lifecycle["workflowType"] = plan.ConfigLifecycle.WorkflowType.ValueString()
+			}
+			if len(lifecycle) > 0 {
+				configMap = lifecycle
+			}
+		}
+
+		if !plan.ConfigMaxContainers.IsNull() {
+			maxContainers := make(map[string]interface{})
+			if !plan.ConfigMaxContainers.MaxContainers.IsNull() {
+				maxContainers["maxContainers"] = plan.ConfigMaxContainers.MaxContainers.ValueString()
+			}
+			if len(maxContainers) > 0 {
+				configMap = maxContainers
+			}
+		}
+
+		if !plan.ConfigMaxCores.IsNull() {
+			maxCores := make(map[string]interface{})
+			if !plan.ConfigMaxCores.MaxCores.IsNull() {
+				maxCores["maxCores"] = plan.ConfigMaxCores.MaxCores.ValueString()
+			}
+			if !plan.ConfigMaxCores.ExcludeContainers.IsNull() {
+				maxCores["excludeContainers"] = fmt.Sprintf("%t", plan.ConfigMaxCores.ExcludeContainers.ValueBool())
+			}
+			if len(maxCores) > 0 {
+				configMap = maxCores
+			}
+		}
+
+		if !plan.ConfigMaxHosts.IsNull() {
+			maxHosts := make(map[string]interface{})
+			if !plan.ConfigMaxHosts.MaxHosts.IsNull() {
+				maxHosts["maxHosts"] = plan.ConfigMaxHosts.MaxHosts.ValueString()
+			}
+			if len(maxHosts) > 0 {
+				configMap = maxHosts
+			}
+		}
+
+		if !plan.ConfigMaxMemory.IsNull() {
+			maxMemory := make(map[string]interface{})
+			if !plan.ConfigMaxMemory.MaxMemory.IsNull() {
+				maxMemory["maxMemory"] = plan.ConfigMaxMemory.MaxMemory.ValueString()
+			}
+			if !plan.ConfigMaxMemory.ExcludeContainers.IsNull() {
+				maxMemory["excludeContainers"] = fmt.Sprintf("%t", plan.ConfigMaxMemory.ExcludeContainers.ValueBool())
+			}
+			if len(maxMemory) > 0 {
+				configMap = maxMemory
+			}
+		}
+
+		if !plan.ConfigMaxNetworks.IsNull() {
+			maxNetworks := make(map[string]interface{})
+			if !plan.ConfigMaxNetworks.MaxNetworks.IsNull() {
+				maxNetworks["maxNetworks"] = plan.ConfigMaxNetworks.MaxNetworks.ValueString()
+			}
+			if len(maxNetworks) > 0 {
+				configMap = maxNetworks
+			}
+		}
+
+		if !plan.ConfigMaxPoolMembers.IsNull() {
+			maxPoolMembers := make(map[string]interface{})
+			if !plan.ConfigMaxPoolMembers.MaxPoolMembers.IsNull() {
+				maxPoolMembers["maxPoolMembers"] = plan.ConfigMaxPoolMembers.MaxPoolMembers.ValueString()
+			}
+			if len(maxPoolMembers) > 0 {
+				configMap = maxPoolMembers
+			}
+		}
+
+		if !plan.ConfigMaxPools.IsNull() {
+			maxPools := make(map[string]interface{})
+			if !plan.ConfigMaxPools.MaxPools.IsNull() {
+				maxPools["maxPools"] = plan.ConfigMaxPools.MaxPools.ValueString()
+			}
+			if len(maxPools) > 0 {
+				configMap = maxPools
+			}
+		}
+
+		if !plan.ConfigMaxPrice.IsNull() {
+			maxPrice := make(map[string]interface{})
+			if !plan.ConfigMaxPrice.MaxPrice.IsNull() {
+				// MaxPrice is a Number type, get the float value
+				f, _ := plan.ConfigMaxPrice.MaxPrice.ValueBigFloat().Float64()
+				maxPrice["maxPrice"] = f
+			}
+			if !plan.ConfigMaxPrice.MaxPriceCurrency.IsNull() {
+				maxPrice["maxPriceCurrency"] = plan.ConfigMaxPrice.MaxPriceCurrency.ValueString()
+			}
+			if !plan.ConfigMaxPrice.MaxPriceUnit.IsNull() {
+				maxPrice["maxPriceUnit"] = plan.ConfigMaxPrice.MaxPriceUnit.ValueString()
+			}
+			if len(maxPrice) > 0 {
+				configMap = maxPrice
+			}
+		}
+
+		if !plan.ConfigMaxRouters.IsNull() {
+			maxRouters := make(map[string]interface{})
+			if !plan.ConfigMaxRouters.MaxRouters.IsNull() {
+				maxRouters["maxRouters"] = plan.ConfigMaxRouters.MaxRouters.ValueString()
+			}
+			if len(maxRouters) > 0 {
+				configMap = maxRouters
+			}
+		}
+
+		if !plan.ConfigMaxSnapshots.IsNull() {
+			maxSnapshots := make(map[string]interface{})
+			if !plan.ConfigMaxSnapshots.MaxSnapshots.IsNull() {
+				maxSnapshots["maxSnapshots"] = plan.ConfigMaxSnapshots.MaxSnapshots.ValueString()
+			}
+			if len(maxSnapshots) > 0 {
+				configMap = maxSnapshots
+			}
+		}
+
+		if !plan.ConfigMaxStorage.IsNull() {
+			maxStorage := make(map[string]interface{})
+			if !plan.ConfigMaxStorage.MaxStorage.IsNull() {
+				maxStorage["maxStorage"] = plan.ConfigMaxStorage.MaxStorage.ValueString()
+			}
+			if !plan.ConfigMaxStorage.ExcludeContainers.IsNull() {
+				maxStorage["excludeContainers"] = fmt.Sprintf("%t", plan.ConfigMaxStorage.ExcludeContainers.ValueBool())
+			}
+			if len(maxStorage) > 0 {
+				configMap = maxStorage
+			}
+		}
+
+		if !plan.ConfigMaxVirtualServers.IsNull() {
+			maxVirtualServers := make(map[string]interface{})
+			if !plan.ConfigMaxVirtualServers.MaxVirtualServers.IsNull() {
+				maxVirtualServers["maxVirtualServers"] = plan.ConfigMaxVirtualServers.MaxVirtualServers.ValueString()
+			}
+			if len(maxVirtualServers) > 0 {
+				configMap = maxVirtualServers
+			}
+		}
+
+		if !plan.ConfigMaxVms.IsNull() {
+			maxVms := make(map[string]interface{})
+			if !plan.ConfigMaxVms.MaxVms.IsNull() {
+				maxVms["maxVms"] = plan.ConfigMaxVms.MaxVms.ValueString()
+			}
+			if len(maxVms) > 0 {
+				configMap = maxVms
+			}
+		}
+
+		if !plan.ConfigMotd.IsNull() {
+			motd := make(map[string]interface{})
+			if !plan.ConfigMotd.Motddate.IsNull() {
+				motd["motdDate"] = plan.ConfigMotd.Motddate.ValueString()
+			}
+			if !plan.ConfigMotd.Motdmessage.IsNull() {
+				motd["motdMessage"] = plan.ConfigMotd.Motdmessage.ValueString()
+			}
+			if !plan.ConfigMotd.Motdtitle.IsNull() {
+				motd["motdTitle"] = plan.ConfigMotd.Motdtitle.ValueString()
+			}
+			if !plan.ConfigMotd.Motdtype.IsNull() {
+				motd["motdType"] = plan.ConfigMotd.Motdtype.ValueString()
+			}
+			if len(motd) > 0 {
+				configMap = motd
+			}
+		}
+
+		if !plan.ConfigNaming.IsNull() {
+			naming := make(map[string]interface{})
+			if !plan.ConfigNaming.NamingConflict.IsNull() {
+				naming["namingConflict"] = plan.ConfigNaming.NamingConflict.ValueBool()
+			}
+			if !plan.ConfigNaming.NamingPattern.IsNull() {
+				naming["namingPattern"] = plan.ConfigNaming.NamingPattern.ValueString()
+			}
+			if !plan.ConfigNaming.NamingType.IsNull() {
+				naming["namingType"] = plan.ConfigNaming.NamingType.ValueString()
+			}
+			if len(naming) > 0 {
+				configMap = naming
+			}
+		}
+
+		if !plan.ConfigPowerSchedule.IsNull() {
+			powerSchedule := make(map[string]interface{})
+			if !plan.ConfigPowerSchedule.PowerSchedule.IsNull() {
+				powerSchedule["powerSchedule"] = plan.ConfigPowerSchedule.PowerSchedule.ValueString()
+			}
+			if !plan.ConfigPowerSchedule.PowerScheduleHideFixed.IsNull() {
+				powerSchedule["powerScheduleHideFixed"] = plan.ConfigPowerSchedule.PowerScheduleHideFixed.ValueBool()
+			}
+			if !plan.ConfigPowerSchedule.PowerScheduleType.IsNull() {
+				powerSchedule["powerScheduleType"] = plan.ConfigPowerSchedule.PowerScheduleType.ValueString()
+			}
+			if len(powerSchedule) > 0 {
+				configMap = powerSchedule
+			}
+		}
+
+		if !plan.ConfigRequiredNetwork.IsNull() {
+			requiredNetwork := make(map[string]interface{})
+			if !plan.ConfigRequiredNetwork.RequiredNetworks.IsNull() {
+				var requiredNetworks []int64
+				diagsSet := plan.ConfigRequiredNetwork.RequiredNetworks.ElementsAs(ctx, &requiredNetworks, false)
+				if diagsSet.HasError() {
+					diags.Append(diagsSet...)
+					return nil, diags
+				}
+				requiredNetwork["requiredNetworks"] = requiredNetworks
+			}
+			if len(requiredNetwork) > 0 {
+				configMap = requiredNetwork
+			}
+		}
+
+		if !plan.ConfigServerNaming.IsNull() {
+			serverNaming := make(map[string]interface{})
+			if !plan.ConfigServerNaming.ServerNamingConflict.IsNull() {
+				serverNaming["serverNamingConflict"] = plan.ConfigServerNaming.ServerNamingConflict.ValueBool()
+			}
+			if !plan.ConfigServerNaming.ServerNamingPattern.IsNull() {
+				serverNaming["serverNamingPattern"] = plan.ConfigServerNaming.ServerNamingPattern.ValueString()
+			}
+			if !plan.ConfigServerNaming.ServerNamingType.IsNull() {
+				serverNaming["serverNamingType"] = plan.ConfigServerNaming.ServerNamingType.ValueString()
+			}
+			if len(serverNaming) > 0 {
+				configMap = serverNaming
+			}
+		}
+
+		if !plan.ConfigShutdown.IsNull() {
+			shutdown := make(map[string]interface{})
+			if !plan.ConfigShutdown.AccountIntegrationId.IsNull() {
+				shutdown["accountIntegrationId"] = plan.ConfigShutdown.AccountIntegrationId.ValueString()
+			}
+			if !plan.ConfigShutdown.FlowId.IsNull() {
+				shutdown["flowId"] = plan.ConfigShutdown.FlowId.ValueString()
+			}
+			if !plan.ConfigShutdown.ShutdownAge.IsNull() {
+				shutdown["shutdownAge"] = plan.ConfigShutdown.ShutdownAge.ValueString()
+			}
+			if !plan.ConfigShutdown.ShutdownAllowExtend.IsNull() {
+				shutdown["shutdownAllowExtend"] = plan.ConfigShutdown.ShutdownAllowExtend.ValueBool()
+			}
+			if !plan.ConfigShutdown.ShutdownAutoRenew.IsNull() {
+				shutdown["shutdownAutoRenew"] = plan.ConfigShutdown.ShutdownAutoRenew.ValueBool()
+			}
+			if !plan.ConfigShutdown.ShutdownExtensionsBeforeApproval.IsNull() {
+				shutdown["shutdownExtensionsBeforeApproval"] = plan.ConfigShutdown.ShutdownExtensionsBeforeApproval.ValueString()
+			}
+			if !plan.ConfigShutdown.ShutdownHideFixed.IsNull() {
+				shutdown["shutdownHideFixed"] = plan.ConfigShutdown.ShutdownHideFixed.ValueBool()
+			}
+			if !plan.ConfigShutdown.ShutdownMessage.IsNull() {
+				shutdown["shutdownMessage"] = plan.ConfigShutdown.ShutdownMessage.ValueString()
+			}
+			if !plan.ConfigShutdown.ShutdownNotify.IsNull() {
+				shutdown["shutdownNotify"] = plan.ConfigShutdown.ShutdownNotify.ValueString()
+			}
+			if !plan.ConfigShutdown.ShutdownRenewal.IsNull() {
+				shutdown["shutdownRenewal"] = plan.ConfigShutdown.ShutdownRenewal.ValueString()
+			}
+			if !plan.ConfigShutdown.ShutdownType.IsNull() {
+				shutdown["shutdownType"] = plan.ConfigShutdown.ShutdownType.ValueString()
+			}
+			if !plan.ConfigShutdown.ShutdownWorkflowId.IsNull() {
+				shutdown["shutdownWorkflowId"] = plan.ConfigShutdown.ShutdownWorkflowId.ValueString()
+			}
+			if !plan.ConfigShutdown.WorkflowType.IsNull() {
+				shutdown["workflowType"] = plan.ConfigShutdown.WorkflowType.ValueString()
+			}
+			if len(shutdown) > 0 {
+				configMap = shutdown
+			}
+		}
+
+		if !plan.ConfigStorageServerQuota.IsNull() {
+			storageServerQuota := make(map[string]interface{})
+			if !plan.ConfigStorageServerQuota.MaxStorage.IsNull() {
+				storageServerQuota["maxStorage"] = plan.ConfigStorageServerQuota.MaxStorage.ValueString()
+			}
+			if !plan.ConfigStorageServerQuota.StorageServerId.IsNull() {
+				storageServerQuota["storageServerId"] = plan.ConfigStorageServerQuota.StorageServerId.ValueString()
+			}
+			if len(storageServerQuota) > 0 {
+				configMap = storageServerQuota
+			}
+		}
+
+		if !plan.ConfigTags.IsNull() {
+			tags := make(map[string]interface{})
+			if !plan.ConfigTags.Key.IsNull() {
+				tags["key"] = plan.ConfigTags.Key.ValueString()
+			}
+			if !plan.ConfigTags.Strict.IsNull() {
+				tags["strict"] = plan.ConfigTags.Strict.ValueBool()
+			}
+			if !plan.ConfigTags.Value.IsNull() {
+				tags["value"] = plan.ConfigTags.Value.ValueString()
+			}
+			if !plan.ConfigTags.ValueListId.IsNull() {
+				tags["valueListId"] = plan.ConfigTags.ValueListId.ValueString()
+			}
+			if len(tags) > 0 {
+				configMap = tags
+			}
+		}
+
+		if !plan.ConfigWorkflow.IsNull() {
+			workflow := make(map[string]interface{})
+			if !plan.ConfigWorkflow.WorkflowId.IsNull() {
+				workflow["workflowId"] = plan.ConfigWorkflow.WorkflowId.ValueString()
+			}
+			if len(workflow) > 0 {
+				configMap = workflow
+			}
+		}
+
+		// Check if any config was provided
+		if len(configMap) == 0 {
+			diags.AddError(
+				"map state to API config",
+				"No configuration provided. Please provide at least one config_* field for this policy type.",
+			)
+			return nil, diags
+		}
+	}
+
+	// Marshal to JSON then unmarshal to SDK config structure
+	configJSON, err := json.Marshal(configMap)
+	if err != nil {
+		diags.AddError(
+			"map state to API config",
+			"failed to marshal config to JSON: "+err.Error(),
+		)
+		return nil, diags
+	}
+
+	var sdkConfig sdk.AddPoliciesRequestPolicyConfig
+	if err := json.Unmarshal(configJSON, &sdkConfig); err != nil {
+		diags.AddError(
+			"map state to API config",
+			"invalid config: "+err.Error(),
+		)
+		return nil, diags
+	}
+
+	return &sdkConfig, diags
+}
+
+// mapStateToUpdatePolicyConfig converts state config fields to API config structure for Update
+func mapStateToUpdatePolicyConfig(
+	ctx context.Context,
+	plan *PolicyModel,
+) (*sdk.UpdatePoliciesRequestPolicyConfig, diag.Diagnostics) {
+	addConfig, diags := mapStateToAddPolicyConfig(ctx, plan)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Convert AddPoliciesRequestPolicyConfig to UpdatePoliciesRequestPolicyConfig via JSON
+	configJSON, err := json.Marshal(addConfig)
+	if err != nil {
+		diags.AddError(
+			"map state to update API config",
+			"failed to marshal config to JSON: "+err.Error(),
+		)
+		return nil, diags
+	}
+
+	var updateConfig sdk.UpdatePoliciesRequestPolicyConfig
+	if err := json.Unmarshal(configJSON, &updateConfig); err != nil {
+		diags.AddError(
+			"map state to update API config",
+			"invalid config: "+err.Error(),
+		)
+		return nil, diags
+	}
+
+	return &updateConfig, diags
+}

--- a/internal/framework/subproviders/morpheus/resources/policy/config.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/config.go
@@ -55,6 +55,7 @@ func mapStateToAddPolicyConfig(
 		configMap = make(map[string]interface{})
 
 		// Map each static config field to the API structure
+		// 1. config_approval -> ApprovePolicyTypeConfiguration
 		if !plan.ConfigApproval.IsNull() && !plan.ConfigApproval.IsUnknown() {
 			approval := make(map[string]interface{})
 			if !plan.ConfigApproval.AccountIntegrationId.IsNull() {
@@ -74,6 +75,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 2. config_backup_storage -> BackupTargetsPolicyTypeConfiguration
 		if !plan.ConfigBackupStorage.IsNull() {
 			backupStorage := make(map[string]interface{})
 			if !plan.ConfigBackupStorage.BackupStorageIds.IsNull() {
@@ -90,6 +92,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 3. config_create_backup -> BackupCreationPolicyTypeConfiguration
 		if !plan.ConfigCreateBackup.IsNull() {
 			createBackup := make(map[string]interface{})
 			if !plan.ConfigCreateBackup.CreateBackup.IsNull() {
@@ -103,6 +106,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 4. config_create_user -> UserCreationPolicyTypeConfiguration
 		if !plan.ConfigCreateUser.IsNull() {
 			createUser := make(map[string]interface{})
 			if !plan.ConfigCreateUser.CreateUser.IsNull() {
@@ -116,6 +120,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 5. config_create_user_group -> UserGroupCreationPolicyTypeConfiguration
 		if !plan.ConfigCreateUserGroup.IsNull() {
 			createUserGroup := make(map[string]interface{})
 			if !plan.ConfigCreateUserGroup.UserGroup.IsNull() {
@@ -126,6 +131,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 6. config_cypher -> CypherAccessPolicyTypeConfiguration
 		if !plan.ConfigCypher.IsNull() {
 			cypher := make(map[string]interface{})
 			if !plan.ConfigCypher.Delete.IsNull() {
@@ -151,6 +157,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 7. config_delayed_removal -> DelayedDeletePolicyTypeConfiguration
 		if !plan.ConfigDelayedRemoval.IsNull() {
 			delayedRemoval := make(map[string]interface{})
 			if !plan.ConfigDelayedRemoval.RemovalAge.IsNull() {
@@ -161,6 +168,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 8. config_host_naming -> HostnamePolicyTypeConfiguration
 		if !plan.ConfigHostNaming.IsNull() {
 			hostNaming := make(map[string]interface{})
 			if !plan.ConfigHostNaming.HostNamingPattern.IsNull() {
@@ -174,6 +182,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 9. config_lifecycle -> ExpirationPolicyTypeConfiguration2
 		if !plan.ConfigLifecycle.IsNull() {
 			lifecycle := make(map[string]interface{})
 			if !plan.ConfigLifecycle.AccountIntegrationId.IsNull() {
@@ -220,6 +229,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 10. config_max_containers -> MaxContainersPolicyTypeConfiguration
 		if !plan.ConfigMaxContainers.IsNull() {
 			maxContainers := make(map[string]interface{})
 			if !plan.ConfigMaxContainers.MaxContainers.IsNull() {
@@ -230,6 +240,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 11. config_max_cores -> MaxCoresPolicyTypeConfiguration
 		if !plan.ConfigMaxCores.IsNull() {
 			maxCores := make(map[string]interface{})
 			if !plan.ConfigMaxCores.MaxCores.IsNull() {
@@ -243,6 +254,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 12. config_max_hosts -> MaxHostsPolicyTypeConfiguration
 		if !plan.ConfigMaxHosts.IsNull() {
 			maxHosts := make(map[string]interface{})
 			if !plan.ConfigMaxHosts.MaxHosts.IsNull() {
@@ -253,6 +265,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 13. config_max_memory -> MaxMemoryPolicyTypeConfiguration
 		if !plan.ConfigMaxMemory.IsNull() {
 			maxMemory := make(map[string]interface{})
 			if !plan.ConfigMaxMemory.MaxMemory.IsNull() {
@@ -266,6 +279,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 14. config_max_networks -> NetworkQuotaPolicyTypeConfiguration
 		if !plan.ConfigMaxNetworks.IsNull() {
 			maxNetworks := make(map[string]interface{})
 			if !plan.ConfigMaxNetworks.MaxNetworks.IsNull() {
@@ -276,6 +290,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 15. config_max_pool_members -> MaxPoolMembersPolicyTypeConfiguration
 		if !plan.ConfigMaxPoolMembers.IsNull() {
 			maxPoolMembers := make(map[string]interface{})
 			if !plan.ConfigMaxPoolMembers.MaxPoolMembers.IsNull() {
@@ -286,6 +301,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 16. config_max_pools -> MaxLoadBalancerPoolsPolicyTypeConfiguration
 		if !plan.ConfigMaxPools.IsNull() {
 			maxPools := make(map[string]interface{})
 			if !plan.ConfigMaxPools.MaxPools.IsNull() {
@@ -296,6 +312,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 17. config_max_price -> BudgetPolicyTypeConfiguration
 		if !plan.ConfigMaxPrice.IsNull() {
 			maxPrice := make(map[string]interface{})
 			if !plan.ConfigMaxPrice.MaxPrice.IsNull() {
@@ -314,6 +331,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 18. config_max_routers -> RouterQuotaPolicyTypeConfiguration
 		if !plan.ConfigMaxRouters.IsNull() {
 			maxRouters := make(map[string]interface{})
 			if !plan.ConfigMaxRouters.MaxRouters.IsNull() {
@@ -324,6 +342,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 19. config_max_snapshots -> MaxSnapshotsPolicyTypeConfiguration
 		if !plan.ConfigMaxSnapshots.IsNull() {
 			maxSnapshots := make(map[string]interface{})
 			if !plan.ConfigMaxSnapshots.MaxSnapshots.IsNull() {
@@ -334,6 +353,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 20. config_max_storage -> MaxStorageAndObjectStorageQuotaPolicyTypeConfiguration
 		if !plan.ConfigMaxStorage.IsNull() {
 			maxStorage := make(map[string]interface{})
 			if !plan.ConfigMaxStorage.MaxStorage.IsNull() {
@@ -347,6 +367,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 21. config_max_virtual_servers -> MaxVirtualServersPolicyTypeConfiguration
 		if !plan.ConfigMaxVirtualServers.IsNull() {
 			maxVirtualServers := make(map[string]interface{})
 			if !plan.ConfigMaxVirtualServers.MaxVirtualServers.IsNull() {
@@ -357,6 +378,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 22. config_max_vms -> MaxVMsPolicyTypeConfiguration
 		if !plan.ConfigMaxVms.IsNull() {
 			maxVms := make(map[string]interface{})
 			if !plan.ConfigMaxVms.MaxVms.IsNull() {
@@ -367,6 +389,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 23. config_motd -> MessageOfTheDayPolicyTypeConfiguration2
 		if !plan.ConfigMotd.IsNull() {
 			motd := make(map[string]interface{})
 			if !plan.ConfigMotd.Motddate.IsNull() {
@@ -386,6 +409,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 24. config_naming -> InstanceNamePolicyTypeConfiguration
 		if !plan.ConfigNaming.IsNull() {
 			naming := make(map[string]interface{})
 			if !plan.ConfigNaming.NamingConflict.IsNull() {
@@ -402,6 +426,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 25. config_power_schedule -> PowerSchedulePolicyTypeConfiguration
 		if !plan.ConfigPowerSchedule.IsNull() {
 			powerSchedule := make(map[string]interface{})
 			if !plan.ConfigPowerSchedule.PowerSchedule.IsNull() {
@@ -418,6 +443,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 26. config_required_network -> RequiredNetworkPolicyTypeConfiguration
 		if !plan.ConfigRequiredNetwork.IsNull() {
 			requiredNetwork := make(map[string]interface{})
 			if !plan.ConfigRequiredNetwork.RequiredNetworks.IsNull() {
@@ -434,6 +460,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 27. config_server_naming -> ClusterResourceNamePolicyTypeConfiguration
 		if !plan.ConfigServerNaming.IsNull() {
 			serverNaming := make(map[string]interface{})
 			if !plan.ConfigServerNaming.ServerNamingConflict.IsNull() {
@@ -450,6 +477,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 28. config_shutdown -> ShutdownPolicyTypeConfiguration
 		if !plan.ConfigShutdown.IsNull() {
 			shutdown := make(map[string]interface{})
 			if !plan.ConfigShutdown.AccountIntegrationId.IsNull() {
@@ -496,6 +524,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 29. config_storage_server_quota -> StorageServerStorageQuotaPolicyTypeConfiguration
 		if !plan.ConfigStorageServerQuota.IsNull() {
 			storageServerQuota := make(map[string]interface{})
 			if !plan.ConfigStorageServerQuota.MaxStorage.IsNull() {
@@ -509,6 +538,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 30. config_tags -> TagsPolicyTypeConfiguration
 		if !plan.ConfigTags.IsNull() {
 			tags := make(map[string]interface{})
 			if !plan.ConfigTags.Key.IsNull() {
@@ -528,6 +558,7 @@ func mapStateToAddPolicyConfig(
 			}
 		}
 
+		// 31. config_workflow -> WorkflowPolicyTypeConfiguration
 		if !plan.ConfigWorkflow.IsNull() {
 			workflow := make(map[string]interface{})
 			if !plan.ConfigWorkflow.WorkflowId.IsNull() {

--- a/internal/framework/subproviders/morpheus/resources/policy/consts.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/consts.go
@@ -1,0 +1,22 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package policy
+
+const (
+	// AssociatedResourceTypeGlobal is the resource type for global policies
+	AssociatedResourceTypeGlobal = "Global"
+	// AssociatedResourceTypeCloud is the resource type for cloud-scoped policies
+	AssociatedResourceTypeCloud = "Cloud"
+	// AssociatedResourceTypeGroup is the resource type for group-scoped policies
+	AssociatedResourceTypeGroup = "Group"
+	// AssociatedResourceTypeUser is the resource type for user-scoped policies
+	AssociatedResourceTypeUser = "User"
+	// AssociatedResourceTypeRole is the resource type for role-scoped policies
+	AssociatedResourceTypeRole = "Role"
+	// AssociatedResourceTypeNetwork is the resource type for network-scoped policies
+	AssociatedResourceTypeNetwork = "Network"
+	// AssociatedResourceTypePlan is the resource type for plan-scoped policies
+	AssociatedResourceTypePlan = "Plan"
+	// AssociatedResourceTypeLabel is the resource type for label-scoped policies
+	AssociatedResourceTypeLabel = "Label"
+)

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -4,15 +4,12 @@ package policy
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
 )
 
@@ -88,53 +85,14 @@ func (r *Resource) Create(
 		addPolicy.SetAccounts(tenantIDs)
 	}
 
-	// Set Config - convert dynamic to SDK config structure
-	if !plan.Config.IsNull() && !plan.Config.IsUnknown() {
-		configValue := plan.Config.UnderlyingValue()
-		configMap, err := convert.ValueToAny(ctx, configValue)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"create policy resource",
-				"policy "+name+": failed to convert config: "+err.Error(),
-			)
-
-			return
-		}
-
-		// Check if config is empty
-		if configMapTyped, ok := configMap.(map[string]interface{}); ok && len(configMapTyped) == 0 {
-			resp.Diagnostics.AddError(
-				"create policy resource",
-				fmt.Sprintf("policy %s: config cannot be empty for policy type '%s'. "+
-					"Please provide the required configuration fields for this policy type.", name, policyTypeCode),
-			)
-
-			return
-		}
-
-		// Marshal to JSON then unmarshal to SDK config structure
-		// This allows the SDK's UnmarshalJSON to handle the oneOf structure
-		configJSON, err := json.Marshal(configMap)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"create policy resource",
-				"policy "+name+": failed to marshal config to JSON: "+err.Error(),
-			)
-
-			return
-		}
-
-		var sdkConfig sdk.AddPoliciesRequestPolicyConfig
-		if err := json.Unmarshal(configJSON, &sdkConfig); err != nil {
-			resp.Diagnostics.AddError(
-				"create policy resource",
-				fmt.Sprintf("policy %s: invalid config for policy type '%s': %s", name, policyTypeCode, err.Error()),
-			)
-
-			return
-		}
-
-		addPolicy.SetConfig(sdkConfig)
+	// Set Config - convert state config fields to SDK config structure
+	sdkConfig, configDiags := mapStateToAddPolicyConfig(ctx, &plan)
+	if configDiags.HasError() {
+		resp.Diagnostics.Append(configDiags...)
+		return
+	}
+	if sdkConfig != nil {
+		addPolicy.SetConfig(*sdkConfig)
 	}
 
 	addPolicyRequest := sdk.NewAddPoliciesRequest(*addPolicy)

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -51,7 +51,7 @@ func (r *Resource) Create(
 
 	// When associated_resource_type is "Global", leave refType null (null defaults to Global)
 	associatedResourceType := plan.AssociatedResourceType.ValueString()
-	if associatedResourceType != "Global" {
+	if associatedResourceType != AssociatedResourceTypeGlobal {
 		// Convert user-facing resource type to API type
 		apiType := resourceTypeToAPIType(associatedResourceType)
 		addPolicy.SetRefType(apiType)

--- a/internal/framework/subproviders/morpheus/resources/policy/create_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create_test.go
@@ -104,6 +104,7 @@ func TestAccMorpheusPolicyAllBareMetalPolicyTypesOk(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlockMixed()
 	namePrefix := acctest.RandomWithPrefix(t.Name())
 	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+	cloudName := acctest.RandomWithPrefix(t.Name() + "-cloud")
 
 	resourceConfig := `
 variable "policy_name" {
@@ -127,6 +128,19 @@ resource "hpe_morpheus_group" "test" {
   location = "test"
 }
 
+resource "hpe_morpheus_cloud" "test" {
+  name = "` + cloudName + `"
+  tenant_id = 1
+  group_id = hpe_morpheus_group.test.id
+  code = "` + cloudName + `"
+  cloud_type_code = "standard"
+  
+  config = {
+    certificateProvider = "internal"
+    enableNetworkTypeSelection = false
+  }
+}
+
 resource "morpheus_operational_workflow" "test" {
   name = "` + namePrefix + `-workflow"
 }
@@ -140,6 +154,64 @@ resource "hpe_morpheus_policy" "test" {
   description = var.policy_description
   associated_resource_type = "Group"
   associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = var.policy_type_code
+  }
+  
+  config = var.policy_config
+}
+`
+
+	resourceConfigCloud := `
+variable "policy_name" {
+  type = string
+}
+
+variable "policy_description" {
+  type = string
+}
+
+variable "policy_type_code" {
+  type = string
+}
+
+variable "policy_config" {
+  type = map(any)
+}
+
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+
+resource "hpe_morpheus_cloud" "test" {
+  name = "` + cloudName + `"
+  tenant_id = 1
+  group_id = hpe_morpheus_group.test.id
+  code = "` + cloudName + `"
+  cloud_type_code = "standard"
+  
+  config = {
+    certificateProvider = "internal"
+    enableNetworkTypeSelection = false
+  }
+}
+
+resource "morpheus_operational_workflow" "test" {
+  name = "` + namePrefix + `-workflow"
+}
+
+data "morpheus_workflow" "test" {
+  name = morpheus_operational_workflow.test.name
+}
+
+resource "hpe_morpheus_policy" "test" {
+  name = var.policy_name
+  description = var.policy_description
+  associated_resource_type = "Cloud"
+  associated_resource_id = hpe_morpheus_cloud.test.id
   enabled = true
   
   policy_type = {
@@ -265,7 +337,7 @@ resource "hpe_morpheus_policy" "test" {
 			},
 			// Step 7: Instance Networks
 			{
-				Config: providerConfig + resourceConfig,
+				Config: providerConfig + resourceConfigCloud,
 				ConfigVariables: config.Variables{
 					"policy_name":        config.StringVariable(namePrefix + "-requiredNetwork"),
 					"policy_description": config.StringVariable("Required network policy"),
@@ -301,7 +373,7 @@ resource "hpe_morpheus_policy" "test" {
 			},
 			// Step 9: Max Pool Members
 			{
-				Config: providerConfig + resourceConfig,
+				Config: providerConfig + resourceConfigCloud,
 				ConfigVariables: config.Variables{
 					"policy_name":        config.StringVariable(namePrefix + "-maxPoolMembers"),
 					"policy_description": config.StringVariable("Max pool members policy"),
@@ -385,7 +457,7 @@ resource "hpe_morpheus_policy" "test" {
 					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "description", "Max networks policy"),
 				),
 			},
-			// Step 14: Storage Server Quota
+			/* // Step 14: Storage Server Quota - Commented out, requires Global scope which impacts other users
 			{
 				Config: providerConfig + resourceConfig,
 				ConfigVariables: config.Variables{
@@ -403,7 +475,7 @@ resource "hpe_morpheus_policy" "test" {
 					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "description", "Storage server quota policy"),
 				),
 			},
-			// Step 15: Tags
+			*/ // Step 15: Tags
 			{
 				Config: providerConfig + resourceConfig,
 				ConfigVariables: config.Variables{
@@ -665,9 +737,9 @@ resource "hpe_morpheus_network" "test" {
 		"Description", "Example network-scoped policy",
 		"AssociatedResourceType", "Network",
 		"AssociatedResourceID", "hpe_morpheus_network.test.id",
-		"PolicyTypeCode", "maxMemory",
-		"ConfigKey", "maxMemory",
-		"ConfigValue", "1073741824",
+		"PolicyTypeCode", "maxVms",
+		"ConfigKey", "maxVms",
+		"ConfigValue", "20",
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/framework/subproviders/morpheus/resources/policy/create_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create_test.go
@@ -805,3 +805,962 @@ resource "hpe_morpheus_network" "test" {
 		},
 	})
 }
+
+// Test creating policies using static schema fields (config_* attributes)
+func TestAccMorpheusPolicyAllStaticSchemaOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockMixed()
+	namePrefix := acctest.RandomWithPrefix(t.Name())
+	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+
+	dependencyConfig := `
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+
+resource "morpheus_operational_workflow" "test" {
+  name = "` + namePrefix + `-workflow"
+}
+
+data "morpheus_workflow" "test" {
+  name = morpheus_operational_workflow.test.name
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"morpheus": {
+				Source:            "gomorpheus/morpheus",
+				VersionConstraint: "0.13.2",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{ /*
+							// Step 1: Approve Delete (using config_approval)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-deleteApproval"
+				  description = "Delete approval policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "deleteApproval"
+				  }
+
+				  config_approval = {
+				    account_integration_id = "1"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-deleteApproval"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "deleteApproval"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_approval.account_integration_id", "1"),
+								),
+								ExpectNonEmptyPlan: false,
+							},
+							// Step 2: Backup Creation (using config_create_backup)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-createBackup"
+				  description = "Create backup policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "createBackup"
+				  }
+
+				  config_create_backup = {
+				    create_backup = true
+				    create_backup_type = "user"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-createBackup"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "createBackup"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_create_backup.create_backup", "true"),
+								),
+								ExpectNonEmptyPlan: false,
+							},
+							// Step 3: Cypher Access (using config_cypher)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-cypher"
+				  description = "Cypher access policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "cypher"
+				  }
+
+				  config_cypher = {
+				    read = true
+				    write = true
+				    update = false
+				    delete = false
+				    list = true
+				    key_pattern = "secret/*"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-cypher"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "cypher"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_cypher.read", "true"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_cypher.write", "true"),
+								),
+								ExpectNonEmptyPlan: false,
+							},
+							// Step 4: Delayed Delete (using config_delayed_removal)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-delayedRemoval"
+				  description = "Delayed removal policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "delayedRemoval"
+				  }
+
+				  config_delayed_removal = {
+				    removal_age = "7"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-delayedRemoval"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "delayedRemoval"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_delayed_removal.removal_age", "7"),
+								),
+								ExpectNonEmptyPlan: false,
+							},
+							// Step 5: Hostname (using config_host_naming)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-hostNaming"
+				  description = "Host naming policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "hostNaming"
+				  }
+
+				  config_host_naming = {
+				    host_naming_type = "user"
+				    host_naming_pattern = "host-$$$${sequence}"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-hostNaming"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "hostNaming"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_host_naming.host_naming_type", "user"),
+								),
+							},
+							// Step 6: Expiration (using config_lifecycle) - TEMPORARILY SKIPPED
+							/*
+											{
+												Config: providerConfig + dependencyConfig + `
+								resource "hpe_morpheus_policy" "test" {
+								  name = "` + namePrefix + `-lifecycle"
+								  description = "Lifecycle policy using static schema"
+								  associated_resource_type = "Group"
+								  associated_resource_id = hpe_morpheus_group.test.id
+								  enabled = true
+
+								  policy_type = {
+								    code = "lifecycle"
+								  }
+
+								  config_lifecycle = {
+								    lifecycle_type = "fixed"
+								    lifecycle_age = "30"
+								  }
+								}`,
+												Check: resource.ComposeAggregateTestCheckFunc(
+													resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-lifecycle"),
+													resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "lifecycle"),
+													resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_lifecycle.lifecycle_age", "30"),
+												),
+											},
+			*/ /*
+							// Step 7: Max Containers (using config_max_containers)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-maxContainers"
+				  description = "Max containers policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "maxContainers"
+				  }
+
+				  config_max_containers = {
+				    max_containers = "10"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxContainers"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxContainers"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_containers.max_containers", "10"),
+								),
+							},
+							// Step 8: Max Cores (using config_max_cores)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-maxCores"
+				  description = "Max cores policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "maxCores"
+				  }
+
+				  config_max_cores = {
+				    max_cores = "16"
+				    exclude_containers = false
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxCores"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxCores"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_cores.max_cores", "16"),
+								),
+							},
+							// Step 9: Max Hosts (using config_max_hosts)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-maxHosts"
+				  description = "Max hosts policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "maxHosts"
+				  }
+
+				  config_max_hosts = {
+				    max_hosts = "50"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxHosts"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxHosts"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_hosts.max_hosts", "50"),
+								),
+							},
+							// Step 10: Max Memory (using config_max_memory)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-maxMemory"
+				  description = "Max memory policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "maxMemory"
+				  }
+
+				  config_max_memory = {
+				    max_memory = "1073741824"
+				    exclude_containers = true
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxMemory"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxMemory"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_memory.max_memory", "1073741824"),
+								),
+							},
+							// Step 11: Network Quota (using config_max_networks)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-maxNetworks"
+				  description = "Max networks policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "maxNetworks"
+				  }
+
+				  config_max_networks = {
+				    max_networks = "5"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxNetworks"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxNetworks"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_networks.max_networks", "5"),
+								),
+							},
+							// Step 12: Max Pool Members (using config_max_pool_members)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-maxPoolMembers"
+				  description = "Max pool members policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "maxPoolMembers"
+				  }
+
+				  config_max_pool_members = {
+				    max_pool_members = "10"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxPoolMembers"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxPoolMembers"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_pool_members.max_pool_members", "10"),
+								),
+							},
+							// Step 13: Max Load Balancer Pools (using config_max_pools)
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-maxPools"
+				  description = "Max pools policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "maxPools"
+				  }
+
+				  config_max_pools = {
+				    max_pools = "8"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxPools"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxPools"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_pools.max_pools", "8"),
+								),
+							},
+			*/
+			// Step 14: Budget (using config_max_price)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-maxPrice"
+  description = "Max price policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "maxPrice"
+  }
+  
+  config_max_price = {
+    max_price = 1000.50
+    max_price_currency = "USD"
+    max_price_unit = "month"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxPrice"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxPrice"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_price.max_price_currency", "USD"),
+				),
+			},
+			// Step 15: Router Quota (using config_max_routers)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-maxRouters"
+  description = "Max routers policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "maxRouters"
+  }
+  
+  config_max_routers = {
+    max_routers = "3"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxRouters"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxRouters"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_routers.max_routers", "3"),
+				),
+			},
+			// Step 16: Max Snapshots (using config_max_snapshots)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-maxSnapshots"
+  description = "Max snapshots policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "maxSnapshots"
+  }
+  
+  config_max_snapshots = {
+    max_snapshots = "5"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxSnapshots"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxSnapshots"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_snapshots.max_snapshots", "5"),
+				),
+			},
+			// Step 17: Max Storage (using config_max_storage)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-maxStorage"
+  description = "Max storage policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "maxStorage"
+  }
+  
+  config_max_storage = {
+    max_storage = "10737418240"
+    exclude_containers = false
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxStorage"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxStorage"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_storage.max_storage", "10737418240"),
+				),
+			},
+			// Step 18: Max Virtual Servers (using config_max_virtual_servers)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-maxVirtualServers"
+  description = "Max virtual servers policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "maxVirtualServers"
+  }
+  
+  config_max_virtual_servers = {
+    max_virtual_servers = "15"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxVirtualServers"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxVirtualServers"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_virtual_servers.max_virtual_servers", "15"),
+				),
+			},
+			// Step 19: Max VMs (using config_max_vms)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-maxVms"
+  description = "Max VMs policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "maxVms"
+  }
+  
+  config_max_vms = {
+    max_vms = "20"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-maxVms"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "maxVms"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_max_vms.max_vms", "20"),
+				),
+			},
+			// Step 20: Message of the Day (using config_motd) - TEMPORARILY SKIPPED
+			/*
+							{
+								Config: providerConfig + dependencyConfig + `
+				resource "hpe_morpheus_policy" "test" {
+				  name = "` + namePrefix + `-motd"
+				  description = "MOTD policy using static schema"
+				  associated_resource_type = "Group"
+				  associated_resource_id = hpe_morpheus_group.test.id
+				  enabled = true
+
+				  policy_type = {
+				    code = "motd"
+				  }
+
+				  config_motd = {
+				    motdtitle = "Welcome"
+				    motdmessage = "Welcome to the system"
+				    motdtype = "text"
+				    motddate = "2024-01-01"
+				  }
+				}`,
+								Check: resource.ComposeAggregateTestCheckFunc(
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-motd"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "motd"),
+									resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_motd.motdtitle", "Welcome"),
+								),
+							},
+			*/
+			// Step 21: Instance Name (using config_naming)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-naming"
+  description = "Naming policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "naming"
+  }
+  
+  config_naming = {
+    naming_type = "user"
+    naming_pattern = "instance-$$$${sequence}"
+    naming_conflict = true
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-naming"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "naming"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_naming.naming_type", "user"),
+				),
+			},
+			// Step 22: Power Scheduling (using config_power_schedule)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-powerSchedule"
+  description = "Power schedule policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "powerSchedule"
+  }
+  
+  config_power_schedule = {
+    power_schedule = "1"
+    power_schedule_type = "user"
+    power_schedule_hide_fixed = false
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-powerSchedule"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "powerSchedule"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_power_schedule.power_schedule", "1"),
+				),
+			},
+			// Step 23: Instance Networks (using config_required_network)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-requiredNetwork"
+  description = "Required network policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "requiredNetwork"
+  }
+  
+  config_required_network = {
+    required_networks = [1, 2]
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-requiredNetwork"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "requiredNetwork"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_required_network.required_networks.#", "2"),
+				),
+			},
+			// Step 24: Cluster Resource Name (using config_server_naming)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-serverNaming"
+  description = "Server naming policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "serverNaming"
+  }
+  
+  config_server_naming = {
+    server_naming_type = "user"
+    server_naming_pattern = "server-$$$${sequence}"
+    server_naming_conflict = true
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-serverNaming"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "serverNaming"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_server_naming.server_naming_type", "user"),
+				),
+			},
+			// Step 25: Shutdown (using config_shutdown)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-shutdown"
+  description = "Shutdown policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "shutdown"
+  }
+  
+  config_shutdown = {
+    shutdown_type = "fixed"
+    shutdown_age = "30"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-shutdown"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "shutdown"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_shutdown.shutdown_age", "30"),
+				),
+			},
+			// Step 26: Storage Server Storage Quota (using config_storage_server_quota)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-storageServerQuota"
+  description = "Storage server quota policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "storageServerQuota"
+  }
+  
+  config_storage_server_quota = {
+    storage_server_id = "1"
+    max_storage = "10737418240"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-storageServerQuota"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "storageServerQuota"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_storage_server_quota.storage_server_id", "1"),
+				),
+			},
+			// Step 27: Tags (using config_tags)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-tags"
+  description = "Tags policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "tags"
+  }
+  
+  config_tags = {
+    strict = true
+    key = "environment"
+    value = "production"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-tags"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "tags"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_tags.key", "environment"),
+				),
+			},
+			// Step 28: User Creation (using config_create_user)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-createUser"
+  description = "Create user policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "createUser"
+  }
+  
+  config_create_user = {
+    create_user_type = "fixed"
+    create_user = true
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-createUser"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "createUser"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_create_user.create_user", "true"),
+				),
+			},
+			// Step 29: User Group Creation (using config_create_user_group)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-createUserGroup"
+  description = "Create user group policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "createUserGroup"
+  }
+  
+  config_create_user_group = {
+    user_group = "1"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-createUserGroup"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "createUserGroup"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_create_user_group.user_group", "1"),
+				),
+			},
+			// Step 30: Workflow (using config_workflow)
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-workflow"
+  description = "Workflow policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "workflow"
+  }
+  
+  config_workflow = {
+    workflow_id = data.morpheus_workflow.test.id
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-workflow"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "workflow"),
+					resource.TestCheckResourceAttrSet("hpe_morpheus_policy.test", "config_workflow.workflow_id"),
+				),
+			},
+		},
+	})
+}
+
+// Test lifecycle policy using static schema
+func TestAccMorpheusPolicyLifecycleStaticSchemaOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockMixed()
+	namePrefix := acctest.RandomWithPrefix(t.Name())
+	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+
+	dependencyConfig := `
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-lifecycle"
+  description = "Lifecycle policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "lifecycle"
+  }
+  
+  config_lifecycle = {
+    lifecycle_type = "fixed"
+    lifecycle_age = "30"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-lifecycle"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "lifecycle"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_lifecycle.lifecycle_age", "30"),
+				),
+			},
+		},
+	})
+}
+
+// Test MOTD policy using static schema
+func TestAccMorpheusPolicyMotdStaticSchemaOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockMixed()
+	namePrefix := acctest.RandomWithPrefix(t.Name())
+	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+
+	dependencyConfig := `
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-motd"
+  description = "MOTD policy using static schema"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "motd"
+  }
+  
+  config_motd = {
+    motdtitle = "Welcome"
+    motdmessage = "Welcome to the system"
+    motdtype = "text"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-motd"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "motd"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_motd.motdtitle", "Welcome"),
+				),
+			},
+		},
+	})
+}
+
+// Test shutdown policy using static schema with full config
+func TestAccMorpheusPolicyShutdownStaticSchemaOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockMixed()
+	namePrefix := acctest.RandomWithPrefix(t.Name())
+	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+
+	dependencyConfig := `
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + dependencyConfig + `
+resource "hpe_morpheus_policy" "test" {
+  name = "` + namePrefix + `-shutdown"
+  description = "Shutdown policy using static schema with full config"
+  associated_resource_type = "Group"
+  associated_resource_id = hpe_morpheus_group.test.id
+  enabled = true
+  
+  policy_type = {
+    code = "shutdown"
+  }
+  
+  config_shutdown = {
+    shutdown_type = "user"
+    shutdown_age = "30"
+    shutdown_renewal = "5"
+    shutdown_notify = "7"
+    shutdown_message = "Instance will shutdown"
+    shutdown_allow_extend = true
+    shutdown_auto_renew = false
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-shutdown"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "shutdown"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_shutdown.shutdown_age", "30"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_shutdown.shutdown_allow_extend", "true"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_shutdown.shutdown_auto_renew", "false"),
+				),
+			},
+		},
+	})
+}

--- a/internal/framework/subproviders/morpheus/resources/policy/read.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/read.go
@@ -75,7 +75,7 @@ func getPolicyAsState(
 		// Convert API type to user-facing resource type
 		state.AssociatedResourceType = types.StringValue(apiTypeToResourceType(apiType))
 	} else {
-		state.AssociatedResourceType = types.StringValue("Global")
+		state.AssociatedResourceType = types.StringValue(AssociatedResourceTypeGlobal)
 	}
 
 	// Set Tenant IDs

--- a/internal/framework/subproviders/morpheus/resources/policy/read.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/read.go
@@ -17,6 +17,647 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
 )
 
+// mapPolicyConfigToState maps the API config structure to the resource schema structure
+func mapPolicyConfigToState(
+	ctx context.Context,
+	state *PolicyModel,
+	apiConfig *sdk.AddPolicies200ResponseAllOfPolicyConfig,
+) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	// Map each API config field to the corresponding schema field - only populate non-null configurations
+	// 1. ApprovePolicyTypeConfiguration -> config_approval
+	if apiConfig.ApprovePolicyTypeConfiguration != nil {
+		approvalValue, approvalDiags := NewConfigApprovalValue(
+			ConfigApprovalValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"account_integration_id": convert.StrToType(&apiConfig.ApprovePolicyTypeConfiguration.AccountIntegrationId),
+				"flow_id":                convert.StrToType(apiConfig.ApprovePolicyTypeConfiguration.FlowId),
+				"workflow_id":            convert.StrToType(apiConfig.ApprovePolicyTypeConfiguration.WorkflowId),
+				"workflow_type":          convert.StrToType(apiConfig.ApprovePolicyTypeConfiguration.WorkflowType),
+			},
+		)
+		if approvalDiags.HasError() {
+			diags.Append(approvalDiags...)
+		} else {
+			state.ConfigApproval = approvalValue
+		}
+	}
+
+	// 2. BackupTargetsPolicyTypeConfiguration -> config_backup_storage
+	if apiConfig.BackupTargetsPolicyTypeConfiguration != nil {
+		// Handle BackupStorageIds as a set of int64
+		var backupStorageIDsSet types.Set
+		var setDiags diag.Diagnostics
+		if len(apiConfig.BackupTargetsPolicyTypeConfiguration.BackupStorageIds) == 0 {
+			backupStorageIDsSet = types.SetValueMust(types.Int64Type, []attr.Value{})
+		} else {
+			// BackupStorageIds come from API as []string, convert to []int64
+			backupStorageIDsSet, setDiags = types.SetValueFrom(ctx, types.Int64Type, apiConfig.BackupTargetsPolicyTypeConfiguration.BackupStorageIds)
+			if setDiags.HasError() {
+				diags.Append(setDiags...)
+			}
+		}
+
+		backupStorageAttrs := map[string]attr.Value{
+			"backup_storage_ids": backupStorageIDsSet,
+		}
+
+		backupStorageValue, backupStorageDiags := NewConfigBackupStorageValue(
+			ConfigBackupStorageValue{}.AttributeTypes(ctx),
+			backupStorageAttrs,
+		)
+		if backupStorageDiags.HasError() {
+			diags.Append(backupStorageDiags...)
+		} else {
+			state.ConfigBackupStorage = backupStorageValue
+		}
+	}
+
+	// 3. BackupCreationPolicyTypeConfiguration -> config_create_backup
+	if apiConfig.BackupCreationPolicyTypeConfiguration != nil {
+		createBackupValue, createBackupDiags := NewConfigCreateBackupValue(
+			ConfigCreateBackupValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"create_backup":      convert.BoolToType(apiConfig.BackupCreationPolicyTypeConfiguration.CreateBackup),
+				"create_backup_type": convert.StrToType(&apiConfig.BackupCreationPolicyTypeConfiguration.CreateBackupType),
+			},
+		)
+		if createBackupDiags.HasError() {
+			diags.Append(createBackupDiags...)
+		} else {
+			state.ConfigCreateBackup = createBackupValue
+		}
+	}
+
+	// 4. UserCreationPolicyTypeConfiguration -> config_create_user
+	if apiConfig.UserCreationPolicyTypeConfiguration != nil {
+		createUserValue, createUserDiags := NewConfigCreateUserValue(
+			ConfigCreateUserValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"create_user":      convert.BoolToType(apiConfig.UserCreationPolicyTypeConfiguration.CreateUser),
+				"create_user_type": convert.StrToType(&apiConfig.UserCreationPolicyTypeConfiguration.CreateUserType),
+			},
+		)
+		if createUserDiags.HasError() {
+			diags.Append(createUserDiags...)
+		} else {
+			state.ConfigCreateUser = createUserValue
+		}
+	}
+
+	// 5. UserGroupCreationPolicyTypeConfiguration -> config_create_user_group
+	if apiConfig.UserGroupCreationPolicyTypeConfiguration != nil {
+		createUserGroupValue, createUserGroupDiags := NewConfigCreateUserGroupValue(
+			ConfigCreateUserGroupValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"user_group": convert.StrToType(&apiConfig.UserGroupCreationPolicyTypeConfiguration.UserGroup),
+			},
+		)
+		if createUserGroupDiags.HasError() {
+			diags.Append(createUserGroupDiags...)
+		} else {
+			state.ConfigCreateUserGroup = createUserGroupValue
+		}
+	}
+
+	// 6. CypherAccessPolicyTypeConfiguration -> config_cypher
+	if apiConfig.CypherAccessPolicyTypeConfiguration != nil {
+		cypherValue, cypherDiags := NewConfigCypherValue(
+			ConfigCypherValue{}.AttributeTypes(ctx),
+			map[string]attr.Value{
+				"delete":      convert.BoolToType(apiConfig.CypherAccessPolicyTypeConfiguration.Delete),
+				"key_pattern": convert.StrToType(&apiConfig.CypherAccessPolicyTypeConfiguration.KeyPattern),
+				"list":        convert.BoolToType(apiConfig.CypherAccessPolicyTypeConfiguration.List),
+				"read":        convert.BoolToType(apiConfig.CypherAccessPolicyTypeConfiguration.Read),
+				"update":      convert.BoolToType(apiConfig.CypherAccessPolicyTypeConfiguration.Update),
+				"write":       convert.BoolToType(apiConfig.CypherAccessPolicyTypeConfiguration.Write),
+			},
+		)
+		if cypherDiags.HasError() {
+			diags.Append(cypherDiags...)
+		} else {
+			state.ConfigCypher = cypherValue
+		}
+	}
+
+	// 7. BudgetPolicyTypeConfiguration -> config_max_price
+	if apiConfig.BudgetPolicyTypeConfiguration != nil {
+		maxPriceAttrs := map[string]attr.Value{
+			"max_price":          convert.StrToNumber(&apiConfig.BudgetPolicyTypeConfiguration.MaxPrice),
+			"max_price_currency": convert.StrToType(apiConfig.BudgetPolicyTypeConfiguration.MaxPriceCurrency),
+			"max_price_unit":     convert.StrToType(apiConfig.BudgetPolicyTypeConfiguration.MaxPriceUnit),
+		}
+
+		maxPriceValue, maxPriceDiags := NewConfigMaxPriceValue(ConfigMaxPriceValue{}.AttributeTypes(ctx), maxPriceAttrs)
+		if maxPriceDiags.HasError() {
+			diags.Append(maxPriceDiags...)
+		} else {
+			state.ConfigMaxPrice = maxPriceValue
+		}
+	}
+
+	// 8. MaxMemoryPolicyTypeConfiguration -> config_max_memory
+	if apiConfig.MaxMemoryPolicyTypeConfiguration != nil {
+		maxMemoryAttrs := map[string]attr.Value{
+			"max_memory":         convert.StrToType(&apiConfig.MaxMemoryPolicyTypeConfiguration.MaxMemory),
+			"exclude_containers": convert.StringToBool(ctx, apiConfig.MaxMemoryPolicyTypeConfiguration.GetExcludeContainers()),
+		}
+
+		maxMemoryValue, maxMemoryDiags := NewConfigMaxMemoryValue(ConfigMaxMemoryValue{}.AttributeTypes(ctx), maxMemoryAttrs)
+		if maxMemoryDiags.HasError() {
+			diags.Append(maxMemoryDiags...)
+		} else {
+			state.ConfigMaxMemory = maxMemoryValue
+		}
+	}
+
+	// 9. MaxCoresPolicyTypeConfiguration -> config_max_cores
+	if apiConfig.MaxCoresPolicyTypeConfiguration != nil {
+		maxCoresAttrs := map[string]attr.Value{
+			"max_cores":          convert.StrToType(&apiConfig.MaxCoresPolicyTypeConfiguration.MaxCores),
+			"exclude_containers": convert.StringToBool(ctx, apiConfig.MaxCoresPolicyTypeConfiguration.GetExcludeContainers()),
+		}
+
+		maxCoresValue, maxCoresDiags := NewConfigMaxCoresValue(ConfigMaxCoresValue{}.AttributeTypes(ctx), maxCoresAttrs)
+		if maxCoresDiags.HasError() {
+			diags.Append(maxCoresDiags...)
+		} else {
+			state.ConfigMaxCores = maxCoresValue
+		}
+	}
+
+	// 10. DelayedDeletePolicyTypeConfiguration -> config_delayed_removal
+	if apiConfig.DelayedDeletePolicyTypeConfiguration != nil {
+		delayedRemovalAttrs := map[string]attr.Value{
+			"removal_age": convert.StrToType(&apiConfig.DelayedDeletePolicyTypeConfiguration.RemovalAge),
+		}
+
+		delayedRemovalValue, delayedRemovalDiags := NewConfigDelayedRemovalValue(
+			ConfigDelayedRemovalValue{}.AttributeTypes(ctx),
+			delayedRemovalAttrs,
+		)
+		if delayedRemovalDiags.HasError() {
+			diags.Append(delayedRemovalDiags...)
+		} else {
+			state.ConfigDelayedRemoval = delayedRemovalValue
+		}
+	}
+
+	// 11. ExpirationPolicyTypeConfiguration2 -> config_lifecycle
+	if apiConfig.ExpirationPolicyTypeConfiguration2 != nil {
+		lifecycleAttrs := map[string]attr.Value{
+			"account_integration_id": convert.StrToType(
+				apiConfig.ExpirationPolicyTypeConfiguration2.AccountIntegrationId,
+			),
+			"flow_id":       convert.StrToType(apiConfig.ExpirationPolicyTypeConfiguration2.FlowId),
+			"lifecycle_age": convert.StrToType(apiConfig.ExpirationPolicyTypeConfiguration2.LifecycleAge),
+			"lifecycle_allow_extend": convert.StringToBool(
+				ctx,
+				apiConfig.ExpirationPolicyTypeConfiguration2.GetLifecycleAllowExtend(),
+			),
+			"lifecycle_auto_renew": convert.StringToBool(
+				ctx,
+				apiConfig.ExpirationPolicyTypeConfiguration2.GetLifecycleAutoRenew(),
+			),
+			"lifecycle_extensions_before_approval": convert.StrToType(
+				apiConfig.ExpirationPolicyTypeConfiguration2.LifecycleExtensionsBeforeApproval,
+			),
+			"lifecycle_hide_fixed": convert.BoolToType(
+				apiConfig.ExpirationPolicyTypeConfiguration2.LifecycleHideFixed,
+			),
+			"lifecycle_message": convert.StrToType(
+				apiConfig.ExpirationPolicyTypeConfiguration2.LifecycleMessage,
+			),
+			"lifecycle_notify": convert.StrToType(
+				apiConfig.ExpirationPolicyTypeConfiguration2.LifecycleNotify,
+			),
+			"lifecycle_renewal": convert.StrToType(
+				apiConfig.ExpirationPolicyTypeConfiguration2.LifecycleRenewal,
+			),
+			"lifecycle_type": convert.StrToType(
+				&apiConfig.ExpirationPolicyTypeConfiguration2.LifecycleType,
+			),
+			"lifecycle_workflow_id": convert.StrToType(
+				apiConfig.ExpirationPolicyTypeConfiguration2.LifecycleWorkflowId,
+			),
+			"workflow_type": convert.StrToType(apiConfig.ExpirationPolicyTypeConfiguration2.WorkflowType),
+		}
+
+		lifecycleValue, lifecycleDiags := NewConfigLifecycleValue(ConfigLifecycleValue{}.AttributeTypes(ctx), lifecycleAttrs)
+		if lifecycleDiags.HasError() {
+			diags.Append(lifecycleDiags...)
+		} else {
+			state.ConfigLifecycle = lifecycleValue
+		}
+	}
+
+	// 12. HostnamePolicyTypeConfiguration -> config_host_naming
+	if apiConfig.HostnamePolicyTypeConfiguration != nil {
+		hostNamingAttrs := map[string]attr.Value{
+			"host_naming_pattern": convert.StrToType(apiConfig.HostnamePolicyTypeConfiguration.HostNamingPattern),
+			"host_naming_type":    convert.StrToType(&apiConfig.HostnamePolicyTypeConfiguration.HostNamingType),
+		}
+
+		hostNamingValue, hostNamingDiags := NewConfigHostNamingValue(
+			ConfigHostNamingValue{}.AttributeTypes(ctx),
+			hostNamingAttrs,
+		)
+		if hostNamingDiags.HasError() {
+			diags.Append(hostNamingDiags...)
+		} else {
+			state.ConfigHostNaming = hostNamingValue
+		}
+	}
+
+	// 13. InstanceNamePolicyTypeConfiguration -> config_naming
+	if apiConfig.InstanceNamePolicyTypeConfiguration != nil {
+		namingAttrs := map[string]attr.Value{
+			"naming_conflict": convert.BoolToType(apiConfig.InstanceNamePolicyTypeConfiguration.NamingConflict),
+			"naming_pattern":  convert.StrToType(apiConfig.InstanceNamePolicyTypeConfiguration.NamingPattern),
+			"naming_type":     convert.StrToType(&apiConfig.InstanceNamePolicyTypeConfiguration.NamingType),
+		}
+
+		namingValue, namingDiags := NewConfigNamingValue(ConfigNamingValue{}.AttributeTypes(ctx), namingAttrs)
+		if namingDiags.HasError() {
+			diags.Append(namingDiags...)
+		} else {
+			state.ConfigNaming = namingValue
+		}
+	}
+
+	// 14. MaxContainersPolicyTypeConfiguration -> config_max_containers
+	if apiConfig.MaxContainersPolicyTypeConfiguration != nil {
+		maxContainersAttrs := map[string]attr.Value{
+			"max_containers": convert.StrToType(&apiConfig.MaxContainersPolicyTypeConfiguration.MaxContainers),
+		}
+
+		maxContainersValue, maxContainersDiags := NewConfigMaxContainersValue(
+			ConfigMaxContainersValue{}.AttributeTypes(ctx),
+			maxContainersAttrs,
+		)
+		if maxContainersDiags.HasError() {
+			diags.Append(maxContainersDiags...)
+		} else {
+			state.ConfigMaxContainers = maxContainersValue
+		}
+	}
+
+	// 15. MaxHostsPolicyTypeConfiguration -> config_max_hosts
+	if apiConfig.MaxHostsPolicyTypeConfiguration != nil {
+		maxHostsAttrs := map[string]attr.Value{
+			"max_hosts": convert.StrToType(&apiConfig.MaxHostsPolicyTypeConfiguration.MaxHosts),
+		}
+
+		maxHostsValue, maxHostsDiags := NewConfigMaxHostsValue(ConfigMaxHostsValue{}.AttributeTypes(ctx), maxHostsAttrs)
+		if maxHostsDiags.HasError() {
+			diags.Append(maxHostsDiags...)
+		} else {
+			state.ConfigMaxHosts = maxHostsValue
+		}
+	}
+
+	// 16. NetworkQuotaPolicyTypeConfiguration -> config_max_networks
+	if apiConfig.NetworkQuotaPolicyTypeConfiguration != nil {
+		maxNetworksAttrs := map[string]attr.Value{
+			"max_networks": convert.StrToType(&apiConfig.NetworkQuotaPolicyTypeConfiguration.MaxNetworks),
+		}
+
+		maxNetworksValue, maxNetworksDiags := NewConfigMaxNetworksValue(
+			ConfigMaxNetworksValue{}.AttributeTypes(ctx),
+			maxNetworksAttrs,
+		)
+		if maxNetworksDiags.HasError() {
+			diags.Append(maxNetworksDiags...)
+		} else {
+			state.ConfigMaxNetworks = maxNetworksValue
+		}
+	}
+
+	// 17. MaxPoolMembersPolicyTypeConfiguration -> config_max_pool_members
+	if apiConfig.MaxPoolMembersPolicyTypeConfiguration != nil {
+		maxPoolMembersAttrs := map[string]attr.Value{
+			"max_pool_members": convert.StrToType(&apiConfig.MaxPoolMembersPolicyTypeConfiguration.MaxPoolMembers),
+		}
+
+		maxPoolMembersValue, maxPoolMembersDiags := NewConfigMaxPoolMembersValue(
+			ConfigMaxPoolMembersValue{}.AttributeTypes(ctx),
+			maxPoolMembersAttrs,
+		)
+		if maxPoolMembersDiags.HasError() {
+			diags.Append(maxPoolMembersDiags...)
+		} else {
+			state.ConfigMaxPoolMembers = maxPoolMembersValue
+		}
+	}
+
+	// 18. MaxLoadBalancerPoolsPolicyTypeConfiguration -> config_max_pools
+	if apiConfig.MaxLoadBalancerPoolsPolicyTypeConfiguration != nil {
+		maxPoolsAttrs := map[string]attr.Value{
+			"max_pools": convert.StrToType(&apiConfig.MaxLoadBalancerPoolsPolicyTypeConfiguration.MaxPools),
+		}
+
+		maxPoolsValue, maxPoolsDiags := NewConfigMaxPoolsValue(ConfigMaxPoolsValue{}.AttributeTypes(ctx), maxPoolsAttrs)
+		if maxPoolsDiags.HasError() {
+			diags.Append(maxPoolsDiags...)
+		} else {
+			state.ConfigMaxPools = maxPoolsValue
+		}
+	}
+
+	// 19. RouterQuotaPolicyTypeConfiguration -> config_max_routers
+	if apiConfig.RouterQuotaPolicyTypeConfiguration != nil {
+		maxRoutersAttrs := map[string]attr.Value{
+			"max_routers": convert.StrToType(&apiConfig.RouterQuotaPolicyTypeConfiguration.MaxRouters),
+		}
+
+		maxRoutersValue, maxRoutersDiags := NewConfigMaxRoutersValue(
+			ConfigMaxRoutersValue{}.AttributeTypes(ctx),
+			maxRoutersAttrs,
+		)
+		if maxRoutersDiags.HasError() {
+			diags.Append(maxRoutersDiags...)
+		} else {
+			state.ConfigMaxRouters = maxRoutersValue
+		}
+	}
+
+	// 20. MaxSnapshotsPolicyTypeConfiguration -> config_max_snapshots
+	if apiConfig.MaxSnapshotsPolicyTypeConfiguration != nil {
+		maxSnapshotsAttrs := map[string]attr.Value{
+			"max_snapshots": convert.StrToType(&apiConfig.MaxSnapshotsPolicyTypeConfiguration.MaxSnapshots),
+		}
+
+		maxSnapshotsValue, maxSnapshotsDiags := NewConfigMaxSnapshotsValue(
+			ConfigMaxSnapshotsValue{}.AttributeTypes(ctx),
+			maxSnapshotsAttrs,
+		)
+		if maxSnapshotsDiags.HasError() {
+			diags.Append(maxSnapshotsDiags...)
+		} else {
+			state.ConfigMaxSnapshots = maxSnapshotsValue
+		}
+	}
+
+	// 21. MaxStorageAndObjectStorageQuotaPolicyTypeConfiguration -> config_max_storage
+	if apiConfig.MaxStorageAndObjectStorageQuotaPolicyTypeConfiguration != nil {
+		maxStorageAttrs := map[string]attr.Value{
+			"exclude_containers": convert.StringToBool(
+				ctx,
+				apiConfig.MaxStorageAndObjectStorageQuotaPolicyTypeConfiguration.GetExcludeContainers(),
+			),
+			"max_storage": convert.StrToType(
+				&apiConfig.MaxStorageAndObjectStorageQuotaPolicyTypeConfiguration.MaxStorage,
+			),
+		}
+
+		maxStorageValue, maxStorageDiags := NewConfigMaxStorageValue(
+			ConfigMaxStorageValue{}.AttributeTypes(ctx),
+			maxStorageAttrs,
+		)
+		if maxStorageDiags.HasError() {
+			diags.Append(maxStorageDiags...)
+		} else {
+			state.ConfigMaxStorage = maxStorageValue
+		}
+	}
+
+	// 22. MaxVirtualServersPolicyTypeConfiguration -> config_max_virtual_servers
+	if apiConfig.MaxVirtualServersPolicyTypeConfiguration != nil {
+		maxVirtualServersAttrs := map[string]attr.Value{
+			"max_virtual_servers": convert.StrToType(&apiConfig.MaxVirtualServersPolicyTypeConfiguration.MaxVirtualServers),
+		}
+
+		maxVirtualServersValue, maxVirtualServersDiags := NewConfigMaxVirtualServersValue(
+			ConfigMaxVirtualServersValue{}.AttributeTypes(ctx),
+			maxVirtualServersAttrs,
+		)
+		if maxVirtualServersDiags.HasError() {
+			diags.Append(maxVirtualServersDiags...)
+		} else {
+			state.ConfigMaxVirtualServers = maxVirtualServersValue
+		}
+	}
+
+	// 23. MaxVMsPolicyTypeConfiguration -> config_max_vms
+	if apiConfig.MaxVMsPolicyTypeConfiguration != nil {
+		maxVmsAttrs := map[string]attr.Value{
+			"max_vms": convert.StrToType(&apiConfig.MaxVMsPolicyTypeConfiguration.MaxVms),
+		}
+
+		maxVmsValue, maxVmsDiags := NewConfigMaxVmsValue(ConfigMaxVmsValue{}.AttributeTypes(ctx), maxVmsAttrs)
+		if maxVmsDiags.HasError() {
+			diags.Append(maxVmsDiags...)
+		} else {
+			state.ConfigMaxVms = maxVmsValue
+		}
+	}
+
+	// 24. MessageOfTheDayPolicyTypeConfiguration2 -> config_motd
+	if apiConfig.MessageOfTheDayPolicyTypeConfiguration2 != nil {
+		motdAttrs := map[string]attr.Value{
+			"motddate":    convert.StrToType(apiConfig.MessageOfTheDayPolicyTypeConfiguration2.MotdDate),
+			"motdmessage": convert.StrToType(apiConfig.MessageOfTheDayPolicyTypeConfiguration2.MotdMessage),
+			"motdtitle":   types.StringNull(),
+			"motdtype":    convert.StrToType(apiConfig.MessageOfTheDayPolicyTypeConfiguration2.MotdType),
+		}
+
+		// Handle NullableString for MotdTitle
+		if apiConfig.MessageOfTheDayPolicyTypeConfiguration2.MotdTitle.IsSet() {
+			motdAttrs["motdtitle"] = types.StringValue(*apiConfig.MessageOfTheDayPolicyTypeConfiguration2.MotdTitle.Get())
+		}
+
+		motdValue, motdDiags := NewConfigMotdValue(ConfigMotdValue{}.AttributeTypes(ctx), motdAttrs)
+		if motdDiags.HasError() {
+			diags.Append(motdDiags...)
+		} else {
+			state.ConfigMotd = motdValue
+		}
+	}
+
+	// 25. PowerSchedulePolicyTypeConfiguration -> config_power_schedule
+	if apiConfig.PowerSchedulePolicyTypeConfiguration != nil {
+		powerScheduleAttrs := map[string]attr.Value{
+			"power_schedule": convert.StrToType(
+				apiConfig.PowerSchedulePolicyTypeConfiguration.PowerSchedule,
+			),
+			"power_schedule_hide_fixed": convert.BoolToType(
+				apiConfig.PowerSchedulePolicyTypeConfiguration.PowerScheduleHideFixed,
+			),
+			"power_schedule_type": convert.StrToType(
+				&apiConfig.PowerSchedulePolicyTypeConfiguration.PowerScheduleType,
+			),
+		}
+
+		powerScheduleValue, powerScheduleDiags := NewConfigPowerScheduleValue(
+			ConfigPowerScheduleValue{}.AttributeTypes(ctx),
+			powerScheduleAttrs,
+		)
+		if powerScheduleDiags.HasError() {
+			diags.Append(powerScheduleDiags...)
+		} else {
+			state.ConfigPowerSchedule = powerScheduleValue
+		}
+	}
+
+	// 26. RequiredNetworkPolicyTypeConfiguration -> config_required_network
+	if apiConfig.RequiredNetworkPolicyTypeConfiguration != nil {
+		// Handle RequiredNetworks as a set of integers
+		var requiredNetworksSet types.Set
+		if len(apiConfig.RequiredNetworkPolicyTypeConfiguration.RequiredNetworks) == 0 {
+			requiredNetworksSet = types.SetValueMust(types.Int64Type, []attr.Value{})
+		} else {
+			int64Values := make([]attr.Value, len(apiConfig.RequiredNetworkPolicyTypeConfiguration.RequiredNetworks))
+			for i, networkID := range apiConfig.RequiredNetworkPolicyTypeConfiguration.RequiredNetworks {
+				int64Values[i] = types.Int64Value(networkID)
+			}
+			var setDiags diag.Diagnostics
+			requiredNetworksSet, setDiags = types.SetValueFrom(ctx, types.Int64Type, int64Values)
+			if setDiags.HasError() {
+				diags.Append(setDiags...)
+			}
+		}
+
+		requiredNetworkAttrs := map[string]attr.Value{
+			"required_networks": requiredNetworksSet,
+		}
+
+		requiredNetworkValue, requiredNetworkDiags := NewConfigRequiredNetworkValue(
+			ConfigRequiredNetworkValue{}.AttributeTypes(ctx),
+			requiredNetworkAttrs,
+		)
+		if requiredNetworkDiags.HasError() {
+			diags.Append(requiredNetworkDiags...)
+		} else {
+			state.ConfigRequiredNetwork = requiredNetworkValue
+		}
+	}
+
+	// 27. ClusterResourceNamePolicyTypeConfiguration -> config_server_naming
+	if apiConfig.ClusterResourceNamePolicyTypeConfiguration != nil {
+		serverNamingAttrs := map[string]attr.Value{
+			"server_naming_conflict": convert.BoolToType(
+				apiConfig.ClusterResourceNamePolicyTypeConfiguration.ServerNamingConflict,
+			),
+			"server_naming_pattern": convert.StrToType(
+				apiConfig.ClusterResourceNamePolicyTypeConfiguration.ServerNamingPattern,
+			),
+			"server_naming_type": convert.StrToType(
+				&apiConfig.ClusterResourceNamePolicyTypeConfiguration.ServerNamingType,
+			),
+		}
+
+		serverNamingValue, serverNamingDiags := NewConfigServerNamingValue(
+			ConfigServerNamingValue{}.AttributeTypes(ctx),
+			serverNamingAttrs,
+		)
+		if serverNamingDiags.HasError() {
+			diags.Append(serverNamingDiags...)
+		} else {
+			state.ConfigServerNaming = serverNamingValue
+		}
+	}
+
+	// 28. ShutdownPolicyTypeConfiguration -> config_shutdown
+	if apiConfig.ShutdownPolicyTypeConfiguration != nil {
+		shutdownAttrs := map[string]attr.Value{
+			"account_integration_id": convert.StrToType(
+				apiConfig.ShutdownPolicyTypeConfiguration.AccountIntegrationId,
+			),
+			"flow_id":      convert.StrToType(apiConfig.ShutdownPolicyTypeConfiguration.FlowId),
+			"shutdown_age": convert.StrToType(apiConfig.ShutdownPolicyTypeConfiguration.ShutdownAge),
+			"shutdown_allow_extend": convert.StringToBool(
+				ctx,
+				apiConfig.ShutdownPolicyTypeConfiguration.GetShutdownAllowExtend(),
+			),
+			"shutdown_auto_renew": convert.StringToBool(
+				ctx,
+				apiConfig.ShutdownPolicyTypeConfiguration.GetShutdownAutoRenew(),
+			),
+			"shutdown_extensions_before_approval": convert.StrToType(
+				apiConfig.ShutdownPolicyTypeConfiguration.ShutdownExtensionsBeforeApproval,
+			),
+			"shutdown_hide_fixed": convert.BoolToType(
+				apiConfig.ShutdownPolicyTypeConfiguration.ShutdownHideFixed,
+			),
+			"shutdown_message": convert.StrToType(
+				apiConfig.ShutdownPolicyTypeConfiguration.ShutdownMessage,
+			),
+			"shutdown_notify": convert.StrToType(
+				apiConfig.ShutdownPolicyTypeConfiguration.ShutdownNotify,
+			),
+			"shutdown_renewal": convert.StrToType(
+				apiConfig.ShutdownPolicyTypeConfiguration.ShutdownRenewal,
+			),
+			"shutdown_type": convert.StrToType(
+				&apiConfig.ShutdownPolicyTypeConfiguration.ShutdownType,
+			),
+			"shutdown_workflow_id": convert.StrToType(
+				apiConfig.ShutdownPolicyTypeConfiguration.ShutdownWorkflowId,
+			),
+			"workflow_type": convert.StrToType(apiConfig.ShutdownPolicyTypeConfiguration.WorkflowType),
+		}
+
+		shutdownValue, shutdownDiags := NewConfigShutdownValue(ConfigShutdownValue{}.AttributeTypes(ctx), shutdownAttrs)
+		if shutdownDiags.HasError() {
+			diags.Append(shutdownDiags...)
+		} else {
+			state.ConfigShutdown = shutdownValue
+		}
+	}
+
+	// 29. StorageServerStorageQuotaPolicyTypeConfiguration -> config_storage_server_quota
+	if apiConfig.StorageServerStorageQuotaPolicyTypeConfiguration != nil {
+		storageServerQuotaAttrs := map[string]attr.Value{
+			"max_storage":       convert.StrToType(apiConfig.StorageServerStorageQuotaPolicyTypeConfiguration.MaxStorage),
+			"storage_server_id": convert.StrToType(&apiConfig.StorageServerStorageQuotaPolicyTypeConfiguration.StorageServerId),
+		}
+
+		storageServerQuotaValue, storageServerQuotaDiags := NewConfigStorageServerQuotaValue(
+			ConfigStorageServerQuotaValue{}.AttributeTypes(ctx),
+			storageServerQuotaAttrs,
+		)
+		if storageServerQuotaDiags.HasError() {
+			diags.Append(storageServerQuotaDiags...)
+		} else {
+			state.ConfigStorageServerQuota = storageServerQuotaValue
+		}
+	}
+
+	// 30. TagsPolicyTypeConfiguration -> config_tags
+	if apiConfig.TagsPolicyTypeConfiguration != nil {
+		tagsAttrs := map[string]attr.Value{
+			"key":           convert.StrToType(apiConfig.TagsPolicyTypeConfiguration.Key),
+			"strict":        types.BoolValue(apiConfig.TagsPolicyTypeConfiguration.Strict),
+			"value":         convert.StrToType(apiConfig.TagsPolicyTypeConfiguration.Value),
+			"value_list_id": convert.StrToType(apiConfig.TagsPolicyTypeConfiguration.ValueListId),
+		}
+
+		tagsValue, tagsDiags := NewConfigTagsValue(ConfigTagsValue{}.AttributeTypes(ctx), tagsAttrs)
+		if tagsDiags.HasError() {
+			diags.Append(tagsDiags...)
+		} else {
+			state.ConfigTags = tagsValue
+		}
+	}
+
+	// 31. WorkflowPolicyTypeConfiguration -> config_workflow
+	if apiConfig.WorkflowPolicyTypeConfiguration != nil {
+		workflowAttrs := map[string]attr.Value{
+			"workflow_id": convert.StrToType(&apiConfig.WorkflowPolicyTypeConfiguration.WorkflowId),
+		}
+
+		workflowValue, workflowDiags := NewConfigWorkflowValue(ConfigWorkflowValue{}.AttributeTypes(ctx), workflowAttrs)
+		if workflowDiags.HasError() {
+			diags.Append(workflowDiags...)
+		} else {
+			state.ConfigWorkflow = workflowValue
+		}
+	}
+
+	return diags
+}
+
 // populate policy resource model with current API values
 func getPolicyAsState(
 	ctx context.Context,
@@ -127,22 +768,64 @@ func getPolicyAsState(
 		state.PolicyType = policyTypeValue
 	}
 
-	// Handle Config - preserve from plan or convert from API
-	state.Config = types.DynamicNull()
+	// Initialize all config_* fields to null by default
+	state.ConfigApproval = NewConfigApprovalValueNull()
+	state.ConfigBackupStorage = NewConfigBackupStorageValueNull()
+	state.ConfigCreateBackup = NewConfigCreateBackupValueNull()
+	state.ConfigCreateUser = NewConfigCreateUserValueNull()
+	state.ConfigCreateUserGroup = NewConfigCreateUserGroupValueNull()
+	state.ConfigCypher = NewConfigCypherValueNull()
+	state.ConfigDelayedRemoval = NewConfigDelayedRemovalValueNull()
+	state.ConfigHostNaming = NewConfigHostNamingValueNull()
+	state.ConfigLifecycle = NewConfigLifecycleValueNull()
+	state.ConfigMaxContainers = NewConfigMaxContainersValueNull()
+	state.ConfigMaxCores = NewConfigMaxCoresValueNull()
+	state.ConfigMaxHosts = NewConfigMaxHostsValueNull()
+	state.ConfigMaxMemory = NewConfigMaxMemoryValueNull()
+	state.ConfigMaxNetworks = NewConfigMaxNetworksValueNull()
+	state.ConfigMaxPoolMembers = NewConfigMaxPoolMembersValueNull()
+	state.ConfigMaxPools = NewConfigMaxPoolsValueNull()
+	state.ConfigMaxPrice = NewConfigMaxPriceValueNull()
+	state.ConfigMaxRouters = NewConfigMaxRoutersValueNull()
+	state.ConfigMaxSnapshots = NewConfigMaxSnapshotsValueNull()
+	state.ConfigMaxStorage = NewConfigMaxStorageValueNull()
+	state.ConfigMaxVirtualServers = NewConfigMaxVirtualServersValueNull()
+	state.ConfigMaxVms = NewConfigMaxVmsValueNull()
+	state.ConfigMotd = NewConfigMotdValueNull()
+	state.ConfigNaming = NewConfigNamingValueNull()
+	state.ConfigPowerSchedule = NewConfigPowerScheduleValueNull()
+	state.ConfigRequiredNetwork = NewConfigRequiredNetworkValueNull()
+	state.ConfigServerNaming = NewConfigServerNamingValueNull()
+	state.ConfigShutdown = NewConfigShutdownValueNull()
+	state.ConfigStorageServerQuota = NewConfigStorageServerQuotaValueNull()
+	state.ConfigTags = NewConfigTagsValueNull()
+	state.ConfigWorkflow = NewConfigWorkflowValueNull()
 
-	if plan != nil && !plan.Config.IsNull() && !plan.Config.IsUnknown() {
-		state.Config = plan.Config
-	} else if p.Config != nil {
-		// Convert API config to dynamic type
-		var err error
-		state.Config, err = convert.StructToDynamic(ctx, p.Config)
-		if err != nil {
-			diags.AddError(
-				"populate policy resource",
-				fmt.Sprintf("policy %d: failed to convert config: %s", id, err.Error()),
-			)
+	// Handle Config - use static schema fields when available, fallback to dynamic
+	if p.Config != nil {
+		// Map API config to static schema fields
+		configDiags := mapPolicyConfigToState(ctx, &state, p.Config)
+		if configDiags.HasError() {
+			diags.Append(configDiags...)
 
 			return state, diags
+		}
+
+		// Also preserve the dynamic config field if it was set in plan
+		if plan != nil && !plan.Config.IsNull() && !plan.Config.IsUnknown() {
+			state.Config = plan.Config
+		} else {
+			// Convert API config to dynamic type as fallback
+			var err error
+			state.Config, err = convert.StructToDynamic(ctx, p.Config)
+			if err != nil {
+				diags.AddError(
+					"populate policy resource",
+					fmt.Sprintf("policy %d: failed to convert config: %s", id, err.Error()),
+				)
+
+				return state, diags
+			}
 		}
 	}
 

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -216,7 +216,16 @@ func (r *Resource) ModifyPlan(
 	}
 
 	// Validate tenants field is only set when allowOnTenant is true
-	if !plan.Tenants.IsNull() && !plan.Tenants.IsUnknown() {
+	// Only validate if tenants is explicitly set in the config (not null and not unknown)
+	// Get the config value to check if it was actually set by the user
+	var config PolicyModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only validate if tenants was explicitly set in the user's config
+	if !config.Tenants.IsNull() && !config.Tenants.IsUnknown() {
 		allowOnTenant := false
 		if allowValue, ok := matchingPolicyType["allowOnTenant"]; ok {
 			if allowBool, ok := allowValue.(bool); ok {

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -17,6 +17,7 @@ var (
 	_ resource.Resource                   = &Resource{}
 	_ resource.ResourceWithImportState    = &Resource{}
 	_ resource.ResourceWithValidateConfig = &Resource{}
+	_ resource.ResourceWithModifyPlan     = &Resource{}
 )
 
 func NewResource() resource.Resource {
@@ -120,4 +121,180 @@ func (r *Resource) ValidateConfig(
 			)
 		}
 	}
+}
+
+// ModifyPlan validates policy type compatibility during the plan phase when the provider is configured
+func (r *Resource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	// Only run validation if we have a plan (not during destroy)
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan PolicyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate policy type is compatible with the associated resource type
+	if plan.PolicyType.IsNull() || plan.PolicyType.IsUnknown() {
+		return
+	}
+
+	policyTypeCode := plan.PolicyType.Code.ValueString()
+	resourceType := plan.AssociatedResourceType.ValueString()
+
+	// Get API client - provider is configured at this point
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		// If we can't get a client, skip validation - will be caught during apply
+		return
+	}
+
+	// Fetch policy types from the API
+	policyTypesResp, httpResp, err := client.OptionsAPI.GetOptionSourceData(ctx, "policyTypes").Execute()
+	if err != nil || httpResp == nil || httpResp.StatusCode != 200 {
+		return
+	}
+
+	// Find the matching policy type
+	var matchingPolicyType map[string]interface{}
+	if policyTypesResp != nil && policyTypesResp.Data != nil {
+		for _, pt := range policyTypesResp.Data {
+			if code, ok := pt["code"].(string); ok && code == policyTypeCode {
+				matchingPolicyType = pt
+				break
+			}
+		}
+	}
+
+	if matchingPolicyType == nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("policy_type").AtName("code"),
+			"Invalid policy type",
+			fmt.Sprintf("Policy type with code '%s' not found", policyTypeCode),
+		)
+		return
+	}
+
+	// Map resource type to the corresponding "allowOn" field
+	var allowFieldName string
+	switch resourceType {
+	case "Global":
+		allowFieldName = "allowOnGlobal"
+	case "Group":
+		allowFieldName = "allowOnSite"
+	case "Cloud":
+		allowFieldName = "allowOnZone"
+	case "User":
+		allowFieldName = "allowOnUser"
+	case "Role":
+		allowFieldName = "allowOnRole"
+	case "Network":
+		allowFieldName = "allowOnNetwork"
+	case "Plan":
+		allowFieldName = "allowOnPlan"
+	case "Label":
+		allowFieldName = "allowOnLabel"
+	default:
+		// Unknown resource type - should not happen due to schema validation
+		resp.Diagnostics.AddAttributeError(
+			path.Root("associated_resource_type"),
+			"Unknown resource type",
+			fmt.Sprintf("Resource type '%s' is not recognized", resourceType),
+		)
+		return
+	}
+
+	// Check if the policy type allows this resource type
+	allowed := false
+	if allowValue, ok := matchingPolicyType[allowFieldName]; ok {
+		if allowBool, ok := allowValue.(bool); ok {
+			allowed = allowBool
+		}
+	}
+
+	// Validate tenants field is only set when allowOnTenant is true
+	if !plan.Tenants.IsNull() && !plan.Tenants.IsUnknown() {
+		allowOnTenant := false
+		if allowValue, ok := matchingPolicyType["allowOnTenant"]; ok {
+			if allowBool, ok := allowValue.(bool); ok {
+				allowOnTenant = allowBool
+			}
+		}
+
+		if !allowOnTenant {
+			policyTypeName := ""
+			if name, ok := matchingPolicyType["name"].(string); ok {
+				policyTypeName = name
+			}
+
+			resp.Diagnostics.AddAttributeError(
+				path.Root("tenants"),
+				"Tenants not supported for this policy type",
+				fmt.Sprintf(
+					"Policy type '%s' (%s) does not support specifying tenants. "+
+						"Remove the tenants attribute or choose a different policy type.",
+					policyTypeName, policyTypeCode,
+				),
+			)
+		}
+	}
+
+	if !allowed {
+		policyTypeName := ""
+		if name, ok := matchingPolicyType["name"].(string); ok {
+			policyTypeName = name
+		}
+
+		// Build a list of allowed scopes for this policy type
+		var allowedScopes []string
+		scopeMapping := map[string]string{
+			"allowOnGlobal":  "Global",
+			"allowOnSite":    "Group",
+			"allowOnZone":    "Cloud",
+			"allowOnUser":    "User",
+			"allowOnRole":    "Role",
+			"allowOnNetwork": "Network",
+			"allowOnPlan":    "Plan",
+			"allowOnLabel":   "Label",
+		}
+
+		for field, scope := range scopeMapping {
+			if val, ok := matchingPolicyType[field].(bool); ok && val {
+				if !contains(allowedScopes, scope) {
+					allowedScopes = append(allowedScopes, scope)
+				}
+			}
+		}
+
+		availableMsg := ""
+		if len(allowedScopes) > 0 {
+			availableMsg = fmt.Sprintf("\n\nThis policy type can be applied to the following resource types: %v", allowedScopes)
+		}
+
+		resp.Diagnostics.AddAttributeError(
+			path.Root("associated_resource_type"),
+			"Incompatible policy type and resource type",
+			fmt.Sprintf(
+				"Policy type '%s' (%s) cannot be applied to resource type '%s'. "+
+					"This policy type does not support the selected scope.%s",
+				policyTypeName, policyTypeCode, resourceType, availableMsg,
+			),
+		)
+	}
+}
+
+// contains checks if a string slice contains a specific string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -141,11 +141,11 @@ func (r *Resource) ModifyPlan(
 	}
 
 	// Validate policy type is compatible with the associated resource type
-	if plan.PolicyType.IsNull() || plan.PolicyType.IsUnknown() {
+	policyTypeCode := plan.PolicyType.Code.ValueString()
+	if plan.PolicyType.Code.IsUnknown() {
 		return
 	}
 
-	policyTypeCode := plan.PolicyType.Code.ValueString()
 	resourceType := plan.AssociatedResourceType.ValueString()
 
 	// Get API client - provider is configured at this point
@@ -202,15 +202,6 @@ func (r *Resource) ModifyPlan(
 		allowFieldName = "allowOnPlan"
 	case AssociatedResourceTypeLabel:
 		allowFieldName = "allowOnLabel"
-	default:
-		// Unknown resource type - should not happen due to schema validation
-		resp.Diagnostics.AddAttributeError(
-			path.Root("associated_resource_type"),
-			"Unknown resource type",
-			fmt.Sprintf("Resource type '%s' is not recognized", resourceType),
-		)
-
-		return
 	}
 
 	// Check if the policy type allows this resource type

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -211,8 +211,11 @@ func (r *Resource) ModifyPlan(
 	}
 
 	// Check if the policy type allows this resource type
+	// Treat Global as always allowed (API may return nil for allowOnGlobal)
 	allowed := false
-	if allowValue, ok := matchingPolicyType[allowFieldName]; ok {
+	if resourceType == "Global" {
+		allowed = true
+	} else if allowValue, ok := matchingPolicyType[allowFieldName]; ok {
 		if allowBool, ok := allowValue.(bool); ok {
 			allowed = allowBool
 		}
@@ -265,7 +268,12 @@ func (r *Resource) ModifyPlan(
 		}
 
 		for field, scope := range scopeMapping {
-			if val, ok := matchingPolicyType[field].(bool); ok && val {
+			// Always treat Global as allowed (API may return nil for allowOnGlobal)
+			if scope == "Global" {
+				if !contains(allowedScopes, scope) {
+					allowedScopes = append(allowedScopes, scope)
+				}
+			} else if val, ok := matchingPolicyType[field].(bool); ok && val {
 				if !contains(allowedScopes, scope) {
 					allowedScopes = append(allowedScopes, scope)
 				}

--- a/internal/framework/subproviders/morpheus/resources/policy/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource.go
@@ -49,9 +49,9 @@ func (r *Resource) Schema(
 // resourceTypeToAPIType converts user-facing resource types to API types
 func resourceTypeToAPIType(resourceType string) string {
 	switch resourceType {
-	case "Cloud":
+	case AssociatedResourceTypeCloud:
 		return "ComputeZone"
-	case "Group":
+	case AssociatedResourceTypeGroup:
 		return "ComputeSite"
 	default:
 		// For other types (User, Role, Network, Plan), pass through as-is
@@ -63,9 +63,9 @@ func resourceTypeToAPIType(resourceType string) string {
 func apiTypeToResourceType(apiType string) string {
 	switch apiType {
 	case "ComputeZone":
-		return "Cloud"
+		return AssociatedResourceTypeCloud
 	case "ComputeSite":
-		return "Group"
+		return AssociatedResourceTypeGroup
 	default:
 		// For other types (User, Role, Network, Plan), pass through as-is
 		return apiType
@@ -91,7 +91,7 @@ func (r *Resource) ValidateConfig(
 	// If associated_resource_type is not "Global", associated_resource_id must be set
 	resourceType := config.AssociatedResourceType.ValueString()
 
-	if resourceType != "Global" {
+	if resourceType != AssociatedResourceTypeGlobal {
 		// Check if associated_resource_id is set
 		if config.AssociatedResourceId.IsNull() {
 			resp.Diagnostics.AddAttributeError(
@@ -108,7 +108,7 @@ func (r *Resource) ValidateConfig(
 
 	// Validate each_user is only set when associated_resource_type is "Role"
 	if !config.EachUser.IsNull() {
-		if resourceType != "Role" {
+		if resourceType != AssociatedResourceTypeRole {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("each_user"),
 				"Invalid attribute combination",
@@ -167,6 +167,7 @@ func (r *Resource) ModifyPlan(
 		for _, pt := range policyTypesResp.Data {
 			if code, ok := pt["code"].(string); ok && code == policyTypeCode {
 				matchingPolicyType = pt
+
 				break
 			}
 		}
@@ -178,27 +179,28 @@ func (r *Resource) ModifyPlan(
 			"Invalid policy type",
 			fmt.Sprintf("Policy type with code '%s' not found", policyTypeCode),
 		)
+
 		return
 	}
 
 	// Map resource type to the corresponding "allowOn" field
 	var allowFieldName string
 	switch resourceType {
-	case "Global":
+	case AssociatedResourceTypeGlobal:
 		allowFieldName = "allowOnGlobal"
-	case "Group":
+	case AssociatedResourceTypeGroup:
 		allowFieldName = "allowOnSite"
-	case "Cloud":
+	case AssociatedResourceTypeCloud:
 		allowFieldName = "allowOnZone"
-	case "User":
+	case AssociatedResourceTypeUser:
 		allowFieldName = "allowOnUser"
-	case "Role":
+	case AssociatedResourceTypeRole:
 		allowFieldName = "allowOnRole"
-	case "Network":
+	case AssociatedResourceTypeNetwork:
 		allowFieldName = "allowOnNetwork"
-	case "Plan":
+	case AssociatedResourceTypePlan:
 		allowFieldName = "allowOnPlan"
-	case "Label":
+	case AssociatedResourceTypeLabel:
 		allowFieldName = "allowOnLabel"
 	default:
 		// Unknown resource type - should not happen due to schema validation
@@ -207,13 +209,14 @@ func (r *Resource) ModifyPlan(
 			"Unknown resource type",
 			fmt.Sprintf("Resource type '%s' is not recognized", resourceType),
 		)
+
 		return
 	}
 
 	// Check if the policy type allows this resource type
 	// Treat Global as always allowed (API may return nil for allowOnGlobal)
 	allowed := false
-	if resourceType == "Global" {
+	if resourceType == AssociatedResourceTypeGlobal {
 		allowed = true
 	} else if allowValue, ok := matchingPolicyType[allowFieldName]; ok {
 		if allowBool, ok := allowValue.(bool); ok {
@@ -257,19 +260,19 @@ func (r *Resource) ModifyPlan(
 		// Build a list of allowed scopes for this policy type
 		var allowedScopes []string
 		scopeMapping := map[string]string{
-			"allowOnGlobal":  "Global",
-			"allowOnSite":    "Group",
-			"allowOnZone":    "Cloud",
-			"allowOnUser":    "User",
-			"allowOnRole":    "Role",
-			"allowOnNetwork": "Network",
-			"allowOnPlan":    "Plan",
-			"allowOnLabel":   "Label",
+			"allowOnGlobal":  AssociatedResourceTypeGlobal,
+			"allowOnSite":    AssociatedResourceTypeGroup,
+			"allowOnZone":    AssociatedResourceTypeCloud,
+			"allowOnUser":    AssociatedResourceTypeUser,
+			"allowOnRole":    AssociatedResourceTypeRole,
+			"allowOnNetwork": AssociatedResourceTypeNetwork,
+			"allowOnPlan":    AssociatedResourceTypePlan,
+			"allowOnLabel":   AssociatedResourceTypeLabel,
 		}
 
 		for field, scope := range scopeMapping {
 			// Always treat Global as allowed (API may return nil for allowOnGlobal)
-			if scope == "Global" {
+			if scope == AssociatedResourceTypeGlobal {
 				if !contains(allowedScopes, scope) {
 					allowedScopes = append(allowedScopes, scope)
 				}
@@ -304,5 +307,6 @@ func contains(slice []string, item string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
@@ -161,3 +161,125 @@ resource "hpe_morpheus_policy" "validation_test" {
 		},
 	})
 }
+
+// Test validation: incompatible policy type and resource type (motd does not support User)
+func TestAccMorpheusPolicyValidationIncompatiblePolicyAndResourceType(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockMixed()
+	name := acctest.RandomWithPrefix(t.Name())
+	roleName := acctest.RandomWithPrefix(t.Name() + "-role")
+	userName := acctest.RandomWithPrefix(t.Name() + "-user")
+
+	resourceConfig := `
+resource "hpe_morpheus_role" "test" {
+  name = "` + roleName + `"
+  role_type = "user"
+}
+
+resource "hpe_morpheus_user" "test" {
+  username = "` + userName + `"
+  email = "` + userName + `@test.com"
+  role_ids = [hpe_morpheus_role.test.id]
+  password_wo = "TestPassword123!"
+}
+
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "User"
+  associated_resource_id = hpe_morpheus_user.test.id
+  
+  policy_type = {
+    code = "motd"
+  }
+  
+  config = {
+    enabled = true
+    message = "Test message"
+    fullPage = false
+    title = "MOTD"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"morpheus": {
+				Source:            "gomorpheus/morpheus",
+				VersionConstraint: "0.13.2",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("Incompatible policy type and resource type"),
+			},
+		},
+	})
+}
+
+// Test validation: tenants not supported for policy type
+func TestAccMorpheusPolicyValidationTenantsNotSupported(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+	cloudName := acctest.RandomWithPrefix(t.Name() + "-cloud")
+
+	resourceConfig := `
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+
+resource "hpe_morpheus_cloud" "test" {
+  name = "` + cloudName + `"
+  tenant_id = 1
+  group_id = hpe_morpheus_group.test.id
+  code = "` + cloudName + `"
+  cloud_type_code = "standard"
+  
+  config = {
+    certificateProvider = "internal"
+    enableNetworkTypeSelection = false
+  }
+}
+
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Cloud"
+  associated_resource_id = hpe_morpheus_cloud.test.id
+  tenants = [1]
+  
+  policy_type = {
+    code = "requiredNetwork"
+  }
+  
+  config = {
+    requiredNetworks = [1]
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("Tenants not supported for this policy type"),
+			},
+		},
+	})
+}

--- a/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
@@ -5,6 +5,8 @@ package policy
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -16,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -62,8 +63,752 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"config": schema.DynamicAttribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "Generic Policy Configuration",
 				MarkdownDescription: "Generic Policy Configuration",
+			},
+			"config_approval": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"account_integration_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"flow_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"workflow_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"workflow_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigApprovalType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigApprovalValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy types:\n\t- Approve Delete (deleteApproval)\n\t- Approve Provision (provisionApproval)\n\t- Approve Reconfigure (reconfigureApproval)\n\t- Approve Workflow Execute (workflowApproval)\n",
+				MarkdownDescription: "Configuration for the following policy types:\n\t- Approve Delete (deleteApproval)\n\t- Approve Provision (provisionApproval)\n\t- Approve Reconfigure (reconfigureApproval)\n\t- Approve Workflow Execute (workflowApproval)\n",
+			},
+			"config_backup_storage": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"backup_storage_ids": schema.SetAttribute{
+						ElementType: types.Int64Type,
+						Optional:    true,
+						Computed:    true,
+					},
+				},
+				CustomType: ConfigBackupStorageType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigBackupStorageValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Backup Targets (backupStorage)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Backup Targets (backupStorage)\n",
+			},
+			"config_create_backup": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"create_backup": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"create_backup_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigCreateBackupType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigCreateBackupValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Backup Creation (createBackup)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Backup Creation (createBackup)\n",
+			},
+			"config_create_user": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"create_user": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"create_user_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigCreateUserType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigCreateUserValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- User Creation (createUser)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- User Creation (createUser)\n",
+			},
+			"config_create_user_group": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"user_group": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigCreateUserGroupType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigCreateUserGroupValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- User Group Creation (createUserGroup)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- User Group Creation (createUserGroup)\n",
+			},
+			"config_cypher": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"delete": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"key_pattern": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"list": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"read": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"update": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"write": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigCypherType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigCypherValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Cypher Access (cypher)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Cypher Access (cypher)\n",
+			},
+			"config_delayed_removal": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"removal_age": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigDelayedRemovalType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigDelayedRemovalValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Delayed Delete (delayedRemoval)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Delayed Delete (delayedRemoval)\n",
+			},
+			"config_host_naming": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"host_naming_pattern": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"host_naming_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigHostNamingType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigHostNamingValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Hostname (hostNaming)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Hostname (hostNaming)\n",
+			},
+			"config_lifecycle": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"account_integration_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"flow_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_age": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_allow_extend": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_auto_renew": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_extensions_before_approval": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_hide_fixed": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_message": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_notify": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_renewal": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"lifecycle_workflow_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"workflow_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigLifecycleType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigLifecycleValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Expiration (lifecycle)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Expiration (lifecycle)\n",
+			},
+			"config_max_containers": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_containers": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxContainersType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxContainersValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max Containers (maxContainers)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Containers (maxContainers)\n",
+			},
+			"config_max_cores": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"exclude_containers": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"max_cores": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxCoresType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxCoresValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max Cores (maxCores)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Cores (maxCores)\n",
+			},
+			"config_max_hosts": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_hosts": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxHostsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxHostsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max Hosts (maxHosts)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Hosts (maxHosts)\n",
+			},
+			"config_max_memory": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"exclude_containers": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"max_memory": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxMemoryType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxMemoryValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max Memory (maxMemory)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Memory (maxMemory)\n",
+			},
+			"config_max_networks": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_networks": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxNetworksType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxNetworksValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Network Quota (maxNetworks)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Network Quota (maxNetworks)\n",
+			},
+			"config_max_pool_members": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_pool_members": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxPoolMembersType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxPoolMembersValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max Pool Members (maxPoolMembers)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Pool Members (maxPoolMembers)\n",
+			},
+			"config_max_pools": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_pools": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxPoolsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxPoolsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max Load Balancer Pools (maxPools)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Load Balancer Pools (maxPools)\n",
+			},
+			"config_max_price": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_price": schema.NumberAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"max_price_currency": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"max_price_unit": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxPriceType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxPriceValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Budget (maxPrice)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Budget (maxPrice)\n",
+			},
+			"config_max_routers": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_routers": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxRoutersType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxRoutersValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Router Quota (maxRouters)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Router Quota (maxRouters)\n",
+			},
+			"config_max_snapshots": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_snapshots": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxSnapshotsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxSnapshotsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max Snapshots (maxSnapshots)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Snapshots (maxSnapshots)\n",
+			},
+			"config_max_storage": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"exclude_containers": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"max_storage": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxStorageType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxStorageValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy types:\n\t- Max Storage (maxStorage)\n\t- Object Storage Quota (storageBucketQuota)\n\t- File Share Storage Quota (storageShareQuota)\n",
+				MarkdownDescription: "Configuration for the following policy types:\n\t- Max Storage (maxStorage)\n\t- Object Storage Quota (storageBucketQuota)\n\t- File Share Storage Quota (storageShareQuota)\n",
+			},
+			"config_max_virtual_servers": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_virtual_servers": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxVirtualServersType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxVirtualServersValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max Virtual Servers (maxVirtualServers)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Virtual Servers (maxVirtualServers)\n",
+			},
+			"config_max_vms": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_vms": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMaxVmsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMaxVmsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Max VMs (maxVms)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Max VMs (maxVms)\n",
+			},
+			"config_motd": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"motddate": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"motdmessage": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"motdtitle": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"motdtype": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigMotdType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigMotdValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Message of the Day (motd)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Message of the Day (motd)\n",
+			},
+			"config_naming": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"naming_conflict": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"naming_pattern": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"naming_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigNamingType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigNamingValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Instance Name (naming)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Instance Name (naming)\n",
+			},
+			"config_power_schedule": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"power_schedule": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"power_schedule_hide_fixed": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"power_schedule_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigPowerScheduleType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigPowerScheduleValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Power Scheduling (powerSchedule)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Power Scheduling (powerSchedule)\n",
+			},
+			"config_required_network": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"required_networks": schema.SetAttribute{
+						ElementType:         types.Int64Type,
+						Optional:            true,
+						Computed:            true,
+						Description:         "Array of network IDs that are required",
+						MarkdownDescription: "Array of network IDs that are required",
+					},
+				},
+				CustomType: ConfigRequiredNetworkType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigRequiredNetworkValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Instance Networks (requiredNetwork)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Instance Networks (requiredNetwork)\n",
+			},
+			"config_server_naming": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"server_naming_conflict": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"server_naming_pattern": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"server_naming_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigServerNamingType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigServerNamingValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Cluster Resource Name (serverNaming)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Cluster Resource Name (serverNaming)\n",
+			},
+			"config_shutdown": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"account_integration_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"flow_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_age": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_allow_extend": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_auto_renew": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_extensions_before_approval": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_hide_fixed": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_message": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_notify": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_renewal": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"shutdown_workflow_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"workflow_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigShutdownType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigShutdownValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Shutdown (shutdown)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Shutdown (shutdown)\n",
+			},
+			"config_storage_server_quota": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"max_storage": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"storage_server_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigStorageServerQuotaType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigStorageServerQuotaValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Storage Server Storage Quota (storageServerQuota)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Storage Server Storage Quota (storageServerQuota)\n",
+			},
+			"config_tags": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"key": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"strict": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"value": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+					"value_list_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigTagsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigTagsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Tags (tags)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Tags (tags)\n",
+			},
+			"config_workflow": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"workflow_id": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+				},
+				CustomType: ConfigWorkflowType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigWorkflowValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Configuration for the following policy type:\n\t- Workflow (workflow)\n",
+				MarkdownDescription: "Configuration for the following policy type:\n\t- Workflow (workflow)\n",
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,
@@ -232,21 +977,52 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type PolicyModel struct {
-	AssociatedResourceId   types.Int64     `tfsdk:"associated_resource_id"`
-	AssociatedResourceType types.String    `tfsdk:"associated_resource_type"`
-	Cloud                  CloudValue      `tfsdk:"cloud"`
-	Config                 types.Dynamic   `tfsdk:"config"`
-	Description            types.String    `tfsdk:"description"`
-	EachUser               types.Bool      `tfsdk:"each_user"`
-	Enabled                types.Bool      `tfsdk:"enabled"`
-	Group                  GroupValue      `tfsdk:"group"`
-	Id                     types.Int64     `tfsdk:"id"`
-	Name                   types.String    `tfsdk:"name"`
-	Owner                  OwnerValue      `tfsdk:"owner"`
-	PolicyType             PolicyTypeValue `tfsdk:"policy_type"`
-	Role                   RoleValue       `tfsdk:"role"`
-	Tenants                types.Set       `tfsdk:"tenants"`
-	User                   UserValue       `tfsdk:"user"`
+	AssociatedResourceId     types.Int64                   `tfsdk:"associated_resource_id"`
+	AssociatedResourceType   types.String                  `tfsdk:"associated_resource_type"`
+	Cloud                    CloudValue                    `tfsdk:"cloud"`
+	Config                   types.Dynamic                 `tfsdk:"config"`
+	ConfigApproval           ConfigApprovalValue           `tfsdk:"config_approval"`
+	ConfigBackupStorage      ConfigBackupStorageValue      `tfsdk:"config_backup_storage"`
+	ConfigCreateBackup       ConfigCreateBackupValue       `tfsdk:"config_create_backup"`
+	ConfigCreateUser         ConfigCreateUserValue         `tfsdk:"config_create_user"`
+	ConfigCreateUserGroup    ConfigCreateUserGroupValue    `tfsdk:"config_create_user_group"`
+	ConfigCypher             ConfigCypherValue             `tfsdk:"config_cypher"`
+	ConfigDelayedRemoval     ConfigDelayedRemovalValue     `tfsdk:"config_delayed_removal"`
+	ConfigHostNaming         ConfigHostNamingValue         `tfsdk:"config_host_naming"`
+	ConfigLifecycle          ConfigLifecycleValue          `tfsdk:"config_lifecycle"`
+	ConfigMaxContainers      ConfigMaxContainersValue      `tfsdk:"config_max_containers"`
+	ConfigMaxCores           ConfigMaxCoresValue           `tfsdk:"config_max_cores"`
+	ConfigMaxHosts           ConfigMaxHostsValue           `tfsdk:"config_max_hosts"`
+	ConfigMaxMemory          ConfigMaxMemoryValue          `tfsdk:"config_max_memory"`
+	ConfigMaxNetworks        ConfigMaxNetworksValue        `tfsdk:"config_max_networks"`
+	ConfigMaxPoolMembers     ConfigMaxPoolMembersValue     `tfsdk:"config_max_pool_members"`
+	ConfigMaxPools           ConfigMaxPoolsValue           `tfsdk:"config_max_pools"`
+	ConfigMaxPrice           ConfigMaxPriceValue           `tfsdk:"config_max_price"`
+	ConfigMaxRouters         ConfigMaxRoutersValue         `tfsdk:"config_max_routers"`
+	ConfigMaxSnapshots       ConfigMaxSnapshotsValue       `tfsdk:"config_max_snapshots"`
+	ConfigMaxStorage         ConfigMaxStorageValue         `tfsdk:"config_max_storage"`
+	ConfigMaxVirtualServers  ConfigMaxVirtualServersValue  `tfsdk:"config_max_virtual_servers"`
+	ConfigMaxVms             ConfigMaxVmsValue             `tfsdk:"config_max_vms"`
+	ConfigMotd               ConfigMotdValue               `tfsdk:"config_motd"`
+	ConfigNaming             ConfigNamingValue             `tfsdk:"config_naming"`
+	ConfigPowerSchedule      ConfigPowerScheduleValue      `tfsdk:"config_power_schedule"`
+	ConfigRequiredNetwork    ConfigRequiredNetworkValue    `tfsdk:"config_required_network"`
+	ConfigServerNaming       ConfigServerNamingValue       `tfsdk:"config_server_naming"`
+	ConfigShutdown           ConfigShutdownValue           `tfsdk:"config_shutdown"`
+	ConfigStorageServerQuota ConfigStorageServerQuotaValue `tfsdk:"config_storage_server_quota"`
+	ConfigTags               ConfigTagsValue               `tfsdk:"config_tags"`
+	ConfigWorkflow           ConfigWorkflowValue           `tfsdk:"config_workflow"`
+	Description              types.String                  `tfsdk:"description"`
+	EachUser                 types.Bool                    `tfsdk:"each_user"`
+	Enabled                  types.Bool                    `tfsdk:"enabled"`
+	Group                    GroupValue                    `tfsdk:"group"`
+	Id                       types.Int64                   `tfsdk:"id"`
+	Name                     types.String                  `tfsdk:"name"`
+	Owner                    OwnerValue                    `tfsdk:"owner"`
+	PolicyType               PolicyTypeValue               `tfsdk:"policy_type"`
+	Role                     RoleValue                     `tfsdk:"role"`
+	Tenants                  types.Set                     `tfsdk:"tenants"`
+	User                     UserValue                     `tfsdk:"user"`
 }
 
 var _ basetypes.ObjectTypable = CloudType{}
@@ -633,6 +1409,13265 @@ func (v CloudValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
 		"id":   basetypes.Int64Type{},
 		"name": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigApprovalType{}
+
+type ConfigApprovalType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigApprovalType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigApprovalType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigApprovalType) String() string {
+	return "ConfigApprovalType"
+}
+
+func (t ConfigApprovalType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigApprovalValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigApprovalValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	accountIntegrationIdAttribute, ok := attributes["account_integration_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`account_integration_id is missing from object`)
+
+		return nil, diags
+	}
+
+	accountIntegrationIdVal, ok := accountIntegrationIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`account_integration_id expected to be basetypes.StringValue, was: %T`, accountIntegrationIdAttribute))
+	}
+
+	flowIdAttribute, ok := attributes["flow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`flow_id is missing from object`)
+
+		return nil, diags
+	}
+
+	flowIdVal, ok := flowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`flow_id expected to be basetypes.StringValue, was: %T`, flowIdAttribute))
+	}
+
+	workflowIdAttribute, ok := attributes["workflow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_id is missing from object`)
+
+		return nil, diags
+	}
+
+	workflowIdVal, ok := workflowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_id expected to be basetypes.StringValue, was: %T`, workflowIdAttribute))
+	}
+
+	workflowTypeAttribute, ok := attributes["workflow_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_type is missing from object`)
+
+		return nil, diags
+	}
+
+	workflowTypeVal, ok := workflowTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_type expected to be basetypes.StringValue, was: %T`, workflowTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigApprovalValue{
+		AccountIntegrationId: accountIntegrationIdVal,
+		FlowId:               flowIdVal,
+		WorkflowId:           workflowIdVal,
+		WorkflowType:         workflowTypeVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigApprovalValueNull() ConfigApprovalValue {
+	return ConfigApprovalValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigApprovalValueUnknown() ConfigApprovalValue {
+	return ConfigApprovalValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigApprovalValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigApprovalValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigApprovalValue Attribute Value",
+				"While creating a ConfigApprovalValue value, a missing attribute value was detected. "+
+					"A ConfigApprovalValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigApprovalValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigApprovalValue Attribute Type",
+				"While creating a ConfigApprovalValue value, an invalid attribute value was detected. "+
+					"A ConfigApprovalValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigApprovalValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigApprovalValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigApprovalValue Attribute Value",
+				"While creating a ConfigApprovalValue value, an extra attribute value was detected. "+
+					"A ConfigApprovalValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigApprovalValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigApprovalValueUnknown(), diags
+	}
+
+	accountIntegrationIdAttribute, ok := attributes["account_integration_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`account_integration_id is missing from object`)
+
+		return NewConfigApprovalValueUnknown(), diags
+	}
+
+	accountIntegrationIdVal, ok := accountIntegrationIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`account_integration_id expected to be basetypes.StringValue, was: %T`, accountIntegrationIdAttribute))
+	}
+
+	flowIdAttribute, ok := attributes["flow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`flow_id is missing from object`)
+
+		return NewConfigApprovalValueUnknown(), diags
+	}
+
+	flowIdVal, ok := flowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`flow_id expected to be basetypes.StringValue, was: %T`, flowIdAttribute))
+	}
+
+	workflowIdAttribute, ok := attributes["workflow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_id is missing from object`)
+
+		return NewConfigApprovalValueUnknown(), diags
+	}
+
+	workflowIdVal, ok := workflowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_id expected to be basetypes.StringValue, was: %T`, workflowIdAttribute))
+	}
+
+	workflowTypeAttribute, ok := attributes["workflow_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_type is missing from object`)
+
+		return NewConfigApprovalValueUnknown(), diags
+	}
+
+	workflowTypeVal, ok := workflowTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_type expected to be basetypes.StringValue, was: %T`, workflowTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigApprovalValueUnknown(), diags
+	}
+
+	return ConfigApprovalValue{
+		AccountIntegrationId: accountIntegrationIdVal,
+		FlowId:               flowIdVal,
+		WorkflowId:           workflowIdVal,
+		WorkflowType:         workflowTypeVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigApprovalValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigApprovalValue {
+	object, diags := NewConfigApprovalValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigApprovalValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigApprovalType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigApprovalValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigApprovalValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigApprovalValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigApprovalValueMust(ConfigApprovalValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigApprovalType) ValueType(ctx context.Context) attr.Value {
+	return ConfigApprovalValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigApprovalValue{}
+
+type ConfigApprovalValue struct {
+	AccountIntegrationId basetypes.StringValue `tfsdk:"account_integration_id"`
+	FlowId               basetypes.StringValue `tfsdk:"flow_id"`
+	WorkflowId           basetypes.StringValue `tfsdk:"workflow_id"`
+	WorkflowType         basetypes.StringValue `tfsdk:"workflow_type"`
+	state                attr.ValueState
+}
+
+func (v ConfigApprovalValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 4)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["account_integration_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["flow_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["workflow_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["workflow_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 4)
+
+		val, err = v.AccountIntegrationId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["account_integration_id"] = val
+
+		val, err = v.FlowId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["flow_id"] = val
+
+		val, err = v.WorkflowId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["workflow_id"] = val
+
+		val, err = v.WorkflowType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["workflow_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigApprovalValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigApprovalValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigApprovalValue) String() string {
+	return "ConfigApprovalValue"
+}
+
+func (v ConfigApprovalValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"account_integration_id": basetypes.StringType{},
+		"flow_id":                basetypes.StringType{},
+		"workflow_id":            basetypes.StringType{},
+		"workflow_type":          basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"account_integration_id": v.AccountIntegrationId,
+			"flow_id":                v.FlowId,
+			"workflow_id":            v.WorkflowId,
+			"workflow_type":          v.WorkflowType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigApprovalValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigApprovalValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AccountIntegrationId.Equal(other.AccountIntegrationId) {
+		return false
+	}
+
+	if !v.FlowId.Equal(other.FlowId) {
+		return false
+	}
+
+	if !v.WorkflowId.Equal(other.WorkflowId) {
+		return false
+	}
+
+	if !v.WorkflowType.Equal(other.WorkflowType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigApprovalValue) Type(ctx context.Context) attr.Type {
+	return ConfigApprovalType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigApprovalValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"account_integration_id": basetypes.StringType{},
+		"flow_id":                basetypes.StringType{},
+		"workflow_id":            basetypes.StringType{},
+		"workflow_type":          basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigBackupStorageType{}
+
+type ConfigBackupStorageType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigBackupStorageType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigBackupStorageType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigBackupStorageType) String() string {
+	return "ConfigBackupStorageType"
+}
+
+func (t ConfigBackupStorageType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigBackupStorageValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigBackupStorageValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	backupStorageIdsAttribute, ok := attributes["backup_storage_ids"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`backup_storage_ids is missing from object`)
+
+		return nil, diags
+	}
+
+	backupStorageIdsVal, ok := backupStorageIdsAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`backup_storage_ids expected to be basetypes.SetValue, was: %T`, backupStorageIdsAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigBackupStorageValue{
+		BackupStorageIds: backupStorageIdsVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigBackupStorageValueNull() ConfigBackupStorageValue {
+	return ConfigBackupStorageValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigBackupStorageValueUnknown() ConfigBackupStorageValue {
+	return ConfigBackupStorageValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigBackupStorageValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigBackupStorageValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigBackupStorageValue Attribute Value",
+				"While creating a ConfigBackupStorageValue value, a missing attribute value was detected. "+
+					"A ConfigBackupStorageValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigBackupStorageValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigBackupStorageValue Attribute Type",
+				"While creating a ConfigBackupStorageValue value, an invalid attribute value was detected. "+
+					"A ConfigBackupStorageValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigBackupStorageValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigBackupStorageValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigBackupStorageValue Attribute Value",
+				"While creating a ConfigBackupStorageValue value, an extra attribute value was detected. "+
+					"A ConfigBackupStorageValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigBackupStorageValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigBackupStorageValueUnknown(), diags
+	}
+
+	backupStorageIdsAttribute, ok := attributes["backup_storage_ids"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`backup_storage_ids is missing from object`)
+
+		return NewConfigBackupStorageValueUnknown(), diags
+	}
+
+	backupStorageIdsVal, ok := backupStorageIdsAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`backup_storage_ids expected to be basetypes.SetValue, was: %T`, backupStorageIdsAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigBackupStorageValueUnknown(), diags
+	}
+
+	return ConfigBackupStorageValue{
+		BackupStorageIds: backupStorageIdsVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigBackupStorageValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigBackupStorageValue {
+	object, diags := NewConfigBackupStorageValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigBackupStorageValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigBackupStorageType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigBackupStorageValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigBackupStorageValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigBackupStorageValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigBackupStorageValueMust(ConfigBackupStorageValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigBackupStorageType) ValueType(ctx context.Context) attr.Value {
+	return ConfigBackupStorageValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigBackupStorageValue{}
+
+type ConfigBackupStorageValue struct {
+	BackupStorageIds basetypes.SetValue `tfsdk:"backup_storage_ids"`
+	state            attr.ValueState
+}
+
+func (v ConfigBackupStorageValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["backup_storage_ids"] = basetypes.SetType{
+		ElemType: types.Int64Type,
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.BackupStorageIds.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["backup_storage_ids"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigBackupStorageValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigBackupStorageValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigBackupStorageValue) String() string {
+	return "ConfigBackupStorageValue"
+}
+
+func (v ConfigBackupStorageValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var backupStorageIdsVal basetypes.SetValue
+	switch {
+	case v.BackupStorageIds.IsUnknown():
+		backupStorageIdsVal = types.SetUnknown(types.Int64Type)
+	case v.BackupStorageIds.IsNull():
+		backupStorageIdsVal = types.SetNull(types.Int64Type)
+	default:
+		var d diag.Diagnostics
+		backupStorageIdsVal, d = types.SetValue(types.Int64Type, v.BackupStorageIds.Elements())
+		diags.Append(d...)
+	}
+
+	if diags.HasError() {
+		return types.ObjectUnknown(map[string]attr.Type{
+			"backup_storage_ids": basetypes.SetType{
+				ElemType: types.Int64Type,
+			},
+		}), diags
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"backup_storage_ids": basetypes.SetType{
+			ElemType: types.Int64Type,
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"backup_storage_ids": backupStorageIdsVal,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigBackupStorageValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigBackupStorageValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.BackupStorageIds.Equal(other.BackupStorageIds) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigBackupStorageValue) Type(ctx context.Context) attr.Type {
+	return ConfigBackupStorageType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigBackupStorageValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"backup_storage_ids": basetypes.SetType{
+			ElemType: types.Int64Type,
+		},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigCreateBackupType{}
+
+type ConfigCreateBackupType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigCreateBackupType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigCreateBackupType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigCreateBackupType) String() string {
+	return "ConfigCreateBackupType"
+}
+
+func (t ConfigCreateBackupType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigCreateBackupValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigCreateBackupValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	createBackupAttribute, ok := attributes["create_backup"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_backup is missing from object`)
+
+		return nil, diags
+	}
+
+	createBackupVal, ok := createBackupAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_backup expected to be basetypes.BoolValue, was: %T`, createBackupAttribute))
+	}
+
+	createBackupTypeAttribute, ok := attributes["create_backup_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_backup_type is missing from object`)
+
+		return nil, diags
+	}
+
+	createBackupTypeVal, ok := createBackupTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_backup_type expected to be basetypes.StringValue, was: %T`, createBackupTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigCreateBackupValue{
+		CreateBackup:     createBackupVal,
+		CreateBackupType: createBackupTypeVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigCreateBackupValueNull() ConfigCreateBackupValue {
+	return ConfigCreateBackupValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigCreateBackupValueUnknown() ConfigCreateBackupValue {
+	return ConfigCreateBackupValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigCreateBackupValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigCreateBackupValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigCreateBackupValue Attribute Value",
+				"While creating a ConfigCreateBackupValue value, a missing attribute value was detected. "+
+					"A ConfigCreateBackupValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigCreateBackupValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigCreateBackupValue Attribute Type",
+				"While creating a ConfigCreateBackupValue value, an invalid attribute value was detected. "+
+					"A ConfigCreateBackupValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigCreateBackupValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigCreateBackupValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigCreateBackupValue Attribute Value",
+				"While creating a ConfigCreateBackupValue value, an extra attribute value was detected. "+
+					"A ConfigCreateBackupValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigCreateBackupValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigCreateBackupValueUnknown(), diags
+	}
+
+	createBackupAttribute, ok := attributes["create_backup"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_backup is missing from object`)
+
+		return NewConfigCreateBackupValueUnknown(), diags
+	}
+
+	createBackupVal, ok := createBackupAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_backup expected to be basetypes.BoolValue, was: %T`, createBackupAttribute))
+	}
+
+	createBackupTypeAttribute, ok := attributes["create_backup_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_backup_type is missing from object`)
+
+		return NewConfigCreateBackupValueUnknown(), diags
+	}
+
+	createBackupTypeVal, ok := createBackupTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_backup_type expected to be basetypes.StringValue, was: %T`, createBackupTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigCreateBackupValueUnknown(), diags
+	}
+
+	return ConfigCreateBackupValue{
+		CreateBackup:     createBackupVal,
+		CreateBackupType: createBackupTypeVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigCreateBackupValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigCreateBackupValue {
+	object, diags := NewConfigCreateBackupValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigCreateBackupValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigCreateBackupType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigCreateBackupValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigCreateBackupValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigCreateBackupValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigCreateBackupValueMust(ConfigCreateBackupValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigCreateBackupType) ValueType(ctx context.Context) attr.Value {
+	return ConfigCreateBackupValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigCreateBackupValue{}
+
+type ConfigCreateBackupValue struct {
+	CreateBackup     basetypes.BoolValue   `tfsdk:"create_backup"`
+	CreateBackupType basetypes.StringValue `tfsdk:"create_backup_type"`
+	state            attr.ValueState
+}
+
+func (v ConfigCreateBackupValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["create_backup"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["create_backup_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.CreateBackup.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["create_backup"] = val
+
+		val, err = v.CreateBackupType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["create_backup_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigCreateBackupValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigCreateBackupValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigCreateBackupValue) String() string {
+	return "ConfigCreateBackupValue"
+}
+
+func (v ConfigCreateBackupValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"create_backup":      basetypes.BoolType{},
+		"create_backup_type": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"create_backup":      v.CreateBackup,
+			"create_backup_type": v.CreateBackupType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigCreateBackupValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigCreateBackupValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.CreateBackup.Equal(other.CreateBackup) {
+		return false
+	}
+
+	if !v.CreateBackupType.Equal(other.CreateBackupType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigCreateBackupValue) Type(ctx context.Context) attr.Type {
+	return ConfigCreateBackupType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigCreateBackupValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"create_backup":      basetypes.BoolType{},
+		"create_backup_type": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigCreateUserType{}
+
+type ConfigCreateUserType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigCreateUserType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigCreateUserType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigCreateUserType) String() string {
+	return "ConfigCreateUserType"
+}
+
+func (t ConfigCreateUserType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigCreateUserValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigCreateUserValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	createUserAttribute, ok := attributes["create_user"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_user is missing from object`)
+
+		return nil, diags
+	}
+
+	createUserVal, ok := createUserAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_user expected to be basetypes.BoolValue, was: %T`, createUserAttribute))
+	}
+
+	createUserTypeAttribute, ok := attributes["create_user_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_user_type is missing from object`)
+
+		return nil, diags
+	}
+
+	createUserTypeVal, ok := createUserTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_user_type expected to be basetypes.StringValue, was: %T`, createUserTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigCreateUserValue{
+		CreateUser:     createUserVal,
+		CreateUserType: createUserTypeVal,
+		state:          attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigCreateUserValueNull() ConfigCreateUserValue {
+	return ConfigCreateUserValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigCreateUserValueUnknown() ConfigCreateUserValue {
+	return ConfigCreateUserValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigCreateUserValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigCreateUserValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigCreateUserValue Attribute Value",
+				"While creating a ConfigCreateUserValue value, a missing attribute value was detected. "+
+					"A ConfigCreateUserValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigCreateUserValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigCreateUserValue Attribute Type",
+				"While creating a ConfigCreateUserValue value, an invalid attribute value was detected. "+
+					"A ConfigCreateUserValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigCreateUserValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigCreateUserValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigCreateUserValue Attribute Value",
+				"While creating a ConfigCreateUserValue value, an extra attribute value was detected. "+
+					"A ConfigCreateUserValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigCreateUserValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigCreateUserValueUnknown(), diags
+	}
+
+	createUserAttribute, ok := attributes["create_user"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_user is missing from object`)
+
+		return NewConfigCreateUserValueUnknown(), diags
+	}
+
+	createUserVal, ok := createUserAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_user expected to be basetypes.BoolValue, was: %T`, createUserAttribute))
+	}
+
+	createUserTypeAttribute, ok := attributes["create_user_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_user_type is missing from object`)
+
+		return NewConfigCreateUserValueUnknown(), diags
+	}
+
+	createUserTypeVal, ok := createUserTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_user_type expected to be basetypes.StringValue, was: %T`, createUserTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigCreateUserValueUnknown(), diags
+	}
+
+	return ConfigCreateUserValue{
+		CreateUser:     createUserVal,
+		CreateUserType: createUserTypeVal,
+		state:          attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigCreateUserValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigCreateUserValue {
+	object, diags := NewConfigCreateUserValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigCreateUserValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigCreateUserType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigCreateUserValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigCreateUserValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigCreateUserValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigCreateUserValueMust(ConfigCreateUserValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigCreateUserType) ValueType(ctx context.Context) attr.Value {
+	return ConfigCreateUserValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigCreateUserValue{}
+
+type ConfigCreateUserValue struct {
+	CreateUser     basetypes.BoolValue   `tfsdk:"create_user"`
+	CreateUserType basetypes.StringValue `tfsdk:"create_user_type"`
+	state          attr.ValueState
+}
+
+func (v ConfigCreateUserValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["create_user"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["create_user_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.CreateUser.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["create_user"] = val
+
+		val, err = v.CreateUserType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["create_user_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigCreateUserValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigCreateUserValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigCreateUserValue) String() string {
+	return "ConfigCreateUserValue"
+}
+
+func (v ConfigCreateUserValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"create_user":      basetypes.BoolType{},
+		"create_user_type": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"create_user":      v.CreateUser,
+			"create_user_type": v.CreateUserType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigCreateUserValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigCreateUserValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.CreateUser.Equal(other.CreateUser) {
+		return false
+	}
+
+	if !v.CreateUserType.Equal(other.CreateUserType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigCreateUserValue) Type(ctx context.Context) attr.Type {
+	return ConfigCreateUserType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigCreateUserValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"create_user":      basetypes.BoolType{},
+		"create_user_type": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigCreateUserGroupType{}
+
+type ConfigCreateUserGroupType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigCreateUserGroupType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigCreateUserGroupType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigCreateUserGroupType) String() string {
+	return "ConfigCreateUserGroupType"
+}
+
+func (t ConfigCreateUserGroupType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigCreateUserGroupValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigCreateUserGroupValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	userGroupAttribute, ok := attributes["user_group"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`user_group is missing from object`)
+
+		return nil, diags
+	}
+
+	userGroupVal, ok := userGroupAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`user_group expected to be basetypes.StringValue, was: %T`, userGroupAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigCreateUserGroupValue{
+		UserGroup: userGroupVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigCreateUserGroupValueNull() ConfigCreateUserGroupValue {
+	return ConfigCreateUserGroupValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigCreateUserGroupValueUnknown() ConfigCreateUserGroupValue {
+	return ConfigCreateUserGroupValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigCreateUserGroupValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigCreateUserGroupValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigCreateUserGroupValue Attribute Value",
+				"While creating a ConfigCreateUserGroupValue value, a missing attribute value was detected. "+
+					"A ConfigCreateUserGroupValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigCreateUserGroupValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigCreateUserGroupValue Attribute Type",
+				"While creating a ConfigCreateUserGroupValue value, an invalid attribute value was detected. "+
+					"A ConfigCreateUserGroupValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigCreateUserGroupValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigCreateUserGroupValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigCreateUserGroupValue Attribute Value",
+				"While creating a ConfigCreateUserGroupValue value, an extra attribute value was detected. "+
+					"A ConfigCreateUserGroupValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigCreateUserGroupValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigCreateUserGroupValueUnknown(), diags
+	}
+
+	userGroupAttribute, ok := attributes["user_group"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`user_group is missing from object`)
+
+		return NewConfigCreateUserGroupValueUnknown(), diags
+	}
+
+	userGroupVal, ok := userGroupAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`user_group expected to be basetypes.StringValue, was: %T`, userGroupAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigCreateUserGroupValueUnknown(), diags
+	}
+
+	return ConfigCreateUserGroupValue{
+		UserGroup: userGroupVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigCreateUserGroupValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigCreateUserGroupValue {
+	object, diags := NewConfigCreateUserGroupValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigCreateUserGroupValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigCreateUserGroupType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigCreateUserGroupValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigCreateUserGroupValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigCreateUserGroupValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigCreateUserGroupValueMust(ConfigCreateUserGroupValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigCreateUserGroupType) ValueType(ctx context.Context) attr.Value {
+	return ConfigCreateUserGroupValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigCreateUserGroupValue{}
+
+type ConfigCreateUserGroupValue struct {
+	UserGroup basetypes.StringValue `tfsdk:"user_group"`
+	state     attr.ValueState
+}
+
+func (v ConfigCreateUserGroupValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["user_group"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.UserGroup.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["user_group"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigCreateUserGroupValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigCreateUserGroupValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigCreateUserGroupValue) String() string {
+	return "ConfigCreateUserGroupValue"
+}
+
+func (v ConfigCreateUserGroupValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"user_group": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"user_group": v.UserGroup,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigCreateUserGroupValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigCreateUserGroupValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.UserGroup.Equal(other.UserGroup) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigCreateUserGroupValue) Type(ctx context.Context) attr.Type {
+	return ConfigCreateUserGroupType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigCreateUserGroupValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"user_group": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigCypherType{}
+
+type ConfigCypherType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigCypherType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigCypherType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigCypherType) String() string {
+	return "ConfigCypherType"
+}
+
+func (t ConfigCypherType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigCypherValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigCypherValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	deleteAttribute, ok := attributes["delete"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`delete is missing from object`)
+
+		return nil, diags
+	}
+
+	deleteVal, ok := deleteAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`delete expected to be basetypes.BoolValue, was: %T`, deleteAttribute))
+	}
+
+	keyPatternAttribute, ok := attributes["key_pattern"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key_pattern is missing from object`)
+
+		return nil, diags
+	}
+
+	keyPatternVal, ok := keyPatternAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key_pattern expected to be basetypes.StringValue, was: %T`, keyPatternAttribute))
+	}
+
+	listAttribute, ok := attributes["list"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`list is missing from object`)
+
+		return nil, diags
+	}
+
+	listVal, ok := listAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`list expected to be basetypes.BoolValue, was: %T`, listAttribute))
+	}
+
+	readAttribute, ok := attributes["read"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`read is missing from object`)
+
+		return nil, diags
+	}
+
+	readVal, ok := readAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`read expected to be basetypes.BoolValue, was: %T`, readAttribute))
+	}
+
+	updateAttribute, ok := attributes["update"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`update is missing from object`)
+
+		return nil, diags
+	}
+
+	updateVal, ok := updateAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`update expected to be basetypes.BoolValue, was: %T`, updateAttribute))
+	}
+
+	writeAttribute, ok := attributes["write"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`write is missing from object`)
+
+		return nil, diags
+	}
+
+	writeVal, ok := writeAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`write expected to be basetypes.BoolValue, was: %T`, writeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigCypherValue{
+		Delete:     deleteVal,
+		KeyPattern: keyPatternVal,
+		List:       listVal,
+		Read:       readVal,
+		Update:     updateVal,
+		Write:      writeVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigCypherValueNull() ConfigCypherValue {
+	return ConfigCypherValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigCypherValueUnknown() ConfigCypherValue {
+	return ConfigCypherValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigCypherValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigCypherValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigCypherValue Attribute Value",
+				"While creating a ConfigCypherValue value, a missing attribute value was detected. "+
+					"A ConfigCypherValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigCypherValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigCypherValue Attribute Type",
+				"While creating a ConfigCypherValue value, an invalid attribute value was detected. "+
+					"A ConfigCypherValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigCypherValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigCypherValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigCypherValue Attribute Value",
+				"While creating a ConfigCypherValue value, an extra attribute value was detected. "+
+					"A ConfigCypherValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigCypherValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigCypherValueUnknown(), diags
+	}
+
+	deleteAttribute, ok := attributes["delete"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`delete is missing from object`)
+
+		return NewConfigCypherValueUnknown(), diags
+	}
+
+	deleteVal, ok := deleteAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`delete expected to be basetypes.BoolValue, was: %T`, deleteAttribute))
+	}
+
+	keyPatternAttribute, ok := attributes["key_pattern"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key_pattern is missing from object`)
+
+		return NewConfigCypherValueUnknown(), diags
+	}
+
+	keyPatternVal, ok := keyPatternAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key_pattern expected to be basetypes.StringValue, was: %T`, keyPatternAttribute))
+	}
+
+	listAttribute, ok := attributes["list"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`list is missing from object`)
+
+		return NewConfigCypherValueUnknown(), diags
+	}
+
+	listVal, ok := listAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`list expected to be basetypes.BoolValue, was: %T`, listAttribute))
+	}
+
+	readAttribute, ok := attributes["read"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`read is missing from object`)
+
+		return NewConfigCypherValueUnknown(), diags
+	}
+
+	readVal, ok := readAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`read expected to be basetypes.BoolValue, was: %T`, readAttribute))
+	}
+
+	updateAttribute, ok := attributes["update"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`update is missing from object`)
+
+		return NewConfigCypherValueUnknown(), diags
+	}
+
+	updateVal, ok := updateAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`update expected to be basetypes.BoolValue, was: %T`, updateAttribute))
+	}
+
+	writeAttribute, ok := attributes["write"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`write is missing from object`)
+
+		return NewConfigCypherValueUnknown(), diags
+	}
+
+	writeVal, ok := writeAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`write expected to be basetypes.BoolValue, was: %T`, writeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigCypherValueUnknown(), diags
+	}
+
+	return ConfigCypherValue{
+		Delete:     deleteVal,
+		KeyPattern: keyPatternVal,
+		List:       listVal,
+		Read:       readVal,
+		Update:     updateVal,
+		Write:      writeVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigCypherValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigCypherValue {
+	object, diags := NewConfigCypherValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigCypherValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigCypherType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigCypherValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigCypherValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigCypherValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigCypherValueMust(ConfigCypherValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigCypherType) ValueType(ctx context.Context) attr.Value {
+	return ConfigCypherValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigCypherValue{}
+
+type ConfigCypherValue struct {
+	Delete     basetypes.BoolValue   `tfsdk:"delete"`
+	KeyPattern basetypes.StringValue `tfsdk:"key_pattern"`
+	List       basetypes.BoolValue   `tfsdk:"list"`
+	Read       basetypes.BoolValue   `tfsdk:"read"`
+	Update     basetypes.BoolValue   `tfsdk:"update"`
+	Write      basetypes.BoolValue   `tfsdk:"write"`
+	state      attr.ValueState
+}
+
+func (v ConfigCypherValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 6)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["delete"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["key_pattern"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["list"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["read"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["update"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["write"] = basetypes.BoolType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 6)
+
+		val, err = v.Delete.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["delete"] = val
+
+		val, err = v.KeyPattern.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["key_pattern"] = val
+
+		val, err = v.List.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["list"] = val
+
+		val, err = v.Read.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["read"] = val
+
+		val, err = v.Update.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["update"] = val
+
+		val, err = v.Write.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["write"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigCypherValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigCypherValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigCypherValue) String() string {
+	return "ConfigCypherValue"
+}
+
+func (v ConfigCypherValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"delete":      basetypes.BoolType{},
+		"key_pattern": basetypes.StringType{},
+		"list":        basetypes.BoolType{},
+		"read":        basetypes.BoolType{},
+		"update":      basetypes.BoolType{},
+		"write":       basetypes.BoolType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"delete":      v.Delete,
+			"key_pattern": v.KeyPattern,
+			"list":        v.List,
+			"read":        v.Read,
+			"update":      v.Update,
+			"write":       v.Write,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigCypherValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigCypherValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Delete.Equal(other.Delete) {
+		return false
+	}
+
+	if !v.KeyPattern.Equal(other.KeyPattern) {
+		return false
+	}
+
+	if !v.List.Equal(other.List) {
+		return false
+	}
+
+	if !v.Read.Equal(other.Read) {
+		return false
+	}
+
+	if !v.Update.Equal(other.Update) {
+		return false
+	}
+
+	if !v.Write.Equal(other.Write) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigCypherValue) Type(ctx context.Context) attr.Type {
+	return ConfigCypherType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigCypherValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"delete":      basetypes.BoolType{},
+		"key_pattern": basetypes.StringType{},
+		"list":        basetypes.BoolType{},
+		"read":        basetypes.BoolType{},
+		"update":      basetypes.BoolType{},
+		"write":       basetypes.BoolType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigDelayedRemovalType{}
+
+type ConfigDelayedRemovalType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigDelayedRemovalType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigDelayedRemovalType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigDelayedRemovalType) String() string {
+	return "ConfigDelayedRemovalType"
+}
+
+func (t ConfigDelayedRemovalType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigDelayedRemovalValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigDelayedRemovalValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	removalAgeAttribute, ok := attributes["removal_age"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`removal_age is missing from object`)
+
+		return nil, diags
+	}
+
+	removalAgeVal, ok := removalAgeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`removal_age expected to be basetypes.StringValue, was: %T`, removalAgeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigDelayedRemovalValue{
+		RemovalAge: removalAgeVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigDelayedRemovalValueNull() ConfigDelayedRemovalValue {
+	return ConfigDelayedRemovalValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigDelayedRemovalValueUnknown() ConfigDelayedRemovalValue {
+	return ConfigDelayedRemovalValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigDelayedRemovalValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigDelayedRemovalValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigDelayedRemovalValue Attribute Value",
+				"While creating a ConfigDelayedRemovalValue value, a missing attribute value was detected. "+
+					"A ConfigDelayedRemovalValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigDelayedRemovalValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigDelayedRemovalValue Attribute Type",
+				"While creating a ConfigDelayedRemovalValue value, an invalid attribute value was detected. "+
+					"A ConfigDelayedRemovalValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigDelayedRemovalValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigDelayedRemovalValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigDelayedRemovalValue Attribute Value",
+				"While creating a ConfigDelayedRemovalValue value, an extra attribute value was detected. "+
+					"A ConfigDelayedRemovalValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigDelayedRemovalValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigDelayedRemovalValueUnknown(), diags
+	}
+
+	removalAgeAttribute, ok := attributes["removal_age"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`removal_age is missing from object`)
+
+		return NewConfigDelayedRemovalValueUnknown(), diags
+	}
+
+	removalAgeVal, ok := removalAgeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`removal_age expected to be basetypes.StringValue, was: %T`, removalAgeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigDelayedRemovalValueUnknown(), diags
+	}
+
+	return ConfigDelayedRemovalValue{
+		RemovalAge: removalAgeVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigDelayedRemovalValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigDelayedRemovalValue {
+	object, diags := NewConfigDelayedRemovalValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigDelayedRemovalValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigDelayedRemovalType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigDelayedRemovalValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigDelayedRemovalValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigDelayedRemovalValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigDelayedRemovalValueMust(ConfigDelayedRemovalValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigDelayedRemovalType) ValueType(ctx context.Context) attr.Value {
+	return ConfigDelayedRemovalValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigDelayedRemovalValue{}
+
+type ConfigDelayedRemovalValue struct {
+	RemovalAge basetypes.StringValue `tfsdk:"removal_age"`
+	state      attr.ValueState
+}
+
+func (v ConfigDelayedRemovalValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["removal_age"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.RemovalAge.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["removal_age"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigDelayedRemovalValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigDelayedRemovalValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigDelayedRemovalValue) String() string {
+	return "ConfigDelayedRemovalValue"
+}
+
+func (v ConfigDelayedRemovalValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"removal_age": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"removal_age": v.RemovalAge,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigDelayedRemovalValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigDelayedRemovalValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.RemovalAge.Equal(other.RemovalAge) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigDelayedRemovalValue) Type(ctx context.Context) attr.Type {
+	return ConfigDelayedRemovalType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigDelayedRemovalValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"removal_age": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigHostNamingType{}
+
+type ConfigHostNamingType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigHostNamingType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigHostNamingType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigHostNamingType) String() string {
+	return "ConfigHostNamingType"
+}
+
+func (t ConfigHostNamingType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigHostNamingValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigHostNamingValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	hostNamingPatternAttribute, ok := attributes["host_naming_pattern"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`host_naming_pattern is missing from object`)
+
+		return nil, diags
+	}
+
+	hostNamingPatternVal, ok := hostNamingPatternAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`host_naming_pattern expected to be basetypes.StringValue, was: %T`, hostNamingPatternAttribute))
+	}
+
+	hostNamingTypeAttribute, ok := attributes["host_naming_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`host_naming_type is missing from object`)
+
+		return nil, diags
+	}
+
+	hostNamingTypeVal, ok := hostNamingTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`host_naming_type expected to be basetypes.StringValue, was: %T`, hostNamingTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigHostNamingValue{
+		HostNamingPattern: hostNamingPatternVal,
+		HostNamingType:    hostNamingTypeVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigHostNamingValueNull() ConfigHostNamingValue {
+	return ConfigHostNamingValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigHostNamingValueUnknown() ConfigHostNamingValue {
+	return ConfigHostNamingValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigHostNamingValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigHostNamingValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigHostNamingValue Attribute Value",
+				"While creating a ConfigHostNamingValue value, a missing attribute value was detected. "+
+					"A ConfigHostNamingValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigHostNamingValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigHostNamingValue Attribute Type",
+				"While creating a ConfigHostNamingValue value, an invalid attribute value was detected. "+
+					"A ConfigHostNamingValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigHostNamingValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigHostNamingValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigHostNamingValue Attribute Value",
+				"While creating a ConfigHostNamingValue value, an extra attribute value was detected. "+
+					"A ConfigHostNamingValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigHostNamingValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigHostNamingValueUnknown(), diags
+	}
+
+	hostNamingPatternAttribute, ok := attributes["host_naming_pattern"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`host_naming_pattern is missing from object`)
+
+		return NewConfigHostNamingValueUnknown(), diags
+	}
+
+	hostNamingPatternVal, ok := hostNamingPatternAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`host_naming_pattern expected to be basetypes.StringValue, was: %T`, hostNamingPatternAttribute))
+	}
+
+	hostNamingTypeAttribute, ok := attributes["host_naming_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`host_naming_type is missing from object`)
+
+		return NewConfigHostNamingValueUnknown(), diags
+	}
+
+	hostNamingTypeVal, ok := hostNamingTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`host_naming_type expected to be basetypes.StringValue, was: %T`, hostNamingTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigHostNamingValueUnknown(), diags
+	}
+
+	return ConfigHostNamingValue{
+		HostNamingPattern: hostNamingPatternVal,
+		HostNamingType:    hostNamingTypeVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigHostNamingValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigHostNamingValue {
+	object, diags := NewConfigHostNamingValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigHostNamingValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigHostNamingType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigHostNamingValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigHostNamingValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigHostNamingValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigHostNamingValueMust(ConfigHostNamingValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigHostNamingType) ValueType(ctx context.Context) attr.Value {
+	return ConfigHostNamingValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigHostNamingValue{}
+
+type ConfigHostNamingValue struct {
+	HostNamingPattern basetypes.StringValue `tfsdk:"host_naming_pattern"`
+	HostNamingType    basetypes.StringValue `tfsdk:"host_naming_type"`
+	state             attr.ValueState
+}
+
+func (v ConfigHostNamingValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["host_naming_pattern"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["host_naming_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.HostNamingPattern.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["host_naming_pattern"] = val
+
+		val, err = v.HostNamingType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["host_naming_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigHostNamingValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigHostNamingValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigHostNamingValue) String() string {
+	return "ConfigHostNamingValue"
+}
+
+func (v ConfigHostNamingValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"host_naming_pattern": basetypes.StringType{},
+		"host_naming_type":    basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"host_naming_pattern": v.HostNamingPattern,
+			"host_naming_type":    v.HostNamingType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigHostNamingValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigHostNamingValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.HostNamingPattern.Equal(other.HostNamingPattern) {
+		return false
+	}
+
+	if !v.HostNamingType.Equal(other.HostNamingType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigHostNamingValue) Type(ctx context.Context) attr.Type {
+	return ConfigHostNamingType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigHostNamingValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"host_naming_pattern": basetypes.StringType{},
+		"host_naming_type":    basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigLifecycleType{}
+
+type ConfigLifecycleType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigLifecycleType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigLifecycleType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigLifecycleType) String() string {
+	return "ConfigLifecycleType"
+}
+
+func (t ConfigLifecycleType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigLifecycleValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigLifecycleValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	accountIntegrationIdAttribute, ok := attributes["account_integration_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`account_integration_id is missing from object`)
+
+		return nil, diags
+	}
+
+	accountIntegrationIdVal, ok := accountIntegrationIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`account_integration_id expected to be basetypes.StringValue, was: %T`, accountIntegrationIdAttribute))
+	}
+
+	flowIdAttribute, ok := attributes["flow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`flow_id is missing from object`)
+
+		return nil, diags
+	}
+
+	flowIdVal, ok := flowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`flow_id expected to be basetypes.StringValue, was: %T`, flowIdAttribute))
+	}
+
+	lifecycleAgeAttribute, ok := attributes["lifecycle_age"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_age is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleAgeVal, ok := lifecycleAgeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_age expected to be basetypes.StringValue, was: %T`, lifecycleAgeAttribute))
+	}
+
+	lifecycleAllowExtendAttribute, ok := attributes["lifecycle_allow_extend"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_allow_extend is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleAllowExtendVal, ok := lifecycleAllowExtendAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_allow_extend expected to be basetypes.BoolValue, was: %T`, lifecycleAllowExtendAttribute))
+	}
+
+	lifecycleAutoRenewAttribute, ok := attributes["lifecycle_auto_renew"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_auto_renew is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleAutoRenewVal, ok := lifecycleAutoRenewAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_auto_renew expected to be basetypes.BoolValue, was: %T`, lifecycleAutoRenewAttribute))
+	}
+
+	lifecycleExtensionsBeforeApprovalAttribute, ok := attributes["lifecycle_extensions_before_approval"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_extensions_before_approval is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleExtensionsBeforeApprovalVal, ok := lifecycleExtensionsBeforeApprovalAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_extensions_before_approval expected to be basetypes.StringValue, was: %T`, lifecycleExtensionsBeforeApprovalAttribute))
+	}
+
+	lifecycleHideFixedAttribute, ok := attributes["lifecycle_hide_fixed"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_hide_fixed is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleHideFixedVal, ok := lifecycleHideFixedAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_hide_fixed expected to be basetypes.BoolValue, was: %T`, lifecycleHideFixedAttribute))
+	}
+
+	lifecycleMessageAttribute, ok := attributes["lifecycle_message"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_message is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleMessageVal, ok := lifecycleMessageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_message expected to be basetypes.StringValue, was: %T`, lifecycleMessageAttribute))
+	}
+
+	lifecycleNotifyAttribute, ok := attributes["lifecycle_notify"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_notify is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleNotifyVal, ok := lifecycleNotifyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_notify expected to be basetypes.StringValue, was: %T`, lifecycleNotifyAttribute))
+	}
+
+	lifecycleRenewalAttribute, ok := attributes["lifecycle_renewal"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_renewal is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleRenewalVal, ok := lifecycleRenewalAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_renewal expected to be basetypes.StringValue, was: %T`, lifecycleRenewalAttribute))
+	}
+
+	lifecycleTypeAttribute, ok := attributes["lifecycle_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_type is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleTypeVal, ok := lifecycleTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_type expected to be basetypes.StringValue, was: %T`, lifecycleTypeAttribute))
+	}
+
+	lifecycleWorkflowIdAttribute, ok := attributes["lifecycle_workflow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_workflow_id is missing from object`)
+
+		return nil, diags
+	}
+
+	lifecycleWorkflowIdVal, ok := lifecycleWorkflowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_workflow_id expected to be basetypes.StringValue, was: %T`, lifecycleWorkflowIdAttribute))
+	}
+
+	workflowTypeAttribute, ok := attributes["workflow_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_type is missing from object`)
+
+		return nil, diags
+	}
+
+	workflowTypeVal, ok := workflowTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_type expected to be basetypes.StringValue, was: %T`, workflowTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigLifecycleValue{
+		AccountIntegrationId:              accountIntegrationIdVal,
+		FlowId:                            flowIdVal,
+		LifecycleAge:                      lifecycleAgeVal,
+		LifecycleAllowExtend:              lifecycleAllowExtendVal,
+		LifecycleAutoRenew:                lifecycleAutoRenewVal,
+		LifecycleExtensionsBeforeApproval: lifecycleExtensionsBeforeApprovalVal,
+		LifecycleHideFixed:                lifecycleHideFixedVal,
+		LifecycleMessage:                  lifecycleMessageVal,
+		LifecycleNotify:                   lifecycleNotifyVal,
+		LifecycleRenewal:                  lifecycleRenewalVal,
+		LifecycleType:                     lifecycleTypeVal,
+		LifecycleWorkflowId:               lifecycleWorkflowIdVal,
+		WorkflowType:                      workflowTypeVal,
+		state:                             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigLifecycleValueNull() ConfigLifecycleValue {
+	return ConfigLifecycleValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigLifecycleValueUnknown() ConfigLifecycleValue {
+	return ConfigLifecycleValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigLifecycleValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigLifecycleValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigLifecycleValue Attribute Value",
+				"While creating a ConfigLifecycleValue value, a missing attribute value was detected. "+
+					"A ConfigLifecycleValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigLifecycleValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigLifecycleValue Attribute Type",
+				"While creating a ConfigLifecycleValue value, an invalid attribute value was detected. "+
+					"A ConfigLifecycleValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigLifecycleValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigLifecycleValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigLifecycleValue Attribute Value",
+				"While creating a ConfigLifecycleValue value, an extra attribute value was detected. "+
+					"A ConfigLifecycleValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigLifecycleValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	accountIntegrationIdAttribute, ok := attributes["account_integration_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`account_integration_id is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	accountIntegrationIdVal, ok := accountIntegrationIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`account_integration_id expected to be basetypes.StringValue, was: %T`, accountIntegrationIdAttribute))
+	}
+
+	flowIdAttribute, ok := attributes["flow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`flow_id is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	flowIdVal, ok := flowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`flow_id expected to be basetypes.StringValue, was: %T`, flowIdAttribute))
+	}
+
+	lifecycleAgeAttribute, ok := attributes["lifecycle_age"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_age is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleAgeVal, ok := lifecycleAgeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_age expected to be basetypes.StringValue, was: %T`, lifecycleAgeAttribute))
+	}
+
+	lifecycleAllowExtendAttribute, ok := attributes["lifecycle_allow_extend"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_allow_extend is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleAllowExtendVal, ok := lifecycleAllowExtendAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_allow_extend expected to be basetypes.BoolValue, was: %T`, lifecycleAllowExtendAttribute))
+	}
+
+	lifecycleAutoRenewAttribute, ok := attributes["lifecycle_auto_renew"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_auto_renew is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleAutoRenewVal, ok := lifecycleAutoRenewAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_auto_renew expected to be basetypes.BoolValue, was: %T`, lifecycleAutoRenewAttribute))
+	}
+
+	lifecycleExtensionsBeforeApprovalAttribute, ok := attributes["lifecycle_extensions_before_approval"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_extensions_before_approval is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleExtensionsBeforeApprovalVal, ok := lifecycleExtensionsBeforeApprovalAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_extensions_before_approval expected to be basetypes.StringValue, was: %T`, lifecycleExtensionsBeforeApprovalAttribute))
+	}
+
+	lifecycleHideFixedAttribute, ok := attributes["lifecycle_hide_fixed"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_hide_fixed is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleHideFixedVal, ok := lifecycleHideFixedAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_hide_fixed expected to be basetypes.BoolValue, was: %T`, lifecycleHideFixedAttribute))
+	}
+
+	lifecycleMessageAttribute, ok := attributes["lifecycle_message"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_message is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleMessageVal, ok := lifecycleMessageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_message expected to be basetypes.StringValue, was: %T`, lifecycleMessageAttribute))
+	}
+
+	lifecycleNotifyAttribute, ok := attributes["lifecycle_notify"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_notify is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleNotifyVal, ok := lifecycleNotifyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_notify expected to be basetypes.StringValue, was: %T`, lifecycleNotifyAttribute))
+	}
+
+	lifecycleRenewalAttribute, ok := attributes["lifecycle_renewal"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_renewal is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleRenewalVal, ok := lifecycleRenewalAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_renewal expected to be basetypes.StringValue, was: %T`, lifecycleRenewalAttribute))
+	}
+
+	lifecycleTypeAttribute, ok := attributes["lifecycle_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_type is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleTypeVal, ok := lifecycleTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_type expected to be basetypes.StringValue, was: %T`, lifecycleTypeAttribute))
+	}
+
+	lifecycleWorkflowIdAttribute, ok := attributes["lifecycle_workflow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`lifecycle_workflow_id is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	lifecycleWorkflowIdVal, ok := lifecycleWorkflowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`lifecycle_workflow_id expected to be basetypes.StringValue, was: %T`, lifecycleWorkflowIdAttribute))
+	}
+
+	workflowTypeAttribute, ok := attributes["workflow_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_type is missing from object`)
+
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	workflowTypeVal, ok := workflowTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_type expected to be basetypes.StringValue, was: %T`, workflowTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigLifecycleValueUnknown(), diags
+	}
+
+	return ConfigLifecycleValue{
+		AccountIntegrationId:              accountIntegrationIdVal,
+		FlowId:                            flowIdVal,
+		LifecycleAge:                      lifecycleAgeVal,
+		LifecycleAllowExtend:              lifecycleAllowExtendVal,
+		LifecycleAutoRenew:                lifecycleAutoRenewVal,
+		LifecycleExtensionsBeforeApproval: lifecycleExtensionsBeforeApprovalVal,
+		LifecycleHideFixed:                lifecycleHideFixedVal,
+		LifecycleMessage:                  lifecycleMessageVal,
+		LifecycleNotify:                   lifecycleNotifyVal,
+		LifecycleRenewal:                  lifecycleRenewalVal,
+		LifecycleType:                     lifecycleTypeVal,
+		LifecycleWorkflowId:               lifecycleWorkflowIdVal,
+		WorkflowType:                      workflowTypeVal,
+		state:                             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigLifecycleValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigLifecycleValue {
+	object, diags := NewConfigLifecycleValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigLifecycleValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigLifecycleType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigLifecycleValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigLifecycleValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigLifecycleValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigLifecycleValueMust(ConfigLifecycleValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigLifecycleType) ValueType(ctx context.Context) attr.Value {
+	return ConfigLifecycleValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigLifecycleValue{}
+
+type ConfigLifecycleValue struct {
+	AccountIntegrationId              basetypes.StringValue `tfsdk:"account_integration_id"`
+	FlowId                            basetypes.StringValue `tfsdk:"flow_id"`
+	LifecycleAge                      basetypes.StringValue `tfsdk:"lifecycle_age"`
+	LifecycleAllowExtend              basetypes.BoolValue   `tfsdk:"lifecycle_allow_extend"`
+	LifecycleAutoRenew                basetypes.BoolValue   `tfsdk:"lifecycle_auto_renew"`
+	LifecycleExtensionsBeforeApproval basetypes.StringValue `tfsdk:"lifecycle_extensions_before_approval"`
+	LifecycleHideFixed                basetypes.BoolValue   `tfsdk:"lifecycle_hide_fixed"`
+	LifecycleMessage                  basetypes.StringValue `tfsdk:"lifecycle_message"`
+	LifecycleNotify                   basetypes.StringValue `tfsdk:"lifecycle_notify"`
+	LifecycleRenewal                  basetypes.StringValue `tfsdk:"lifecycle_renewal"`
+	LifecycleType                     basetypes.StringValue `tfsdk:"lifecycle_type"`
+	LifecycleWorkflowId               basetypes.StringValue `tfsdk:"lifecycle_workflow_id"`
+	WorkflowType                      basetypes.StringValue `tfsdk:"workflow_type"`
+	state                             attr.ValueState
+}
+
+func (v ConfigLifecycleValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 13)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["account_integration_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["flow_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["lifecycle_age"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["lifecycle_allow_extend"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["lifecycle_auto_renew"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["lifecycle_extensions_before_approval"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["lifecycle_hide_fixed"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["lifecycle_message"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["lifecycle_notify"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["lifecycle_renewal"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["lifecycle_type"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["lifecycle_workflow_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["workflow_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 13)
+
+		val, err = v.AccountIntegrationId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["account_integration_id"] = val
+
+		val, err = v.FlowId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["flow_id"] = val
+
+		val, err = v.LifecycleAge.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_age"] = val
+
+		val, err = v.LifecycleAllowExtend.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_allow_extend"] = val
+
+		val, err = v.LifecycleAutoRenew.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_auto_renew"] = val
+
+		val, err = v.LifecycleExtensionsBeforeApproval.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_extensions_before_approval"] = val
+
+		val, err = v.LifecycleHideFixed.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_hide_fixed"] = val
+
+		val, err = v.LifecycleMessage.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_message"] = val
+
+		val, err = v.LifecycleNotify.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_notify"] = val
+
+		val, err = v.LifecycleRenewal.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_renewal"] = val
+
+		val, err = v.LifecycleType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_type"] = val
+
+		val, err = v.LifecycleWorkflowId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["lifecycle_workflow_id"] = val
+
+		val, err = v.WorkflowType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["workflow_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigLifecycleValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigLifecycleValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigLifecycleValue) String() string {
+	return "ConfigLifecycleValue"
+}
+
+func (v ConfigLifecycleValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"account_integration_id":               basetypes.StringType{},
+		"flow_id":                              basetypes.StringType{},
+		"lifecycle_age":                        basetypes.StringType{},
+		"lifecycle_allow_extend":               basetypes.BoolType{},
+		"lifecycle_auto_renew":                 basetypes.BoolType{},
+		"lifecycle_extensions_before_approval": basetypes.StringType{},
+		"lifecycle_hide_fixed":                 basetypes.BoolType{},
+		"lifecycle_message":                    basetypes.StringType{},
+		"lifecycle_notify":                     basetypes.StringType{},
+		"lifecycle_renewal":                    basetypes.StringType{},
+		"lifecycle_type":                       basetypes.StringType{},
+		"lifecycle_workflow_id":                basetypes.StringType{},
+		"workflow_type":                        basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"account_integration_id":               v.AccountIntegrationId,
+			"flow_id":                              v.FlowId,
+			"lifecycle_age":                        v.LifecycleAge,
+			"lifecycle_allow_extend":               v.LifecycleAllowExtend,
+			"lifecycle_auto_renew":                 v.LifecycleAutoRenew,
+			"lifecycle_extensions_before_approval": v.LifecycleExtensionsBeforeApproval,
+			"lifecycle_hide_fixed":                 v.LifecycleHideFixed,
+			"lifecycle_message":                    v.LifecycleMessage,
+			"lifecycle_notify":                     v.LifecycleNotify,
+			"lifecycle_renewal":                    v.LifecycleRenewal,
+			"lifecycle_type":                       v.LifecycleType,
+			"lifecycle_workflow_id":                v.LifecycleWorkflowId,
+			"workflow_type":                        v.WorkflowType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigLifecycleValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigLifecycleValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AccountIntegrationId.Equal(other.AccountIntegrationId) {
+		return false
+	}
+
+	if !v.FlowId.Equal(other.FlowId) {
+		return false
+	}
+
+	if !v.LifecycleAge.Equal(other.LifecycleAge) {
+		return false
+	}
+
+	if !v.LifecycleAllowExtend.Equal(other.LifecycleAllowExtend) {
+		return false
+	}
+
+	if !v.LifecycleAutoRenew.Equal(other.LifecycleAutoRenew) {
+		return false
+	}
+
+	if !v.LifecycleExtensionsBeforeApproval.Equal(other.LifecycleExtensionsBeforeApproval) {
+		return false
+	}
+
+	if !v.LifecycleHideFixed.Equal(other.LifecycleHideFixed) {
+		return false
+	}
+
+	if !v.LifecycleMessage.Equal(other.LifecycleMessage) {
+		return false
+	}
+
+	if !v.LifecycleNotify.Equal(other.LifecycleNotify) {
+		return false
+	}
+
+	if !v.LifecycleRenewal.Equal(other.LifecycleRenewal) {
+		return false
+	}
+
+	if !v.LifecycleType.Equal(other.LifecycleType) {
+		return false
+	}
+
+	if !v.LifecycleWorkflowId.Equal(other.LifecycleWorkflowId) {
+		return false
+	}
+
+	if !v.WorkflowType.Equal(other.WorkflowType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigLifecycleValue) Type(ctx context.Context) attr.Type {
+	return ConfigLifecycleType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigLifecycleValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"account_integration_id":               basetypes.StringType{},
+		"flow_id":                              basetypes.StringType{},
+		"lifecycle_age":                        basetypes.StringType{},
+		"lifecycle_allow_extend":               basetypes.BoolType{},
+		"lifecycle_auto_renew":                 basetypes.BoolType{},
+		"lifecycle_extensions_before_approval": basetypes.StringType{},
+		"lifecycle_hide_fixed":                 basetypes.BoolType{},
+		"lifecycle_message":                    basetypes.StringType{},
+		"lifecycle_notify":                     basetypes.StringType{},
+		"lifecycle_renewal":                    basetypes.StringType{},
+		"lifecycle_type":                       basetypes.StringType{},
+		"lifecycle_workflow_id":                basetypes.StringType{},
+		"workflow_type":                        basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxContainersType{}
+
+type ConfigMaxContainersType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxContainersType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxContainersType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxContainersType) String() string {
+	return "ConfigMaxContainersType"
+}
+
+func (t ConfigMaxContainersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxContainersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxContainersValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxContainersAttribute, ok := attributes["max_containers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_containers is missing from object`)
+
+		return nil, diags
+	}
+
+	maxContainersVal, ok := maxContainersAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_containers expected to be basetypes.StringValue, was: %T`, maxContainersAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxContainersValue{
+		MaxContainers: maxContainersVal,
+		state:         attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxContainersValueNull() ConfigMaxContainersValue {
+	return ConfigMaxContainersValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxContainersValueUnknown() ConfigMaxContainersValue {
+	return ConfigMaxContainersValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxContainersValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxContainersValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxContainersValue Attribute Value",
+				"While creating a ConfigMaxContainersValue value, a missing attribute value was detected. "+
+					"A ConfigMaxContainersValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxContainersValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxContainersValue Attribute Type",
+				"While creating a ConfigMaxContainersValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxContainersValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxContainersValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxContainersValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxContainersValue Attribute Value",
+				"While creating a ConfigMaxContainersValue value, an extra attribute value was detected. "+
+					"A ConfigMaxContainersValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxContainersValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxContainersValueUnknown(), diags
+	}
+
+	maxContainersAttribute, ok := attributes["max_containers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_containers is missing from object`)
+
+		return NewConfigMaxContainersValueUnknown(), diags
+	}
+
+	maxContainersVal, ok := maxContainersAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_containers expected to be basetypes.StringValue, was: %T`, maxContainersAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxContainersValueUnknown(), diags
+	}
+
+	return ConfigMaxContainersValue{
+		MaxContainers: maxContainersVal,
+		state:         attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxContainersValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxContainersValue {
+	object, diags := NewConfigMaxContainersValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxContainersValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxContainersType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxContainersValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxContainersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxContainersValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxContainersValueMust(ConfigMaxContainersValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxContainersType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxContainersValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxContainersValue{}
+
+type ConfigMaxContainersValue struct {
+	MaxContainers basetypes.StringValue `tfsdk:"max_containers"`
+	state         attr.ValueState
+}
+
+func (v ConfigMaxContainersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_containers"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxContainers.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_containers"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxContainersValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxContainersValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxContainersValue) String() string {
+	return "ConfigMaxContainersValue"
+}
+
+func (v ConfigMaxContainersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_containers": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_containers": v.MaxContainers,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxContainersValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxContainersValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxContainers.Equal(other.MaxContainers) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxContainersValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxContainersType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxContainersValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_containers": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxCoresType{}
+
+type ConfigMaxCoresType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxCoresType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxCoresType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxCoresType) String() string {
+	return "ConfigMaxCoresType"
+}
+
+func (t ConfigMaxCoresType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxCoresValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxCoresValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	excludeContainersAttribute, ok := attributes["exclude_containers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`exclude_containers is missing from object`)
+
+		return nil, diags
+	}
+
+	excludeContainersVal, ok := excludeContainersAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`exclude_containers expected to be basetypes.BoolValue, was: %T`, excludeContainersAttribute))
+	}
+
+	maxCoresAttribute, ok := attributes["max_cores"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_cores is missing from object`)
+
+		return nil, diags
+	}
+
+	maxCoresVal, ok := maxCoresAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_cores expected to be basetypes.StringValue, was: %T`, maxCoresAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxCoresValue{
+		ExcludeContainers: excludeContainersVal,
+		MaxCores:          maxCoresVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxCoresValueNull() ConfigMaxCoresValue {
+	return ConfigMaxCoresValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxCoresValueUnknown() ConfigMaxCoresValue {
+	return ConfigMaxCoresValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxCoresValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxCoresValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxCoresValue Attribute Value",
+				"While creating a ConfigMaxCoresValue value, a missing attribute value was detected. "+
+					"A ConfigMaxCoresValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxCoresValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxCoresValue Attribute Type",
+				"While creating a ConfigMaxCoresValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxCoresValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxCoresValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxCoresValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxCoresValue Attribute Value",
+				"While creating a ConfigMaxCoresValue value, an extra attribute value was detected. "+
+					"A ConfigMaxCoresValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxCoresValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxCoresValueUnknown(), diags
+	}
+
+	excludeContainersAttribute, ok := attributes["exclude_containers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`exclude_containers is missing from object`)
+
+		return NewConfigMaxCoresValueUnknown(), diags
+	}
+
+	excludeContainersVal, ok := excludeContainersAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`exclude_containers expected to be basetypes.BoolValue, was: %T`, excludeContainersAttribute))
+	}
+
+	maxCoresAttribute, ok := attributes["max_cores"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_cores is missing from object`)
+
+		return NewConfigMaxCoresValueUnknown(), diags
+	}
+
+	maxCoresVal, ok := maxCoresAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_cores expected to be basetypes.StringValue, was: %T`, maxCoresAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxCoresValueUnknown(), diags
+	}
+
+	return ConfigMaxCoresValue{
+		ExcludeContainers: excludeContainersVal,
+		MaxCores:          maxCoresVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxCoresValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxCoresValue {
+	object, diags := NewConfigMaxCoresValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxCoresValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxCoresType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxCoresValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxCoresValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxCoresValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxCoresValueMust(ConfigMaxCoresValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxCoresType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxCoresValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxCoresValue{}
+
+type ConfigMaxCoresValue struct {
+	ExcludeContainers basetypes.BoolValue   `tfsdk:"exclude_containers"`
+	MaxCores          basetypes.StringValue `tfsdk:"max_cores"`
+	state             attr.ValueState
+}
+
+func (v ConfigMaxCoresValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["exclude_containers"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["max_cores"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.ExcludeContainers.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["exclude_containers"] = val
+
+		val, err = v.MaxCores.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_cores"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxCoresValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxCoresValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxCoresValue) String() string {
+	return "ConfigMaxCoresValue"
+}
+
+func (v ConfigMaxCoresValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"exclude_containers": basetypes.BoolType{},
+		"max_cores":          basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"exclude_containers": v.ExcludeContainers,
+			"max_cores":          v.MaxCores,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxCoresValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxCoresValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.ExcludeContainers.Equal(other.ExcludeContainers) {
+		return false
+	}
+
+	if !v.MaxCores.Equal(other.MaxCores) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxCoresValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxCoresType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxCoresValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"exclude_containers": basetypes.BoolType{},
+		"max_cores":          basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxHostsType{}
+
+type ConfigMaxHostsType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxHostsType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxHostsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxHostsType) String() string {
+	return "ConfigMaxHostsType"
+}
+
+func (t ConfigMaxHostsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxHostsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxHostsValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxHostsAttribute, ok := attributes["max_hosts"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_hosts is missing from object`)
+
+		return nil, diags
+	}
+
+	maxHostsVal, ok := maxHostsAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_hosts expected to be basetypes.StringValue, was: %T`, maxHostsAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxHostsValue{
+		MaxHosts: maxHostsVal,
+		state:    attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxHostsValueNull() ConfigMaxHostsValue {
+	return ConfigMaxHostsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxHostsValueUnknown() ConfigMaxHostsValue {
+	return ConfigMaxHostsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxHostsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxHostsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxHostsValue Attribute Value",
+				"While creating a ConfigMaxHostsValue value, a missing attribute value was detected. "+
+					"A ConfigMaxHostsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxHostsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxHostsValue Attribute Type",
+				"While creating a ConfigMaxHostsValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxHostsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxHostsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxHostsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxHostsValue Attribute Value",
+				"While creating a ConfigMaxHostsValue value, an extra attribute value was detected. "+
+					"A ConfigMaxHostsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxHostsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxHostsValueUnknown(), diags
+	}
+
+	maxHostsAttribute, ok := attributes["max_hosts"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_hosts is missing from object`)
+
+		return NewConfigMaxHostsValueUnknown(), diags
+	}
+
+	maxHostsVal, ok := maxHostsAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_hosts expected to be basetypes.StringValue, was: %T`, maxHostsAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxHostsValueUnknown(), diags
+	}
+
+	return ConfigMaxHostsValue{
+		MaxHosts: maxHostsVal,
+		state:    attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxHostsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxHostsValue {
+	object, diags := NewConfigMaxHostsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxHostsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxHostsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxHostsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxHostsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxHostsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxHostsValueMust(ConfigMaxHostsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxHostsType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxHostsValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxHostsValue{}
+
+type ConfigMaxHostsValue struct {
+	MaxHosts basetypes.StringValue `tfsdk:"max_hosts"`
+	state    attr.ValueState
+}
+
+func (v ConfigMaxHostsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_hosts"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxHosts.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_hosts"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxHostsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxHostsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxHostsValue) String() string {
+	return "ConfigMaxHostsValue"
+}
+
+func (v ConfigMaxHostsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_hosts": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_hosts": v.MaxHosts,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxHostsValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxHostsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxHosts.Equal(other.MaxHosts) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxHostsValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxHostsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxHostsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_hosts": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxMemoryType{}
+
+type ConfigMaxMemoryType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxMemoryType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxMemoryType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxMemoryType) String() string {
+	return "ConfigMaxMemoryType"
+}
+
+func (t ConfigMaxMemoryType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxMemoryValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxMemoryValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	excludeContainersAttribute, ok := attributes["exclude_containers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`exclude_containers is missing from object`)
+
+		return nil, diags
+	}
+
+	excludeContainersVal, ok := excludeContainersAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`exclude_containers expected to be basetypes.BoolValue, was: %T`, excludeContainersAttribute))
+	}
+
+	maxMemoryAttribute, ok := attributes["max_memory"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_memory is missing from object`)
+
+		return nil, diags
+	}
+
+	maxMemoryVal, ok := maxMemoryAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_memory expected to be basetypes.StringValue, was: %T`, maxMemoryAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxMemoryValue{
+		ExcludeContainers: excludeContainersVal,
+		MaxMemory:         maxMemoryVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxMemoryValueNull() ConfigMaxMemoryValue {
+	return ConfigMaxMemoryValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxMemoryValueUnknown() ConfigMaxMemoryValue {
+	return ConfigMaxMemoryValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxMemoryValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxMemoryValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxMemoryValue Attribute Value",
+				"While creating a ConfigMaxMemoryValue value, a missing attribute value was detected. "+
+					"A ConfigMaxMemoryValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxMemoryValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxMemoryValue Attribute Type",
+				"While creating a ConfigMaxMemoryValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxMemoryValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxMemoryValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxMemoryValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxMemoryValue Attribute Value",
+				"While creating a ConfigMaxMemoryValue value, an extra attribute value was detected. "+
+					"A ConfigMaxMemoryValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxMemoryValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxMemoryValueUnknown(), diags
+	}
+
+	excludeContainersAttribute, ok := attributes["exclude_containers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`exclude_containers is missing from object`)
+
+		return NewConfigMaxMemoryValueUnknown(), diags
+	}
+
+	excludeContainersVal, ok := excludeContainersAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`exclude_containers expected to be basetypes.BoolValue, was: %T`, excludeContainersAttribute))
+	}
+
+	maxMemoryAttribute, ok := attributes["max_memory"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_memory is missing from object`)
+
+		return NewConfigMaxMemoryValueUnknown(), diags
+	}
+
+	maxMemoryVal, ok := maxMemoryAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_memory expected to be basetypes.StringValue, was: %T`, maxMemoryAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxMemoryValueUnknown(), diags
+	}
+
+	return ConfigMaxMemoryValue{
+		ExcludeContainers: excludeContainersVal,
+		MaxMemory:         maxMemoryVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxMemoryValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxMemoryValue {
+	object, diags := NewConfigMaxMemoryValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxMemoryValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxMemoryType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxMemoryValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxMemoryValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxMemoryValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxMemoryValueMust(ConfigMaxMemoryValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxMemoryType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxMemoryValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxMemoryValue{}
+
+type ConfigMaxMemoryValue struct {
+	ExcludeContainers basetypes.BoolValue   `tfsdk:"exclude_containers"`
+	MaxMemory         basetypes.StringValue `tfsdk:"max_memory"`
+	state             attr.ValueState
+}
+
+func (v ConfigMaxMemoryValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["exclude_containers"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["max_memory"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.ExcludeContainers.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["exclude_containers"] = val
+
+		val, err = v.MaxMemory.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_memory"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxMemoryValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxMemoryValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxMemoryValue) String() string {
+	return "ConfigMaxMemoryValue"
+}
+
+func (v ConfigMaxMemoryValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"exclude_containers": basetypes.BoolType{},
+		"max_memory":         basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"exclude_containers": v.ExcludeContainers,
+			"max_memory":         v.MaxMemory,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxMemoryValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxMemoryValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.ExcludeContainers.Equal(other.ExcludeContainers) {
+		return false
+	}
+
+	if !v.MaxMemory.Equal(other.MaxMemory) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxMemoryValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxMemoryType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxMemoryValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"exclude_containers": basetypes.BoolType{},
+		"max_memory":         basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxNetworksType{}
+
+type ConfigMaxNetworksType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxNetworksType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxNetworksType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxNetworksType) String() string {
+	return "ConfigMaxNetworksType"
+}
+
+func (t ConfigMaxNetworksType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxNetworksValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxNetworksValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxNetworksAttribute, ok := attributes["max_networks"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_networks is missing from object`)
+
+		return nil, diags
+	}
+
+	maxNetworksVal, ok := maxNetworksAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_networks expected to be basetypes.StringValue, was: %T`, maxNetworksAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxNetworksValue{
+		MaxNetworks: maxNetworksVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxNetworksValueNull() ConfigMaxNetworksValue {
+	return ConfigMaxNetworksValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxNetworksValueUnknown() ConfigMaxNetworksValue {
+	return ConfigMaxNetworksValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxNetworksValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxNetworksValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxNetworksValue Attribute Value",
+				"While creating a ConfigMaxNetworksValue value, a missing attribute value was detected. "+
+					"A ConfigMaxNetworksValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxNetworksValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxNetworksValue Attribute Type",
+				"While creating a ConfigMaxNetworksValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxNetworksValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxNetworksValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxNetworksValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxNetworksValue Attribute Value",
+				"While creating a ConfigMaxNetworksValue value, an extra attribute value was detected. "+
+					"A ConfigMaxNetworksValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxNetworksValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxNetworksValueUnknown(), diags
+	}
+
+	maxNetworksAttribute, ok := attributes["max_networks"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_networks is missing from object`)
+
+		return NewConfigMaxNetworksValueUnknown(), diags
+	}
+
+	maxNetworksVal, ok := maxNetworksAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_networks expected to be basetypes.StringValue, was: %T`, maxNetworksAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxNetworksValueUnknown(), diags
+	}
+
+	return ConfigMaxNetworksValue{
+		MaxNetworks: maxNetworksVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxNetworksValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxNetworksValue {
+	object, diags := NewConfigMaxNetworksValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxNetworksValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxNetworksType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxNetworksValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxNetworksValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxNetworksValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxNetworksValueMust(ConfigMaxNetworksValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxNetworksType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxNetworksValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxNetworksValue{}
+
+type ConfigMaxNetworksValue struct {
+	MaxNetworks basetypes.StringValue `tfsdk:"max_networks"`
+	state       attr.ValueState
+}
+
+func (v ConfigMaxNetworksValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_networks"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxNetworks.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_networks"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxNetworksValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxNetworksValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxNetworksValue) String() string {
+	return "ConfigMaxNetworksValue"
+}
+
+func (v ConfigMaxNetworksValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_networks": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_networks": v.MaxNetworks,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxNetworksValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxNetworksValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxNetworks.Equal(other.MaxNetworks) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxNetworksValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxNetworksType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxNetworksValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_networks": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxPoolMembersType{}
+
+type ConfigMaxPoolMembersType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxPoolMembersType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxPoolMembersType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxPoolMembersType) String() string {
+	return "ConfigMaxPoolMembersType"
+}
+
+func (t ConfigMaxPoolMembersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxPoolMembersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxPoolMembersValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxPoolMembersAttribute, ok := attributes["max_pool_members"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_pool_members is missing from object`)
+
+		return nil, diags
+	}
+
+	maxPoolMembersVal, ok := maxPoolMembersAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_pool_members expected to be basetypes.StringValue, was: %T`, maxPoolMembersAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxPoolMembersValue{
+		MaxPoolMembers: maxPoolMembersVal,
+		state:          attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxPoolMembersValueNull() ConfigMaxPoolMembersValue {
+	return ConfigMaxPoolMembersValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxPoolMembersValueUnknown() ConfigMaxPoolMembersValue {
+	return ConfigMaxPoolMembersValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxPoolMembersValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxPoolMembersValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxPoolMembersValue Attribute Value",
+				"While creating a ConfigMaxPoolMembersValue value, a missing attribute value was detected. "+
+					"A ConfigMaxPoolMembersValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxPoolMembersValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxPoolMembersValue Attribute Type",
+				"While creating a ConfigMaxPoolMembersValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxPoolMembersValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxPoolMembersValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxPoolMembersValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxPoolMembersValue Attribute Value",
+				"While creating a ConfigMaxPoolMembersValue value, an extra attribute value was detected. "+
+					"A ConfigMaxPoolMembersValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxPoolMembersValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxPoolMembersValueUnknown(), diags
+	}
+
+	maxPoolMembersAttribute, ok := attributes["max_pool_members"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_pool_members is missing from object`)
+
+		return NewConfigMaxPoolMembersValueUnknown(), diags
+	}
+
+	maxPoolMembersVal, ok := maxPoolMembersAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_pool_members expected to be basetypes.StringValue, was: %T`, maxPoolMembersAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxPoolMembersValueUnknown(), diags
+	}
+
+	return ConfigMaxPoolMembersValue{
+		MaxPoolMembers: maxPoolMembersVal,
+		state:          attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxPoolMembersValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxPoolMembersValue {
+	object, diags := NewConfigMaxPoolMembersValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxPoolMembersValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxPoolMembersType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxPoolMembersValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxPoolMembersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxPoolMembersValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxPoolMembersValueMust(ConfigMaxPoolMembersValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxPoolMembersType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxPoolMembersValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxPoolMembersValue{}
+
+type ConfigMaxPoolMembersValue struct {
+	MaxPoolMembers basetypes.StringValue `tfsdk:"max_pool_members"`
+	state          attr.ValueState
+}
+
+func (v ConfigMaxPoolMembersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_pool_members"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxPoolMembers.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_pool_members"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxPoolMembersValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxPoolMembersValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxPoolMembersValue) String() string {
+	return "ConfigMaxPoolMembersValue"
+}
+
+func (v ConfigMaxPoolMembersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_pool_members": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_pool_members": v.MaxPoolMembers,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxPoolMembersValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxPoolMembersValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxPoolMembers.Equal(other.MaxPoolMembers) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxPoolMembersValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxPoolMembersType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxPoolMembersValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_pool_members": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxPoolsType{}
+
+type ConfigMaxPoolsType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxPoolsType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxPoolsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxPoolsType) String() string {
+	return "ConfigMaxPoolsType"
+}
+
+func (t ConfigMaxPoolsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxPoolsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxPoolsValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxPoolsAttribute, ok := attributes["max_pools"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_pools is missing from object`)
+
+		return nil, diags
+	}
+
+	maxPoolsVal, ok := maxPoolsAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_pools expected to be basetypes.StringValue, was: %T`, maxPoolsAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxPoolsValue{
+		MaxPools: maxPoolsVal,
+		state:    attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxPoolsValueNull() ConfigMaxPoolsValue {
+	return ConfigMaxPoolsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxPoolsValueUnknown() ConfigMaxPoolsValue {
+	return ConfigMaxPoolsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxPoolsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxPoolsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxPoolsValue Attribute Value",
+				"While creating a ConfigMaxPoolsValue value, a missing attribute value was detected. "+
+					"A ConfigMaxPoolsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxPoolsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxPoolsValue Attribute Type",
+				"While creating a ConfigMaxPoolsValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxPoolsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxPoolsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxPoolsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxPoolsValue Attribute Value",
+				"While creating a ConfigMaxPoolsValue value, an extra attribute value was detected. "+
+					"A ConfigMaxPoolsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxPoolsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxPoolsValueUnknown(), diags
+	}
+
+	maxPoolsAttribute, ok := attributes["max_pools"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_pools is missing from object`)
+
+		return NewConfigMaxPoolsValueUnknown(), diags
+	}
+
+	maxPoolsVal, ok := maxPoolsAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_pools expected to be basetypes.StringValue, was: %T`, maxPoolsAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxPoolsValueUnknown(), diags
+	}
+
+	return ConfigMaxPoolsValue{
+		MaxPools: maxPoolsVal,
+		state:    attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxPoolsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxPoolsValue {
+	object, diags := NewConfigMaxPoolsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxPoolsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxPoolsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxPoolsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxPoolsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxPoolsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxPoolsValueMust(ConfigMaxPoolsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxPoolsType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxPoolsValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxPoolsValue{}
+
+type ConfigMaxPoolsValue struct {
+	MaxPools basetypes.StringValue `tfsdk:"max_pools"`
+	state    attr.ValueState
+}
+
+func (v ConfigMaxPoolsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_pools"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxPools.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_pools"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxPoolsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxPoolsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxPoolsValue) String() string {
+	return "ConfigMaxPoolsValue"
+}
+
+func (v ConfigMaxPoolsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_pools": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_pools": v.MaxPools,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxPoolsValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxPoolsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxPools.Equal(other.MaxPools) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxPoolsValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxPoolsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxPoolsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_pools": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxPriceType{}
+
+type ConfigMaxPriceType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxPriceType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxPriceType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxPriceType) String() string {
+	return "ConfigMaxPriceType"
+}
+
+func (t ConfigMaxPriceType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxPriceValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxPriceValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxPriceAttribute, ok := attributes["max_price"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_price is missing from object`)
+
+		return nil, diags
+	}
+
+	maxPriceVal, ok := maxPriceAttribute.(basetypes.NumberValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_price expected to be basetypes.NumberValue, was: %T`, maxPriceAttribute))
+	}
+
+	maxPriceCurrencyAttribute, ok := attributes["max_price_currency"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_price_currency is missing from object`)
+
+		return nil, diags
+	}
+
+	maxPriceCurrencyVal, ok := maxPriceCurrencyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_price_currency expected to be basetypes.StringValue, was: %T`, maxPriceCurrencyAttribute))
+	}
+
+	maxPriceUnitAttribute, ok := attributes["max_price_unit"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_price_unit is missing from object`)
+
+		return nil, diags
+	}
+
+	maxPriceUnitVal, ok := maxPriceUnitAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_price_unit expected to be basetypes.StringValue, was: %T`, maxPriceUnitAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxPriceValue{
+		MaxPrice:         maxPriceVal,
+		MaxPriceCurrency: maxPriceCurrencyVal,
+		MaxPriceUnit:     maxPriceUnitVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxPriceValueNull() ConfigMaxPriceValue {
+	return ConfigMaxPriceValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxPriceValueUnknown() ConfigMaxPriceValue {
+	return ConfigMaxPriceValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxPriceValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxPriceValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxPriceValue Attribute Value",
+				"While creating a ConfigMaxPriceValue value, a missing attribute value was detected. "+
+					"A ConfigMaxPriceValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxPriceValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxPriceValue Attribute Type",
+				"While creating a ConfigMaxPriceValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxPriceValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxPriceValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxPriceValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxPriceValue Attribute Value",
+				"While creating a ConfigMaxPriceValue value, an extra attribute value was detected. "+
+					"A ConfigMaxPriceValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxPriceValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxPriceValueUnknown(), diags
+	}
+
+	maxPriceAttribute, ok := attributes["max_price"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_price is missing from object`)
+
+		return NewConfigMaxPriceValueUnknown(), diags
+	}
+
+	maxPriceVal, ok := maxPriceAttribute.(basetypes.NumberValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_price expected to be basetypes.NumberValue, was: %T`, maxPriceAttribute))
+	}
+
+	maxPriceCurrencyAttribute, ok := attributes["max_price_currency"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_price_currency is missing from object`)
+
+		return NewConfigMaxPriceValueUnknown(), diags
+	}
+
+	maxPriceCurrencyVal, ok := maxPriceCurrencyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_price_currency expected to be basetypes.StringValue, was: %T`, maxPriceCurrencyAttribute))
+	}
+
+	maxPriceUnitAttribute, ok := attributes["max_price_unit"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_price_unit is missing from object`)
+
+		return NewConfigMaxPriceValueUnknown(), diags
+	}
+
+	maxPriceUnitVal, ok := maxPriceUnitAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_price_unit expected to be basetypes.StringValue, was: %T`, maxPriceUnitAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxPriceValueUnknown(), diags
+	}
+
+	return ConfigMaxPriceValue{
+		MaxPrice:         maxPriceVal,
+		MaxPriceCurrency: maxPriceCurrencyVal,
+		MaxPriceUnit:     maxPriceUnitVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxPriceValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxPriceValue {
+	object, diags := NewConfigMaxPriceValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxPriceValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxPriceType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxPriceValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxPriceValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxPriceValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxPriceValueMust(ConfigMaxPriceValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxPriceType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxPriceValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxPriceValue{}
+
+type ConfigMaxPriceValue struct {
+	MaxPrice         basetypes.NumberValue `tfsdk:"max_price"`
+	MaxPriceCurrency basetypes.StringValue `tfsdk:"max_price_currency"`
+	MaxPriceUnit     basetypes.StringValue `tfsdk:"max_price_unit"`
+	state            attr.ValueState
+}
+
+func (v ConfigMaxPriceValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_price"] = basetypes.NumberType{}.TerraformType(ctx)
+	attrTypes["max_price_currency"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["max_price_unit"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.MaxPrice.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_price"] = val
+
+		val, err = v.MaxPriceCurrency.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_price_currency"] = val
+
+		val, err = v.MaxPriceUnit.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_price_unit"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxPriceValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxPriceValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxPriceValue) String() string {
+	return "ConfigMaxPriceValue"
+}
+
+func (v ConfigMaxPriceValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_price":          basetypes.NumberType{},
+		"max_price_currency": basetypes.StringType{},
+		"max_price_unit":     basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_price":          v.MaxPrice,
+			"max_price_currency": v.MaxPriceCurrency,
+			"max_price_unit":     v.MaxPriceUnit,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxPriceValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxPriceValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxPrice.Equal(other.MaxPrice) {
+		return false
+	}
+
+	if !v.MaxPriceCurrency.Equal(other.MaxPriceCurrency) {
+		return false
+	}
+
+	if !v.MaxPriceUnit.Equal(other.MaxPriceUnit) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxPriceValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxPriceType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxPriceValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_price":          basetypes.NumberType{},
+		"max_price_currency": basetypes.StringType{},
+		"max_price_unit":     basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxRoutersType{}
+
+type ConfigMaxRoutersType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxRoutersType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxRoutersType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxRoutersType) String() string {
+	return "ConfigMaxRoutersType"
+}
+
+func (t ConfigMaxRoutersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxRoutersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxRoutersValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxRoutersAttribute, ok := attributes["max_routers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_routers is missing from object`)
+
+		return nil, diags
+	}
+
+	maxRoutersVal, ok := maxRoutersAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_routers expected to be basetypes.StringValue, was: %T`, maxRoutersAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxRoutersValue{
+		MaxRouters: maxRoutersVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxRoutersValueNull() ConfigMaxRoutersValue {
+	return ConfigMaxRoutersValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxRoutersValueUnknown() ConfigMaxRoutersValue {
+	return ConfigMaxRoutersValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxRoutersValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxRoutersValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxRoutersValue Attribute Value",
+				"While creating a ConfigMaxRoutersValue value, a missing attribute value was detected. "+
+					"A ConfigMaxRoutersValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxRoutersValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxRoutersValue Attribute Type",
+				"While creating a ConfigMaxRoutersValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxRoutersValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxRoutersValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxRoutersValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxRoutersValue Attribute Value",
+				"While creating a ConfigMaxRoutersValue value, an extra attribute value was detected. "+
+					"A ConfigMaxRoutersValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxRoutersValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxRoutersValueUnknown(), diags
+	}
+
+	maxRoutersAttribute, ok := attributes["max_routers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_routers is missing from object`)
+
+		return NewConfigMaxRoutersValueUnknown(), diags
+	}
+
+	maxRoutersVal, ok := maxRoutersAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_routers expected to be basetypes.StringValue, was: %T`, maxRoutersAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxRoutersValueUnknown(), diags
+	}
+
+	return ConfigMaxRoutersValue{
+		MaxRouters: maxRoutersVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxRoutersValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxRoutersValue {
+	object, diags := NewConfigMaxRoutersValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxRoutersValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxRoutersType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxRoutersValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxRoutersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxRoutersValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxRoutersValueMust(ConfigMaxRoutersValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxRoutersType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxRoutersValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxRoutersValue{}
+
+type ConfigMaxRoutersValue struct {
+	MaxRouters basetypes.StringValue `tfsdk:"max_routers"`
+	state      attr.ValueState
+}
+
+func (v ConfigMaxRoutersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_routers"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxRouters.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_routers"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxRoutersValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxRoutersValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxRoutersValue) String() string {
+	return "ConfigMaxRoutersValue"
+}
+
+func (v ConfigMaxRoutersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_routers": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_routers": v.MaxRouters,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxRoutersValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxRoutersValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxRouters.Equal(other.MaxRouters) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxRoutersValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxRoutersType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxRoutersValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_routers": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxSnapshotsType{}
+
+type ConfigMaxSnapshotsType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxSnapshotsType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxSnapshotsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxSnapshotsType) String() string {
+	return "ConfigMaxSnapshotsType"
+}
+
+func (t ConfigMaxSnapshotsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxSnapshotsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxSnapshotsValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxSnapshotsAttribute, ok := attributes["max_snapshots"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_snapshots is missing from object`)
+
+		return nil, diags
+	}
+
+	maxSnapshotsVal, ok := maxSnapshotsAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_snapshots expected to be basetypes.StringValue, was: %T`, maxSnapshotsAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxSnapshotsValue{
+		MaxSnapshots: maxSnapshotsVal,
+		state:        attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxSnapshotsValueNull() ConfigMaxSnapshotsValue {
+	return ConfigMaxSnapshotsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxSnapshotsValueUnknown() ConfigMaxSnapshotsValue {
+	return ConfigMaxSnapshotsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxSnapshotsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxSnapshotsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxSnapshotsValue Attribute Value",
+				"While creating a ConfigMaxSnapshotsValue value, a missing attribute value was detected. "+
+					"A ConfigMaxSnapshotsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxSnapshotsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxSnapshotsValue Attribute Type",
+				"While creating a ConfigMaxSnapshotsValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxSnapshotsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxSnapshotsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxSnapshotsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxSnapshotsValue Attribute Value",
+				"While creating a ConfigMaxSnapshotsValue value, an extra attribute value was detected. "+
+					"A ConfigMaxSnapshotsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxSnapshotsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxSnapshotsValueUnknown(), diags
+	}
+
+	maxSnapshotsAttribute, ok := attributes["max_snapshots"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_snapshots is missing from object`)
+
+		return NewConfigMaxSnapshotsValueUnknown(), diags
+	}
+
+	maxSnapshotsVal, ok := maxSnapshotsAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_snapshots expected to be basetypes.StringValue, was: %T`, maxSnapshotsAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxSnapshotsValueUnknown(), diags
+	}
+
+	return ConfigMaxSnapshotsValue{
+		MaxSnapshots: maxSnapshotsVal,
+		state:        attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxSnapshotsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxSnapshotsValue {
+	object, diags := NewConfigMaxSnapshotsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxSnapshotsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxSnapshotsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxSnapshotsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxSnapshotsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxSnapshotsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxSnapshotsValueMust(ConfigMaxSnapshotsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxSnapshotsType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxSnapshotsValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxSnapshotsValue{}
+
+type ConfigMaxSnapshotsValue struct {
+	MaxSnapshots basetypes.StringValue `tfsdk:"max_snapshots"`
+	state        attr.ValueState
+}
+
+func (v ConfigMaxSnapshotsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_snapshots"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxSnapshots.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_snapshots"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxSnapshotsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxSnapshotsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxSnapshotsValue) String() string {
+	return "ConfigMaxSnapshotsValue"
+}
+
+func (v ConfigMaxSnapshotsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_snapshots": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_snapshots": v.MaxSnapshots,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxSnapshotsValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxSnapshotsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxSnapshots.Equal(other.MaxSnapshots) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxSnapshotsValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxSnapshotsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxSnapshotsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_snapshots": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxStorageType{}
+
+type ConfigMaxStorageType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxStorageType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxStorageType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxStorageType) String() string {
+	return "ConfigMaxStorageType"
+}
+
+func (t ConfigMaxStorageType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxStorageValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxStorageValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	excludeContainersAttribute, ok := attributes["exclude_containers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`exclude_containers is missing from object`)
+
+		return nil, diags
+	}
+
+	excludeContainersVal, ok := excludeContainersAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`exclude_containers expected to be basetypes.BoolValue, was: %T`, excludeContainersAttribute))
+	}
+
+	maxStorageAttribute, ok := attributes["max_storage"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_storage is missing from object`)
+
+		return nil, diags
+	}
+
+	maxStorageVal, ok := maxStorageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_storage expected to be basetypes.StringValue, was: %T`, maxStorageAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxStorageValue{
+		ExcludeContainers: excludeContainersVal,
+		MaxStorage:        maxStorageVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxStorageValueNull() ConfigMaxStorageValue {
+	return ConfigMaxStorageValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxStorageValueUnknown() ConfigMaxStorageValue {
+	return ConfigMaxStorageValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxStorageValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxStorageValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxStorageValue Attribute Value",
+				"While creating a ConfigMaxStorageValue value, a missing attribute value was detected. "+
+					"A ConfigMaxStorageValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxStorageValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxStorageValue Attribute Type",
+				"While creating a ConfigMaxStorageValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxStorageValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxStorageValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxStorageValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxStorageValue Attribute Value",
+				"While creating a ConfigMaxStorageValue value, an extra attribute value was detected. "+
+					"A ConfigMaxStorageValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxStorageValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxStorageValueUnknown(), diags
+	}
+
+	excludeContainersAttribute, ok := attributes["exclude_containers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`exclude_containers is missing from object`)
+
+		return NewConfigMaxStorageValueUnknown(), diags
+	}
+
+	excludeContainersVal, ok := excludeContainersAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`exclude_containers expected to be basetypes.BoolValue, was: %T`, excludeContainersAttribute))
+	}
+
+	maxStorageAttribute, ok := attributes["max_storage"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_storage is missing from object`)
+
+		return NewConfigMaxStorageValueUnknown(), diags
+	}
+
+	maxStorageVal, ok := maxStorageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_storage expected to be basetypes.StringValue, was: %T`, maxStorageAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxStorageValueUnknown(), diags
+	}
+
+	return ConfigMaxStorageValue{
+		ExcludeContainers: excludeContainersVal,
+		MaxStorage:        maxStorageVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxStorageValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxStorageValue {
+	object, diags := NewConfigMaxStorageValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxStorageValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxStorageType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxStorageValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxStorageValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxStorageValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxStorageValueMust(ConfigMaxStorageValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxStorageType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxStorageValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxStorageValue{}
+
+type ConfigMaxStorageValue struct {
+	ExcludeContainers basetypes.BoolValue   `tfsdk:"exclude_containers"`
+	MaxStorage        basetypes.StringValue `tfsdk:"max_storage"`
+	state             attr.ValueState
+}
+
+func (v ConfigMaxStorageValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["exclude_containers"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["max_storage"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.ExcludeContainers.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["exclude_containers"] = val
+
+		val, err = v.MaxStorage.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_storage"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxStorageValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxStorageValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxStorageValue) String() string {
+	return "ConfigMaxStorageValue"
+}
+
+func (v ConfigMaxStorageValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"exclude_containers": basetypes.BoolType{},
+		"max_storage":        basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"exclude_containers": v.ExcludeContainers,
+			"max_storage":        v.MaxStorage,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxStorageValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxStorageValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.ExcludeContainers.Equal(other.ExcludeContainers) {
+		return false
+	}
+
+	if !v.MaxStorage.Equal(other.MaxStorage) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxStorageValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxStorageType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxStorageValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"exclude_containers": basetypes.BoolType{},
+		"max_storage":        basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxVirtualServersType{}
+
+type ConfigMaxVirtualServersType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxVirtualServersType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxVirtualServersType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxVirtualServersType) String() string {
+	return "ConfigMaxVirtualServersType"
+}
+
+func (t ConfigMaxVirtualServersType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxVirtualServersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxVirtualServersValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxVirtualServersAttribute, ok := attributes["max_virtual_servers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_virtual_servers is missing from object`)
+
+		return nil, diags
+	}
+
+	maxVirtualServersVal, ok := maxVirtualServersAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_virtual_servers expected to be basetypes.StringValue, was: %T`, maxVirtualServersAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxVirtualServersValue{
+		MaxVirtualServers: maxVirtualServersVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxVirtualServersValueNull() ConfigMaxVirtualServersValue {
+	return ConfigMaxVirtualServersValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxVirtualServersValueUnknown() ConfigMaxVirtualServersValue {
+	return ConfigMaxVirtualServersValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxVirtualServersValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxVirtualServersValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxVirtualServersValue Attribute Value",
+				"While creating a ConfigMaxVirtualServersValue value, a missing attribute value was detected. "+
+					"A ConfigMaxVirtualServersValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxVirtualServersValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxVirtualServersValue Attribute Type",
+				"While creating a ConfigMaxVirtualServersValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxVirtualServersValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxVirtualServersValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxVirtualServersValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxVirtualServersValue Attribute Value",
+				"While creating a ConfigMaxVirtualServersValue value, an extra attribute value was detected. "+
+					"A ConfigMaxVirtualServersValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxVirtualServersValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxVirtualServersValueUnknown(), diags
+	}
+
+	maxVirtualServersAttribute, ok := attributes["max_virtual_servers"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_virtual_servers is missing from object`)
+
+		return NewConfigMaxVirtualServersValueUnknown(), diags
+	}
+
+	maxVirtualServersVal, ok := maxVirtualServersAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_virtual_servers expected to be basetypes.StringValue, was: %T`, maxVirtualServersAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxVirtualServersValueUnknown(), diags
+	}
+
+	return ConfigMaxVirtualServersValue{
+		MaxVirtualServers: maxVirtualServersVal,
+		state:             attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxVirtualServersValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxVirtualServersValue {
+	object, diags := NewConfigMaxVirtualServersValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxVirtualServersValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxVirtualServersType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxVirtualServersValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxVirtualServersValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxVirtualServersValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxVirtualServersValueMust(ConfigMaxVirtualServersValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxVirtualServersType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxVirtualServersValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxVirtualServersValue{}
+
+type ConfigMaxVirtualServersValue struct {
+	MaxVirtualServers basetypes.StringValue `tfsdk:"max_virtual_servers"`
+	state             attr.ValueState
+}
+
+func (v ConfigMaxVirtualServersValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_virtual_servers"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxVirtualServers.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_virtual_servers"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxVirtualServersValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxVirtualServersValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxVirtualServersValue) String() string {
+	return "ConfigMaxVirtualServersValue"
+}
+
+func (v ConfigMaxVirtualServersValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_virtual_servers": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_virtual_servers": v.MaxVirtualServers,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxVirtualServersValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxVirtualServersValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxVirtualServers.Equal(other.MaxVirtualServers) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxVirtualServersValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxVirtualServersType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxVirtualServersValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_virtual_servers": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMaxVmsType{}
+
+type ConfigMaxVmsType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMaxVmsType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMaxVmsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMaxVmsType) String() string {
+	return "ConfigMaxVmsType"
+}
+
+func (t ConfigMaxVmsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMaxVmsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxVmsValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxVmsAttribute, ok := attributes["max_vms"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_vms is missing from object`)
+
+		return nil, diags
+	}
+
+	maxVmsVal, ok := maxVmsAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_vms expected to be basetypes.StringValue, was: %T`, maxVmsAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMaxVmsValue{
+		MaxVms: maxVmsVal,
+		state:  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxVmsValueNull() ConfigMaxVmsValue {
+	return ConfigMaxVmsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMaxVmsValueUnknown() ConfigMaxVmsValue {
+	return ConfigMaxVmsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMaxVmsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMaxVmsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMaxVmsValue Attribute Value",
+				"While creating a ConfigMaxVmsValue value, a missing attribute value was detected. "+
+					"A ConfigMaxVmsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxVmsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMaxVmsValue Attribute Type",
+				"While creating a ConfigMaxVmsValue value, an invalid attribute value was detected. "+
+					"A ConfigMaxVmsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMaxVmsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMaxVmsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMaxVmsValue Attribute Value",
+				"While creating a ConfigMaxVmsValue value, an extra attribute value was detected. "+
+					"A ConfigMaxVmsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMaxVmsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxVmsValueUnknown(), diags
+	}
+
+	maxVmsAttribute, ok := attributes["max_vms"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_vms is missing from object`)
+
+		return NewConfigMaxVmsValueUnknown(), diags
+	}
+
+	maxVmsVal, ok := maxVmsAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_vms expected to be basetypes.StringValue, was: %T`, maxVmsAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMaxVmsValueUnknown(), diags
+	}
+
+	return ConfigMaxVmsValue{
+		MaxVms: maxVmsVal,
+		state:  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMaxVmsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMaxVmsValue {
+	object, diags := NewConfigMaxVmsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMaxVmsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMaxVmsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMaxVmsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMaxVmsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMaxVmsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMaxVmsValueMust(ConfigMaxVmsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMaxVmsType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMaxVmsValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMaxVmsValue{}
+
+type ConfigMaxVmsValue struct {
+	MaxVms basetypes.StringValue `tfsdk:"max_vms"`
+	state  attr.ValueState
+}
+
+func (v ConfigMaxVmsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_vms"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.MaxVms.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_vms"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMaxVmsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMaxVmsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMaxVmsValue) String() string {
+	return "ConfigMaxVmsValue"
+}
+
+func (v ConfigMaxVmsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_vms": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_vms": v.MaxVms,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMaxVmsValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMaxVmsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxVms.Equal(other.MaxVms) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMaxVmsValue) Type(ctx context.Context) attr.Type {
+	return ConfigMaxVmsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMaxVmsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_vms": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigMotdType{}
+
+type ConfigMotdType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigMotdType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigMotdType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigMotdType) String() string {
+	return "ConfigMotdType"
+}
+
+func (t ConfigMotdType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigMotdValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMotdValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	motddateAttribute, ok := attributes["motddate"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`motddate is missing from object`)
+
+		return nil, diags
+	}
+
+	motddateVal, ok := motddateAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`motddate expected to be basetypes.StringValue, was: %T`, motddateAttribute))
+	}
+
+	motdmessageAttribute, ok := attributes["motdmessage"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`motdmessage is missing from object`)
+
+		return nil, diags
+	}
+
+	motdmessageVal, ok := motdmessageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`motdmessage expected to be basetypes.StringValue, was: %T`, motdmessageAttribute))
+	}
+
+	motdtitleAttribute, ok := attributes["motdtitle"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`motdtitle is missing from object`)
+
+		return nil, diags
+	}
+
+	motdtitleVal, ok := motdtitleAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`motdtitle expected to be basetypes.StringValue, was: %T`, motdtitleAttribute))
+	}
+
+	motdtypeAttribute, ok := attributes["motdtype"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`motdtype is missing from object`)
+
+		return nil, diags
+	}
+
+	motdtypeVal, ok := motdtypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`motdtype expected to be basetypes.StringValue, was: %T`, motdtypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigMotdValue{
+		Motddate:    motddateVal,
+		Motdmessage: motdmessageVal,
+		Motdtitle:   motdtitleVal,
+		Motdtype:    motdtypeVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMotdValueNull() ConfigMotdValue {
+	return ConfigMotdValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigMotdValueUnknown() ConfigMotdValue {
+	return ConfigMotdValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigMotdValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigMotdValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigMotdValue Attribute Value",
+				"While creating a ConfigMotdValue value, a missing attribute value was detected. "+
+					"A ConfigMotdValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMotdValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigMotdValue Attribute Type",
+				"While creating a ConfigMotdValue value, an invalid attribute value was detected. "+
+					"A ConfigMotdValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigMotdValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigMotdValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigMotdValue Attribute Value",
+				"While creating a ConfigMotdValue value, an extra attribute value was detected. "+
+					"A ConfigMotdValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigMotdValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigMotdValueUnknown(), diags
+	}
+
+	motddateAttribute, ok := attributes["motddate"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`motddate is missing from object`)
+
+		return NewConfigMotdValueUnknown(), diags
+	}
+
+	motddateVal, ok := motddateAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`motddate expected to be basetypes.StringValue, was: %T`, motddateAttribute))
+	}
+
+	motdmessageAttribute, ok := attributes["motdmessage"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`motdmessage is missing from object`)
+
+		return NewConfigMotdValueUnknown(), diags
+	}
+
+	motdmessageVal, ok := motdmessageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`motdmessage expected to be basetypes.StringValue, was: %T`, motdmessageAttribute))
+	}
+
+	motdtitleAttribute, ok := attributes["motdtitle"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`motdtitle is missing from object`)
+
+		return NewConfigMotdValueUnknown(), diags
+	}
+
+	motdtitleVal, ok := motdtitleAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`motdtitle expected to be basetypes.StringValue, was: %T`, motdtitleAttribute))
+	}
+
+	motdtypeAttribute, ok := attributes["motdtype"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`motdtype is missing from object`)
+
+		return NewConfigMotdValueUnknown(), diags
+	}
+
+	motdtypeVal, ok := motdtypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`motdtype expected to be basetypes.StringValue, was: %T`, motdtypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigMotdValueUnknown(), diags
+	}
+
+	return ConfigMotdValue{
+		Motddate:    motddateVal,
+		Motdmessage: motdmessageVal,
+		Motdtitle:   motdtitleVal,
+		Motdtype:    motdtypeVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigMotdValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigMotdValue {
+	object, diags := NewConfigMotdValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigMotdValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigMotdType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigMotdValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigMotdValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigMotdValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigMotdValueMust(ConfigMotdValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigMotdType) ValueType(ctx context.Context) attr.Value {
+	return ConfigMotdValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigMotdValue{}
+
+type ConfigMotdValue struct {
+	Motddate    basetypes.StringValue `tfsdk:"motddate"`
+	Motdmessage basetypes.StringValue `tfsdk:"motdmessage"`
+	Motdtitle   basetypes.StringValue `tfsdk:"motdtitle"`
+	Motdtype    basetypes.StringValue `tfsdk:"motdtype"`
+	state       attr.ValueState
+}
+
+func (v ConfigMotdValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 4)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["motddate"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["motdmessage"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["motdtitle"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["motdtype"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 4)
+
+		val, err = v.Motddate.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["motddate"] = val
+
+		val, err = v.Motdmessage.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["motdmessage"] = val
+
+		val, err = v.Motdtitle.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["motdtitle"] = val
+
+		val, err = v.Motdtype.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["motdtype"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigMotdValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigMotdValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigMotdValue) String() string {
+	return "ConfigMotdValue"
+}
+
+func (v ConfigMotdValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"motddate":    basetypes.StringType{},
+		"motdmessage": basetypes.StringType{},
+		"motdtitle":   basetypes.StringType{},
+		"motdtype":    basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"motddate":    v.Motddate,
+			"motdmessage": v.Motdmessage,
+			"motdtitle":   v.Motdtitle,
+			"motdtype":    v.Motdtype,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigMotdValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigMotdValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Motddate.Equal(other.Motddate) {
+		return false
+	}
+
+	if !v.Motdmessage.Equal(other.Motdmessage) {
+		return false
+	}
+
+	if !v.Motdtitle.Equal(other.Motdtitle) {
+		return false
+	}
+
+	if !v.Motdtype.Equal(other.Motdtype) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigMotdValue) Type(ctx context.Context) attr.Type {
+	return ConfigMotdType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigMotdValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"motddate":    basetypes.StringType{},
+		"motdmessage": basetypes.StringType{},
+		"motdtitle":   basetypes.StringType{},
+		"motdtype":    basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigNamingType{}
+
+type ConfigNamingType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigNamingType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigNamingType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigNamingType) String() string {
+	return "ConfigNamingType"
+}
+
+func (t ConfigNamingType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigNamingValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigNamingValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	namingConflictAttribute, ok := attributes["naming_conflict"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`naming_conflict is missing from object`)
+
+		return nil, diags
+	}
+
+	namingConflictVal, ok := namingConflictAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`naming_conflict expected to be basetypes.BoolValue, was: %T`, namingConflictAttribute))
+	}
+
+	namingPatternAttribute, ok := attributes["naming_pattern"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`naming_pattern is missing from object`)
+
+		return nil, diags
+	}
+
+	namingPatternVal, ok := namingPatternAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`naming_pattern expected to be basetypes.StringValue, was: %T`, namingPatternAttribute))
+	}
+
+	namingTypeAttribute, ok := attributes["naming_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`naming_type is missing from object`)
+
+		return nil, diags
+	}
+
+	namingTypeVal, ok := namingTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`naming_type expected to be basetypes.StringValue, was: %T`, namingTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigNamingValue{
+		NamingConflict: namingConflictVal,
+		NamingPattern:  namingPatternVal,
+		NamingType:     namingTypeVal,
+		state:          attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigNamingValueNull() ConfigNamingValue {
+	return ConfigNamingValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigNamingValueUnknown() ConfigNamingValue {
+	return ConfigNamingValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigNamingValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigNamingValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigNamingValue Attribute Value",
+				"While creating a ConfigNamingValue value, a missing attribute value was detected. "+
+					"A ConfigNamingValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigNamingValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigNamingValue Attribute Type",
+				"While creating a ConfigNamingValue value, an invalid attribute value was detected. "+
+					"A ConfigNamingValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigNamingValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigNamingValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigNamingValue Attribute Value",
+				"While creating a ConfigNamingValue value, an extra attribute value was detected. "+
+					"A ConfigNamingValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigNamingValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigNamingValueUnknown(), diags
+	}
+
+	namingConflictAttribute, ok := attributes["naming_conflict"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`naming_conflict is missing from object`)
+
+		return NewConfigNamingValueUnknown(), diags
+	}
+
+	namingConflictVal, ok := namingConflictAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`naming_conflict expected to be basetypes.BoolValue, was: %T`, namingConflictAttribute))
+	}
+
+	namingPatternAttribute, ok := attributes["naming_pattern"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`naming_pattern is missing from object`)
+
+		return NewConfigNamingValueUnknown(), diags
+	}
+
+	namingPatternVal, ok := namingPatternAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`naming_pattern expected to be basetypes.StringValue, was: %T`, namingPatternAttribute))
+	}
+
+	namingTypeAttribute, ok := attributes["naming_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`naming_type is missing from object`)
+
+		return NewConfigNamingValueUnknown(), diags
+	}
+
+	namingTypeVal, ok := namingTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`naming_type expected to be basetypes.StringValue, was: %T`, namingTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigNamingValueUnknown(), diags
+	}
+
+	return ConfigNamingValue{
+		NamingConflict: namingConflictVal,
+		NamingPattern:  namingPatternVal,
+		NamingType:     namingTypeVal,
+		state:          attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigNamingValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigNamingValue {
+	object, diags := NewConfigNamingValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigNamingValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigNamingType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigNamingValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigNamingValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigNamingValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigNamingValueMust(ConfigNamingValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigNamingType) ValueType(ctx context.Context) attr.Value {
+	return ConfigNamingValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigNamingValue{}
+
+type ConfigNamingValue struct {
+	NamingConflict basetypes.BoolValue   `tfsdk:"naming_conflict"`
+	NamingPattern  basetypes.StringValue `tfsdk:"naming_pattern"`
+	NamingType     basetypes.StringValue `tfsdk:"naming_type"`
+	state          attr.ValueState
+}
+
+func (v ConfigNamingValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["naming_conflict"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["naming_pattern"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["naming_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.NamingConflict.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["naming_conflict"] = val
+
+		val, err = v.NamingPattern.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["naming_pattern"] = val
+
+		val, err = v.NamingType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["naming_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigNamingValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigNamingValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigNamingValue) String() string {
+	return "ConfigNamingValue"
+}
+
+func (v ConfigNamingValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"naming_conflict": basetypes.BoolType{},
+		"naming_pattern":  basetypes.StringType{},
+		"naming_type":     basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"naming_conflict": v.NamingConflict,
+			"naming_pattern":  v.NamingPattern,
+			"naming_type":     v.NamingType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigNamingValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigNamingValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.NamingConflict.Equal(other.NamingConflict) {
+		return false
+	}
+
+	if !v.NamingPattern.Equal(other.NamingPattern) {
+		return false
+	}
+
+	if !v.NamingType.Equal(other.NamingType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigNamingValue) Type(ctx context.Context) attr.Type {
+	return ConfigNamingType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigNamingValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"naming_conflict": basetypes.BoolType{},
+		"naming_pattern":  basetypes.StringType{},
+		"naming_type":     basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigPowerScheduleType{}
+
+type ConfigPowerScheduleType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigPowerScheduleType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigPowerScheduleType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigPowerScheduleType) String() string {
+	return "ConfigPowerScheduleType"
+}
+
+func (t ConfigPowerScheduleType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigPowerScheduleValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigPowerScheduleValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	powerScheduleAttribute, ok := attributes["power_schedule"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`power_schedule is missing from object`)
+
+		return nil, diags
+	}
+
+	powerScheduleVal, ok := powerScheduleAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`power_schedule expected to be basetypes.StringValue, was: %T`, powerScheduleAttribute))
+	}
+
+	powerScheduleHideFixedAttribute, ok := attributes["power_schedule_hide_fixed"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`power_schedule_hide_fixed is missing from object`)
+
+		return nil, diags
+	}
+
+	powerScheduleHideFixedVal, ok := powerScheduleHideFixedAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`power_schedule_hide_fixed expected to be basetypes.BoolValue, was: %T`, powerScheduleHideFixedAttribute))
+	}
+
+	powerScheduleTypeAttribute, ok := attributes["power_schedule_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`power_schedule_type is missing from object`)
+
+		return nil, diags
+	}
+
+	powerScheduleTypeVal, ok := powerScheduleTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`power_schedule_type expected to be basetypes.StringValue, was: %T`, powerScheduleTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigPowerScheduleValue{
+		PowerSchedule:          powerScheduleVal,
+		PowerScheduleHideFixed: powerScheduleHideFixedVal,
+		PowerScheduleType:      powerScheduleTypeVal,
+		state:                  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigPowerScheduleValueNull() ConfigPowerScheduleValue {
+	return ConfigPowerScheduleValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigPowerScheduleValueUnknown() ConfigPowerScheduleValue {
+	return ConfigPowerScheduleValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigPowerScheduleValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigPowerScheduleValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigPowerScheduleValue Attribute Value",
+				"While creating a ConfigPowerScheduleValue value, a missing attribute value was detected. "+
+					"A ConfigPowerScheduleValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigPowerScheduleValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigPowerScheduleValue Attribute Type",
+				"While creating a ConfigPowerScheduleValue value, an invalid attribute value was detected. "+
+					"A ConfigPowerScheduleValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigPowerScheduleValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigPowerScheduleValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigPowerScheduleValue Attribute Value",
+				"While creating a ConfigPowerScheduleValue value, an extra attribute value was detected. "+
+					"A ConfigPowerScheduleValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigPowerScheduleValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigPowerScheduleValueUnknown(), diags
+	}
+
+	powerScheduleAttribute, ok := attributes["power_schedule"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`power_schedule is missing from object`)
+
+		return NewConfigPowerScheduleValueUnknown(), diags
+	}
+
+	powerScheduleVal, ok := powerScheduleAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`power_schedule expected to be basetypes.StringValue, was: %T`, powerScheduleAttribute))
+	}
+
+	powerScheduleHideFixedAttribute, ok := attributes["power_schedule_hide_fixed"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`power_schedule_hide_fixed is missing from object`)
+
+		return NewConfigPowerScheduleValueUnknown(), diags
+	}
+
+	powerScheduleHideFixedVal, ok := powerScheduleHideFixedAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`power_schedule_hide_fixed expected to be basetypes.BoolValue, was: %T`, powerScheduleHideFixedAttribute))
+	}
+
+	powerScheduleTypeAttribute, ok := attributes["power_schedule_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`power_schedule_type is missing from object`)
+
+		return NewConfigPowerScheduleValueUnknown(), diags
+	}
+
+	powerScheduleTypeVal, ok := powerScheduleTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`power_schedule_type expected to be basetypes.StringValue, was: %T`, powerScheduleTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigPowerScheduleValueUnknown(), diags
+	}
+
+	return ConfigPowerScheduleValue{
+		PowerSchedule:          powerScheduleVal,
+		PowerScheduleHideFixed: powerScheduleHideFixedVal,
+		PowerScheduleType:      powerScheduleTypeVal,
+		state:                  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigPowerScheduleValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigPowerScheduleValue {
+	object, diags := NewConfigPowerScheduleValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigPowerScheduleValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigPowerScheduleType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigPowerScheduleValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigPowerScheduleValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigPowerScheduleValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigPowerScheduleValueMust(ConfigPowerScheduleValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigPowerScheduleType) ValueType(ctx context.Context) attr.Value {
+	return ConfigPowerScheduleValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigPowerScheduleValue{}
+
+type ConfigPowerScheduleValue struct {
+	PowerSchedule          basetypes.StringValue `tfsdk:"power_schedule"`
+	PowerScheduleHideFixed basetypes.BoolValue   `tfsdk:"power_schedule_hide_fixed"`
+	PowerScheduleType      basetypes.StringValue `tfsdk:"power_schedule_type"`
+	state                  attr.ValueState
+}
+
+func (v ConfigPowerScheduleValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["power_schedule"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["power_schedule_hide_fixed"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["power_schedule_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.PowerSchedule.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["power_schedule"] = val
+
+		val, err = v.PowerScheduleHideFixed.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["power_schedule_hide_fixed"] = val
+
+		val, err = v.PowerScheduleType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["power_schedule_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigPowerScheduleValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigPowerScheduleValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigPowerScheduleValue) String() string {
+	return "ConfigPowerScheduleValue"
+}
+
+func (v ConfigPowerScheduleValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"power_schedule":            basetypes.StringType{},
+		"power_schedule_hide_fixed": basetypes.BoolType{},
+		"power_schedule_type":       basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"power_schedule":            v.PowerSchedule,
+			"power_schedule_hide_fixed": v.PowerScheduleHideFixed,
+			"power_schedule_type":       v.PowerScheduleType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigPowerScheduleValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigPowerScheduleValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.PowerSchedule.Equal(other.PowerSchedule) {
+		return false
+	}
+
+	if !v.PowerScheduleHideFixed.Equal(other.PowerScheduleHideFixed) {
+		return false
+	}
+
+	if !v.PowerScheduleType.Equal(other.PowerScheduleType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigPowerScheduleValue) Type(ctx context.Context) attr.Type {
+	return ConfigPowerScheduleType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigPowerScheduleValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"power_schedule":            basetypes.StringType{},
+		"power_schedule_hide_fixed": basetypes.BoolType{},
+		"power_schedule_type":       basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigRequiredNetworkType{}
+
+type ConfigRequiredNetworkType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigRequiredNetworkType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigRequiredNetworkType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigRequiredNetworkType) String() string {
+	return "ConfigRequiredNetworkType"
+}
+
+func (t ConfigRequiredNetworkType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigRequiredNetworkValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigRequiredNetworkValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	requiredNetworksAttribute, ok := attributes["required_networks"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`required_networks is missing from object`)
+
+		return nil, diags
+	}
+
+	requiredNetworksVal, ok := requiredNetworksAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`required_networks expected to be basetypes.SetValue, was: %T`, requiredNetworksAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigRequiredNetworkValue{
+		RequiredNetworks: requiredNetworksVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigRequiredNetworkValueNull() ConfigRequiredNetworkValue {
+	return ConfigRequiredNetworkValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigRequiredNetworkValueUnknown() ConfigRequiredNetworkValue {
+	return ConfigRequiredNetworkValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigRequiredNetworkValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigRequiredNetworkValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigRequiredNetworkValue Attribute Value",
+				"While creating a ConfigRequiredNetworkValue value, a missing attribute value was detected. "+
+					"A ConfigRequiredNetworkValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigRequiredNetworkValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigRequiredNetworkValue Attribute Type",
+				"While creating a ConfigRequiredNetworkValue value, an invalid attribute value was detected. "+
+					"A ConfigRequiredNetworkValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigRequiredNetworkValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigRequiredNetworkValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigRequiredNetworkValue Attribute Value",
+				"While creating a ConfigRequiredNetworkValue value, an extra attribute value was detected. "+
+					"A ConfigRequiredNetworkValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigRequiredNetworkValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigRequiredNetworkValueUnknown(), diags
+	}
+
+	requiredNetworksAttribute, ok := attributes["required_networks"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`required_networks is missing from object`)
+
+		return NewConfigRequiredNetworkValueUnknown(), diags
+	}
+
+	requiredNetworksVal, ok := requiredNetworksAttribute.(basetypes.SetValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`required_networks expected to be basetypes.SetValue, was: %T`, requiredNetworksAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigRequiredNetworkValueUnknown(), diags
+	}
+
+	return ConfigRequiredNetworkValue{
+		RequiredNetworks: requiredNetworksVal,
+		state:            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigRequiredNetworkValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigRequiredNetworkValue {
+	object, diags := NewConfigRequiredNetworkValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigRequiredNetworkValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigRequiredNetworkType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigRequiredNetworkValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigRequiredNetworkValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigRequiredNetworkValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigRequiredNetworkValueMust(ConfigRequiredNetworkValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigRequiredNetworkType) ValueType(ctx context.Context) attr.Value {
+	return ConfigRequiredNetworkValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigRequiredNetworkValue{}
+
+type ConfigRequiredNetworkValue struct {
+	RequiredNetworks basetypes.SetValue `tfsdk:"required_networks"`
+	state            attr.ValueState
+}
+
+func (v ConfigRequiredNetworkValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["required_networks"] = basetypes.SetType{
+		ElemType: types.Int64Type,
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.RequiredNetworks.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["required_networks"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigRequiredNetworkValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigRequiredNetworkValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigRequiredNetworkValue) String() string {
+	return "ConfigRequiredNetworkValue"
+}
+
+func (v ConfigRequiredNetworkValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var requiredNetworksVal basetypes.SetValue
+	switch {
+	case v.RequiredNetworks.IsUnknown():
+		requiredNetworksVal = types.SetUnknown(types.Int64Type)
+	case v.RequiredNetworks.IsNull():
+		requiredNetworksVal = types.SetNull(types.Int64Type)
+	default:
+		var d diag.Diagnostics
+		requiredNetworksVal, d = types.SetValue(types.Int64Type, v.RequiredNetworks.Elements())
+		diags.Append(d...)
+	}
+
+	if diags.HasError() {
+		return types.ObjectUnknown(map[string]attr.Type{
+			"required_networks": basetypes.SetType{
+				ElemType: types.Int64Type,
+			},
+		}), diags
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"required_networks": basetypes.SetType{
+			ElemType: types.Int64Type,
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"required_networks": requiredNetworksVal,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigRequiredNetworkValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigRequiredNetworkValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.RequiredNetworks.Equal(other.RequiredNetworks) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigRequiredNetworkValue) Type(ctx context.Context) attr.Type {
+	return ConfigRequiredNetworkType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigRequiredNetworkValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"required_networks": basetypes.SetType{
+			ElemType: types.Int64Type,
+		},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigServerNamingType{}
+
+type ConfigServerNamingType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigServerNamingType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigServerNamingType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigServerNamingType) String() string {
+	return "ConfigServerNamingType"
+}
+
+func (t ConfigServerNamingType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigServerNamingValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigServerNamingValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	serverNamingConflictAttribute, ok := attributes["server_naming_conflict"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`server_naming_conflict is missing from object`)
+
+		return nil, diags
+	}
+
+	serverNamingConflictVal, ok := serverNamingConflictAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`server_naming_conflict expected to be basetypes.BoolValue, was: %T`, serverNamingConflictAttribute))
+	}
+
+	serverNamingPatternAttribute, ok := attributes["server_naming_pattern"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`server_naming_pattern is missing from object`)
+
+		return nil, diags
+	}
+
+	serverNamingPatternVal, ok := serverNamingPatternAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`server_naming_pattern expected to be basetypes.StringValue, was: %T`, serverNamingPatternAttribute))
+	}
+
+	serverNamingTypeAttribute, ok := attributes["server_naming_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`server_naming_type is missing from object`)
+
+		return nil, diags
+	}
+
+	serverNamingTypeVal, ok := serverNamingTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`server_naming_type expected to be basetypes.StringValue, was: %T`, serverNamingTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigServerNamingValue{
+		ServerNamingConflict: serverNamingConflictVal,
+		ServerNamingPattern:  serverNamingPatternVal,
+		ServerNamingType:     serverNamingTypeVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigServerNamingValueNull() ConfigServerNamingValue {
+	return ConfigServerNamingValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigServerNamingValueUnknown() ConfigServerNamingValue {
+	return ConfigServerNamingValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigServerNamingValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigServerNamingValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigServerNamingValue Attribute Value",
+				"While creating a ConfigServerNamingValue value, a missing attribute value was detected. "+
+					"A ConfigServerNamingValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigServerNamingValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigServerNamingValue Attribute Type",
+				"While creating a ConfigServerNamingValue value, an invalid attribute value was detected. "+
+					"A ConfigServerNamingValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigServerNamingValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigServerNamingValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigServerNamingValue Attribute Value",
+				"While creating a ConfigServerNamingValue value, an extra attribute value was detected. "+
+					"A ConfigServerNamingValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigServerNamingValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigServerNamingValueUnknown(), diags
+	}
+
+	serverNamingConflictAttribute, ok := attributes["server_naming_conflict"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`server_naming_conflict is missing from object`)
+
+		return NewConfigServerNamingValueUnknown(), diags
+	}
+
+	serverNamingConflictVal, ok := serverNamingConflictAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`server_naming_conflict expected to be basetypes.BoolValue, was: %T`, serverNamingConflictAttribute))
+	}
+
+	serverNamingPatternAttribute, ok := attributes["server_naming_pattern"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`server_naming_pattern is missing from object`)
+
+		return NewConfigServerNamingValueUnknown(), diags
+	}
+
+	serverNamingPatternVal, ok := serverNamingPatternAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`server_naming_pattern expected to be basetypes.StringValue, was: %T`, serverNamingPatternAttribute))
+	}
+
+	serverNamingTypeAttribute, ok := attributes["server_naming_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`server_naming_type is missing from object`)
+
+		return NewConfigServerNamingValueUnknown(), diags
+	}
+
+	serverNamingTypeVal, ok := serverNamingTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`server_naming_type expected to be basetypes.StringValue, was: %T`, serverNamingTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigServerNamingValueUnknown(), diags
+	}
+
+	return ConfigServerNamingValue{
+		ServerNamingConflict: serverNamingConflictVal,
+		ServerNamingPattern:  serverNamingPatternVal,
+		ServerNamingType:     serverNamingTypeVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigServerNamingValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigServerNamingValue {
+	object, diags := NewConfigServerNamingValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigServerNamingValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigServerNamingType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigServerNamingValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigServerNamingValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigServerNamingValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigServerNamingValueMust(ConfigServerNamingValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigServerNamingType) ValueType(ctx context.Context) attr.Value {
+	return ConfigServerNamingValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigServerNamingValue{}
+
+type ConfigServerNamingValue struct {
+	ServerNamingConflict basetypes.BoolValue   `tfsdk:"server_naming_conflict"`
+	ServerNamingPattern  basetypes.StringValue `tfsdk:"server_naming_pattern"`
+	ServerNamingType     basetypes.StringValue `tfsdk:"server_naming_type"`
+	state                attr.ValueState
+}
+
+func (v ConfigServerNamingValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["server_naming_conflict"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["server_naming_pattern"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["server_naming_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.ServerNamingConflict.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["server_naming_conflict"] = val
+
+		val, err = v.ServerNamingPattern.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["server_naming_pattern"] = val
+
+		val, err = v.ServerNamingType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["server_naming_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigServerNamingValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigServerNamingValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigServerNamingValue) String() string {
+	return "ConfigServerNamingValue"
+}
+
+func (v ConfigServerNamingValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"server_naming_conflict": basetypes.BoolType{},
+		"server_naming_pattern":  basetypes.StringType{},
+		"server_naming_type":     basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"server_naming_conflict": v.ServerNamingConflict,
+			"server_naming_pattern":  v.ServerNamingPattern,
+			"server_naming_type":     v.ServerNamingType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigServerNamingValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigServerNamingValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.ServerNamingConflict.Equal(other.ServerNamingConflict) {
+		return false
+	}
+
+	if !v.ServerNamingPattern.Equal(other.ServerNamingPattern) {
+		return false
+	}
+
+	if !v.ServerNamingType.Equal(other.ServerNamingType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigServerNamingValue) Type(ctx context.Context) attr.Type {
+	return ConfigServerNamingType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigServerNamingValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"server_naming_conflict": basetypes.BoolType{},
+		"server_naming_pattern":  basetypes.StringType{},
+		"server_naming_type":     basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigShutdownType{}
+
+type ConfigShutdownType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigShutdownType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigShutdownType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigShutdownType) String() string {
+	return "ConfigShutdownType"
+}
+
+func (t ConfigShutdownType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigShutdownValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigShutdownValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	accountIntegrationIdAttribute, ok := attributes["account_integration_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`account_integration_id is missing from object`)
+
+		return nil, diags
+	}
+
+	accountIntegrationIdVal, ok := accountIntegrationIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`account_integration_id expected to be basetypes.StringValue, was: %T`, accountIntegrationIdAttribute))
+	}
+
+	flowIdAttribute, ok := attributes["flow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`flow_id is missing from object`)
+
+		return nil, diags
+	}
+
+	flowIdVal, ok := flowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`flow_id expected to be basetypes.StringValue, was: %T`, flowIdAttribute))
+	}
+
+	shutdownAgeAttribute, ok := attributes["shutdown_age"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_age is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownAgeVal, ok := shutdownAgeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_age expected to be basetypes.StringValue, was: %T`, shutdownAgeAttribute))
+	}
+
+	shutdownAllowExtendAttribute, ok := attributes["shutdown_allow_extend"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_allow_extend is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownAllowExtendVal, ok := shutdownAllowExtendAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_allow_extend expected to be basetypes.BoolValue, was: %T`, shutdownAllowExtendAttribute))
+	}
+
+	shutdownAutoRenewAttribute, ok := attributes["shutdown_auto_renew"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_auto_renew is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownAutoRenewVal, ok := shutdownAutoRenewAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_auto_renew expected to be basetypes.BoolValue, was: %T`, shutdownAutoRenewAttribute))
+	}
+
+	shutdownExtensionsBeforeApprovalAttribute, ok := attributes["shutdown_extensions_before_approval"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_extensions_before_approval is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownExtensionsBeforeApprovalVal, ok := shutdownExtensionsBeforeApprovalAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_extensions_before_approval expected to be basetypes.StringValue, was: %T`, shutdownExtensionsBeforeApprovalAttribute))
+	}
+
+	shutdownHideFixedAttribute, ok := attributes["shutdown_hide_fixed"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_hide_fixed is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownHideFixedVal, ok := shutdownHideFixedAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_hide_fixed expected to be basetypes.BoolValue, was: %T`, shutdownHideFixedAttribute))
+	}
+
+	shutdownMessageAttribute, ok := attributes["shutdown_message"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_message is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownMessageVal, ok := shutdownMessageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_message expected to be basetypes.StringValue, was: %T`, shutdownMessageAttribute))
+	}
+
+	shutdownNotifyAttribute, ok := attributes["shutdown_notify"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_notify is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownNotifyVal, ok := shutdownNotifyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_notify expected to be basetypes.StringValue, was: %T`, shutdownNotifyAttribute))
+	}
+
+	shutdownRenewalAttribute, ok := attributes["shutdown_renewal"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_renewal is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownRenewalVal, ok := shutdownRenewalAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_renewal expected to be basetypes.StringValue, was: %T`, shutdownRenewalAttribute))
+	}
+
+	shutdownTypeAttribute, ok := attributes["shutdown_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_type is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownTypeVal, ok := shutdownTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_type expected to be basetypes.StringValue, was: %T`, shutdownTypeAttribute))
+	}
+
+	shutdownWorkflowIdAttribute, ok := attributes["shutdown_workflow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_workflow_id is missing from object`)
+
+		return nil, diags
+	}
+
+	shutdownWorkflowIdVal, ok := shutdownWorkflowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_workflow_id expected to be basetypes.StringValue, was: %T`, shutdownWorkflowIdAttribute))
+	}
+
+	workflowTypeAttribute, ok := attributes["workflow_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_type is missing from object`)
+
+		return nil, diags
+	}
+
+	workflowTypeVal, ok := workflowTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_type expected to be basetypes.StringValue, was: %T`, workflowTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigShutdownValue{
+		AccountIntegrationId:             accountIntegrationIdVal,
+		FlowId:                           flowIdVal,
+		ShutdownAge:                      shutdownAgeVal,
+		ShutdownAllowExtend:              shutdownAllowExtendVal,
+		ShutdownAutoRenew:                shutdownAutoRenewVal,
+		ShutdownExtensionsBeforeApproval: shutdownExtensionsBeforeApprovalVal,
+		ShutdownHideFixed:                shutdownHideFixedVal,
+		ShutdownMessage:                  shutdownMessageVal,
+		ShutdownNotify:                   shutdownNotifyVal,
+		ShutdownRenewal:                  shutdownRenewalVal,
+		ShutdownType:                     shutdownTypeVal,
+		ShutdownWorkflowId:               shutdownWorkflowIdVal,
+		WorkflowType:                     workflowTypeVal,
+		state:                            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigShutdownValueNull() ConfigShutdownValue {
+	return ConfigShutdownValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigShutdownValueUnknown() ConfigShutdownValue {
+	return ConfigShutdownValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigShutdownValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigShutdownValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigShutdownValue Attribute Value",
+				"While creating a ConfigShutdownValue value, a missing attribute value was detected. "+
+					"A ConfigShutdownValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigShutdownValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigShutdownValue Attribute Type",
+				"While creating a ConfigShutdownValue value, an invalid attribute value was detected. "+
+					"A ConfigShutdownValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigShutdownValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigShutdownValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigShutdownValue Attribute Value",
+				"While creating a ConfigShutdownValue value, an extra attribute value was detected. "+
+					"A ConfigShutdownValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigShutdownValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	accountIntegrationIdAttribute, ok := attributes["account_integration_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`account_integration_id is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	accountIntegrationIdVal, ok := accountIntegrationIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`account_integration_id expected to be basetypes.StringValue, was: %T`, accountIntegrationIdAttribute))
+	}
+
+	flowIdAttribute, ok := attributes["flow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`flow_id is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	flowIdVal, ok := flowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`flow_id expected to be basetypes.StringValue, was: %T`, flowIdAttribute))
+	}
+
+	shutdownAgeAttribute, ok := attributes["shutdown_age"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_age is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownAgeVal, ok := shutdownAgeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_age expected to be basetypes.StringValue, was: %T`, shutdownAgeAttribute))
+	}
+
+	shutdownAllowExtendAttribute, ok := attributes["shutdown_allow_extend"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_allow_extend is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownAllowExtendVal, ok := shutdownAllowExtendAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_allow_extend expected to be basetypes.BoolValue, was: %T`, shutdownAllowExtendAttribute))
+	}
+
+	shutdownAutoRenewAttribute, ok := attributes["shutdown_auto_renew"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_auto_renew is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownAutoRenewVal, ok := shutdownAutoRenewAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_auto_renew expected to be basetypes.BoolValue, was: %T`, shutdownAutoRenewAttribute))
+	}
+
+	shutdownExtensionsBeforeApprovalAttribute, ok := attributes["shutdown_extensions_before_approval"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_extensions_before_approval is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownExtensionsBeforeApprovalVal, ok := shutdownExtensionsBeforeApprovalAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_extensions_before_approval expected to be basetypes.StringValue, was: %T`, shutdownExtensionsBeforeApprovalAttribute))
+	}
+
+	shutdownHideFixedAttribute, ok := attributes["shutdown_hide_fixed"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_hide_fixed is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownHideFixedVal, ok := shutdownHideFixedAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_hide_fixed expected to be basetypes.BoolValue, was: %T`, shutdownHideFixedAttribute))
+	}
+
+	shutdownMessageAttribute, ok := attributes["shutdown_message"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_message is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownMessageVal, ok := shutdownMessageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_message expected to be basetypes.StringValue, was: %T`, shutdownMessageAttribute))
+	}
+
+	shutdownNotifyAttribute, ok := attributes["shutdown_notify"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_notify is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownNotifyVal, ok := shutdownNotifyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_notify expected to be basetypes.StringValue, was: %T`, shutdownNotifyAttribute))
+	}
+
+	shutdownRenewalAttribute, ok := attributes["shutdown_renewal"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_renewal is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownRenewalVal, ok := shutdownRenewalAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_renewal expected to be basetypes.StringValue, was: %T`, shutdownRenewalAttribute))
+	}
+
+	shutdownTypeAttribute, ok := attributes["shutdown_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_type is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownTypeVal, ok := shutdownTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_type expected to be basetypes.StringValue, was: %T`, shutdownTypeAttribute))
+	}
+
+	shutdownWorkflowIdAttribute, ok := attributes["shutdown_workflow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`shutdown_workflow_id is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	shutdownWorkflowIdVal, ok := shutdownWorkflowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`shutdown_workflow_id expected to be basetypes.StringValue, was: %T`, shutdownWorkflowIdAttribute))
+	}
+
+	workflowTypeAttribute, ok := attributes["workflow_type"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_type is missing from object`)
+
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	workflowTypeVal, ok := workflowTypeAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_type expected to be basetypes.StringValue, was: %T`, workflowTypeAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigShutdownValueUnknown(), diags
+	}
+
+	return ConfigShutdownValue{
+		AccountIntegrationId:             accountIntegrationIdVal,
+		FlowId:                           flowIdVal,
+		ShutdownAge:                      shutdownAgeVal,
+		ShutdownAllowExtend:              shutdownAllowExtendVal,
+		ShutdownAutoRenew:                shutdownAutoRenewVal,
+		ShutdownExtensionsBeforeApproval: shutdownExtensionsBeforeApprovalVal,
+		ShutdownHideFixed:                shutdownHideFixedVal,
+		ShutdownMessage:                  shutdownMessageVal,
+		ShutdownNotify:                   shutdownNotifyVal,
+		ShutdownRenewal:                  shutdownRenewalVal,
+		ShutdownType:                     shutdownTypeVal,
+		ShutdownWorkflowId:               shutdownWorkflowIdVal,
+		WorkflowType:                     workflowTypeVal,
+		state:                            attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigShutdownValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigShutdownValue {
+	object, diags := NewConfigShutdownValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigShutdownValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigShutdownType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigShutdownValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigShutdownValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigShutdownValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigShutdownValueMust(ConfigShutdownValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigShutdownType) ValueType(ctx context.Context) attr.Value {
+	return ConfigShutdownValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigShutdownValue{}
+
+type ConfigShutdownValue struct {
+	AccountIntegrationId             basetypes.StringValue `tfsdk:"account_integration_id"`
+	FlowId                           basetypes.StringValue `tfsdk:"flow_id"`
+	ShutdownAge                      basetypes.StringValue `tfsdk:"shutdown_age"`
+	ShutdownAllowExtend              basetypes.BoolValue   `tfsdk:"shutdown_allow_extend"`
+	ShutdownAutoRenew                basetypes.BoolValue   `tfsdk:"shutdown_auto_renew"`
+	ShutdownExtensionsBeforeApproval basetypes.StringValue `tfsdk:"shutdown_extensions_before_approval"`
+	ShutdownHideFixed                basetypes.BoolValue   `tfsdk:"shutdown_hide_fixed"`
+	ShutdownMessage                  basetypes.StringValue `tfsdk:"shutdown_message"`
+	ShutdownNotify                   basetypes.StringValue `tfsdk:"shutdown_notify"`
+	ShutdownRenewal                  basetypes.StringValue `tfsdk:"shutdown_renewal"`
+	ShutdownType                     basetypes.StringValue `tfsdk:"shutdown_type"`
+	ShutdownWorkflowId               basetypes.StringValue `tfsdk:"shutdown_workflow_id"`
+	WorkflowType                     basetypes.StringValue `tfsdk:"workflow_type"`
+	state                            attr.ValueState
+}
+
+func (v ConfigShutdownValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 13)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["account_integration_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["flow_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["shutdown_age"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["shutdown_allow_extend"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["shutdown_auto_renew"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["shutdown_extensions_before_approval"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["shutdown_hide_fixed"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["shutdown_message"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["shutdown_notify"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["shutdown_renewal"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["shutdown_type"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["shutdown_workflow_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["workflow_type"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 13)
+
+		val, err = v.AccountIntegrationId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["account_integration_id"] = val
+
+		val, err = v.FlowId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["flow_id"] = val
+
+		val, err = v.ShutdownAge.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_age"] = val
+
+		val, err = v.ShutdownAllowExtend.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_allow_extend"] = val
+
+		val, err = v.ShutdownAutoRenew.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_auto_renew"] = val
+
+		val, err = v.ShutdownExtensionsBeforeApproval.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_extensions_before_approval"] = val
+
+		val, err = v.ShutdownHideFixed.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_hide_fixed"] = val
+
+		val, err = v.ShutdownMessage.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_message"] = val
+
+		val, err = v.ShutdownNotify.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_notify"] = val
+
+		val, err = v.ShutdownRenewal.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_renewal"] = val
+
+		val, err = v.ShutdownType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_type"] = val
+
+		val, err = v.ShutdownWorkflowId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["shutdown_workflow_id"] = val
+
+		val, err = v.WorkflowType.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["workflow_type"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigShutdownValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigShutdownValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigShutdownValue) String() string {
+	return "ConfigShutdownValue"
+}
+
+func (v ConfigShutdownValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"account_integration_id":              basetypes.StringType{},
+		"flow_id":                             basetypes.StringType{},
+		"shutdown_age":                        basetypes.StringType{},
+		"shutdown_allow_extend":               basetypes.BoolType{},
+		"shutdown_auto_renew":                 basetypes.BoolType{},
+		"shutdown_extensions_before_approval": basetypes.StringType{},
+		"shutdown_hide_fixed":                 basetypes.BoolType{},
+		"shutdown_message":                    basetypes.StringType{},
+		"shutdown_notify":                     basetypes.StringType{},
+		"shutdown_renewal":                    basetypes.StringType{},
+		"shutdown_type":                       basetypes.StringType{},
+		"shutdown_workflow_id":                basetypes.StringType{},
+		"workflow_type":                       basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"account_integration_id":              v.AccountIntegrationId,
+			"flow_id":                             v.FlowId,
+			"shutdown_age":                        v.ShutdownAge,
+			"shutdown_allow_extend":               v.ShutdownAllowExtend,
+			"shutdown_auto_renew":                 v.ShutdownAutoRenew,
+			"shutdown_extensions_before_approval": v.ShutdownExtensionsBeforeApproval,
+			"shutdown_hide_fixed":                 v.ShutdownHideFixed,
+			"shutdown_message":                    v.ShutdownMessage,
+			"shutdown_notify":                     v.ShutdownNotify,
+			"shutdown_renewal":                    v.ShutdownRenewal,
+			"shutdown_type":                       v.ShutdownType,
+			"shutdown_workflow_id":                v.ShutdownWorkflowId,
+			"workflow_type":                       v.WorkflowType,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigShutdownValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigShutdownValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.AccountIntegrationId.Equal(other.AccountIntegrationId) {
+		return false
+	}
+
+	if !v.FlowId.Equal(other.FlowId) {
+		return false
+	}
+
+	if !v.ShutdownAge.Equal(other.ShutdownAge) {
+		return false
+	}
+
+	if !v.ShutdownAllowExtend.Equal(other.ShutdownAllowExtend) {
+		return false
+	}
+
+	if !v.ShutdownAutoRenew.Equal(other.ShutdownAutoRenew) {
+		return false
+	}
+
+	if !v.ShutdownExtensionsBeforeApproval.Equal(other.ShutdownExtensionsBeforeApproval) {
+		return false
+	}
+
+	if !v.ShutdownHideFixed.Equal(other.ShutdownHideFixed) {
+		return false
+	}
+
+	if !v.ShutdownMessage.Equal(other.ShutdownMessage) {
+		return false
+	}
+
+	if !v.ShutdownNotify.Equal(other.ShutdownNotify) {
+		return false
+	}
+
+	if !v.ShutdownRenewal.Equal(other.ShutdownRenewal) {
+		return false
+	}
+
+	if !v.ShutdownType.Equal(other.ShutdownType) {
+		return false
+	}
+
+	if !v.ShutdownWorkflowId.Equal(other.ShutdownWorkflowId) {
+		return false
+	}
+
+	if !v.WorkflowType.Equal(other.WorkflowType) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigShutdownValue) Type(ctx context.Context) attr.Type {
+	return ConfigShutdownType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigShutdownValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"account_integration_id":              basetypes.StringType{},
+		"flow_id":                             basetypes.StringType{},
+		"shutdown_age":                        basetypes.StringType{},
+		"shutdown_allow_extend":               basetypes.BoolType{},
+		"shutdown_auto_renew":                 basetypes.BoolType{},
+		"shutdown_extensions_before_approval": basetypes.StringType{},
+		"shutdown_hide_fixed":                 basetypes.BoolType{},
+		"shutdown_message":                    basetypes.StringType{},
+		"shutdown_notify":                     basetypes.StringType{},
+		"shutdown_renewal":                    basetypes.StringType{},
+		"shutdown_type":                       basetypes.StringType{},
+		"shutdown_workflow_id":                basetypes.StringType{},
+		"workflow_type":                       basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigStorageServerQuotaType{}
+
+type ConfigStorageServerQuotaType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigStorageServerQuotaType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigStorageServerQuotaType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigStorageServerQuotaType) String() string {
+	return "ConfigStorageServerQuotaType"
+}
+
+func (t ConfigStorageServerQuotaType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigStorageServerQuotaValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigStorageServerQuotaValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	maxStorageAttribute, ok := attributes["max_storage"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_storage is missing from object`)
+
+		return nil, diags
+	}
+
+	maxStorageVal, ok := maxStorageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_storage expected to be basetypes.StringValue, was: %T`, maxStorageAttribute))
+	}
+
+	storageServerIdAttribute, ok := attributes["storage_server_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`storage_server_id is missing from object`)
+
+		return nil, diags
+	}
+
+	storageServerIdVal, ok := storageServerIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`storage_server_id expected to be basetypes.StringValue, was: %T`, storageServerIdAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigStorageServerQuotaValue{
+		MaxStorage:      maxStorageVal,
+		StorageServerId: storageServerIdVal,
+		state:           attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigStorageServerQuotaValueNull() ConfigStorageServerQuotaValue {
+	return ConfigStorageServerQuotaValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigStorageServerQuotaValueUnknown() ConfigStorageServerQuotaValue {
+	return ConfigStorageServerQuotaValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigStorageServerQuotaValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigStorageServerQuotaValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigStorageServerQuotaValue Attribute Value",
+				"While creating a ConfigStorageServerQuotaValue value, a missing attribute value was detected. "+
+					"A ConfigStorageServerQuotaValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigStorageServerQuotaValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigStorageServerQuotaValue Attribute Type",
+				"While creating a ConfigStorageServerQuotaValue value, an invalid attribute value was detected. "+
+					"A ConfigStorageServerQuotaValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigStorageServerQuotaValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigStorageServerQuotaValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigStorageServerQuotaValue Attribute Value",
+				"While creating a ConfigStorageServerQuotaValue value, an extra attribute value was detected. "+
+					"A ConfigStorageServerQuotaValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigStorageServerQuotaValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigStorageServerQuotaValueUnknown(), diags
+	}
+
+	maxStorageAttribute, ok := attributes["max_storage"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_storage is missing from object`)
+
+		return NewConfigStorageServerQuotaValueUnknown(), diags
+	}
+
+	maxStorageVal, ok := maxStorageAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_storage expected to be basetypes.StringValue, was: %T`, maxStorageAttribute))
+	}
+
+	storageServerIdAttribute, ok := attributes["storage_server_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`storage_server_id is missing from object`)
+
+		return NewConfigStorageServerQuotaValueUnknown(), diags
+	}
+
+	storageServerIdVal, ok := storageServerIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`storage_server_id expected to be basetypes.StringValue, was: %T`, storageServerIdAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigStorageServerQuotaValueUnknown(), diags
+	}
+
+	return ConfigStorageServerQuotaValue{
+		MaxStorage:      maxStorageVal,
+		StorageServerId: storageServerIdVal,
+		state:           attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigStorageServerQuotaValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigStorageServerQuotaValue {
+	object, diags := NewConfigStorageServerQuotaValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigStorageServerQuotaValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigStorageServerQuotaType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigStorageServerQuotaValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigStorageServerQuotaValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigStorageServerQuotaValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigStorageServerQuotaValueMust(ConfigStorageServerQuotaValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigStorageServerQuotaType) ValueType(ctx context.Context) attr.Value {
+	return ConfigStorageServerQuotaValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigStorageServerQuotaValue{}
+
+type ConfigStorageServerQuotaValue struct {
+	MaxStorage      basetypes.StringValue `tfsdk:"max_storage"`
+	StorageServerId basetypes.StringValue `tfsdk:"storage_server_id"`
+	state           attr.ValueState
+}
+
+func (v ConfigStorageServerQuotaValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 2)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["max_storage"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["storage_server_id"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 2)
+
+		val, err = v.MaxStorage.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_storage"] = val
+
+		val, err = v.StorageServerId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["storage_server_id"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigStorageServerQuotaValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigStorageServerQuotaValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigStorageServerQuotaValue) String() string {
+	return "ConfigStorageServerQuotaValue"
+}
+
+func (v ConfigStorageServerQuotaValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"max_storage":       basetypes.StringType{},
+		"storage_server_id": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"max_storage":       v.MaxStorage,
+			"storage_server_id": v.StorageServerId,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigStorageServerQuotaValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigStorageServerQuotaValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.MaxStorage.Equal(other.MaxStorage) {
+		return false
+	}
+
+	if !v.StorageServerId.Equal(other.StorageServerId) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigStorageServerQuotaValue) Type(ctx context.Context) attr.Type {
+	return ConfigStorageServerQuotaType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigStorageServerQuotaValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"max_storage":       basetypes.StringType{},
+		"storage_server_id": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigTagsType{}
+
+type ConfigTagsType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigTagsType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigTagsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigTagsType) String() string {
+	return "ConfigTagsType"
+}
+
+func (t ConfigTagsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigTagsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigTagsValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return nil, diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	strictAttribute, ok := attributes["strict"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`strict is missing from object`)
+
+		return nil, diags
+	}
+
+	strictVal, ok := strictAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`strict expected to be basetypes.BoolValue, was: %T`, strictAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return nil, diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	valueListIdAttribute, ok := attributes["value_list_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value_list_id is missing from object`)
+
+		return nil, diags
+	}
+
+	valueListIdVal, ok := valueListIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value_list_id expected to be basetypes.StringValue, was: %T`, valueListIdAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigTagsValue{
+		Key:         keyVal,
+		Strict:      strictVal,
+		Value:       valueVal,
+		ValueListId: valueListIdVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigTagsValueNull() ConfigTagsValue {
+	return ConfigTagsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigTagsValueUnknown() ConfigTagsValue {
+	return ConfigTagsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigTagsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigTagsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigTagsValue Attribute Value",
+				"While creating a ConfigTagsValue value, a missing attribute value was detected. "+
+					"A ConfigTagsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigTagsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigTagsValue Attribute Type",
+				"While creating a ConfigTagsValue value, an invalid attribute value was detected. "+
+					"A ConfigTagsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigTagsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigTagsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigTagsValue Attribute Value",
+				"While creating a ConfigTagsValue value, an extra attribute value was detected. "+
+					"A ConfigTagsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigTagsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigTagsValueUnknown(), diags
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return NewConfigTagsValueUnknown(), diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	strictAttribute, ok := attributes["strict"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`strict is missing from object`)
+
+		return NewConfigTagsValueUnknown(), diags
+	}
+
+	strictVal, ok := strictAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`strict expected to be basetypes.BoolValue, was: %T`, strictAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return NewConfigTagsValueUnknown(), diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	valueListIdAttribute, ok := attributes["value_list_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value_list_id is missing from object`)
+
+		return NewConfigTagsValueUnknown(), diags
+	}
+
+	valueListIdVal, ok := valueListIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value_list_id expected to be basetypes.StringValue, was: %T`, valueListIdAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigTagsValueUnknown(), diags
+	}
+
+	return ConfigTagsValue{
+		Key:         keyVal,
+		Strict:      strictVal,
+		Value:       valueVal,
+		ValueListId: valueListIdVal,
+		state:       attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigTagsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigTagsValue {
+	object, diags := NewConfigTagsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigTagsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigTagsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigTagsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigTagsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigTagsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigTagsValueMust(ConfigTagsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigTagsType) ValueType(ctx context.Context) attr.Value {
+	return ConfigTagsValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigTagsValue{}
+
+type ConfigTagsValue struct {
+	Key         basetypes.StringValue `tfsdk:"key"`
+	Strict      basetypes.BoolValue   `tfsdk:"strict"`
+	Value       basetypes.StringValue `tfsdk:"value"`
+	ValueListId basetypes.StringValue `tfsdk:"value_list_id"`
+	state       attr.ValueState
+}
+
+func (v ConfigTagsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 4)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["strict"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["value"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["value_list_id"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 4)
+
+		val, err = v.Key.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["key"] = val
+
+		val, err = v.Strict.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["strict"] = val
+
+		val, err = v.Value.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["value"] = val
+
+		val, err = v.ValueListId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["value_list_id"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigTagsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigTagsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigTagsValue) String() string {
+	return "ConfigTagsValue"
+}
+
+func (v ConfigTagsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"key":           basetypes.StringType{},
+		"strict":        basetypes.BoolType{},
+		"value":         basetypes.StringType{},
+		"value_list_id": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"key":           v.Key,
+			"strict":        v.Strict,
+			"value":         v.Value,
+			"value_list_id": v.ValueListId,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigTagsValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigTagsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Key.Equal(other.Key) {
+		return false
+	}
+
+	if !v.Strict.Equal(other.Strict) {
+		return false
+	}
+
+	if !v.Value.Equal(other.Value) {
+		return false
+	}
+
+	if !v.ValueListId.Equal(other.ValueListId) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigTagsValue) Type(ctx context.Context) attr.Type {
+	return ConfigTagsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigTagsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"key":           basetypes.StringType{},
+		"strict":        basetypes.BoolType{},
+		"value":         basetypes.StringType{},
+		"value_list_id": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigWorkflowType{}
+
+type ConfigWorkflowType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigWorkflowType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigWorkflowType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigWorkflowType) String() string {
+	return "ConfigWorkflowType"
+}
+
+func (t ConfigWorkflowType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigWorkflowValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigWorkflowValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	workflowIdAttribute, ok := attributes["workflow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_id is missing from object`)
+
+		return nil, diags
+	}
+
+	workflowIdVal, ok := workflowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_id expected to be basetypes.StringValue, was: %T`, workflowIdAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigWorkflowValue{
+		WorkflowId: workflowIdVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigWorkflowValueNull() ConfigWorkflowValue {
+	return ConfigWorkflowValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigWorkflowValueUnknown() ConfigWorkflowValue {
+	return ConfigWorkflowValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigWorkflowValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigWorkflowValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigWorkflowValue Attribute Value",
+				"While creating a ConfigWorkflowValue value, a missing attribute value was detected. "+
+					"A ConfigWorkflowValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigWorkflowValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigWorkflowValue Attribute Type",
+				"While creating a ConfigWorkflowValue value, an invalid attribute value was detected. "+
+					"A ConfigWorkflowValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigWorkflowValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigWorkflowValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigWorkflowValue Attribute Value",
+				"While creating a ConfigWorkflowValue value, an extra attribute value was detected. "+
+					"A ConfigWorkflowValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigWorkflowValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigWorkflowValueUnknown(), diags
+	}
+
+	workflowIdAttribute, ok := attributes["workflow_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`workflow_id is missing from object`)
+
+		return NewConfigWorkflowValueUnknown(), diags
+	}
+
+	workflowIdVal, ok := workflowIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`workflow_id expected to be basetypes.StringValue, was: %T`, workflowIdAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigWorkflowValueUnknown(), diags
+	}
+
+	return ConfigWorkflowValue{
+		WorkflowId: workflowIdVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigWorkflowValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigWorkflowValue {
+	object, diags := NewConfigWorkflowValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigWorkflowValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigWorkflowType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigWorkflowValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigWorkflowValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigWorkflowValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigWorkflowValueMust(ConfigWorkflowValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigWorkflowType) ValueType(ctx context.Context) attr.Value {
+	return ConfigWorkflowValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigWorkflowValue{}
+
+type ConfigWorkflowValue struct {
+	WorkflowId basetypes.StringValue `tfsdk:"workflow_id"`
+	state      attr.ValueState
+}
+
+func (v ConfigWorkflowValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["workflow_id"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.WorkflowId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["workflow_id"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigWorkflowValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigWorkflowValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigWorkflowValue) String() string {
+	return "ConfigWorkflowValue"
+}
+
+func (v ConfigWorkflowValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"workflow_id": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"workflow_id": v.WorkflowId,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigWorkflowValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigWorkflowValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.WorkflowId.Equal(other.WorkflowId) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigWorkflowValue) Type(ctx context.Context) attr.Type {
+	return ConfigWorkflowType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigWorkflowValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"workflow_id": basetypes.StringType{},
 	}
 }
 

--- a/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
@@ -27,21 +27,21 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 			"associated_resource_id": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan",
-				MarkdownDescription: "The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan",
+				Description:         "The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan, Label",
+				MarkdownDescription: "The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan, Label",
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},
 			},
 			"associated_resource_type": schema.StringAttribute{
 				Required:            true,
-				Description:         "Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', or 'Plan'",
-				MarkdownDescription: "Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', or 'Plan'",
+				Description:         "Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', 'Plan' or 'Label'",
+				MarkdownDescription: "Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', 'Plan' or 'Label'",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("Global", "Group", "Cloud", "User", "Role", "Network", "Plan"),
+					stringvalidator.OneOf("Global", "Group", "Cloud", "User", "Role", "Network", "Plan", "Label"),
 				},
 			},
 			"cloud": schema.SingleNestedAttribute{

--- a/internal/framework/subproviders/morpheus/resources/policy/update.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/update.go
@@ -4,14 +4,12 @@ package policy
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
-	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
 )
 
@@ -81,53 +79,14 @@ func (r *Resource) Update(
 		updatePolicy.SetAccounts(tenantIDs)
 	}
 
-	// Set Config - convert dynamic to SDK config structure
-	if !plan.Config.IsNull() && !plan.Config.IsUnknown() {
-		configValue := plan.Config.UnderlyingValue()
-		configMap, err := convert.ValueToAny(ctx, configValue)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"update policy resource",
-				fmt.Sprintf("policy %d: failed to convert config: %s", id, err.Error()),
-			)
-
-			return
-		}
-
-		// Check if config is empty
-		if configMapTyped, ok := configMap.(map[string]interface{}); ok && len(configMapTyped) == 0 {
-			resp.Diagnostics.AddError(
-				"update policy resource",
-				fmt.Sprintf("policy %d: config cannot be empty. "+
-					"Please provide the required configuration fields for this policy type.", id),
-			)
-
-			return
-		}
-
-		// Marshal to JSON then unmarshal to SDK config structure
-		// This allows the SDK's UnmarshalJSON to handle the oneOf structure
-		configJSON, err := json.Marshal(configMap)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"update policy resource",
-				fmt.Sprintf("policy %d: failed to marshal config to JSON: %s", id, err.Error()),
-			)
-
-			return
-		}
-
-		var sdkConfig sdk.UpdatePoliciesRequestPolicyConfig
-		if err := json.Unmarshal(configJSON, &sdkConfig); err != nil {
-			resp.Diagnostics.AddError(
-				"update policy resource",
-				fmt.Sprintf("policy %d: invalid config: %s", id, err.Error()),
-			)
-
-			return
-		}
-
-		updatePolicy.SetConfig(sdkConfig)
+	// Set Config - convert state config fields to SDK config structure
+	sdkConfig, configDiags := mapStateToUpdatePolicyConfig(ctx, &plan)
+	if configDiags.HasError() {
+		resp.Diagnostics.Append(configDiags...)
+		return
+	}
+	if sdkConfig != nil {
+		updatePolicy.SetConfig(*sdkConfig)
 	}
 
 	updatePolicyRequest := sdk.NewUpdatePoliciesRequest(*updatePolicy)


### PR DESCRIPTION
Adding static schema for policy resource so that populating the config is
easier and more intuitive than figuring out how to use the dynamic config.