### PR TITLE
Metal 5: add code to handle Metal RAID

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
@@ -286,7 +286,7 @@ func getVolumes(
 	// Import
 	if plan.Name.IsNull() || plan.Name.IsUnknown() {
 		nonRaidVolumes := removeRaidDisks(apiVolumes)
-		markedRootVolumes := markRootVolume(nonRaidVolumes)
+		markedRootVolumes := markRootVolume(nonRaidVolumes, plan)
 		bootVolumeInFirst := bootVolumeFirst(markedRootVolumes)
 
 		return convertAPIVolumesToStateVolumes(ctx, bootVolumeInFirst)
@@ -301,7 +301,7 @@ func getVolumes(
 
 	// The number of volumes is different to the plan
 	nonRaidVolumes := removeRaidDisks(apiVolumes)
-	markedRootVolumes := markRootVolume(nonRaidVolumes)
+	markedRootVolumes := markRootVolume(nonRaidVolumes, plan)
 	bootVolumeInFirst := bootVolumeFirst(markedRootVolumes)
 	reorderedVolumes := reorderVolumes(bootVolumeInFirst, plan)
 	filledVolumes := fillVolumeFieldsFromPlan(reorderedVolumes, plan)
@@ -471,7 +471,20 @@ func reorderVolumes(
 // Hopefully in future the API will return the rootVolume flag correctly and we can remove this function
 func markRootVolume(
 	apiVolumes []sdk.InstanceContainerServerVolume1,
+	plan InstanceModel,
 ) []sdk.InstanceContainerServerVolume1 {
+	// Get the name of the boot volume from the plan
+	bootVolumeName := ""
+	foundBootVolume := false
+	planVolumes := plan.Volumes.Elements()
+	if len(planVolumes) > 0 {
+		volume := planVolumes[0].(VolumesValue)
+		if volume.RootVolume.ValueBool() {
+			bootVolumeName = volume.Name.ValueString()
+			foundBootVolume = true
+		}
+	}
+
 	// We're going to look for volumes with the same "name" and "deviceDisplayName" of "BootVolume" or similar
 	retVolumes := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
 	for _, volume := range apiVolumes {
@@ -480,6 +493,10 @@ func markRootVolume(
 				strings.Contains(*volume.DeviceDisplayName, "Boot Volume") {
 				rootBool := true
 				volume.RootVolume = &rootBool
+				// Also set the name to match the plan if we found it
+				if foundBootVolume {
+					volume.Name = &bootVolumeName
+				}
 			}
 			retVolumes = append(retVolumes, volume)
 		}

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
@@ -331,13 +331,20 @@ func setDatastoreAutoSelectionAndSize(
 		// Only set fields from plan if we have a corresponding plan volume
 		if i < maxIndex {
 			planVol := planVolumes[i].(VolumesValue)
+
+			// Initialize AdditionalProperties map if it doesn't exist
+			if apiVol.AdditionalProperties == nil {
+				apiVol.AdditionalProperties = make(map[string]interface{})
+			}
+
 			if !planVol.DatastoreAutoSelection.IsNull() && !planVol.DatastoreAutoSelection.IsUnknown() {
 				// Set AdditionalProperties to indicate auto-selection
-				apiVol.AdditionalProperties = map[string]interface{}{
-					"DatastoreAutoSelection": planVol.DatastoreAutoSelection.ValueString(),
-				}
+				apiVol.AdditionalProperties["DatastoreAutoSelection"] = planVol.DatastoreAutoSelection.ValueString()
 			}
+
 			apiVol.MaxStorage = planVol.Size.ValueInt64Pointer()
+			// We set this flag to indicate that Terraform set the MaxStorage value
+			apiVol.AdditionalProperties["TerraformSetMaxStorage"] = true
 		}
 		// If i >= maxIndex, just append the apiVol as-is (unmatched volumes)
 
@@ -540,18 +547,36 @@ func convertAPIVolumesToStateVolumes(
 			v.Id = convert.Int64ToType(in.Id)
 			v.RootVolume = convert.BoolToType(in.RootVolume)
 			v.Name = convert.StrToType(in.Name)
-			v.Size = convert.Int64ToType(convertBytesPtrToGBBytes(in.MaxStorage)) // Convert from bytes to GB
 			v.StorageTypeId = convert.Int64ToType(in.TypeId)
 			v.DatastoreId = convert.Int64ToType(in.DatastoreId)
 			v.ControllerMountPoint = convert.StrToType(in.ControllerMountPoint)
-			// Handle DatastoreAutoSelection from AdditionalProperties
+
+			// Handle DatastoreAutoSelection and TerraformSetMaxStorage from AdditionalProperties
+			// TerraformSetMaxStorage flag indicates that MaxStorage was set from plan (already in GB)
+			// and should not be converted from bytes
+			terraformSetMaxStorage := false
 			if in.AdditionalProperties != nil {
 				if dsAutoSel, ok := in.AdditionalProperties["DatastoreAutoSelection"]; ok {
 					if dsAutoSelStr, ok := dsAutoSel.(string); ok {
 						v.DatastoreAutoSelection = convert.StrToType(&dsAutoSelStr)
 					}
 				}
+
+				if tsms, ok := in.AdditionalProperties["TerraformSetMaxStorage"]; ok {
+					if tsmsBool, ok := tsms.(bool); ok {
+						terraformSetMaxStorage = tsmsBool
+					}
+				}
 			}
+
+			// Set Size: if TerraformSetMaxStorage is true, MaxStorage is already in GB from plan
+			// Otherwise, convert from bytes to GB
+			if terraformSetMaxStorage {
+				v.Size = convert.Int64ToType(in.MaxStorage)
+			} else {
+				v.Size = convert.Int64ToType(convertBytesPtrToGBBytes(in.MaxStorage))
+			}
+
 			v.state = attr.ValueStateKnown
 
 			return v

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
@@ -286,8 +286,7 @@ func getVolumes(
 	// Import
 	if plan.Name.IsNull() || plan.Name.IsUnknown() {
 		nonRaidVolumes := removeRaidDisks(apiVolumes)
-		markedRootVolumes := markRootVolume(nonRaidVolumes, plan)
-		bootVolumeInFirst := bootVolumeFirst(markedRootVolumes)
+		bootVolumeInFirst := bootVolumeFirst(nonRaidVolumes)
 
 		return convertAPIVolumesToStateVolumes(ctx, bootVolumeInFirst)
 	}
@@ -301,9 +300,7 @@ func getVolumes(
 
 	// The number of volumes is different to the plan
 	nonRaidVolumes := removeRaidDisks(apiVolumes)
-	markedRootVolumes := markRootVolume(nonRaidVolumes, plan)
-	bootVolumeInFirst := bootVolumeFirst(markedRootVolumes)
-	reorderedVolumes := reorderVolumes(bootVolumeInFirst, plan)
+	reorderedVolumes := reorderVolumes(nonRaidVolumes, plan)
 	filledVolumes := fillVolumeFieldsFromPlan(reorderedVolumes, plan)
 	autoselectVolumes := setDatastoreAutoSelectionAndSize(filledVolumes, plan)
 
@@ -418,7 +415,7 @@ func bootVolumeFirst(
 	return result
 }
 
-// reorderVolumes re-orders the list of volumes to match the plan with boot volume first
+// reorderVolumes re-orders the list of volumes to match the plan
 func reorderVolumes(
 	apiVolumes []sdk.InstanceContainerServerVolume1,
 	plan InstanceModel,
@@ -433,22 +430,18 @@ func reorderVolumes(
 
 	// Now re-order to match plan
 	orderedVolumes := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
-	orderedVolumes = append(orderedVolumes, apiVolumes[0]) // Boot volume first
-	matchedVolumes[0] = true
 
 	// Match remaining volumes with plan volumes by name
 	for _, planVol := range plan.Volumes.Elements() {
 		planVolTyped := planVol.(VolumesValue)
-		for i, apiVol := range apiVolumes[1:] {
-			actualIndex := i + 1 // Account for slice starting at index 1
-			if matchedVolumes[actualIndex] {
+		for i, apiVol := range apiVolumes {
+			if matchedVolumes[i] {
 				continue // Skip already matched volumes
 			}
 
-			if apiVol.Name != nil && planVolTyped.Name.ValueString() == *apiVol.Name &&
-				apiVol.RootVolume != nil && !*apiVol.RootVolume {
+			if apiVol.Name != nil && planVolTyped.Name.ValueString() == *apiVol.Name {
 				orderedVolumes = append(orderedVolumes, apiVol)
-				matchedVolumes[actualIndex] = true
+				matchedVolumes[i] = true
 
 				break
 			}
@@ -463,46 +456,6 @@ func reorderVolumes(
 	}
 
 	return orderedVolumes
-}
-
-// markRootVolume marks the root volume in the list of volumes
-// Note that we hope that there is only one root volume
-// Also this function is almost entirely specific to Metal RAID volumes
-// Hopefully in future the API will return the rootVolume flag correctly and we can remove this function
-func markRootVolume(
-	apiVolumes []sdk.InstanceContainerServerVolume1,
-	plan InstanceModel,
-) []sdk.InstanceContainerServerVolume1 {
-	// Get the name of the boot volume from the plan
-	bootVolumeName := ""
-	foundBootVolume := false
-	planVolumes := plan.Volumes.Elements()
-	if len(planVolumes) > 0 {
-		volume := planVolumes[0].(VolumesValue)
-		if volume.RootVolume.ValueBool() {
-			bootVolumeName = volume.Name.ValueString()
-			foundBootVolume = true
-		}
-	}
-
-	// We're going to look for volumes with the same "name" and "deviceDisplayName" of "BootVolume" or similar
-	retVolumes := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
-	for _, volume := range apiVolumes {
-		if volume.Name != nil && volume.DeviceDisplayName != nil {
-			if strings.Contains(*volume.DeviceDisplayName, "BootVolume") ||
-				strings.Contains(*volume.DeviceDisplayName, "Boot Volume") {
-				rootBool := true
-				volume.RootVolume = &rootBool
-				// Also set the name to match the plan if we found it
-				if foundBootVolume {
-					volume.Name = &bootVolumeName
-				}
-			}
-			retVolumes = append(retVolumes, volume)
-		}
-	}
-
-	return retVolumes
 }
 
 // removeRaidDisks removes any RAID disks from the list of volumes

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_read.go
@@ -202,7 +202,7 @@ func getInstanceAsState(
 	state.TaskSetId = plan.TaskSetId
 
 	// volumes
-	volumes, d := getVolumes(ctx, instance)
+	volumes, d := getVolumes(ctx, instance, plan)
 	diags.Append(d...)
 	state.Volumes = volumes
 
@@ -235,6 +235,7 @@ func getInstanceEnvVars(
 func getVolumes(
 	ctx context.Context,
 	instance sdk.AddInstance200ResponseAllOfOneOfInstance,
+	plan InstanceModel,
 ) (basetypes.ListValue, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
@@ -282,6 +283,253 @@ func getVolumes(
 		},
 	)
 
+	// Import
+	if plan.Name.IsNull() || plan.Name.IsUnknown() {
+		nonRaidVolumes := removeRaidDisks(apiVolumes)
+		markedRootVolumes := markRootVolume(nonRaidVolumes)
+		bootVolumeInFirst := bootVolumeFirst(markedRootVolumes)
+
+		return convertAPIVolumesToStateVolumes(ctx, bootVolumeInFirst)
+	}
+
+	// If the number of volumes is the same as the plan, we can do a direct conversion
+	if len(apiVolumes) == len(plan.Volumes.Elements()) {
+		autoselectVolumes := setDatastoreAutoSelectionAndSize(apiVolumes, plan)
+
+		return convertAPIVolumesToStateVolumes(ctx, autoselectVolumes)
+	}
+
+	// The number of volumes is different to the plan
+	nonRaidVolumes := removeRaidDisks(apiVolumes)
+	markedRootVolumes := markRootVolume(nonRaidVolumes)
+	bootVolumeInFirst := bootVolumeFirst(markedRootVolumes)
+	reorderedVolumes := reorderVolumes(bootVolumeInFirst, plan)
+	filledVolumes := fillVolumeFieldsFromPlan(reorderedVolumes, plan)
+	autoselectVolumes := setDatastoreAutoSelectionAndSize(filledVolumes, plan)
+
+	return convertAPIVolumesToStateVolumes(ctx, autoselectVolumes)
+}
+
+// setDatastoreAutoSelectionAndSize sets the AdditionalProperties field for volumes with
+// DatastoreAutoSelection set to that in the plan
+// Also sets the MaxStorage field from the plan size
+// Handles cases where the number of API volumes differs from plan volumes
+func setDatastoreAutoSelectionAndSize(
+	apiVolumes []sdk.InstanceContainerServerVolume1,
+	plan InstanceModel,
+) []sdk.InstanceContainerServerVolume1 {
+	autoSelection := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
+	planVolumes := plan.Volumes.Elements()
+
+	// Determine how many volumes we can safely access from the plan
+	maxIndex := len(apiVolumes)
+	if len(planVolumes) < maxIndex {
+		maxIndex = len(planVolumes)
+	}
+
+	for i, apiVol := range apiVolumes {
+		// Only set fields from plan if we have a corresponding plan volume
+		if i < maxIndex {
+			planVol := planVolumes[i].(VolumesValue)
+			if !planVol.DatastoreAutoSelection.IsNull() && !planVol.DatastoreAutoSelection.IsUnknown() {
+				// Set AdditionalProperties to indicate auto-selection
+				apiVol.AdditionalProperties = map[string]interface{}{
+					"DatastoreAutoSelection": planVol.DatastoreAutoSelection.ValueString(),
+				}
+			}
+			apiVol.MaxStorage = planVol.Size.ValueInt64Pointer()
+		}
+		// If i >= maxIndex, just append the apiVol as-is (unmatched volumes)
+
+		autoSelection = append(autoSelection, apiVol)
+	}
+
+	return autoSelection
+}
+
+// fillVolumeFieldsFromPlan fills in some missing fields in the API volumes from the plan
+// This is needed because some fields are not returned by the API
+// for certain volume types (e.g. Metal RAID volumes)
+// We assume that the volumes are in the same order as the plan, but handle cases where
+// the number of volumes differs
+func fillVolumeFieldsFromPlan(
+	apiVolumes []sdk.InstanceContainerServerVolume1,
+	plan InstanceModel,
+) []sdk.InstanceContainerServerVolume1 {
+	// Now fill in any missing fields from the plan
+	filledVolumes := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
+	planVolumes := plan.Volumes.Elements()
+
+	// Determine how many volumes we can safely fill from the plan
+	maxIndex := len(apiVolumes)
+	if len(planVolumes) < maxIndex {
+		maxIndex = len(planVolumes)
+	}
+
+	for i, apiVol := range apiVolumes {
+		// Only fill from plan if we have a corresponding plan volume
+		if i < maxIndex {
+			planVol := planVolumes[i].(VolumesValue)
+			if apiVol.DatastoreId == nil {
+				apiVol.DatastoreId = planVol.DatastoreId.ValueInt64Pointer()
+			}
+			// We set TypeId for all volume types since for some types (e.g. Metal RAID) the API TypeId is different
+			apiVol.TypeId = planVol.StorageTypeId.ValueInt64Pointer()
+		}
+		// If i >= maxIndex, just append the apiVol as-is (unmatched volumes)
+
+		filledVolumes = append(filledVolumes, apiVol)
+	}
+
+	return filledVolumes
+}
+
+// bootVolumeFirst puts the boot volume first in the list of volumes
+// We hope to remove this function in future when the API names RAID volumes correctly
+func bootVolumeFirst(
+	apiVolumes []sdk.InstanceContainerServerVolume1,
+) []sdk.InstanceContainerServerVolume1 {
+	// If there are no volumes, return the original list
+	if len(apiVolumes) == 0 {
+		return apiVolumes
+	}
+
+	// Put boot volume first
+	bootVolumes := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
+	otherVolumes := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
+	for _, v := range apiVolumes {
+		if v.RootVolume != nil && *v.RootVolume {
+			bootVolumes = append(bootVolumes, v)
+		} else {
+			otherVolumes = append(otherVolumes, v)
+		}
+	}
+
+	// Combine boot volumes first, then other volumes
+	result := append(bootVolumes, otherVolumes...)
+
+	return result
+}
+
+// reorderVolumes re-orders the list of volumes to match the plan with boot volume first
+func reorderVolumes(
+	apiVolumes []sdk.InstanceContainerServerVolume1,
+	plan InstanceModel,
+) []sdk.InstanceContainerServerVolume1 {
+	// If there are no volumes, return empty list
+	if len(apiVolumes) == 0 {
+		return apiVolumes
+	}
+
+	// Track which API volumes have been matched to avoid duplicates
+	matchedVolumes := make(map[int]bool)
+
+	// Now re-order to match plan
+	orderedVolumes := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
+	orderedVolumes = append(orderedVolumes, apiVolumes[0]) // Boot volume first
+	matchedVolumes[0] = true
+
+	// Match remaining volumes with plan volumes by name
+	for _, planVol := range plan.Volumes.Elements() {
+		planVolTyped := planVol.(VolumesValue)
+		for i, apiVol := range apiVolumes[1:] {
+			actualIndex := i + 1 // Account for slice starting at index 1
+			if matchedVolumes[actualIndex] {
+				continue // Skip already matched volumes
+			}
+
+			if apiVol.Name != nil && planVolTyped.Name.ValueString() == *apiVol.Name &&
+				apiVol.RootVolume != nil && !*apiVol.RootVolume {
+				orderedVolumes = append(orderedVolumes, apiVol)
+				matchedVolumes[actualIndex] = true
+
+				break
+			}
+		}
+	}
+
+	// Append any unmatched volumes at the end to avoid data loss
+	for i, apiVol := range apiVolumes {
+		if !matchedVolumes[i] {
+			orderedVolumes = append(orderedVolumes, apiVol)
+		}
+	}
+
+	return orderedVolumes
+}
+
+// markRootVolume marks the root volume in the list of volumes
+// Note that we hope that there is only one root volume
+// Also this function is almost entirely specific to Metal RAID volumes
+// Hopefully in future the API will return the rootVolume flag correctly and we can remove this function
+func markRootVolume(
+	apiVolumes []sdk.InstanceContainerServerVolume1,
+) []sdk.InstanceContainerServerVolume1 {
+	// We're going to look for volumes with the same "name" and "deviceDisplayName" of "BootVolume" or similar
+	retVolumes := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
+	for _, volume := range apiVolumes {
+		if volume.Name != nil && volume.DeviceDisplayName != nil {
+			if strings.Contains(*volume.DeviceDisplayName, "BootVolume") ||
+				strings.Contains(*volume.DeviceDisplayName, "Boot Volume") {
+				rootBool := true
+				volume.RootVolume = &rootBool
+			}
+			retVolumes = append(retVolumes, volume)
+		}
+	}
+
+	return retVolumes
+}
+
+// removeRaidDisks removes any RAID disks from the list of volumes
+func removeRaidDisks(
+	apiVolumes []sdk.InstanceContainerServerVolume1,
+) []sdk.InstanceContainerServerVolume1 {
+	// build a map of device-counts for the API volumes
+	deviceCount := make(map[string]int)
+	for _, volume := range apiVolumes {
+		if volume.DeviceName != nil {
+			deviceCount[*volume.DeviceName]++
+		}
+	}
+
+	// remove the RAID disks from the apiVolumes list
+	nonRaidDiskVolumes := slices.DeleteFunc(
+		apiVolumes,
+		func(v sdk.InstanceContainerServerVolume1) bool {
+			// Skip volumes without a device name
+			if v.DeviceName == nil {
+				return false
+			}
+
+			if deviceCount[*v.DeviceName] > 1 {
+				// We're going to remove volumes which have a diskType
+				if v.DiskType != nil && v.DiskMode == nil {
+					return true
+				}
+			}
+
+			return false
+		},
+	)
+
+	return nonRaidDiskVolumes
+}
+
+// convertBytesPtrToGBBytes converts a pointer to int64 bytes to a pointer to int64 GB bytes
+func convertBytesPtrToGBBytes(b *int64) *int64 {
+	if b == nil {
+		return nil
+	}
+	gb := *b / (1 << 30)
+
+	return &gb
+}
+
+func convertAPIVolumesToStateVolumes(
+	ctx context.Context,
+	apiVolumes []sdk.InstanceContainerServerVolume1,
+) (basetypes.ListValue, diag.Diagnostics) {
 	volumes, d := convert.ToListType(
 		ctx,
 		apiVolumes,
@@ -296,6 +544,14 @@ func getVolumes(
 			v.StorageTypeId = convert.Int64ToType(in.TypeId)
 			v.DatastoreId = convert.Int64ToType(in.DatastoreId)
 			v.ControllerMountPoint = convert.StrToType(in.ControllerMountPoint)
+			// Handle DatastoreAutoSelection from AdditionalProperties
+			if in.AdditionalProperties != nil {
+				if dsAutoSel, ok := in.AdditionalProperties["DatastoreAutoSelection"]; ok {
+					if dsAutoSelStr, ok := dsAutoSel.(string); ok {
+						v.DatastoreAutoSelection = convert.StrToType(&dsAutoSelStr)
+					}
+				}
+			}
 			v.state = attr.ValueStateKnown
 
 			return v
@@ -303,16 +559,6 @@ func getVolumes(
 	)
 
 	return volumes, d
-}
-
-// convertBytesPtrToGBBytes converts a pointer to int64 bytes to a pointer to int64 GB bytes
-func convertBytesPtrToGBBytes(b *int64) *int64 {
-	if b == nil {
-		return nil
-	}
-	gb := *b / (1 << 30)
-
-	return &gb
 }
 
 // getConnectionInfo builds the connection_info list


### PR DESCRIPTION
In this PR we make extensive changes to getVolumes() to handle the discrepancies that we seeing between HCL and API Volumes for Metal RAID. We hope to remove the need for some of the processing done here with changes to the Metal plugin.

The changes:
- we pass plan down to getVolumes
- we add a number of new functions that process the API list of volumes:
  - removeRaidDisks() removes RAID disk volumes from the list of API volumes, the trigger is repeated deviceName and also diskMode of nil and diskType not nil
  - markRootVolume() sets the rootVolume bool in an API volume if the volume deviceDisplayName is "BootVolume" or "Boot Volume", we hope to remove the need for this function
  - bootVolumeFirst() puts the boot (rootVolume=true) volume first in the list, we hope to remove this function when we get the boot volume name to be that set in the HCL
  - reorderVolumes() reorders the list of volumes to match the plan with boot volume first, we hope to remove the need to have the boot volume first here (see above)
  - fillVolumeFieldsFromPlan() we hope to remove the need for this function when we get a datastoreId and also the "correct" storage_type_id from the API
  - setDatastoreAutoSelectionAndSize() sets the API volume size to that in the plan and also puts the value of DatasoreAutoSelection into the AdditionalProperties map
- if the number of volumes from the API matches the number of volumes from the plan then we call setDatatstoreAutoSelectionAndSize()
- we call the following functions in the below order for imports and build the State volumes from the resulting list of API volumes:
  - removeRaidDisks
  - markRootVolume
  - bootVolumeFirst
- we call the following functions in the below order where the number of volumes from the API and plan differ and build the State volumes from the resulting list of API volumes:
  - removeRaidDisks
  - markRootVolume
  - bootVolumeFirst
  - reorderVolumes
  - fillVolumeFieldsFromPlan
  - setDatastoreAutoSelectionAndSize