### PR TITLE
Metal 2: Various instance network_interfaces changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+# v0.5.0 Release Notes
+
+In this release (v0.5.0) we have added the following resource functionality:
+
+- hpe_morpheus_policy has a comprehensive collection of static schema for the various supported policies
+
+
+In this release (v0.5.0) we have added the following data-source functionality:
+
+- hpe_morpheus_instance
+
+
+### New known issues
+
+## Known issues from previous releases
+
+- `hpe_morpheus_datastore` data-source if a datastore with the specified name cannot be found (i.e. the corresponding
+  list API request fails), the error message will indicate a 403 (Forbidden) even if the user has permission to list
+  datastores.  This is an API bug which is being investigated.
+- `hpe_morpheus_policy` resource does not currently support the Backup Targets (`backupStorage`) policy type
+  due to improper handling of the `backupStorageIds` attribute. This is an API bug which is being investigated.
+- `hpe_morpheus_instance` has issues with using the same `datastore_id` with multiple volumes, please use
+  a different `datastore_id` for each volume.
+- `hpe_morpheus_instance` updates fail when removing optional fields.
+  This will be addressed in a future release.
+- `hpe_morpheus_instance` updates fail when removing `evars`.
+  This will be addressed in a future release.
+- Long running operations can fail when using username and password.
+- `hpe_morpheus_instance` depending on the layout used may require one or more `volumes` to be specified,
+  in these cases not specifying the correct number of `volumes` will cause instance creation to fail.
+- There are intermittent issues with the provider failing to authenticate, a 500 error is returned from the Morpheus API.
+  If this happens please retry the operation.  This is being investigated.
+- `hpe_morpheus_datastore` when creating a datastore of type NFS the creation will silently fail if the NFS server is not reachable or the share is not accessible.
+  The datastore will remain in a `provisioning` state indefinitely. Ensure the Morpheus appliance can reach the NFS server
+  and that the share is accessible before creating.
+- `hpe_morpheus_datastore` delete is not guaranteed to succeed.  AlletraMP HVM datastores will delete but NFS datastores
+  may fail to delete.  Always delete VMs and other resources using the datastore before deleting the datastore itself.
+- `hpe_morpheus_instance` in Morpheus versions prior to 8.0.11 requires that the `root` volume is the first entry in
+  the `volumes` block list
+
 # v0.4.0 Release Notes
 
 In this release (v0.4.0) we have added the following resource functionality:

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Morpheus API SSL cert checking is enabled by default in this provider.
 ## Morpheus
 
 This provider can be used to manage Morpheus resources.  Support will grow over time.  See below for
-release notes for the current version (v0.4.0).
+release notes for the current version (v0.5.0).
 
 ### Authentication
 
@@ -49,7 +49,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.4.0"
+      version = "= 0.5.0"
     }
   }
 }
@@ -73,7 +73,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.4.0"
+      version = "= 0.5.0"
     }
   }
 }
@@ -96,7 +96,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.4.0"
+      version = "= 0.5.0"
     }
   }
 }
@@ -129,17 +129,15 @@ will be evaluated at run-time.  Examples of these are shown in the documentation
 
 ### New functionality
 
-In this release (v0.4.0) we have added the following resource functionality:
+In this release (v0.5.0) we have added the following resource functionality:
 
-- hpe_morpheus_image Update functionality has been added
-- hpe_morpheus_instance supports multiple networks and child virtual networks
-- hpe_morpheus_instance no longer requires that `ip_mode` is set to avoid forced replaces on Update
-- hpe_morpheus_instance supports `timeouts`
+- hpe_morpheus_policy has a comprehensive collection of static schema for the various supported policies
 
-In this release (v0.4.0) we have added the following data-source functionality:
 
-- hpe_morpheus_image
-- hpe_morpheus_policy
+In this release (v0.5.0) we have added the following data-source functionality:
+
+- hpe_morpheus_instance
+
 
 ### New known issues
 

--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -36,10 +36,12 @@ If the `timeouts` settings are changed in HCL an
 the new settings but no `Morpheus` `Update` API calls will be made.  The default timeout for `create`, `delete`
 `read` and `update` is 45 minutes
 
--> Beware when importing an instance where DHCP has been enabled: if the experimental `plan` functionality
-to generate HCL (flag `-generate-config-out`) is being used the resulting HCL will contain IP addresses for
-each of the interfaces. Remove these IP addresses from the generated HCL *before* executing `terraform apply`
-to import the instance. Otherwise the import will result in the instance being destroyed.
+-> We've added a `connection_info` section (read-only) which contains the IP address(es) by which the instance
+can be accessed
+
+-> When creating an instance with network bonding and/or LAGs we cannot reconcile the created list of `network_interfaces`
+with the HCL supplied.  In these cases the `connection_info` section will contain IP address(es).  To access the full
+network configuration use the `hpe_morpheus_instance` `data-source` to read back the created instance.
 
 ## Example Usage
 
