### PR TITLE
Some Instance Read fixes

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -31,7 +31,7 @@ the creation of one VM per instance.  When executing terraform an error will be 
 to infrastructure after removal and on the next `apply` the attribute will be removed from the state-file.
 
 -> We support `timeouts` using the Hashicorp Framework [timeouts package](https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts).
-Note that we don't use the `timeouts` settings for `read`.  If the `timeouts` settings are changed in HCL an
+If the `timeouts` settings are changed in HCL an
 `Update` will be triggered.  If the only change detected is for `timeouts` then the State will be updated with
 the new settings but no `Morpheus` `Update` API calls will be made.
 
@@ -218,8 +218,8 @@ resource "hpe_morpheus_instance" "example" {
 ### HVM Instance with timeouts
 
 We support `timeouts` using the Hashicorp Framework [timeouts package](https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts).
-The following example specifies `timeouts` for `create`, `delete` and `update`.  Note that we don't use the `timeouts`
-settings for `read`.  If the `timeouts` settings are changed in HCL an `Update` will be triggered.  If the only change
+The following example specifies `timeouts` for `create`, `delete`, `update` and `read`.
+If the `timeouts` settings are changed in HCL an `Update` will be triggered.  If the only change
 detected is for `timeouts` then the State will be updated with the new settings but no `Morpheus` `Update` API calls
 will be made.
 
@@ -301,6 +301,7 @@ resource "hpe_morpheus_instance" "example" {
     create = "1h"
     delete = "20m"
     update = "20m"
+    read   = "10m"
   }
 }
 ```

--- a/internal/framework/subproviders/morpheus/auth/creds.go
+++ b/internal/framework/subproviders/morpheus/auth/creds.go
@@ -127,7 +127,7 @@ func NewCredsRoundTripper(
 
 	morpheusCfg.HTTPClient = &http.Client{
 		Transport: transport,
-		Timeout:   15 * time.Second,
+		Timeout:   15 * time.Minute,
 	}
 
 	rt := CredsRoundTripper{

--- a/internal/framework/subproviders/morpheus/clientfactory/clientfactory.go
+++ b/internal/framework/subproviders/morpheus/clientfactory/clientfactory.go
@@ -143,7 +143,7 @@ func NewAPIClient(
 		}
 		c.GetConfig().HTTPClient = &http.Client{
 			Transport: authRoundTripper,
-			Timeout:   15 * time.Second,
+			Timeout:   15 * time.Minute,
 		}
 	}
 

--- a/internal/framework/subproviders/morpheus/resources/instance/example_timeouts.tf
+++ b/internal/framework/subproviders/morpheus/resources/instance/example_timeouts.tf
@@ -75,5 +75,6 @@ resource "hpe_morpheus_instance" "example" {
     create = "1h"
     delete = "20m"
     update = "20m"
+    read   = "10m"
   }
 }

--- a/internal/framework/subproviders/morpheus/resources/instance/example_timeouts.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/instance/example_timeouts.tf.tmpl
@@ -75,5 +75,6 @@ resource "hpe_morpheus_instance" "example" {
     create = "1h"
     delete = "20m"
     update = "20m"
+    read   = "10m"
   }
 }

--- a/internal/framework/subproviders/morpheus/resources/instance/instance.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance.go
@@ -251,7 +251,9 @@ func getInstanceAsState(
 		if pool, ok := iface.GetNetworkPoolOk(); ok {
 			ifaceVal.IpPool = convert.Int64ToType(pool.Id)
 		}
-		ifaceVal.NetworkId = convert.Int64ToType(iface.Network.Id)
+		if net, ok := iface.GetNetworkOk(); ok {
+			ifaceVal.NetworkId = convert.Int64ToType(net.Id)
+		}
 		ifaceVal.Name = convert.StrToType(iface.Name)
 		ifaceVal.PrimaryInterface = convert.BoolToType(iface.PrimaryInterface)
 
@@ -876,6 +878,16 @@ func (g *Resource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Get timeout from HCL if set, the default is 45 minutes
+	createTimeout, diags := data.Timeouts.Read(ctx, 45*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
 
 	client, err := g.NewClient(ctx)
 	if err != nil {

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -31,7 +31,7 @@ the creation of one VM per instance.  When executing terraform an error will be 
 to infrastructure after removal and on the next `apply` the attribute will be removed from the state-file.
 
 -> We support `timeouts` using the Hashicorp Framework [timeouts package](https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts).
-Note that we don't use the `timeouts` settings for `read`.  If the `timeouts` settings are changed in HCL an
+If the `timeouts` settings are changed in HCL an
 `Update` will be triggered.  If the only change detected is for `timeouts` then the State will be updated with
 the new settings but no `Morpheus` `Update` API calls will be made.
 
@@ -56,8 +56,8 @@ The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" ca
 ### HVM Instance with timeouts
 
 We support `timeouts` using the Hashicorp Framework [timeouts package](https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts).
-The following example specifies `timeouts` for `create`, `delete` and `update`.  Note that we don't use the `timeouts`
-settings for `read`.  If the `timeouts` settings are changed in HCL an `Update` will be triggered.  If the only change
+The following example specifies `timeouts` for `create`, `delete`, `update` and `read`.
+If the `timeouts` settings are changed in HCL an `Update` will be triggered.  If the only change
 detected is for `timeouts` then the State will be updated with the new settings but no `Morpheus` `Update` API calls
 will be made.
 


### PR DESCRIPTION
Some fixes:
- we add code to read the timeouts section for read, and set a default timeout of 45 minutes
- we update the template and docs
- we add a check around the read of the network entry for an interface to ensure that it is non-nil

We also increase the default http client timeout to 15 minutes.  In
future we will likely ditch this timeout in favour of the timeouts
package