### PR TITLE
sdkv2: Sync generated examples

### DIFF
--- a/examples/resources/morpheus_cluster_package/resource.tf
+++ b/examples/resources/morpheus_cluster_package/resource.tf
@@ -7,5 +7,5 @@ resource "hpe_morpheus_cluster_package" "tf_example_cluster_package" {
   package_type      = "example"
   enabled           = true
   repeat_install    = true
-  spec_template_ids = [1, 2]
+  spec_template_ids = [1,2]
 }

--- a/examples/resources/morpheus_file_template/resource.tf
+++ b/examples/resources/morpheus_file_template/resource.tf
@@ -1,6 +1,6 @@
 resource "hpe_morpheus_file_template" "tfexample_file_template" {
   name             = "tf-terraform-file-template"
-  labels           = ["demo", "template", "terraform"]
+  labels           = ["demo","template","terraform"]
   file_name        = "tfcustom.cnf"
   file_path        = "/etc/my.cnf.d"
   phase            = "preProvision"

--- a/examples/resources/morpheus_option_type_hidden/resource.tf
+++ b/examples/resources/morpheus_option_type_hidden/resource.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_option_type_hidden" "tf_example_hidden_option_type" {
   name                     = "tf_example_hidden_option_type"
   description              = "Terraform hidden option type example"
-  labels                   = ["demo", "terraform"]
+  labels                   = ["demo","terraform"]
   field_name               = "hidden_example"
   export_meta              = true
   dependent_field          = "dependent_example"

--- a/examples/resources/morpheus_option_type_textarea/resource.tf
+++ b/examples/resources/morpheus_option_type_textarea/resource.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_option_type_textarea" "tf_example_textarea_option_type" {
   name                     = "tf_example_textarea_option_type"
   description              = "Terraform text area option type example"
-  labels                   = ["demo", "terraform"]
+  labels                   = ["demo","terraform"]
   field_name               = "textareaExample"
   export_meta              = true
   dependent_field          = "dependent_example"

--- a/examples/resources/morpheus_task_email/resource.tf
+++ b/examples/resources/morpheus_task_email/resource.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_task_email" "tfexample_email" {
   name                        = "tfexample_email"
   code                        = "tfexample_email"
-  labels                      = ["demo", "terraform"]
+  labels                      = ["demo","terraform"]
   email_address               = "<%=instance.createdByEmail%>"
   subject                     = "<%=instance.hostname%> provisioning complete"
   source                      = "local"

--- a/examples/resources/morpheus_task_email/resource_git.tf
+++ b/examples/resources/morpheus_task_email/resource_git.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_task_email" "tfexample_email_git" {
   name                        = "tfexample_email_git"
   code                        = "tfexample_email_git"
-  labels                      = ["demo", "terraform"]
+  labels                      = ["demo","terraform"]
   email_address               = "<%=instance.createdByEmail%>"
   subject                     = "<%=instance.hostname%> provisioning complete"
   source                      = "repository"

--- a/examples/resources/morpheus_task_email/resource_url.tf
+++ b/examples/resources/morpheus_task_email/resource_url.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_task_email" "tfexample_email_url" {
   name                        = "tfexample_email_url"
   code                        = "tfexample_email_url"
-  labels                      = ["demo", "terraform"]
+  labels                      = ["demo","terraform"]
   email_address               = "<%=instance.createdByEmail%>"
   subject                     = "<%=instance.hostname%> provisioning complete"
   source                      = "url"

--- a/examples/resources/morpheus_task_groovy_script/resource.tf
+++ b/examples/resources/morpheus_task_groovy_script/resource.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_task_groovy_script" "tfexample_groovy_local" {
   name                = "tfexample_groovy_local"
   code                = "tfexample_groovy_local"
-  labels              = ["demo", "terraform"]
+  labels              = ["demo","terraform"]
   source_type         = "local"
   script_content      = <<EOF
 println "hello"

--- a/examples/resources/morpheus_task_groovy_script/resource_git.tf
+++ b/examples/resources/morpheus_task_groovy_script/resource_git.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_task_groovy_script" "tfexample_groovy_git" {
   name                = "tfexample_groovy_git"
   code                = "tfexample_groovy_git"
-  labels              = ["demo", "terraform"]
+  labels              = ["demo","terraform"]
   source_type         = "repository"
   result_type         = "json"
   script_path         = "example.groovy"

--- a/examples/resources/morpheus_task_groovy_script/resource_url.tf
+++ b/examples/resources/morpheus_task_groovy_script/resource_url.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_task_groovy_script" "tfexample_groovy_url" {
   name                = "tfexample_groovy_url"
   code                = "tfexample_groovy_url"
-  labels              = ["demo", "terraform"]
+  labels              = ["demo","terraform"]
   source_type         = "url"
   result_type         = "json"
   script_path         = "https://example.com/example.groovy"

--- a/examples/resources/morpheus_task_javascript/resource.tf
+++ b/examples/resources/morpheus_task_javascript/resource.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_task_javascript" "tfexample_javascript" {
   name                = "tfexample_javascript"
   code                = "tfexample_javascript"
-  labels              = ["demo", "terraform"]
+  labels              = ["demo","terraform"]
   script_content      = <<EOF
 console.log("testing")
 EOF


### PR DESCRIPTION
Picks up the generated docs changes from some of the migration work, i.e. run `go generate ./...`.