### PR TITLE
Add render config function support for Role

### DIFF
--- a/docs/resources/morpheus_role.md
+++ b/docs/resources/morpheus_role.md
@@ -10,14 +10,24 @@ description: |-
 
 Roles in HPE Morpheus Enterprise control the access levels for Morpheus resources and features that a User or Tenant has access to.
 
-## Example Usage
+## Example Usage (User Role)
 
 ```terraform
 resource "hpe_morpheus_role" "example" {
-  name = "ExampleRole"
+  name        = "ExampleUserRole"
   multitenant = false
-  description = "An example role"
-  role_type = "user"
+  description = "An example user role"
+  role_type   = "user"
+}
+```
+
+## Example Usage (Tenant Role)
+
+```terraform
+resource "hpe_morpheus_role" "example" {
+  name        = "ExampleTenantRole"
+  description = "An example tenant role"
+  role_type   = "tenant"
 }
 ```
 
@@ -30,9 +40,9 @@ data "morpheus_task" "example_legacy_task" {
 }
 
 resource "hpe_morpheus_role" "example_with_legacy_provider" {
-  name = "ExampleRoleWithLegacyProvider"
+  name        = "ExampleRoleWithLegacyProvider"
   description = "An example role using legacy provider"
-  role_type = "user"
+  role_type   = "user"
   permissions = {
     task_permissions = [
       {

--- a/examples/resources/morpheus_role/example-using-legacy-provider.tf
+++ b/examples/resources/morpheus_role/example-using-legacy-provider.tf
@@ -3,9 +3,9 @@ data "morpheus_task" "example_legacy_task" {
 }
 
 resource "hpe_morpheus_role" "example_with_legacy_provider" {
-  name = "ExampleRoleWithLegacyProvider"
+  name        = "ExampleRoleWithLegacyProvider"
   description = "An example role using legacy provider"
-  role_type = "user"
+  role_type   = "user"
   permissions = {
     task_permissions = [
       {

--- a/examples/resources/morpheus_role/role_tenant.tf
+++ b/examples/resources/morpheus_role/role_tenant.tf
@@ -1,0 +1,5 @@
+resource "hpe_morpheus_role" "example" {
+  name        = "ExampleTenantRole"
+  description = "An example tenant role"
+  role_type   = "tenant"
+}

--- a/examples/resources/morpheus_role/role_user.tf
+++ b/examples/resources/morpheus_role/role_user.tf
@@ -1,0 +1,6 @@
+resource "hpe_morpheus_role" "example" {
+  name        = "ExampleUserRole"
+  multitenant = false
+  description = "An example user role"
+  role_type   = "user"
+}

--- a/internal/framework/subproviders/morpheus/resources/role/example.tf
+++ b/internal/framework/subproviders/morpheus/resources/role/example.tf
@@ -1,6 +1,0 @@
-resource "hpe_morpheus_role" "example" {
-  name = "ExampleRole"
-  multitenant = false
-  description = "An example role"
-  role_type = "user"
-}

--- a/internal/framework/subproviders/morpheus/resources/role/morpheus_role.md.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/role/morpheus_role.md.tmpl
@@ -10,12 +10,16 @@ description: |-
 
 `hpe_morpheus_role` resource ....
 
-## Example Usage
+## Example Usage (User Role)
 
-{{ tffile "internal/subproviders/morpheus/resources/role/example.tf" }}
+{{ tffile "examples/resources/morpheus_role/role_user.tf" }}
+
+## Example Usage (Tenant Role)
+
+{{ tffile "examples/resources/morpheus_role/role_tenant.tf" }}
 
 ## Example Usage (Using legacy Morpheus Terraform provider)
 
-{{ tffile "internal/subproviders/morpheus/resources/role/example-using-legacy-provider.tf" }}
+{{ tffile "examples/resources/morpheus_role/example-using-legacy-provider.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}

--- a/internal/framework/subproviders/morpheus/resources/role/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/role/resource_test.go
@@ -1,8 +1,5 @@
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
-//go:generate go run ../../../../../../cmd/render example.tf.tmpl Name "ExampleRole" Multitenant "false" Description "An example role" RoleType "user"
-//go:generate go run ../../../../../../cmd/render example-using-legacy-provider.tf.tmpl TaskDataSourceName "example_legacy_task" TaskName "example_task" ResourceName "example_with_legacy_provider" Name "ExampleRoleWithLegacyProvider" Description "An example role using legacy provider" RoleType "user" Task0Access "full"
-
 package role_test
 
 import (

--- a/internal/framework/subproviders/morpheus/resources/role/role_example.go
+++ b/internal/framework/subproviders/morpheus/resources/role/role_example.go
@@ -1,0 +1,85 @@
+package role
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
+)
+
+//go:generate go run ../../../../../../cmd/render -out examples/resources/morpheus_role/role_user.tf role_user.tf.tmpl Name "ExampleUserRole" Multitenant "false" Description "An example user role" RoleType "user"
+
+//go:generate go run ../../../../../../cmd/render -out examples/resources/morpheus_role/role_tenant.tf role_tenant.tf.tmpl Name "ExampleTenantRole" Description "An example tenant role" RoleType "tenant"
+
+//go:generate go run ../../../../../../cmd/render -out examples/resources/morpheus_role/example-using-legacy-provider.tf example-using-legacy-provider.tf.tmpl TaskDataSourceName "example_legacy_task" TaskName "example_task" ResourceName "example_with_legacy_provider" Name "ExampleRoleWithLegacyProvider" Description "An example role using legacy provider" RoleType "user" Task0Access "full"
+
+func RenderRoleUserConfig(t *testing.T, overrides map[string]string) (string, error) {
+	t.Helper()
+
+	defaults := map[string]string{
+		"Name":        "ExampleUserRole",
+		"Multitenant": "false",
+		"Description": "An example user role",
+		"RoleType":    "user",
+	}
+
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	// Get the directory where this source file is located
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to get current file path")
+	}
+	dir := filepath.Dir(filename)
+	templatePath := filepath.Join(dir, "role_user.tf.tmpl")
+
+	return testhelpers.RenderExample(
+		t,
+		templatePath,
+		"Name",
+		defaults["Name"],
+		"Multitenant",
+		defaults["Multitenant"],
+		"Description",
+		defaults["Description"],
+		"RoleType",
+		defaults["RoleType"],
+	)
+}
+
+func RenderRoleTenantConfig(t *testing.T, overrides map[string]string) (string, error) {
+	t.Helper()
+
+	defaults := map[string]string{
+		"Name":        "ExampleTenantRole",
+		"Description": "An example tenant role",
+		"RoleType":    "tenant",
+	}
+
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	// Get the directory where this source file is located
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to get current file path")
+	}
+	dir := filepath.Dir(filename)
+	templatePath := filepath.Join(dir, "role_tenant.tf.tmpl")
+
+	return testhelpers.RenderExample(
+		t,
+		templatePath,
+		"Name",
+		defaults["Name"],
+		"Description",
+		defaults["Description"],
+		"RoleType",
+		defaults["RoleType"],
+	)
+}

--- a/internal/framework/subproviders/morpheus/resources/role/role_tenant.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/role/role_tenant.tf.tmpl
@@ -1,0 +1,5 @@
+resource "hpe_morpheus_role" "example" {
+  name = "{{.Name}}"
+  description = "{{.Description}}"
+  role_type = "{{.RoleType}}"
+}

--- a/internal/framework/subproviders/morpheus/resources/role/role_user.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/role/role_user.tf.tmpl
@@ -1,0 +1,6 @@
+resource "hpe_morpheus_role" "example" {
+  name = "{{.Name}}"
+  multitenant = {{.Multitenant}}
+  description = "{{.Description}}"
+  role_type = "{{.RoleType}}"
+}

--- a/templates/resources/morpheus_role.md.tmpl
+++ b/templates/resources/morpheus_role.md.tmpl
@@ -10,14 +10,18 @@ description: |-
 
 Roles in HPE Morpheus Enterprise control the access levels for Morpheus resources and features that a User or Tenant has access to.
 
-## Example Usage
+## Example Usage (User Role)
 
-{{ tffile "internal/framework/subproviders/morpheus/resources/role/example.tf" }}
+{{ tffile "examples/resources/morpheus_role/role_user.tf" }}
+
+## Example Usage (Tenant Role)
+
+{{ tffile "examples/resources/morpheus_role/role_tenant.tf" }}
 
 
 ## Example Usage (Using legacy Morpheus Terraform provider)
 
-{{ tffile "internal/framework/subproviders/morpheus/resources/role/example-using-legacy-provider.tf" }}
+{{ tffile "examples/resources/morpheus_role/example-using-legacy-provider.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
 


### PR DESCRIPTION
This is going to be useful for acceptance testing for resources which have role as a dependency.

This adds separate documentation for `user` and `tenant` Role creation, and render config functions for each.
This moves the rendered `.tf` files into `examples/resources/morpheus_role`. 