### PR TITLE
Fixes for Alletra MP HVM datastore

### DIFF
--- a/docs/resources/morpheus_datastore.md
+++ b/docs/resources/morpheus_datastore.md
@@ -128,8 +128,11 @@ Required:
 
 Required:
 
-- `enable_ransomware` (Boolean) Enable ransomware protection for this datastore.
 - `protocol_type` (String) Storage protocol type, either iSCSI or FC (Fibre Channel)
+
+Optional:
+
+- `enable_ransomware` (Boolean) Enable ransomware protection for this datastore.
 
 
 <a id="nestedatt--config_nfs"></a>

--- a/internal/framework/subproviders/morpheus/datasources/datastore/datasource.go
+++ b/internal/framework/subproviders/morpheus/datasources/datastore/datasource.go
@@ -173,8 +173,12 @@ func getDatastoreById(
 		for k, v := range datastore.Config {
 			switch k {
 			case "enableransomware":
-				s := v.(string)
-				configAlletraMPHVM.EnableRansomware = convert.StringToBool(ctx, s)
+				switch t := v.(type) {
+				case bool:
+					configAlletraMPHVM.EnableRansomware = convert.BoolToType(&t)
+				case string:
+					configAlletraMPHVM.EnableRansomware = convert.StringToBool(ctx, t)
+				}
 			case "protocolType":
 				str := v.(string)
 				configAlletraMPHVM.ProtocolType = convert.StrToType(&str)

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_read.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_read.go
@@ -175,8 +175,12 @@ func getDatastoreAsState(
 		for k, v := range datastore.Config {
 			switch k {
 			case "enableransomware":
-				s := v.(string)
-				configAlletraMPHVM.EnableRansomware = convert.StringToBool(ctx, s)
+				switch t := v.(type) {
+				case bool:
+					configAlletraMPHVM.EnableRansomware = convert.BoolToType(&t)
+				case string:
+					configAlletraMPHVM.EnableRansomware = convert.StringToBool(ctx, t)
+				}
 			case "protocolType":
 				str := v.(string)
 				configAlletraMPHVM.ProtocolType = convert.StrToType(&str)

--- a/internal/framework/subproviders/morpheus/resources/datastore/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/schema_gen.go
@@ -93,7 +93,8 @@ func DatastoreResourceSchema(ctx context.Context) schema.Schema {
 			"config_alletramp_hvm": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"enable_ransomware": schema.BoolAttribute{
-						Required:            true,
+						Computed:            true,
+						Optional:            true,
 						Description:         "Enable ransomware protection for this datastore.",
 						MarkdownDescription: "Enable ransomware protection for this datastore.",
 					},


### PR DESCRIPTION
There have been a couple of changes to the Alletra MP plugin that we neeed to accommodate:
- enableransomware returned by the plugin can now be a bool as well as a string, we've updated the datastore data-source and resource
- enableransomware might not be supported by the version of Alletra MP, so we've had to make the corresponding datastore resource Schema attribute computed_optional