### PR TITLE
Instance network_interfaces ip_mode of ""

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4bb578ba
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.7.0
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.8.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4bb578ba/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.7.0 h1:sqO8khOFjz7uFs43HmaOfWwgCehxlGGn+1l1uOFEwZU=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.7.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.8.0 h1:aHZorCP1C78ahcVV8YsxqpmseICuPae8SEhC1eHZ1w0=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.8.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=

--- a/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
@@ -123,10 +123,13 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 										Computed:            true,
 										Description:         "The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.",
 										MarkdownDescription: "The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.",
-										Validators: []validator.String{
-											stringvalidator.OneOf("static", "dhcp"),
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
 										},
-										Default: stringdefault.StaticString("dhcp"),
+										Validators: []validator.String{
+											stringvalidator.OneOf("static", "dhcp", ""),
+										},
+										Default: stringdefault.StaticString(""),
 									},
 									"ip_pool": schema.Int64Attribute{
 										Optional:            true,
@@ -231,10 +234,13 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.",
 							MarkdownDescription: "The mode for determining ip address. Use 'static' when specifying an ipAddress, otherwise 'dhcp' is used.",
-							Validators: []validator.String{
-								stringvalidator.OneOf("static", "dhcp"),
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
 							},
-							Default: stringdefault.StaticString("dhcp"),
+							Validators: []validator.String{
+								stringvalidator.OneOf("static", "dhcp", ""),
+							},
+							Default: stringdefault.StaticString(""),
 						},
 						"ip_pool": schema.Int64Attribute{
 							Optional:            true,


### PR DESCRIPTION
In this PR we allow an ip_mode of "" for network_interfaces and child_virtual_networks.  We also set the default value of ip_mode to "". Finally we use state_for_unknown with ip_mode.