### PR TITLE
Add switch statement for policy config population

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/policy/config.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/config.go
@@ -53,12 +53,14 @@ func mapStateToAddPolicyConfig(
 			return nil, diags
 		}
 	} else {
-		// Use static config fields
+		// Use static config fields based on policy type code
 		configMap = make(map[string]interface{})
 
-		// Map each static config field to the API structure
-		// 1. config_approval -> ApprovePolicyTypeConfiguration
-		if !plan.ConfigApproval.IsNull() && !plan.ConfigApproval.IsUnknown() {
+		policyTypeCode := plan.PolicyType.Code.ValueString()
+
+		// Map config based on policy type code
+		switch policyTypeCode {
+		case "deleteApproval", "provisionApproval", "reconfigureApproval", "workflowApproval":
 			approval := make(map[string]interface{})
 			if !plan.ConfigApproval.AccountIntegrationId.IsNull() {
 				approval["accountIntegrationId"] = plan.ConfigApproval.AccountIntegrationId.ValueString()
@@ -75,10 +77,8 @@ func mapStateToAddPolicyConfig(
 			if len(approval) > 0 {
 				configMap = approval
 			}
-		}
 
-		// 2. config_backup_storage -> BackupTargetsPolicyTypeConfiguration
-		if !plan.ConfigBackupStorage.IsNull() && !plan.ConfigBackupStorage.IsUnknown() {
+		case "backupStorage":
 			backupStorage := make(map[string]interface{})
 			if !plan.ConfigBackupStorage.BackupStorageIds.IsNull() {
 				var backupStorageIDs []int64
@@ -93,10 +93,8 @@ func mapStateToAddPolicyConfig(
 			if len(backupStorage) > 0 {
 				configMap = backupStorage
 			}
-		}
 
-		// 3. config_create_backup -> BackupCreationPolicyTypeConfiguration
-		if !plan.ConfigCreateBackup.IsNull() && !plan.ConfigCreateBackup.IsUnknown() {
+		case "createBackup":
 			createBackup := make(map[string]interface{})
 			if !plan.ConfigCreateBackup.CreateBackup.IsNull() {
 				createBackup["createBackup"] = plan.ConfigCreateBackup.CreateBackup.ValueBool()
@@ -107,10 +105,8 @@ func mapStateToAddPolicyConfig(
 			if len(createBackup) > 0 {
 				configMap = createBackup
 			}
-		}
 
-		// 4. config_create_user -> UserCreationPolicyTypeConfiguration
-		if !plan.ConfigCreateUser.IsNull() && !plan.ConfigCreateUser.IsUnknown() {
+		case "createUser":
 			createUser := make(map[string]interface{})
 			if !plan.ConfigCreateUser.CreateUser.IsNull() {
 				createUser["createUser"] = plan.ConfigCreateUser.CreateUser.ValueBool()
@@ -121,10 +117,8 @@ func mapStateToAddPolicyConfig(
 			if len(createUser) > 0 {
 				configMap = createUser
 			}
-		}
 
-		// 5. config_create_user_group -> UserGroupCreationPolicyTypeConfiguration
-		if !plan.ConfigCreateUserGroup.IsNull() && !plan.ConfigCreateUserGroup.IsUnknown() {
+		case "createUserGroup":
 			createUserGroup := make(map[string]interface{})
 			if !plan.ConfigCreateUserGroup.UserGroup.IsNull() {
 				createUserGroup["userGroup"] = plan.ConfigCreateUserGroup.UserGroup.ValueString()
@@ -132,10 +126,8 @@ func mapStateToAddPolicyConfig(
 			if len(createUserGroup) > 0 {
 				configMap = createUserGroup
 			}
-		}
 
-		// 6. config_cypher -> CypherAccessPolicyTypeConfiguration
-		if !plan.ConfigCypher.IsNull() && !plan.ConfigCypher.IsUnknown() {
+		case "cypher":
 			cypher := make(map[string]interface{})
 			if !plan.ConfigCypher.Delete.IsNull() {
 				cypher["delete"] = plan.ConfigCypher.Delete.ValueBool()
@@ -158,10 +150,8 @@ func mapStateToAddPolicyConfig(
 			if len(cypher) > 0 {
 				configMap = cypher
 			}
-		}
 
-		// 7. config_delayed_removal -> DelayedDeletePolicyTypeConfiguration
-		if !plan.ConfigDelayedRemoval.IsNull() && !plan.ConfigDelayedRemoval.IsUnknown() {
+		case "delayedRemoval":
 			delayedRemoval := make(map[string]interface{})
 			if !plan.ConfigDelayedRemoval.RemovalAge.IsNull() {
 				delayedRemoval["removalAge"] = plan.ConfigDelayedRemoval.RemovalAge.ValueString()
@@ -169,10 +159,8 @@ func mapStateToAddPolicyConfig(
 			if len(delayedRemoval) > 0 {
 				configMap = delayedRemoval
 			}
-		}
 
-		// 8. config_host_naming -> HostnamePolicyTypeConfiguration
-		if !plan.ConfigHostNaming.IsNull() && !plan.ConfigHostNaming.IsUnknown() {
+		case "hostNaming":
 			hostNaming := make(map[string]interface{})
 			if !plan.ConfigHostNaming.HostNamingPattern.IsNull() {
 				hostNaming["hostNamingPattern"] = plan.ConfigHostNaming.HostNamingPattern.ValueString()
@@ -183,10 +171,8 @@ func mapStateToAddPolicyConfig(
 			if len(hostNaming) > 0 {
 				configMap = hostNaming
 			}
-		}
 
-		// 9. config_lifecycle -> ExpirationPolicyTypeConfiguration2
-		if !plan.ConfigLifecycle.IsNull() && !plan.ConfigLifecycle.IsUnknown() {
+		case "lifecycle":
 			lifecycle := make(map[string]interface{})
 			if !plan.ConfigLifecycle.AccountIntegrationId.IsNull() {
 				lifecycle["accountIntegrationId"] = plan.ConfigLifecycle.AccountIntegrationId.ValueString()
@@ -235,10 +221,8 @@ func mapStateToAddPolicyConfig(
 			if len(lifecycle) > 0 {
 				configMap = lifecycle
 			}
-		}
 
-		// 10. config_max_containers -> MaxContainersPolicyTypeConfiguration
-		if !plan.ConfigMaxContainers.IsNull() && !plan.ConfigMaxContainers.IsUnknown() {
+		case "maxContainers":
 			maxContainers := make(map[string]interface{})
 			if !plan.ConfigMaxContainers.MaxContainers.IsNull() {
 				maxContainers["maxContainers"] = plan.ConfigMaxContainers.MaxContainers.ValueString()
@@ -246,10 +230,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxContainers) > 0 {
 				configMap = maxContainers
 			}
-		}
 
-		// 11. config_max_cores -> MaxCoresPolicyTypeConfiguration
-		if !plan.ConfigMaxCores.IsNull() && !plan.ConfigMaxCores.IsUnknown() {
+		case "maxCores":
 			maxCores := make(map[string]interface{})
 			if !plan.ConfigMaxCores.MaxCores.IsNull() {
 				maxCores["maxCores"] = plan.ConfigMaxCores.MaxCores.ValueString()
@@ -262,10 +244,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxCores) > 0 {
 				configMap = maxCores
 			}
-		}
 
-		// 12. config_max_hosts -> MaxHostsPolicyTypeConfiguration
-		if !plan.ConfigMaxHosts.IsNull() && !plan.ConfigMaxHosts.IsUnknown() {
+		case "maxHosts":
 			maxHosts := make(map[string]interface{})
 			if !plan.ConfigMaxHosts.MaxHosts.IsNull() {
 				maxHosts["maxHosts"] = plan.ConfigMaxHosts.MaxHosts.ValueString()
@@ -273,10 +253,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxHosts) > 0 {
 				configMap = maxHosts
 			}
-		}
 
-		// 13. config_max_memory -> MaxMemoryPolicyTypeConfiguration
-		if !plan.ConfigMaxMemory.IsNull() && !plan.ConfigMaxMemory.IsUnknown() {
+		case "maxMemory":
 			maxMemory := make(map[string]interface{})
 			if !plan.ConfigMaxMemory.MaxMemory.IsNull() {
 				maxMemory["maxMemory"] = plan.ConfigMaxMemory.MaxMemory.ValueString()
@@ -289,10 +267,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxMemory) > 0 {
 				configMap = maxMemory
 			}
-		}
 
-		// 14. config_max_networks -> NetworkQuotaPolicyTypeConfiguration
-		if !plan.ConfigMaxNetworks.IsNull() && !plan.ConfigMaxNetworks.IsUnknown() {
+		case "maxNetworks":
 			maxNetworks := make(map[string]interface{})
 			if !plan.ConfigMaxNetworks.MaxNetworks.IsNull() {
 				maxNetworks["maxNetworks"] = plan.ConfigMaxNetworks.MaxNetworks.ValueString()
@@ -300,10 +276,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxNetworks) > 0 {
 				configMap = maxNetworks
 			}
-		}
 
-		// 15. config_max_pool_members -> MaxPoolMembersPolicyTypeConfiguration
-		if !plan.ConfigMaxPoolMembers.IsNull() && !plan.ConfigMaxPoolMembers.IsUnknown() {
+		case "maxPoolMembers":
 			maxPoolMembers := make(map[string]interface{})
 			if !plan.ConfigMaxPoolMembers.MaxPoolMembers.IsNull() {
 				maxPoolMembers["maxPoolMembers"] = plan.ConfigMaxPoolMembers.MaxPoolMembers.ValueString()
@@ -311,10 +285,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxPoolMembers) > 0 {
 				configMap = maxPoolMembers
 			}
-		}
 
-		// 16. config_max_pools -> MaxLoadBalancerPoolsPolicyTypeConfiguration
-		if !plan.ConfigMaxPools.IsNull() && !plan.ConfigMaxPools.IsUnknown() {
+		case "maxPools":
 			maxPools := make(map[string]interface{})
 			if !plan.ConfigMaxPools.MaxPools.IsNull() {
 				maxPools["maxPools"] = plan.ConfigMaxPools.MaxPools.ValueString()
@@ -322,10 +294,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxPools) > 0 {
 				configMap = maxPools
 			}
-		}
 
-		// 17. config_max_price -> BudgetPolicyTypeConfiguration
-		if !plan.ConfigMaxPrice.IsNull() && !plan.ConfigMaxPrice.IsUnknown() {
+		case "maxPrice":
 			maxPrice := make(map[string]interface{})
 			if !plan.ConfigMaxPrice.MaxPrice.IsNull() {
 				// MaxPrice is a Number type, get the float value
@@ -341,10 +311,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxPrice) > 0 {
 				configMap = maxPrice
 			}
-		}
 
-		// 18. config_max_routers -> RouterQuotaPolicyTypeConfiguration
-		if !plan.ConfigMaxRouters.IsNull() && !plan.ConfigMaxRouters.IsUnknown() {
+		case "maxRouters":
 			maxRouters := make(map[string]interface{})
 			if !plan.ConfigMaxRouters.MaxRouters.IsNull() {
 				maxRouters["maxRouters"] = plan.ConfigMaxRouters.MaxRouters.ValueString()
@@ -352,10 +320,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxRouters) > 0 {
 				configMap = maxRouters
 			}
-		}
 
-		// 19. config_max_snapshots -> MaxSnapshotsPolicyTypeConfiguration
-		if !plan.ConfigMaxSnapshots.IsNull() && !plan.ConfigMaxSnapshots.IsUnknown() {
+		case "maxSnapshots":
 			maxSnapshots := make(map[string]interface{})
 			if !plan.ConfigMaxSnapshots.MaxSnapshots.IsNull() {
 				maxSnapshots["maxSnapshots"] = plan.ConfigMaxSnapshots.MaxSnapshots.ValueString()
@@ -363,10 +329,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxSnapshots) > 0 {
 				configMap = maxSnapshots
 			}
-		}
 
-		// 20. config_max_storage -> MaxStorageAndObjectStorageQuotaPolicyTypeConfiguration
-		if !plan.ConfigMaxStorage.IsNull() && !plan.ConfigMaxStorage.IsUnknown() {
+		case "maxStorage":
 			maxStorage := make(map[string]interface{})
 			if !plan.ConfigMaxStorage.MaxStorage.IsNull() {
 				maxStorage["maxStorage"] = plan.ConfigMaxStorage.MaxStorage.ValueString()
@@ -379,10 +343,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxStorage) > 0 {
 				configMap = maxStorage
 			}
-		}
 
-		// 21. config_max_virtual_servers -> MaxVirtualServersPolicyTypeConfiguration
-		if !plan.ConfigMaxVirtualServers.IsNull() && !plan.ConfigMaxVirtualServers.IsUnknown() {
+		case "maxVirtualServers":
 			maxVirtualServers := make(map[string]interface{})
 			if !plan.ConfigMaxVirtualServers.MaxVirtualServers.IsNull() {
 				maxVirtualServers["maxVirtualServers"] = plan.ConfigMaxVirtualServers.MaxVirtualServers.ValueString()
@@ -390,10 +352,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxVirtualServers) > 0 {
 				configMap = maxVirtualServers
 			}
-		}
 
-		// 22. config_max_vms -> MaxVMsPolicyTypeConfiguration
-		if !plan.ConfigMaxVms.IsNull() && !plan.ConfigMaxVms.IsUnknown() {
+		case "maxVms":
 			maxVms := make(map[string]interface{})
 			if !plan.ConfigMaxVms.MaxVms.IsNull() {
 				maxVms["maxVms"] = plan.ConfigMaxVms.MaxVms.ValueString()
@@ -401,10 +361,8 @@ func mapStateToAddPolicyConfig(
 			if len(maxVms) > 0 {
 				configMap = maxVms
 			}
-		}
 
-		// 23. config_motd -> MessageOfTheDayPolicyTypeConfiguration2
-		if !plan.ConfigMotd.IsNull() && !plan.ConfigMotd.IsUnknown() {
+		case "motd":
 			motd := make(map[string]interface{})
 			if !plan.ConfigMotd.Motdtitle.IsNull() {
 				motd["motd.title"] = plan.ConfigMotd.Motdtitle.ValueString()
@@ -421,10 +379,8 @@ func mapStateToAddPolicyConfig(
 			if len(motd) > 0 {
 				configMap = motd
 			}
-		}
 
-		// 24. config_naming -> InstanceNamePolicyTypeConfiguration
-		if !plan.ConfigNaming.IsNull() && !plan.ConfigNaming.IsUnknown() {
+		case "naming":
 			naming := make(map[string]interface{})
 			if !plan.ConfigNaming.NamingConflict.IsNull() {
 				naming["namingConflict"] = plan.ConfigNaming.NamingConflict.ValueBool()
@@ -438,10 +394,8 @@ func mapStateToAddPolicyConfig(
 			if len(naming) > 0 {
 				configMap = naming
 			}
-		}
 
-		// 25. config_power_schedule -> PowerSchedulePolicyTypeConfiguration
-		if !plan.ConfigPowerSchedule.IsNull() && !plan.ConfigPowerSchedule.IsUnknown() {
+		case "powerSchedule":
 			powerSchedule := make(map[string]interface{})
 			if !plan.ConfigPowerSchedule.PowerSchedule.IsNull() {
 				powerSchedule["powerSchedule"] = plan.ConfigPowerSchedule.PowerSchedule.ValueString()
@@ -455,10 +409,8 @@ func mapStateToAddPolicyConfig(
 			if len(powerSchedule) > 0 {
 				configMap = powerSchedule
 			}
-		}
 
-		// 26. config_required_network -> RequiredNetworkPolicyTypeConfiguration
-		if !plan.ConfigRequiredNetwork.IsNull() && !plan.ConfigRequiredNetwork.IsUnknown() {
+		case "requiredNetwork":
 			requiredNetwork := make(map[string]interface{})
 			if !plan.ConfigRequiredNetwork.RequiredNetworks.IsNull() {
 				var requiredNetworks []int64
@@ -473,10 +425,8 @@ func mapStateToAddPolicyConfig(
 			if len(requiredNetwork) > 0 {
 				configMap = requiredNetwork
 			}
-		}
 
-		// 27. config_server_naming -> ClusterResourceNamePolicyTypeConfiguration
-		if !plan.ConfigServerNaming.IsNull() && !plan.ConfigServerNaming.IsUnknown() {
+		case "serverNaming":
 			serverNaming := make(map[string]interface{})
 			if !plan.ConfigServerNaming.ServerNamingConflict.IsNull() {
 				serverNaming["serverNamingConflict"] = plan.ConfigServerNaming.ServerNamingConflict.ValueBool()
@@ -490,10 +440,8 @@ func mapStateToAddPolicyConfig(
 			if len(serverNaming) > 0 {
 				configMap = serverNaming
 			}
-		}
 
-		// 28. config_shutdown -> ShutdownPolicyTypeConfiguration
-		if !plan.ConfigShutdown.IsNull() && !plan.ConfigShutdown.IsUnknown() {
+		case "shutdown":
 			shutdown := make(map[string]interface{})
 			if !plan.ConfigShutdown.AccountIntegrationId.IsNull() {
 				shutdown["accountIntegrationId"] = plan.ConfigShutdown.AccountIntegrationId.ValueString()
@@ -541,10 +489,8 @@ func mapStateToAddPolicyConfig(
 			if len(shutdown) > 0 {
 				configMap = shutdown
 			}
-		}
 
-		// 29. config_storage_server_quota -> StorageServerStorageQuotaPolicyTypeConfiguration
-		if !plan.ConfigStorageServerQuota.IsNull() && !plan.ConfigStorageServerQuota.IsUnknown() {
+		case "storageServerQuota":
 			storageServerQuota := make(map[string]interface{})
 			if !plan.ConfigStorageServerQuota.MaxStorage.IsNull() {
 				storageServerQuota["maxStorage"] = plan.ConfigStorageServerQuota.MaxStorage.ValueString()
@@ -555,10 +501,8 @@ func mapStateToAddPolicyConfig(
 			if len(storageServerQuota) > 0 {
 				configMap = storageServerQuota
 			}
-		}
 
-		// 30. config_tags -> TagsPolicyTypeConfiguration
-		if !plan.ConfigTags.IsNull() && !plan.ConfigTags.IsUnknown() {
+		case "tags":
 			tags := make(map[string]interface{})
 			if !plan.ConfigTags.Key.IsNull() {
 				tags["key"] = plan.ConfigTags.Key.ValueString()
@@ -575,10 +519,8 @@ func mapStateToAddPolicyConfig(
 			if len(tags) > 0 {
 				configMap = tags
 			}
-		}
 
-		// 31. config_workflow -> WorkflowPolicyTypeConfiguration
-		if !plan.ConfigWorkflow.IsNull() && !plan.ConfigWorkflow.IsUnknown() {
+		case "workflow":
 			workflow := make(map[string]interface{})
 			if !plan.ConfigWorkflow.WorkflowId.IsNull() {
 				workflow["workflowId"] = plan.ConfigWorkflow.WorkflowId.ValueString()
@@ -586,10 +528,10 @@ func mapStateToAddPolicyConfig(
 			if len(workflow) > 0 {
 				configMap = workflow
 			}
-		}
 
-		// Check if any config was provided
-		if len(configMap) == 0 {
+		default:
+
+			// No config was provided
 			diags.AddError(
 				"map state to API config",
 				"No configuration provided. Please provide at least one config_* field for this policy type.",

--- a/internal/framework/subproviders/morpheus/resources/policy/read.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/read.go
@@ -715,35 +715,29 @@ func getPolicyAsState(
 
 	// Handle Config - use static schema fields when available, fallback to dynamic
 	if p.Config != nil {
-		// Get policy type code for mapping (required field, but API could return nil)
-		policyTypeCode := ""
-		if p.PolicyType != nil && p.PolicyType.Code != nil {
-			policyTypeCode = *p.PolicyType.Code
-		}
+		// Check if user is using dynamic config field
+		usingDynamicConfig := plan != nil && !plan.Config.IsNull() && !plan.Config.IsUnknown()
 
-		// Map API config to static schema fields
-		configDiags := mapPolicyConfigToState(ctx, &state, p.Config, policyTypeCode)
-		if configDiags.HasError() {
-			diags.Append(configDiags...)
-
-			return state, diags
-		}
-
-		// Also preserve the dynamic config field if it was set in plan
-		if plan != nil && !plan.Config.IsNull() && !plan.Config.IsUnknown() {
+		if usingDynamicConfig {
+			// User is using dynamic config - only populate the dynamic field
 			state.Config = plan.Config
 		} else {
-			// Convert API config to dynamic type as fallback
-			var err error
-			state.Config, err = convert.StructToDynamic(ctx, p.Config)
-			if err != nil {
-				diags.AddError(
-					"populate policy resource",
-					fmt.Sprintf("policy %d: failed to convert config: %s", id, err.Error()),
-				)
+			// User is using static config fields - populate them from API response
+			// Get policy type code for mapping (required field, but API could return nil)
+			policyTypeCode := ""
+			if p.PolicyType != nil && p.PolicyType.Code != nil {
+				policyTypeCode = *p.PolicyType.Code
+			}
+
+			// Map API config to static schema fields
+			configDiags := mapPolicyConfigToState(ctx, &state, p.Config, policyTypeCode)
+			if configDiags.HasError() {
+				diags.Append(configDiags...)
 
 				return state, diags
 			}
+
+			// Don't populate dynamic config when using static fields to avoid drift
 		}
 	}
 

--- a/internal/framework/subproviders/morpheus/resources/policy/read.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/read.go
@@ -22,12 +22,13 @@ func mapPolicyConfigToState(
 	ctx context.Context,
 	state *PolicyModel,
 	apiConfig *sdk.AddPolicies200ResponseAllOfPolicyConfig,
+	policyTypeCode string,
 ) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 
-	// Map each API config field to the corresponding schema field - only populate non-null configurations
-	// 1. ApprovePolicyTypeConfiguration -> config_approval
-	if apiConfig.ApprovePolicyTypeConfiguration != nil {
+	// Map API config field to the corresponding schema field based on policy type code
+	switch policyTypeCode {
+	case "deleteApproval", "provisionApproval", "reconfigureApproval", "workflowApproval":
 		approvalValue, approvalDiags := NewConfigApprovalValue(
 			ConfigApprovalValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
@@ -42,10 +43,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigApproval = approvalValue
 		}
-	}
 
-	// 2. BackupTargetsPolicyTypeConfiguration -> config_backup_storage
-	if apiConfig.BackupTargetsPolicyTypeConfiguration != nil {
+	case "backupStorage":
 		// Handle BackupStorageIds as a set of int64
 		var backupStorageIDsSet types.Set
 		var setDiags diag.Diagnostics
@@ -76,10 +75,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigBackupStorage = backupStorageValue
 		}
-	}
 
-	// 3. BackupCreationPolicyTypeConfiguration -> config_create_backup
-	if apiConfig.BackupCreationPolicyTypeConfiguration != nil {
+	case "createBackup":
 		createBackupValue, createBackupDiags := NewConfigCreateBackupValue(
 			ConfigCreateBackupValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
@@ -92,10 +89,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigCreateBackup = createBackupValue
 		}
-	}
 
-	// 4. UserCreationPolicyTypeConfiguration -> config_create_user
-	if apiConfig.UserCreationPolicyTypeConfiguration != nil {
+	case "createUser":
 		createUserValue, createUserDiags := NewConfigCreateUserValue(
 			ConfigCreateUserValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
@@ -108,10 +103,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigCreateUser = createUserValue
 		}
-	}
 
-	// 5. UserGroupCreationPolicyTypeConfiguration -> config_create_user_group
-	if apiConfig.UserGroupCreationPolicyTypeConfiguration != nil {
+	case "createUserGroup":
 		createUserGroupValue, createUserGroupDiags := NewConfigCreateUserGroupValue(
 			ConfigCreateUserGroupValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
@@ -123,10 +116,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigCreateUserGroup = createUserGroupValue
 		}
-	}
 
-	// 6. CypherAccessPolicyTypeConfiguration -> config_cypher
-	if apiConfig.CypherAccessPolicyTypeConfiguration != nil {
+	case "cypher":
 		cypherValue, cypherDiags := NewConfigCypherValue(
 			ConfigCypherValue{}.AttributeTypes(ctx),
 			map[string]attr.Value{
@@ -143,10 +134,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigCypher = cypherValue
 		}
-	}
 
-	// 7. BudgetPolicyTypeConfiguration -> config_max_price
-	if apiConfig.BudgetPolicyTypeConfiguration != nil {
+	case "maxPrice":
 		maxPriceAttrs := map[string]attr.Value{
 			"max_price":          convert.NumToType(&apiConfig.BudgetPolicyTypeConfiguration.MaxPrice),
 			"max_price_currency": convert.StrToType(apiConfig.BudgetPolicyTypeConfiguration.MaxPriceCurrency),
@@ -159,10 +148,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxPrice = maxPriceValue
 		}
-	}
 
-	// 8. MaxMemoryPolicyTypeConfiguration -> config_max_memory
-	if apiConfig.MaxMemoryPolicyTypeConfiguration != nil {
+	case "maxMemory":
 		maxMemoryAttrs := map[string]attr.Value{
 			"max_memory":         convert.StrToType(&apiConfig.MaxMemoryPolicyTypeConfiguration.MaxMemory),
 			"exclude_containers": convert.StringToBool(ctx, apiConfig.MaxMemoryPolicyTypeConfiguration.GetExcludeContainers()),
@@ -174,10 +161,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxMemory = maxMemoryValue
 		}
-	}
 
-	// 9. MaxCoresPolicyTypeConfiguration -> config_max_cores
-	if apiConfig.MaxCoresPolicyTypeConfiguration != nil {
+	case "maxCores":
 		maxCoresAttrs := map[string]attr.Value{
 			"max_cores":          convert.StrToType(&apiConfig.MaxCoresPolicyTypeConfiguration.MaxCores),
 			"exclude_containers": convert.StringToBool(ctx, apiConfig.MaxCoresPolicyTypeConfiguration.GetExcludeContainers()),
@@ -189,10 +174,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxCores = maxCoresValue
 		}
-	}
 
-	// 10. DelayedDeletePolicyTypeConfiguration -> config_delayed_removal
-	if apiConfig.DelayedDeletePolicyTypeConfiguration != nil {
+	case "delayedRemoval":
 		delayedRemovalAttrs := map[string]attr.Value{
 			"removal_age": convert.StrToType(&apiConfig.DelayedDeletePolicyTypeConfiguration.RemovalAge),
 		}
@@ -206,10 +189,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigDelayedRemoval = delayedRemovalValue
 		}
-	}
 
-	// 11. ExpirationPolicyTypeConfiguration2 -> config_lifecycle
-	if apiConfig.ExpirationPolicyTypeConfiguration2 != nil {
+	case "lifecycle":
 		lifecycleAttrs := map[string]attr.Value{
 			"account_integration_id": convert.StrToType(
 				apiConfig.ExpirationPolicyTypeConfiguration2.AccountIntegrationId,
@@ -254,10 +235,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigLifecycle = lifecycleValue
 		}
-	}
 
-	// 12. HostnamePolicyTypeConfiguration -> config_host_naming
-	if apiConfig.HostnamePolicyTypeConfiguration != nil {
+	case "hostNaming":
 		hostNamingAttrs := map[string]attr.Value{
 			"host_naming_pattern": convert.StrToType(apiConfig.HostnamePolicyTypeConfiguration.HostNamingPattern),
 			"host_naming_type":    convert.StrToType(&apiConfig.HostnamePolicyTypeConfiguration.HostNamingType),
@@ -272,10 +251,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigHostNaming = hostNamingValue
 		}
-	}
 
-	// 13. InstanceNamePolicyTypeConfiguration -> config_naming
-	if apiConfig.InstanceNamePolicyTypeConfiguration != nil {
+	case "naming":
 		namingAttrs := map[string]attr.Value{
 			"naming_conflict": convert.BoolToType(apiConfig.InstanceNamePolicyTypeConfiguration.NamingConflict),
 			"naming_pattern":  convert.StrToType(apiConfig.InstanceNamePolicyTypeConfiguration.NamingPattern),
@@ -288,10 +265,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigNaming = namingValue
 		}
-	}
 
-	// 14. MaxContainersPolicyTypeConfiguration -> config_max_containers
-	if apiConfig.MaxContainersPolicyTypeConfiguration != nil {
+	case "maxContainers":
 		maxContainersAttrs := map[string]attr.Value{
 			"max_containers": convert.StrToType(&apiConfig.MaxContainersPolicyTypeConfiguration.MaxContainers),
 		}
@@ -305,10 +280,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxContainers = maxContainersValue
 		}
-	}
 
-	// 15. MaxHostsPolicyTypeConfiguration -> config_max_hosts
-	if apiConfig.MaxHostsPolicyTypeConfiguration != nil {
+	case "maxHosts":
 		maxHostsAttrs := map[string]attr.Value{
 			"max_hosts": convert.StrToType(&apiConfig.MaxHostsPolicyTypeConfiguration.MaxHosts),
 		}
@@ -319,10 +292,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxHosts = maxHostsValue
 		}
-	}
 
-	// 16. NetworkQuotaPolicyTypeConfiguration -> config_max_networks
-	if apiConfig.NetworkQuotaPolicyTypeConfiguration != nil {
+	case "maxNetworks":
 		maxNetworksAttrs := map[string]attr.Value{
 			"max_networks": convert.StrToType(&apiConfig.NetworkQuotaPolicyTypeConfiguration.MaxNetworks),
 		}
@@ -336,10 +307,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxNetworks = maxNetworksValue
 		}
-	}
 
-	// 17. MaxPoolMembersPolicyTypeConfiguration -> config_max_pool_members
-	if apiConfig.MaxPoolMembersPolicyTypeConfiguration != nil {
+	case "maxPoolMembers":
 		maxPoolMembersAttrs := map[string]attr.Value{
 			"max_pool_members": convert.StrToType(&apiConfig.MaxPoolMembersPolicyTypeConfiguration.MaxPoolMembers),
 		}
@@ -353,10 +322,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxPoolMembers = maxPoolMembersValue
 		}
-	}
 
-	// 18. MaxLoadBalancerPoolsPolicyTypeConfiguration -> config_max_pools
-	if apiConfig.MaxLoadBalancerPoolsPolicyTypeConfiguration != nil {
+	case "maxPools":
 		maxPoolsAttrs := map[string]attr.Value{
 			"max_pools": convert.StrToType(&apiConfig.MaxLoadBalancerPoolsPolicyTypeConfiguration.MaxPools),
 		}
@@ -367,10 +334,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxPools = maxPoolsValue
 		}
-	}
 
-	// 19. RouterQuotaPolicyTypeConfiguration -> config_max_routers
-	if apiConfig.RouterQuotaPolicyTypeConfiguration != nil {
+	case "maxRouters":
 		maxRoutersAttrs := map[string]attr.Value{
 			"max_routers": convert.StrToType(&apiConfig.RouterQuotaPolicyTypeConfiguration.MaxRouters),
 		}
@@ -384,10 +349,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxRouters = maxRoutersValue
 		}
-	}
 
-	// 20. MaxSnapshotsPolicyTypeConfiguration -> config_max_snapshots
-	if apiConfig.MaxSnapshotsPolicyTypeConfiguration != nil {
+	case "maxSnapshots":
 		maxSnapshotsAttrs := map[string]attr.Value{
 			"max_snapshots": convert.StrToType(&apiConfig.MaxSnapshotsPolicyTypeConfiguration.MaxSnapshots),
 		}
@@ -401,10 +364,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxSnapshots = maxSnapshotsValue
 		}
-	}
 
-	// 21. MaxStorageAndObjectStorageQuotaPolicyTypeConfiguration -> config_max_storage
-	if apiConfig.MaxStorageAndObjectStorageQuotaPolicyTypeConfiguration != nil {
+	case "maxStorage":
 		maxStorageAttrs := map[string]attr.Value{
 			"exclude_containers": convert.StringToBool(
 				ctx,
@@ -424,10 +385,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxStorage = maxStorageValue
 		}
-	}
 
-	// 22. MaxVirtualServersPolicyTypeConfiguration -> config_max_virtual_servers
-	if apiConfig.MaxVirtualServersPolicyTypeConfiguration != nil {
+	case "maxVirtualServers":
 		maxVirtualServersAttrs := map[string]attr.Value{
 			"max_virtual_servers": convert.StrToType(&apiConfig.MaxVirtualServersPolicyTypeConfiguration.MaxVirtualServers),
 		}
@@ -441,10 +400,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxVirtualServers = maxVirtualServersValue
 		}
-	}
 
-	// 23. MaxVMsPolicyTypeConfiguration -> config_max_vms
-	if apiConfig.MaxVMsPolicyTypeConfiguration != nil {
+	case "maxVms":
 		maxVmsAttrs := map[string]attr.Value{
 			"max_vms": convert.StrToType(&apiConfig.MaxVMsPolicyTypeConfiguration.MaxVms),
 		}
@@ -455,10 +412,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMaxVms = maxVmsValue
 		}
-	}
 
-	// 24. MessageOfTheDayPolicyTypeConfiguration2 -> config_motd
-	if apiConfig.MessageOfTheDayPolicyTypeConfiguration2 != nil {
+	case "motd":
 		motdAttrs := map[string]attr.Value{
 			"motddate":    convert.StrToType(apiConfig.MessageOfTheDayPolicyTypeConfiguration2.MotdDate),
 			"motdmessage": convert.StrToType(apiConfig.MessageOfTheDayPolicyTypeConfiguration2.MotdMessage),
@@ -477,10 +432,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigMotd = motdValue
 		}
-	}
 
-	// 25. PowerSchedulePolicyTypeConfiguration -> config_power_schedule
-	if apiConfig.PowerSchedulePolicyTypeConfiguration != nil {
+	case "powerSchedule":
 		powerScheduleAttrs := map[string]attr.Value{
 			"power_schedule": convert.StrToType(
 				apiConfig.PowerSchedulePolicyTypeConfiguration.PowerSchedule,
@@ -502,10 +455,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigPowerSchedule = powerScheduleValue
 		}
-	}
 
-	// 26. RequiredNetworkPolicyTypeConfiguration -> config_required_network
-	if apiConfig.RequiredNetworkPolicyTypeConfiguration != nil {
+	case "requiredNetwork":
 		// Handle RequiredNetworks as a set of integers
 		var requiredNetworksSet types.Set
 		if len(apiConfig.RequiredNetworkPolicyTypeConfiguration.RequiredNetworks) == 0 {
@@ -535,10 +486,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigRequiredNetwork = requiredNetworkValue
 		}
-	}
 
-	// 27. ClusterResourceNamePolicyTypeConfiguration -> config_server_naming
-	if apiConfig.ClusterResourceNamePolicyTypeConfiguration != nil {
+	case "serverNaming":
 		serverNamingAttrs := map[string]attr.Value{
 			"server_naming_conflict": convert.BoolToType(
 				apiConfig.ClusterResourceNamePolicyTypeConfiguration.ServerNamingConflict,
@@ -560,10 +509,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigServerNaming = serverNamingValue
 		}
-	}
 
-	// 28. ShutdownPolicyTypeConfiguration -> config_shutdown
-	if apiConfig.ShutdownPolicyTypeConfiguration != nil {
+	case "shutdown":
 		shutdownAttrs := map[string]attr.Value{
 			"account_integration_id": convert.StrToType(
 				apiConfig.ShutdownPolicyTypeConfiguration.AccountIntegrationId,
@@ -608,10 +555,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigShutdown = shutdownValue
 		}
-	}
 
-	// 29. StorageServerStorageQuotaPolicyTypeConfiguration -> config_storage_server_quota
-	if apiConfig.StorageServerStorageQuotaPolicyTypeConfiguration != nil {
+	case "storageServerQuota":
 		storageServerQuotaAttrs := map[string]attr.Value{
 			"max_storage":       convert.StrToType(apiConfig.StorageServerStorageQuotaPolicyTypeConfiguration.MaxStorage),
 			"storage_server_id": convert.StrToType(&apiConfig.StorageServerStorageQuotaPolicyTypeConfiguration.StorageServerId),
@@ -626,10 +571,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigStorageServerQuota = storageServerQuotaValue
 		}
-	}
 
-	// 30. TagsPolicyTypeConfiguration -> config_tags
-	if apiConfig.TagsPolicyTypeConfiguration != nil {
+	case "tags":
 		tagsAttrs := map[string]attr.Value{
 			"key":           convert.StrToType(apiConfig.TagsPolicyTypeConfiguration.Key),
 			"strict":        types.BoolValue(apiConfig.TagsPolicyTypeConfiguration.Strict),
@@ -643,10 +586,8 @@ func mapPolicyConfigToState(
 		} else {
 			state.ConfigTags = tagsValue
 		}
-	}
 
-	// 31. WorkflowPolicyTypeConfiguration -> config_workflow
-	if apiConfig.WorkflowPolicyTypeConfiguration != nil {
+	case "workflow":
 		workflowAttrs := map[string]attr.Value{
 			"workflow_id": convert.StrToType(&apiConfig.WorkflowPolicyTypeConfiguration.WorkflowId),
 		}
@@ -774,8 +715,14 @@ func getPolicyAsState(
 
 	// Handle Config - use static schema fields when available, fallback to dynamic
 	if p.Config != nil {
+		// Get policy type code for mapping (required field, but API could return nil)
+		policyTypeCode := ""
+		if p.PolicyType != nil && p.PolicyType.Code != nil {
+			policyTypeCode = *p.PolicyType.Code
+		}
+
 		// Map API config to static schema fields
-		configDiags := mapPolicyConfigToState(ctx, &state, p.Config)
+		configDiags := mapPolicyConfigToState(ctx, &state, p.Config, policyTypeCode)
 		if configDiags.HasError() {
 			diags.Append(configDiags...)
 

--- a/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/schema_gen.go
@@ -115,7 +115,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy types:\n\t- Approve Delete (deleteApproval)\n\t- Approve Provision (provisionApproval)\n\t- Approve Reconfigure (reconfigureApproval)\n\t- Approve Workflow Execute (workflowApproval)\n",
 				MarkdownDescription: "Configuration for the following policy types:\n\t- Approve Delete (deleteApproval)\n\t- Approve Provision (provisionApproval)\n\t- Approve Reconfigure (reconfigureApproval)\n\t- Approve Workflow Execute (workflowApproval)\n",
 				Validators: []validator.Object{
@@ -138,7 +137,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Backup Targets (backupStorage)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Backup Targets (backupStorage)\n",
 				Validators: []validator.Object{
@@ -166,7 +164,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Backup Creation (createBackup)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Backup Creation (createBackup)\n",
 				Validators: []validator.Object{
@@ -194,7 +191,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- User Creation (createUser)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- User Creation (createUser)\n",
 				Validators: []validator.Object{
@@ -216,7 +212,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- User Group Creation (createUserGroup)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- User Group Creation (createUserGroup)\n",
 				Validators: []validator.Object{
@@ -268,7 +263,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Cypher Access (cypher)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Cypher Access (cypher)\n",
 				Validators: []validator.Object{
@@ -290,7 +284,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Delayed Delete (delayedRemoval)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Delayed Delete (delayedRemoval)\n",
 				Validators: []validator.Object{
@@ -318,7 +311,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Hostname (hostNaming)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Hostname (hostNaming)\n",
 				Validators: []validator.Object{
@@ -418,7 +410,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Expiration (lifecycle)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Expiration (lifecycle)\n",
 				Validators: []validator.Object{
@@ -440,7 +431,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max Containers (maxContainers)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Containers (maxContainers)\n",
 				Validators: []validator.Object{
@@ -466,7 +456,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max Cores (maxCores)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Cores (maxCores)\n",
 				Validators: []validator.Object{
@@ -488,7 +477,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max Hosts (maxHosts)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Hosts (maxHosts)\n",
 				Validators: []validator.Object{
@@ -514,7 +502,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max Memory (maxMemory)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Memory (maxMemory)\n",
 				Validators: []validator.Object{
@@ -536,7 +523,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Network Quota (maxNetworks)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Network Quota (maxNetworks)\n",
 				Validators: []validator.Object{
@@ -558,7 +544,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max Pool Members (maxPoolMembers)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Pool Members (maxPoolMembers)\n",
 				Validators: []validator.Object{
@@ -580,7 +565,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max Load Balancer Pools (maxPools)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Load Balancer Pools (maxPools)\n",
 				Validators: []validator.Object{
@@ -614,7 +598,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Budget (maxPrice)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Budget (maxPrice)\n",
 				Validators: []validator.Object{
@@ -636,7 +619,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Router Quota (maxRouters)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Router Quota (maxRouters)\n",
 				Validators: []validator.Object{
@@ -658,7 +640,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max Snapshots (maxSnapshots)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Snapshots (maxSnapshots)\n",
 				Validators: []validator.Object{
@@ -684,7 +665,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy types:\n\t- Max Storage (maxStorage)\n\t- Object Storage Quota (storageBucketQuota)\n\t- File Share Storage Quota (storageShareQuota)\n",
 				MarkdownDescription: "Configuration for the following policy types:\n\t- Max Storage (maxStorage)\n\t- Object Storage Quota (storageBucketQuota)\n\t- File Share Storage Quota (storageShareQuota)\n",
 				Validators: []validator.Object{
@@ -706,7 +686,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max Virtual Servers (maxVirtualServers)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max Virtual Servers (maxVirtualServers)\n",
 				Validators: []validator.Object{
@@ -728,7 +707,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Max VMs (maxVms)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Max VMs (maxVms)\n",
 				Validators: []validator.Object{
@@ -768,7 +746,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Message of the Day (motd)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Message of the Day (motd)\n",
 				Validators: []validator.Object{
@@ -802,7 +779,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Instance Name (naming)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Instance Name (naming)\n",
 				Validators: []validator.Object{
@@ -836,7 +812,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Power Scheduling (powerSchedule)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Power Scheduling (powerSchedule)\n",
 				Validators: []validator.Object{
@@ -859,7 +834,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Instance Networks (requiredNetwork)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Instance Networks (requiredNetwork)\n",
 				Validators: []validator.Object{
@@ -893,7 +867,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Cluster Resource Name (serverNaming)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Cluster Resource Name (serverNaming)\n",
 				Validators: []validator.Object{
@@ -993,7 +966,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Shutdown (shutdown)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Shutdown (shutdown)\n",
 				Validators: []validator.Object{
@@ -1021,7 +993,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Storage Server Storage Quota (storageServerQuota)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Storage Server Storage Quota (storageServerQuota)\n",
 				Validators: []validator.Object{
@@ -1061,7 +1032,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Tags (tags)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Tags (tags)\n",
 				Validators: []validator.Object{
@@ -1083,7 +1053,6 @@ func PolicyResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Configuration for the following policy type:\n\t- Workflow (workflow)\n",
 				MarkdownDescription: "Configuration for the following policy type:\n\t- Workflow (workflow)\n",
 				Validators: []validator.Object{


### PR DESCRIPTION
Adding a switch statement based off the policy type code to populate the policy config_* configs. This allows for state to only be concerned with the relevant config fields for the given policy type.
- Switch config.go to use a switch statement for mapStateToAddPolicyConfig (also applies for Update thanks to JSON trick)
- Switch read.go to use a switch statement for populating the config_* fields based off policy type code.
- Updated schema_gen.go to use optional for config_* fields.