### PR TITLE
Instance network interface and update changes

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
@@ -5,8 +5,6 @@ package instance
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/morpheusvalidators"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -15,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -25,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -133,6 +133,9 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 										Computed:            true,
 										Description:         "id of the ip pool to be used with this network",
 										MarkdownDescription: "id of the ip pool to be used with this network",
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 										Validators: []validator.Int64{
 											int64validator.ConflictsWith(path.Expressions{
 												path.MatchRelative().AtParent().AtName("ip_address"),
@@ -143,6 +146,9 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 										Computed:            true,
 										Description:         "The name of the interface, e.g. 'eth0', 'eth1'",
 										MarkdownDescription: "The name of the interface, e.g. 'eth0', 'eth1'",
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"network_group_id": schema.Int64Attribute{
 										Optional:            true,
@@ -183,6 +189,9 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 										Computed:            true,
 										Description:         "Is this interface the 'primary interface'?",
 										MarkdownDescription: "Is this interface the 'primary interface'?",
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 								CustomType: ChildVirtualNetworksType{
@@ -232,6 +241,9 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "id of the ip pool to be used with this network",
 							MarkdownDescription: "id of the ip pool to be used with this network",
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
 							Validators: []validator.Int64{
 								int64validator.ConflictsWith(path.Expressions{
 									path.MatchRelative().AtParent().AtName("ip_address"),
@@ -242,6 +254,9 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "The name of the interface, e.g. 'eth0', 'eth1'",
 							MarkdownDescription: "The name of the interface, e.g. 'eth0', 'eth1'",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"network_group_id": schema.Int64Attribute{
 							Optional:            true,
@@ -282,6 +297,9 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "Is this interface the 'primary interface'?",
 							MarkdownDescription: "Is this interface the 'primary interface'?",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 					CustomType: NetworkInterfacesType{

--- a/internal/framework/subproviders/morpheus/resources/instance/update.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/update.go
@@ -252,8 +252,11 @@ func isAPIUpdateNeeded(plan, state InstanceModel) bool {
 		return true
 	}
 
-	// TODO when resizing of network_interfaces is allowed be careful because it looks as if plan and state will
-	// TODO always be different
+	// network-interfaces
+	// TODO check this carefully when resizing of networks is allowed
+	if !plan.NetworkInterfaces.Equal(state.NetworkInterfaces) {
+		return true
+	}
 
 	// timeouts - this should be the last comparison
 	if !plan.Timeouts.Equal(state.Timeouts) {


### PR DESCRIPTION
In this PR we make changes to the instance network interfaces Schema. We add UseStateForUnknown to:
- ip_pool
- name
- primary_interface

for network_interfaces and child_virtual_networks.  This suppresses and spurious detection of changes in configuration.

We've added a check on network-interfaces to the Instance Update isApiUpdateNeeded function since it is now safe to do so.