@@ -337,6 +339,7 @@ The layout may have default ports, which are defined in node types, that are alw
 
 ### Read-Only
 
+- `connection_info` (List of String) List of IP addresses to use when connecting to instance
 - `id` (Number) The ID of this resource.
 
 <a id="nestedatt--network_interfaces"></a>

--- a/examples/provider/morpheus/provider-accesstoken.tf
+++ b/examples/provider/morpheus/provider-accesstoken.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.4.0"
+      version = "= 0.5.0"
     }
   }
 }

--- a/examples/provider/morpheus/provider-insecure.tf
+++ b/examples/provider/morpheus/provider-insecure.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.4.0"
+      version = "= 0.5.0"
     }
   }
 }

--- a/examples/provider/morpheus/provider-unamepasswd.tf
+++ b/examples/provider/morpheus/provider-unamepasswd.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = "= 0.4.0"
+      version = "= 0.5.0"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20251023165624-010e4bb578ba
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.8.0
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.9.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.7.0 h1:sqO8khOFjz7uFs43
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.7.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.8.0 h1:aHZorCP1C78ahcVV8YsxqpmseICuPae8SEhC1eHZ1w0=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.8.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.9.0 h1:ghG6bSsB0ltUFqLln2RDFQ7eZQ4Z+nYXtjO8hUaFBY0=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.9.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
@@ -93,6 +93,15 @@ func getInstanceAsState(
 		state.Config = plan.Config
 	}
 
+	// connection_info
+	cInfo, dc := getConnectionInfo(instance)
+	diags.Append(dc...)
+	if diags.HasError() {
+		return state, diags
+	}
+
+	state.ConnectionInfo = cInfo
+
 	// evars
 	// API may respond with more evars than what the user set so we need to
 	// check the /instance/{id}/envs endpoint which gives us the user specified
