### PR TITLE
Make the renderer `-out` switch a full path

### DIFF
--- a/cmd/render/main.go
+++ b/cmd/render/main.go
@@ -3,14 +3,49 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"os"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
 )
 
-func main() {
-	name := os.Args[1]
-	args := os.Args[2:len(os.Args)]
+const usage = `
+Usage: 
+go run render <type/name> <example_path> [args...]
 
-	testhelpers.WriteExample(name, args...)
+Examples:
+
+Render to the same directory as the template:
+
+go run render group.tf.tmpl Name 'Test'
+
+Render to examples/resources/hpe_morpheus_group/group.tf:
+
+go run render -out resources/hpe_morpheus_group group.tf.tmpl Name 'Test'
+  `
+
+func main() {
+	out := flag.String("out", "", "Location in examples directory")
+	flag.Parse()
+
+	osArgs := flag.Args()
+
+	if len(osArgs) < 1 {
+		fmt.Println(usage)
+		os.Exit(1)
+	}
+
+	fn := osArgs[0]
+
+	var args []string
+	if len(osArgs) > 1 {
+		args = osArgs[1:]
+	}
+
+	if out != nil && *out != "" {
+		testhelpers.WriteExampleToDir(*out, fn, args...)
+	} else {
+		testhelpers.WriteExample(fn, args...)
+	}
 }

--- a/cmd/render/main.go
+++ b/cmd/render/main.go
@@ -26,7 +26,7 @@ go run render -out resources/hpe_morpheus_group group.tf.tmpl Name 'Test'
   `
 
 func main() {
-	out := flag.String("out", "", "Location in examples directory")
+	out := flag.String("out", "", "Destination relative to .git directory")
 	flag.Parse()
 
 	osArgs := flag.Args()

--- a/cmd/render/main.go
+++ b/cmd/render/main.go
@@ -43,7 +43,7 @@ func main() {
 		args = osArgs[1:]
 	}
 
-	if out != nil && *out != "" {
+	if *out != "" {
 		testhelpers.WriteExampleToDir(*out, fn, args...)
 	} else {
 		testhelpers.WriteExample(fn, args...)

--- a/internal/framework/subproviders/morpheus/testhelpers/examples.go
+++ b/internal/framework/subproviders/morpheus/testhelpers/examples.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -48,6 +49,37 @@ func WriteExample(name string, args ...string) {
 
 	err = os.WriteFile(name, []byte(text), 0o600)
 	if err != nil {
+		panic(err)
+	}
+}
+
+func WriteExampleToDir(dest, fn string, args ...string) {
+	text, err := renderExample(fn, args...)
+	if err != nil {
+		panic(err)
+	}
+
+	absPath, err := filepath.Abs(fn)
+	if err != nil {
+		panic(err)
+	}
+	absPath = filepath.Dir(absPath)
+
+	for {
+		if _, err := os.Stat(filepath.Join(absPath, ".git")); err == nil {
+			break
+		}
+		absPath = filepath.Dir(absPath)
+	}
+
+	fn = strings.TrimSuffix(fn, ".tmpl")
+	dest = filepath.Join(absPath, "examples", dest, fn)
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		panic(err)
+	}
+
+	if err = os.WriteFile(dest, []byte(text), 0o600); err != nil {
 		panic(err)
 	}
 }

--- a/internal/framework/subproviders/morpheus/testhelpers/examples.go
+++ b/internal/framework/subproviders/morpheus/testhelpers/examples.go
@@ -72,8 +72,7 @@ func WriteExampleToDir(dest, fn string, args ...string) {
 		absPath = filepath.Dir(absPath)
 	}
 
-	fn = strings.TrimSuffix(fn, ".tmpl")
-	dest = filepath.Join(absPath, "examples", dest, fn)
+	dest = filepath.Join(absPath, dest)
 
 	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
 		panic(err)


### PR DESCRIPTION
This PR make the `-out` parameter of the example renderer a full path relative to the .git directory.