### PR TITLE
Adding acceptance tests for Policy Static Schema

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/policy/create_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create_test.go
@@ -805,3 +805,124 @@ resource "hpe_morpheus_network" "test" {
 		},
 	})
 }
+
+// Test creating policies using static schema fields (config_* attributes)
+func TestAccMorpheusPolicyAllStaticSchemaOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockMixed()
+	namePrefix := acctest.RandomWithPrefix(t.Name())
+	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
+
+	roleName := acctest.RandomWithPrefix(t.Name() + "-role")
+	userName := acctest.RandomWithPrefix(t.Name() + "-user")
+	cloudName := acctest.RandomWithPrefix(t.Name() + "-cloud")
+
+	dependencyConfig := `
+resource "hpe_morpheus_group" "test" {
+  name = "` + groupName + `"
+  location = "test"
+}
+
+resource "hpe_morpheus_role" "test" {
+  name = "` + roleName + `"
+  role_type = "user"
+}
+
+resource "hpe_morpheus_user" "test" {
+  username = "` + userName + `"
+  email = "` + userName + `@test.com"
+  role_ids = [hpe_morpheus_role.test.id]
+  password_wo = "TestPassword123!"
+}
+
+resource "morpheus_operational_workflow" "test" {
+  name = "` + namePrefix + `-workflow"
+}
+
+resource "hpe_morpheus_cloud" "test" {
+  name = "` + cloudName + `"
+  tenant_id = 1
+  group_id = hpe_morpheus_group.test.id
+  code = "` + cloudName + `"
+  cloud_type_code = "standard"
+  
+  config = {
+    certificateProvider = "internal"
+    enableNetworkTypeSelection = false
+  }
+}
+
+data "morpheus_workflow" "test" {
+  name = morpheus_operational_workflow.test.name
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"morpheus": {
+				Source:            "gomorpheus/morpheus",
+				VersionConstraint: "0.13.2",
+			},
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Approve Delete (using config_approval)
+			{
+				Config: providerConfig + dependencyConfig + `
+			resource "hpe_morpheus_policy" "test" {
+			  name = "` + namePrefix + `-deleteApproval"
+			  description = "Delete approval policy using static schema"
+			  associated_resource_type = "Group"
+			  associated_resource_id = hpe_morpheus_group.test.id
+			  enabled = true
+
+			  policy_type = {
+			    code = "deleteApproval"
+			  }
+
+			  config_approval = {
+			    account_integration_id = "1"
+			  }
+			}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-deleteApproval"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "deleteApproval"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_approval.account_integration_id", "1"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
+			// Step 2: Backup Creation (using config_create_backup)
+			{
+				Config: providerConfig + dependencyConfig + `
+			resource "hpe_morpheus_policy" "test" {
+			  name = "` + namePrefix + `-createBackup"
+			  description = "Create backup policy using static schema"
+			  associated_resource_type = "Group"
+			  associated_resource_id = hpe_morpheus_group.test.id
+			  enabled = true
+
+			  policy_type = {
+			    code = "createBackup"
+			  }
+
+			  config_create_backup = {
+			    create_backup = true
+			    create_backup_type = "user"
+			  }
+			}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "name", namePrefix+"-createBackup"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "policy_type.code", "createBackup"),
+					resource.TestCheckResourceAttr("hpe_morpheus_policy.test", "config_create_backup.create_backup", "true"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}

--- a/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
@@ -43,9 +43,6 @@ var testAccProtoV6ProviderFactories = map[string]func() (
 // Test validation: associated_resource_id required when not Global
 func TestAccMorpheusPolicyValidationResourceIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -68,6 +65,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -81,26 +79,17 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: invalid policy type code
 func TestAccMorpheusPolicyValidationInvalidPolicyType(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
 	providerConfig := testhelpers.ProviderBlock()
 	name := acctest.RandomWithPrefix(t.Name())
-	groupName := acctest.RandomWithPrefix(t.Name() + "-group")
 
 	resourceConfig := `
-resource "hpe_morpheus_group" "test" {
-  name = "` + groupName + `"
-  location = "test"
-}
-
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
   associated_resource_type = "Group"
-  associated_resource_id = hpe_morpheus_group.test.id
+  associated_resource_id = 1
   
   policy_type = {
     code = "invalidPolicyType"
@@ -113,6 +102,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -126,9 +116,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: invalid associated_resource_type
 func TestAccMorpheusPolicyValidationInvalidResourceType(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -152,6 +139,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -287,9 +275,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: config_approval flow_id and workflow_id conflict
 func TestAccMorpheusPolicyValidationApprovalWorkflowConflict(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -299,7 +284,8 @@ func TestAccMorpheusPolicyValidationApprovalWorkflowConflict(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
-  associated_resource_type = "Global"
+  associated_resource_type = "Group"
+  associated_resource_id = 1
   
   policy_type = {
     code = "approval"
@@ -315,6 +301,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -328,9 +315,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: config_approval flow_id required when workflow_type is flow
 func TestAccMorpheusPolicyValidationApprovalFlowIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -340,7 +324,8 @@ func TestAccMorpheusPolicyValidationApprovalFlowIdRequired(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
-  associated_resource_type = "Global"
+  associated_resource_type = "Group"
+  associated_resource_id = 1
   
   policy_type = {
     code = "provisionApproval"
@@ -354,6 +339,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -367,9 +353,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: config_approval workflow_id required when workflow_type is workflow
 func TestAccMorpheusPolicyValidationApprovalWorkflowIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -379,7 +362,8 @@ func TestAccMorpheusPolicyValidationApprovalWorkflowIdRequired(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
-  associated_resource_type = "Global"
+  associated_resource_type = "Group"
+  associated_resource_id = 1
   
   policy_type = {
     code = "provisionApproval"
@@ -393,6 +377,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -406,9 +391,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: config_lifecycle flow_id required when workflow_type is flow
 func TestAccMorpheusPolicyValidationLifecycleFlowIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -418,7 +400,8 @@ func TestAccMorpheusPolicyValidationLifecycleFlowIdRequired(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
-  associated_resource_type = "Global"
+  associated_resource_type = "Group"
+  associated_resource_id = 1
   
   policy_type = {
     code = "lifecycle"
@@ -432,6 +415,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -445,9 +429,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: config_lifecycle lifecycle_workflow_id required when workflow_type is workflow
 func TestAccMorpheusPolicyValidationLifecycleWorkflowIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -457,7 +438,8 @@ func TestAccMorpheusPolicyValidationLifecycleWorkflowIdRequired(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
-  associated_resource_type = "Global"
+  associated_resource_type = "Group"
+  associated_resource_id = 1
   
   policy_type = {
     code = "lifecycle"
@@ -471,6 +453,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -484,9 +467,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: config_shutdown flow_id required when workflow_type is flow
 func TestAccMorpheusPolicyValidationShutdownFlowIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -496,7 +476,8 @@ func TestAccMorpheusPolicyValidationShutdownFlowIdRequired(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
-  associated_resource_type = "Global"
+  associated_resource_type = "Group"
+  associated_resource_id = 1
   
   policy_type = {
     code = "shutdown"
@@ -510,6 +491,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -523,9 +505,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: config_shutdown shutdown_workflow_id required when workflow_type is workflow
 func TestAccMorpheusPolicyValidationShutdownWorkflowIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -535,7 +514,8 @@ func TestAccMorpheusPolicyValidationShutdownWorkflowIdRequired(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
-  associated_resource_type = "Global"
+  associated_resource_type = "Group"
+  associated_resource_id = 1
   
   policy_type = {
     code = "shutdown"
@@ -549,6 +529,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -562,9 +543,6 @@ resource "hpe_morpheus_policy" "validation_test" {
 // Test validation: config conflicts with config_* attributes
 func TestAccMorpheusPolicyValidationConfigConflict(t *testing.T) {
 	defer testhelpers.RecordResult(t)
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode")
-	}
 
 	t.Parallel()
 
@@ -574,7 +552,8 @@ func TestAccMorpheusPolicyValidationConfigConflict(t *testing.T) {
 	resourceConfig := `
 resource "hpe_morpheus_policy" "validation_test" {
   name = "` + name + `"
-  associated_resource_type = "Global"
+  associated_resource_type = "Group"
+  associated_resource_id = 1
   
   policy_type = {
     code = "maxMemory"
@@ -591,6 +570,7 @@ resource "hpe_morpheus_policy" "validation_test" {
 `
 
 	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
@@ -284,6 +284,46 @@ resource "hpe_morpheus_policy" "validation_test" {
 	})
 }
 
+// Test validation: config_approval flow_id and workflow_id conflict
+func TestAccMorpheusPolicyValidationApprovalWorkflowConflict(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig := `
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Global"
+  
+  policy_type = {
+    code = "approval"
+  }
+  
+  config_approval = {
+    workflow_type = "flow"
+    flow_id = "1"
+    workflow_id = "1"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("Attribute \"config_approval.workflow_id\" cannot be specified when"),
+			},
+		},
+	})
+}
+
 // Test validation: config_approval flow_id required when workflow_type is flow
 func TestAccMorpheusPolicyValidationApprovalFlowIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)

--- a/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
@@ -306,6 +306,7 @@ resource "hpe_morpheus_policy" "validation_test" {
   }
   
   config_approval = {
+    account_integration_id = "1"
     workflow_type = "flow"
     flow_id = "1"
     workflow_id = "1"
@@ -346,6 +347,7 @@ resource "hpe_morpheus_policy" "validation_test" {
   }
   
   config_approval = {
+    account_integration_id = "1"
     workflow_type = "flow"
   }
 }
@@ -384,6 +386,7 @@ resource "hpe_morpheus_policy" "validation_test" {
   }
   
   config_approval = {
+    account_integration_id = "1"
     workflow_type = "workflow"
   }
 }
@@ -422,6 +425,7 @@ resource "hpe_morpheus_policy" "validation_test" {
   }
   
   config_lifecycle = {
+    lifecycle_type = "user"
     workflow_type = "flow"
   }
 }
@@ -460,6 +464,7 @@ resource "hpe_morpheus_policy" "validation_test" {
   }
   
   config_lifecycle = {
+    lifecycle_type = "user"
     workflow_type = "workflow"
   }
 }
@@ -498,6 +503,7 @@ resource "hpe_morpheus_policy" "validation_test" {
   }
   
   config_shutdown = {
+    shutdown_type = "user"
     workflow_type = "flow"
   }
 }
@@ -536,6 +542,7 @@ resource "hpe_morpheus_policy" "validation_test" {
   }
   
   config_shutdown = {
+    shutdown_type = "user"
     workflow_type = "workflow"
   }
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/resource_test.go
@@ -283,3 +283,273 @@ resource "hpe_morpheus_policy" "validation_test" {
 		},
 	})
 }
+
+// Test validation: config_approval flow_id required when workflow_type is flow
+func TestAccMorpheusPolicyValidationApprovalFlowIdRequired(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig := `
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Global"
+  
+  policy_type = {
+    code = "provisionApproval"
+  }
+  
+  config_approval = {
+    workflow_type = "flow"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("flow_id is required when workflow_type is 'flow'"),
+			},
+		},
+	})
+}
+
+// Test validation: config_approval workflow_id required when workflow_type is workflow
+func TestAccMorpheusPolicyValidationApprovalWorkflowIdRequired(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig := `
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Global"
+  
+  policy_type = {
+    code = "provisionApproval"
+  }
+  
+  config_approval = {
+    workflow_type = "workflow"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("workflow_id is required when workflow_type is 'workflow'"),
+			},
+		},
+	})
+}
+
+// Test validation: config_lifecycle flow_id required when workflow_type is flow
+func TestAccMorpheusPolicyValidationLifecycleFlowIdRequired(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig := `
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Global"
+  
+  policy_type = {
+    code = "lifecycle"
+  }
+  
+  config_lifecycle = {
+    workflow_type = "flow"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("flow_id is required when workflow_type is 'flow'"),
+			},
+		},
+	})
+}
+
+// Test validation: config_lifecycle lifecycle_workflow_id required when workflow_type is workflow
+func TestAccMorpheusPolicyValidationLifecycleWorkflowIdRequired(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig := `
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Global"
+  
+  policy_type = {
+    code = "lifecycle"
+  }
+  
+  config_lifecycle = {
+    workflow_type = "workflow"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("lifecycle_workflow_id is required when workflow_type is 'workflow'"),
+			},
+		},
+	})
+}
+
+// Test validation: config_shutdown flow_id required when workflow_type is flow
+func TestAccMorpheusPolicyValidationShutdownFlowIdRequired(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig := `
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Global"
+  
+  policy_type = {
+    code = "shutdown"
+  }
+  
+  config_shutdown = {
+    workflow_type = "flow"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("flow_id is required when workflow_type is 'flow'"),
+			},
+		},
+	})
+}
+
+// Test validation: config_shutdown shutdown_workflow_id required when workflow_type is workflow
+func TestAccMorpheusPolicyValidationShutdownWorkflowIdRequired(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig := `
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Global"
+  
+  policy_type = {
+    code = "shutdown"
+  }
+  
+  config_shutdown = {
+    workflow_type = "workflow"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("shutdown_workflow_id is required when workflow_type is 'workflow'"),
+			},
+		},
+	})
+}
+
+// Test validation: config conflicts with config_* attributes
+func TestAccMorpheusPolicyValidationConfigConflict(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig := `
+resource "hpe_morpheus_policy" "validation_test" {
+  name = "` + name + `"
+  associated_resource_type = "Global"
+  
+  policy_type = {
+    code = "maxMemory"
+  }
+  
+  config = {
+    maxMemory = 8
+  }
+  
+  config_max_memory = {
+    max_memory = 8
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile("Attribute \"config_max_memory\" cannot be specified when"),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adding acceptance tests for the policy static schemas.
- Testing static schema creation in TestAccMorpheusPolicyAllStaticSchemaOk
- Testing flow_id and workflow_id requirement
- Testing config conflicts between config blocks
- Validation test for conflicts with between workflow_id/flow_id