@@ -140,7 +149,7 @@ func getInstanceAsState(
 	state.Name = convert.StrToType(instance.Name)
 
 	// interfaces
-	ifaces, ifDiags := getStateInterfacesFromInstance(ctx, instance)
+	ifaces, ifDiags := getStateInterfaces(ctx, instance, plan)
 	diags = append(diags, ifDiags...)
 	if diags.HasError() {
 		return state, diags
@@ -265,8 +274,196 @@ func getInstanceEnvVars(
 	return resp.GetEnvs(), diags
 }
 
-// getStateInterfacesFromInstance get the []NetworkInterfacesValue from containerDetails.server.interfaces
+// getConnectionInfo builds the connection_info list
+func getConnectionInfo(
+	instance sdk.AddInstance200ResponseAllOfOneOfInstance,
+) (types.List, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+	cInfo, ok := instance.GetConnectionInfoOk()
+	if !ok {
+		diags.AddError(
+			"cannot get instance connectionInfo",
+			fmt.Sprintf("instance %d GET connectionInfo failed", instance.GetId()))
+
+		return types.ListNull(types.StringType), diags
+	}
+
+	if len(cInfo) == 0 {
+		return types.ListNull(types.StringType), diags
+	}
+
+	var vals []attr.Value
+	for _, c := range cInfo {
+		if ip, ok := c.GetIpOk(); ok {
+			vals = append(vals, types.StringValue(*ip))
+		}
+	}
+
+	cList, dl := types.ListValue(types.StringType, vals)
+	diags = append(diags, dl...)
+
+	return cList, diags
+}
+
+// getStateInterfaces get the interfaces to be returned as state entries
+func getStateInterfaces(
+	ctx context.Context,
+	instance sdk.AddInstance200ResponseAllOfOneOfInstance,
+	plan InstanceModel,
+) ([]NetworkInterfacesValue, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if plan.Name.IsNull() || plan.Name.IsUnknown() {
+		return getStateInterfacesFromInstance(ctx, instance)
+	}
+
+	// Generate []NetworkInterfacesValue from the API instance
+	intfsFromAPI, id := getStateInterfacesFromInstanceServer(ctx, instance)
+	diags = append(diags, id...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	var planIntfs []NetworkInterfacesValue
+	pd := plan.NetworkInterfaces.ElementsAs(ctx, &planIntfs, false)
+	diags = append(diags, pd...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Compare intfsFromAPI against the plan, to see if the "shapes" are the same
+	if compareAPIPlanIntfs(intfsFromAPI, planIntfs) {
+		return intfsFromAPI, diags
+	}
+
+	return planIntfs, diags
+}
+
+// compareAPIPlanIntfs compares the []NetworkInterfacesValues from the API and Plan to see if they are the same shape
+// Returns true if they are, false otherwise
+func compareAPIPlanIntfs(
+	apiIntfs, planIntfs []NetworkInterfacesValue,
+) bool {
+	// Check length of lists first
+	if len(apiIntfs) != len(planIntfs) {
+		return false
+	}
+
+	// Get list of lengths of child interfaces for api list
+	apiSubIntfs := make([]int, len(apiIntfs))
+	for _, apiIntf := range apiIntfs {
+		apiSubIntfs = append(apiSubIntfs, len(apiIntf.ChildVirtualNetworks.Elements()))
+	}
+
+	// Get list of lengths of child interfaces for plan list
+	planSubIntfs := make([]int, len(planIntfs))
+	for _, planIntf := range planIntfs {
+		planSubIntfs = append(planSubIntfs, len(planIntf.ChildVirtualNetworks.Elements()))
+	}
+
+	// Compare lengths of child interfaces for api and plan
+	for i := range apiSubIntfs {
+		if apiSubIntfs[i] != planSubIntfs[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// getStateInterfacesFromInstance build []NetworkInterfacesValue from interfaces, used on import
 func getStateInterfacesFromInstance(
+	ctx context.Context,
+	instance sdk.AddInstance200ResponseAllOfOneOfInstance,
+) ([]NetworkInterfacesValue, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	instIntfs, ok := instance.GetInterfacesOk()
+	if !ok {
+		diags.AddError(
+			"instance GetInterfaces failed",
+			fmt.Sprintf("instance %d GET interfaces failed", instance.GetId()))
+
+		return nil, diags
+	}
+
+	var ifaces []NetworkInterfacesValue
+	for _, instIntf := range instIntfs {
+		ifaceVal := NetworkInterfacesValue{}
+		ifaceVal.IpAddress = convert.StrToType(instIntf.IpAddress)
+		ifaceVal.IpMode = convert.StrToType(instIntf.IpMode)
+		ifaceVal.PrimaryInterface = types.BoolNull()
+		ifaceVal.Name = types.StringNull()
+		ifaceVal.NetworkId = types.Int64Null()
+		if net, ok := instIntf.GetNetworkOk(); ok {
+			ifaceVal.NetworkId = convert.Int64ToType(net.Id)
+			ifaceVal.IpPool = types.Int64Null()
+			if pool, ok := net.GetPoolOk(); ok {
+				ifaceVal.IpPool = convert.Int64ToType(pool.Id)
+			}
+			ifaceVal.NetworkGroupId = convert.Int64ToType(net.Group)
+		}
+		ifaceVal.NetworkTypeId = networkTypeId(instIntf.NetworkInterfaceTypeId)
+		ifaceVal.ChildVirtualNetworks = types.ListNull(ChildVirtualNetworksValue{}.Type(ctx))
+		if cnets, ok := instIntf.GetNetworkInterfacesOk(); ok {
+			if len(cnets) > 0 {
+				childNetworks, cd := getInstanceInterfacesChildNetworks(ctx, cnets)
+				ifaceVal.ChildVirtualNetworks = childNetworks
+				diags = append(diags, cd...)
+			}
+		}
+		ifaceVal.state = attr.ValueStateKnown
+
+		ifaces = append(ifaces, ifaceVal)
+	}
+
+	return ifaces, diags
+}
+
+// networkTypeId helper function to handle NetworkInterfaceTypeId
+// We only use this function on import, and it looks as if NetworkInterfaceTypeId will have a value of 0 instead
+// of null.  In this case we return a null value to avoid inadvertent instance recreations when the HCL has been
+// generated on import and a plan/apply following the initial import is performed
+func networkTypeId(i *int64) basetypes.Int64Value {
+	if i != nil && *i == 0 {
+		return basetypes.NewInt64Null()
+	}
+
+	return convert.Int64ToType(i)
+}
+
+// getInstanceInterfacesChildNetworks returns child_networks from interfaces.networkInterfaces, used on import
+func getInstanceInterfacesChildNetworks(
+	ctx context.Context,
+	nets []sdk.InstanceInterfacesNetworkInterfacesInner1,
+) (basetypes.ListValue, diag.Diagnostics) {
+	children := make([]ChildVirtualNetworksValue, 0)
+	for _, instIntf := range nets {
+		ifaceVal := ChildVirtualNetworksValue{}
+		ifaceVal.IpAddress = convert.StrToType(instIntf.IpAddress)
+		ifaceVal.IpMode = convert.StrToType(instIntf.IpMode)
+		ifaceVal.PrimaryInterface = types.BoolNull()
+		ifaceVal.Name = types.StringNull()
+		ifaceVal.NetworkId = types.Int64Null()
+		if net, ok := instIntf.GetNetworkOk(); ok {
+			ifaceVal.NetworkId = convert.Int64ToType(net.Id)
+			ifaceVal.IpPool = types.Int64Null()
+			if pool, ok := net.GetPoolOk(); ok {
+				ifaceVal.IpPool = convert.Int64ToType(pool.Id)
+			}
+			ifaceVal.NetworkGroupId = convert.Int64ToType(net.Group)
+		}
+		ifaceVal.NetworkTypeId = networkTypeId(instIntf.NetworkInterfaceTypeId)
+
+		ifaceVal.state = attr.ValueStateKnown
+		children = append(children, ifaceVal)
+	}
+
+	return types.ListValueFrom(ctx, ChildVirtualNetworksValue{}.Type(ctx), children)
+}
+
+// getStateInterfacesFromInstanceServer get the []NetworkInterfacesValue from containerDetails.server.interfaces
+func getStateInterfacesFromInstanceServer(
 	ctx context.Context,
 	instance sdk.AddInstance200ResponseAllOfOneOfInstance,
 ) ([]NetworkInterfacesValue, diag.Diagnostics) {

--- a/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/schema_gen.go
@@ -49,6 +49,12 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 					morpheusvalidators.ValidObjectMap(),
 				},
 			},
+			"connection_info": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				Description:         "List of IP addresses to use when connecting to instance",
+				MarkdownDescription: "List of IP addresses to use when connecting to instance",
+			},
 			"evars": schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -488,6 +494,7 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 type InstanceModel struct {
 	CloudId           types.Int64    `tfsdk:"cloud_id"`
 	Config            types.Dynamic  `tfsdk:"config"`
+	ConnectionInfo    types.List     `tfsdk:"connection_info"`
 	Evars             types.Set      `tfsdk:"evars"`
 	GroupId           types.Int64    `tfsdk:"group_id"`
 	Id                types.Int64    `tfsdk:"id"`

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -25,7 +25,7 @@ Morpheus API SSL cert checking is enabled by default in this provider.
 ## Morpheus
 
 This provider can be used to manage Morpheus resources.  Support will grow over time.  See below for
-release notes for the current version (v0.4.0).
+release notes for the current version (v0.5.0).
 
 ### Authentication
 
@@ -70,17 +70,15 @@ will be evaluated at run-time.  Examples of these are shown in the documentation
 
 ### New functionality
 
-In this release (v0.4.0) we have added the following resource functionality:
+In this release (v0.5.0) we have added the following resource functionality:
 
-- hpe_morpheus_image Update functionality has been added
-- hpe_morpheus_instance supports multiple networks and child virtual networks
-- hpe_morpheus_instance no longer requires that `ip_mode` is set to avoid forced replaces on Update
-- hpe_morpheus_instance supports `timeouts`
+- hpe_morpheus_policy has a comprehensive collection of static schema for the various supported policies
 
-In this release (v0.4.0) we have added the following data-source functionality:
 
-- hpe_morpheus_image
-- hpe_morpheus_policy
+In this release (v0.5.0) we have added the following data-source functionality:
+
+- hpe_morpheus_instance
+
 
 ### New known issues
 

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -36,10 +36,12 @@ If the `timeouts` settings are changed in HCL an
 the new settings but no `Morpheus` `Update` API calls will be made.  The default timeout for `create`, `delete`
 `read` and `update` is 45 minutes
 
--> Beware when importing an instance where DHCP has been enabled: if the experimental `plan` functionality
-to generate HCL (flag `-generate-config-out`) is being used the resulting HCL will contain IP addresses for
-each of the interfaces. Remove these IP addresses from the generated HCL *before* executing `terraform apply`
-to import the instance. Otherwise the import will result in the instance being destroyed.
+-> We've added a `connection_info` section (read-only) which contains the IP address(es) by which the instance
+can be accessed
+
+-> When creating an instance with network bonding and/or LAGs we cannot reconcile the created list of `network_interfaces`
+with the HCL supplied.  In these cases the `connection_info` section will contain IP address(es).  To access the full
+network configuration use the `hpe_morpheus_instance` `data-source` to read back the created instance.
 
 ## Example Usage
 


### PR DESCRIPTION
In this PR we make the following changes to instance
- we add a "connection_info" section which is a list of accessible IP addresses for the instance, this is created by the getConnectionInfo() function
- we add a new function getStateInterfaces() which returns the list of NetworkInterfacesValue to be added to the State file:
  - if this is an import, getStateInterfacesFromInstance() is called which uses the instance.interfaces list to create the retrurned list
  - otherwise the existing code to create the list for the State file is called which processes instance.containerDetails.server.interfaces
  - the list returned by the above is compared with the HCL, if the "shape" is the same then we return the processed list, otherwise we return the list from the HCL
  - this last step is there to deal with bonding and LAGs where we cannot reconcile the created set of interfaces with that specified in the HCL, in this case we just use the plan network_interfaces in state
- we update the version of the SDK to that which includes "networkInterfaces" sub-interfaces to instance.interfaces
- we update the hpe_morpheus_instance docs

We also start the release notes for the next version (0.5.0)