### PR TITLE
Fix instance intefaces order in state-file

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -37,6 +37,8 @@ to import the instance. Otherwise the import will result in the instance being d
 
 ## Example Usage
 
+### HVM instance
+
 ```terraform
 data "hpe_morpheus_cloud" "vme_cloud" {
   name = "HPE Alletra VME"
@@ -61,6 +63,101 @@ resource "hpe_morpheus_instance" "example" {
     {
       network_id = 103481
     }
+  ]
+
+  volumes = [
+    {
+      root_volume     = true
+      name            = "root"
+      size            = 10
+      storage_type_id = 1
+      datastore_id    = 38658
+    },
+    {
+      root_volume     = false
+      name            = "data"
+      size            = 10
+      storage_type_id = 1
+      datastore_id    = 38658
+    }
+  ]
+
+  tags = [
+    {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
+      name  = "managed_by"
+      value = "terraform"
+    }
+  ]
+
+  config = {
+    resourcePoolId       = "pool-62299"
+    poolProviderType     = "mvm"
+    nestedVirtualization = "off"
+    noAgent              = true
+    createUser           = false
+  }
+}
+```
+
+### HVM Instance with two networks
+
+One of these networks has a `child_virtual_networks` entry.  Note that only some network types support `child_virtual_networks`.
+The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" can be used to see which options are available.
+
+```terraform
+data "hpe_morpheus_cloud" "vme_cloud" {
+  name = "HPE Alletra VME"
+}
+
+data "hpe_morpheus_service_plan" "vme_512mb" {
+  name                = "1 CPU, 1GB Memory"
+  provision_type_code = "kvm"
+}
+
+resource "hpe_morpheus_instance" "example" {
+  name             = "TestInstance"
+  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
+  layout_id        = 5385                                 # Single KVM VM
+  instance_type_id = 9                  # (HVM) mvm-cluster
+
+  group_id = 1
+  plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
+
+  instance_context = "dev"
+  network_interfaces = [
+    {
+      network_id = 103481
+    }
+  ]
+
+  network_interfaces = [
+    {
+      network_id = 103481
+      child_virtual_networks = [
+        {
+          network_id = 103481
+        }
+      ]
+    },
+    {
+      network_id = 103481
+    },
   ]
 
   volumes = [

--- a/internal/framework/subproviders/morpheus/resources/instance/example_twonetworks.tf
+++ b/internal/framework/subproviders/morpheus/resources/instance/example_twonetworks.tf
@@ -1,0 +1,87 @@
+data "hpe_morpheus_cloud" "vme_cloud" {
+  name = "HPE Alletra VME"
+}
+
+data "hpe_morpheus_service_plan" "vme_512mb" {
+  name                = "1 CPU, 1GB Memory"
+  provision_type_code = "kvm"
+}
+
+resource "hpe_morpheus_instance" "example" {
+  name             = "TestInstance"
+  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
+  layout_id        = 5385                                 # Single KVM VM
+  instance_type_id = 9                  # (HVM) mvm-cluster
+
+  group_id = 1
+  plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
+
+  instance_context = "dev"
+  network_interfaces = [
+    {
+      network_id = 103481
+    }
+  ]
+
+  network_interfaces = [
+    {
+      network_id = 103481
+      child_virtual_networks = [
+        {
+          network_id = 103481
+        }
+      ]
+    },
+    {
+      network_id = 103481
+    },
+  ]
+
+  volumes = [
+    {
+      root_volume     = true
+      name            = "root"
+      size            = 10
+      storage_type_id = 1
+      datastore_id    = 38658
+    },
+    {
+      root_volume     = false
+      name            = "data"
+      size            = 10
+      storage_type_id = 1
+      datastore_id    = 38658
+    }
+  ]
+
+  tags = [
+    {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
+      name  = "managed_by"
+      value = "terraform"
+    }
+  ]
+
+  config = {
+    resourcePoolId       = "pool-62299"
+    poolProviderType     = "mvm"
+    nestedVirtualization = "off"
+    noAgent              = true
+    createUser           = false
+  }
+}

--- a/internal/framework/subproviders/morpheus/resources/instance/example_twonetworks.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/instance/example_twonetworks.tf.tmpl
@@ -1,0 +1,87 @@
+data "hpe_morpheus_cloud" "vme_cloud" {
+  name = "HPE Alletra VME"
+}
+
+data "hpe_morpheus_service_plan" "vme_512mb" {
+  name                = "1 CPU, 1GB Memory"
+  provision_type_code = "kvm"
+}
+
+resource "hpe_morpheus_instance" "example" {
+  name             = "{{.Name}}"
+  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
+  layout_id        = 5385                                 # Single KVM VM
+  instance_type_id = {{.InstanceType}}                  # (HVM) mvm-cluster
+
+  group_id = 1
+  plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
+
+  instance_context = "dev"
+  network_interfaces = [
+    {
+      network_id = 103481
+    }
+  ]
+
+  network_interfaces = [
+    {
+      network_id = 103481
+      child_virtual_networks = [
+        {
+          network_id = 103481
+        }
+      ]
+    },
+    {
+      network_id = 103481
+    },
+  ]
+
+  volumes = [
+    {
+      root_volume     = true
+      name            = "root"
+      size            = 10
+      storage_type_id = 1
+      datastore_id    = 38658
+    },
+    {
+      root_volume     = false
+      name            = "data"
+      size            = 10
+      storage_type_id = 1
+      datastore_id    = 38658
+    }
+  ]
+
+  tags = [
+    {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
+      name  = "managed_by"
+      value = "terraform"
+    }
+  ]
+
+  config = {
+    resourcePoolId       = "{{.ResourcePool}}"
+    poolProviderType     = "mvm"
+    nestedVirtualization = "off"
+    noAgent              = true
+    createUser           = false
+  }
+}

--- a/internal/framework/subproviders/morpheus/resources/instance/instance.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance.go
@@ -389,6 +389,11 @@ func getAllServerInterfaces(
 		serverIntfsNameListMap := make(map[string]struct{})
 		serverIntfsMergedNameMap := make(map[string]sdk.InstanceContainerServerInterfacesInner1)
 		for _, serverIntf := range serverIntfList {
+			// Skip this list entry if it doesn't have a name
+			if _, ok := serverIntf.GetNameOk(); !ok {
+				continue
+			}
+
 			serverIntfsNameMap[*serverIntf.Name] = append(serverIntfsNameMap[*serverIntf.Name], serverIntf)
 			// Keep a record of the order of the interface name ("eth0" etc) in the input list
 			// We allow for duplicate name entries, so we're looking for the first entry
@@ -794,7 +799,7 @@ func (g *Resource) Delete(
 		return
 	}
 
-	deleteReq := client.InstancesAPI.DeleteInstance(ctx, id.ValueInt64()).Force("on")
+	deleteReq := client.InstancesAPI.DeleteInstance(ctx, id.ValueInt64()).Force("true")
 	_, hresp, err := deleteReq.Execute()
 	if err != nil || hresp.StatusCode != http.StatusOK {
 		resp.Diagnostics.AddError(

--- a/internal/framework/subproviders/morpheus/resources/instance/instance.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance.go
@@ -385,13 +385,22 @@ func getAllServerInterfaces(
 		server, _ := container.GetServerOk()
 		serverIntfList, _ := server.GetInterfacesOk()
 		serverIntfsNameMap := make(map[string][]sdk.InstanceContainerServerInterfacesInner1)
+		serverIntfsNameListPosition := make([]string, 0)
+		serverIntfsNameListMap := make(map[string]struct{})
+		serverIntfsMergedNameMap := make(map[string]sdk.InstanceContainerServerInterfacesInner1)
 		for _, serverIntf := range serverIntfList {
 			serverIntfsNameMap[*serverIntf.Name] = append(serverIntfsNameMap[*serverIntf.Name], serverIntf)
+			// Keep a record of the order of the interface name ("eth0" etc) in the input list
+			// We allow for duplicate name entries, so we're looking for the first entry
+			if _, ok := serverIntfsNameListMap[*serverIntf.Name]; !ok {
+				serverIntfsNameListPosition = append(serverIntfsNameListPosition, *serverIntf.Name)
+				serverIntfsNameListMap[*serverIntf.Name] = struct{}{}
+			}
 		}
 
-		for _, v := range serverIntfsNameMap {
+		for intfName, v := range serverIntfsNameMap {
 			if len(v) == 1 {
-				serverIntfsList = append(serverIntfsList, v[0])
+				serverIntfsMergedNameMap[intfName] = v[0]
 
 				continue
 			}
@@ -418,7 +427,12 @@ func getAllServerInterfaces(
 			}
 
 			cumulativeIntf.IpAddress = ipAddress
-			serverIntfsList = append(serverIntfsList, cumulativeIntf)
+			serverIntfsMergedNameMap[intfName] = cumulativeIntf
+		}
+
+		// Order serverIntfsList by order that the entries appeared in the original list
+		for _, intfName := range serverIntfsNameListPosition {
+			serverIntfsList = append(serverIntfsList, serverIntfsMergedNameMap[intfName])
 		}
 	}
 

--- a/internal/framework/subproviders/morpheus/resources/instance/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/resource_test.go
@@ -1,6 +1,7 @@
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 //go:generate go run ../../../../../../cmd/render example.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
+//go:generate go run ../../../../../../cmd/render example_twonetworks.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
 
 package instance_test
 

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -37,6 +37,15 @@ to import the instance. Otherwise the import will result in the instance being d
 
 ## Example Usage
 
+### HVM instance
+
 {{ tffile "internal/framework/subproviders/morpheus/resources/instance/example.tf" }}
+
+### HVM Instance with two networks
+
+One of these networks has a `child_virtual_networks` entry.  Note that only some network types support `child_virtual_networks`.
+The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" can be used to see which options are available.
+
+{{ tffile "internal/framework/subproviders/morpheus/resources/instance/example_twonetworks.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
There was a bug in the code use to process the list of interfaces in the server part of a container which meant that the order of interface "names" (e.g. eth0, eth1 etc) would be changed.  This meant that an instance plan would report a replace since the order of interfaces in the state-file would be changed.  This PR fixes that bug.

We've added an example HCL with two networks to the docs.