### PR TITLE
Adding TaintResourceState for when Create fails after POST

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
@@ -212,9 +212,9 @@ func (r *Resource) Create(
 
 	id := *cloud.GetZone().Id
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "cloud",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -229,7 +229,7 @@ func (r *Resource) Create(
 			"failed to read cloud state",
 			fmt.Sprintf("Cloud %d was created but could not be read", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -240,7 +240,7 @@ func (r *Resource) Create(
 			"failed to set cloud state",
 			fmt.Sprintf("Cloud %d was created but state could not be saved", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
@@ -212,6 +212,16 @@ func (r *Resource) Create(
 
 	id := *cloud.GetZone().Id
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "cloud",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	state, pdiags := getCloudAsState(ctx, id, client, plan)
 	if pdiags.HasError() {
 		resp.Diagnostics.Append(pdiags...)
@@ -219,12 +229,7 @@ func (r *Resource) Create(
 			"failed to read cloud state",
 			fmt.Sprintf("Cloud %d was created but could not be read", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "cloud",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 
@@ -234,12 +239,7 @@ func (r *Resource) Create(
 			"failed to set cloud state",
 			fmt.Sprintf("Cloud %d was created but state could not be saved", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "cloud",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
@@ -230,6 +230,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Cloud %d was created but could not be read", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 
@@ -240,6 +241,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Cloud %d was created but state could not be saved", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
@@ -212,37 +212,34 @@ func (r *Resource) Create(
 
 	id := *cloud.GetZone().Id
 
-	// Helper function to delete the cloud if anything goes wrong
-	deleteOnError := func() {
-		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
-			ResourceType: "cloud",
-			ResourceID:   id,
-			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.CloudsAPI.RemoveClouds(ctx, id).Force(true).Execute()
-				return resp, err
-			},
-			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.CloudsAPI.GetClouds(ctx, id).Execute()
-				return resp, err
-			},
-			Diagnostics: &resp.Diagnostics,
-		})
-	}
-
 	state, pdiags := getCloudAsState(ctx, id, client, plan)
 	if pdiags.HasError() {
 		resp.Diagnostics.Append(pdiags...)
 		resp.Diagnostics.AddError(
-			"create cloud resource",
-			fmt.Sprintf("cloud %d: failed to read from api", id),
+			"failed to read cloud state",
+			fmt.Sprintf("Cloud %d was created but could not be read", id),
 		)
-		deleteOnError()
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "cloud",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		deleteOnError()
+		resp.Diagnostics.AddError(
+			"failed to set cloud state",
+			fmt.Sprintf("Cloud %d was created but state could not be saved", id),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "cloud",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
@@ -9,13 +9,13 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/sdkfuncs"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 const defaultCloudType = "standard"
@@ -211,12 +211,22 @@ func (r *Resource) Create(
 	}
 
 	id := *cloud.GetZone().Id
-	plan.Id = types.Int64Value(id)
 
-	// write id as soon as possible
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
+	// Helper function to delete the cloud if anything goes wrong
+	deleteOnError := func() {
+		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
+			ResourceType: "cloud",
+			ResourceID:   id,
+			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.CloudsAPI.RemoveClouds(ctx, id).Force(true).Execute()
+				return resp, err
+			},
+			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.CloudsAPI.GetClouds(ctx, id).Execute()
+				return resp, err
+			},
+			Diagnostics: &resp.Diagnostics,
+		})
 	}
 
 	state, pdiags := getCloudAsState(ctx, id, client, plan)
@@ -226,12 +236,13 @@ func (r *Resource) Create(
 			"create cloud resource",
 			fmt.Sprintf("cloud %d: failed to read from api", id),
 		)
-
+		deleteOnError()
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		deleteOnError()
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -172,6 +172,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Datastore %d failed to reach provisioned status. Current status: %v", id, status),
 		)
 		setPartialState(id)
+
 		return
 	}
 
@@ -183,6 +184,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Datastore %d was created but could not be read", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 
@@ -196,6 +198,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Datastore %d was created but permissions could not be updated", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 
@@ -206,6 +209,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Datastore %d was created but state could not be saved", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -129,6 +129,16 @@ func (r *Resource) Create(
 
 	// Set the resource ID locally but NOT in state yet
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "datastore",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	// Wait for the datastore to be ready
 	waitForReady := func() (*sdk.GetDatastores200Response, error) {
 		response, hresp, err := client.DatastoresAPI.GetDatastores(ctx, plan.Id.ValueInt64()).Execute()
@@ -161,12 +171,7 @@ func (r *Resource) Create(
 			"datastore provisioning failed",
 			fmt.Sprintf("Datastore %d failed to reach provisioned status. Current status: %v", id, status),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "datastore",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 
@@ -177,12 +182,7 @@ func (r *Resource) Create(
 			"failed to read datastore state",
 			fmt.Sprintf("Datastore %d was created but could not be read", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "datastore",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 
@@ -195,12 +195,7 @@ func (r *Resource) Create(
 			"failed to update datastore",
 			fmt.Sprintf("Datastore %d was created but permissions could not be updated", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "datastore",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 
@@ -210,12 +205,7 @@ func (r *Resource) Create(
 			"failed to set datastore state",
 			fmt.Sprintf("Datastore %d was created but state could not be saved", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "datastore",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -129,9 +129,9 @@ func (r *Resource) Create(
 
 	// Set the resource ID locally but NOT in state yet
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "datastore",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -171,7 +171,7 @@ func (r *Resource) Create(
 			"datastore provisioning failed",
 			fmt.Sprintf("Datastore %d failed to reach provisioned status. Current status: %v", id, status),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -183,7 +183,7 @@ func (r *Resource) Create(
 			"failed to read datastore state",
 			fmt.Sprintf("Datastore %d was created but could not be read", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -197,7 +197,7 @@ func (r *Resource) Create(
 			"failed to update datastore",
 			fmt.Sprintf("Datastore %d was created but permissions could not be updated", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -208,7 +208,7 @@ func (r *Resource) Create(
 			"failed to set datastore state",
 			fmt.Sprintf("Datastore %d was created but state could not be saved", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -13,7 +13,6 @@ import (
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/cenkalti/backoff/v5"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
@@ -129,24 +128,6 @@ func (r *Resource) Create(
 	}
 
 	// Set the resource ID locally but NOT in state yet
-	plan.Id = types.Int64Value(id)
-
-	// Helper function to delete the datastore if anything goes wrong
-	deleteOnError := func() {
-		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
-			ResourceType: "datastore",
-			ResourceID:   id,
-			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.DatastoresAPI.DeleteDatastores(ctx, id).Execute()
-				return resp, err
-			},
-			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
-				return resp, err
-			},
-			Diagnostics: &resp.Diagnostics,
-		})
-	}
 
 	// Wait for the datastore to be ready
 	waitForReady := func() (*sdk.GetDatastores200Response, error) {
@@ -177,44 +158,64 @@ func (r *Resource) Create(
 		}
 
 		resp.Diagnostics.AddError(
-			"create datastore resource",
-			fmt.Sprintf(
-				"datastore %d: provisioning failed current status is: %v",
-				plan.Id.ValueInt64(),
-				status,
-			),
+			"datastore provisioning failed",
+			fmt.Sprintf("Datastore %d failed to reach provisioned status. Current status: %v", id, status),
 		)
-		deleteOnError()
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "datastore",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
-	state, gdiags := getDatastoreAsState(ctx, plan.Id.ValueInt64(), plan, client)
+	state, gdiags := getDatastoreAsState(ctx, id, plan, client)
 	if gdiags.HasError() {
 		resp.Diagnostics.Append(gdiags...)
 		resp.Diagnostics.AddError(
-			"create datastore resource",
-			fmt.Sprintf("datastore %d: failed to read from api", plan.Id.ValueInt64()),
+			"failed to read datastore state",
+			fmt.Sprintf("Datastore %d was created but could not be read", id),
 		)
-		deleteOnError()
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "datastore",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
 	// For now, we need to call update to set resourcePermission and tenantPermissions
 	// because the API does not set these on create, even if provided.
-	state, gdiags = updateDatastore(ctx, plan.Id.ValueInt64(), plan, state, client)
+	state, gdiags = updateDatastore(ctx, id, plan, state, client)
 	if gdiags.HasError() {
 		resp.Diagnostics.Append(gdiags...)
 		resp.Diagnostics.AddError(
-			"create datastore resource",
-			fmt.Sprintf("datastore %d: failed to update", plan.Id.ValueInt64()),
+			"failed to update datastore",
+			fmt.Sprintf("Datastore %d was created but permissions could not be updated", id),
 		)
-		deleteOnError()
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "datastore",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		deleteOnError()
+		resp.Diagnostics.AddError(
+			"failed to set datastore state",
+			fmt.Sprintf("Datastore %d was created but state could not be saved", id),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "datastore",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cenkalti/backoff/v5"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 const (
@@ -126,13 +128,24 @@ func (r *Resource) Create(
 		return
 	}
 
-	// Set the resource ID
+	// Set the resource ID locally but NOT in state yet
 	plan.Id = types.Int64Value(id)
 
-	// write id as soon as possible
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
+	// Helper function to delete the datastore if anything goes wrong
+	deleteOnError := func() {
+		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
+			ResourceType: "datastore",
+			ResourceID:   id,
+			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.DatastoresAPI.DeleteDatastores(ctx, id).Execute()
+				return resp, err
+			},
+			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
+				return resp, err
+			},
+			Diagnostics: &resp.Diagnostics,
+		})
 	}
 
 	// Wait for the datastore to be ready
@@ -171,9 +184,7 @@ func (r *Resource) Create(
 				status,
 			),
 		)
-	}
-
-	if resp.Diagnostics.HasError() {
+		deleteOnError()
 		return
 	}
 
@@ -184,7 +195,7 @@ func (r *Resource) Create(
 			"create datastore resource",
 			fmt.Sprintf("datastore %d: failed to read from api", plan.Id.ValueInt64()),
 		)
-
+		deleteOnError()
 		return
 	}
 
@@ -197,12 +208,13 @@ func (r *Resource) Create(
 			"create datastore resource",
 			fmt.Sprintf("datastore %d: failed to update", plan.Id.ValueInt64()),
 		)
-
+		deleteOnError()
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		deleteOnError()
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/group/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/group/resource.go
@@ -157,9 +157,9 @@ func (r *Resource) Create(
 	id := *group.GetGroup().Id
 	plan.Id = types.Int64Value(id)
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "group",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -180,7 +180,7 @@ func (r *Resource) Create(
 			"create group resource",
 			fmt.Sprintf("group %d: failed to read from api", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -191,7 +191,7 @@ func (r *Resource) Create(
 			"failed to set group state",
 			fmt.Sprintf("Group %d was created but state could not be saved", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/group/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/group/resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -156,6 +157,16 @@ func (r *Resource) Create(
 	id := *group.GetGroup().Id
 	plan.Id = types.Int64Value(id)
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "group",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	// write id as soon as possible
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -169,12 +180,19 @@ func (r *Resource) Create(
 			"create group resource",
 			fmt.Sprintf("group %d: failed to read from api", id),
 		)
+		setPartialState(id)
 
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(
+			"failed to set group state",
+			fmt.Sprintf("Group %d was created but state could not be saved", id),
+		)
+		setPartialState(id)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -305,12 +305,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			"create image resource",
 			fmt.Sprintf("image %s: creation failed current status is: %s", plan.Name.ValueString(), status),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "image",
-			ResourceID:   plan.Id.ValueInt64(),
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(plan.Id.ValueInt64())
 
 		return
 	}
@@ -321,12 +316,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			"failed to read image state",
 			fmt.Sprintf("Image %d was created but could not be read", plan.Id.ValueInt64()),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "image",
-			ResourceID:   plan.Id.ValueInt64(),
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(plan.Id.ValueInt64())
 
 		return
 	}
@@ -337,12 +327,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			"failed to set image state",
 			fmt.Sprintf("Image %d was created but state could not be saved", plan.Id.ValueInt64()),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "image",
-			ResourceID:   plan.Id.ValueInt64(),
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(plan.Id.ValueInt64())
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -232,28 +232,20 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	imageId := image.VirtualImage.GetId()
 
-	// Helper function to delete the image if anything goes wrong
-	deleteOnError := func() {
-		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
-			ResourceType: "image",
-			ResourceID:   imageId,
-			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.LibraryAPI.RemoveVirtualImage(ctx, id).Execute()
-				return resp, err
-			},
-			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.LibraryAPI.GetVirtualImage(ctx, id).Execute()
-				return resp, err
-			},
-			Diagnostics: &resp.Diagnostics,
-		})
-	}
-
-	// Set state only after everything succeeds (no read operation needed for images)
+	// Set state
 	plan.Id = convert.Int64ToType(&imageId)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
-		deleteOnError()
+		resp.Diagnostics.AddError(
+			"failed to set initial image state",
+			fmt.Sprintf("Image %d was created but state could not be saved", imageId),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "image",
+			ResourceID:   imageId,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
@@ -305,21 +297,44 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	); err != nil {
 		resp.Diagnostics.AddError(
 			"create image resource",
-			fmt.Sprintf(
-				"image %s: creation failed current status is: %s",
-				plan.Name.ValueString(),
-				status,
-			),
+			fmt.Sprintf("image %s: creation failed current status is: %s", plan.Name.ValueString(), status),
 		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "image",
+			ResourceID:   plan.Id.ValueInt64(),
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+		return
 	}
 
 	state, diag := getImageAsState(ctx, plan.Id.ValueInt64(), client, plan)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(
+			"failed to read image state",
+			fmt.Sprintf("Image %d was created but could not be read", plan.Id.ValueInt64()),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "image",
+			ResourceID:   plan.Id.ValueInt64(),
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(
+			"failed to set image state",
+			fmt.Sprintf("Image %d was created but state could not be saved", plan.Id.ValueInt64()),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "image",
+			ResourceID:   plan.Id.ValueInt64(),
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -232,6 +232,16 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	imageId := image.VirtualImage.GetId()
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "image",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	// Set state
 	plan.Id = convert.Int64ToType(&imageId)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -240,12 +250,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			"failed to set initial image state",
 			fmt.Sprintf("Image %d was created but state could not be saved", imageId),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "image",
-			ResourceID:   imageId,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(imageId)
 		return
 	}
 

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -232,9 +232,9 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	imageId := image.VirtualImage.GetId()
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "image",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -250,7 +250,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			"failed to set initial image state",
 			fmt.Sprintf("Image %d was created but state could not be saved", imageId),
 		)
-		setPartialState(imageId)
+		taintResourceState(imageId)
 
 		return
 	}
@@ -305,7 +305,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			"create image resource",
 			fmt.Sprintf("image %s: creation failed current status is: %s", plan.Name.ValueString(), status),
 		)
-		setPartialState(plan.Id.ValueInt64())
+		taintResourceState(plan.Id.ValueInt64())
 
 		return
 	}
@@ -316,7 +316,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			"failed to read image state",
 			fmt.Sprintf("Image %d was created but could not be read", plan.Id.ValueInt64()),
 		)
-		setPartialState(plan.Id.ValueInt64())
+		taintResourceState(plan.Id.ValueInt64())
 
 		return
 	}
@@ -327,7 +327,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			"failed to set image state",
 			fmt.Sprintf("Image %d was created but state could not be saved", plan.Id.ValueInt64()),
 		)
-		setPartialState(plan.Id.ValueInt64())
+		taintResourceState(plan.Id.ValueInt64())
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 // Create implements resource.Resource.
@@ -229,10 +230,30 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	plan.Id = convert.Int64ToType(image.VirtualImage.Id)
+	imageId := image.VirtualImage.GetId()
 
+	// Helper function to delete the image if anything goes wrong
+	deleteOnError := func() {
+		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
+			ResourceType: "image",
+			ResourceID:   imageId,
+			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.LibraryAPI.RemoveVirtualImage(ctx, id).Execute()
+				return resp, err
+			},
+			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.LibraryAPI.GetVirtualImage(ctx, id).Execute()
+				return resp, err
+			},
+			Diagnostics: &resp.Diagnostics,
+		})
+	}
+
+	// Set state only after everything succeeds (no read operation needed for images)
+	plan.Id = convert.Int64ToType(&imageId)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		deleteOnError()
 		return
 	}
 

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -251,6 +251,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			fmt.Sprintf("Image %d was created but state could not be saved", imageId),
 		)
 		setPartialState(imageId)
+
 		return
 	}
 
@@ -310,6 +311,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			StateWriter:  &resp.State,
 			Diagnostics:  &resp.Diagnostics,
 		})
+
 		return
 	}
 
@@ -325,6 +327,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			StateWriter:  &resp.State,
 			Diagnostics:  &resp.Diagnostics,
 		})
+
 		return
 	}
 
@@ -340,6 +343,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			StateWriter:  &resp.State,
 			Diagnostics:  &resp.Diagnostics,
 		})
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	errfmt "github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 var (
@@ -231,15 +232,30 @@ func (g *Resource) Create(
 		return
 	}
 
-	plan.Id = convert.Int64ToType(instance.Instance.Id)
+	// OPTION 2: Don't set state until everything succeeds
+	// Store ID locally but NOT in state yet
+	instanceId := instance.Instance.GetId()
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
+	// Helper function to delete the instance if anything goes wrong
+	deleteOnError := func() {
+		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
+			ResourceType: "instance",
+			ResourceID:   instanceId,
+			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.InstancesAPI.DeleteInstance(ctx, id).Execute()
+				return resp, err
+			},
+			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.InstancesAPI.GetInstance(ctx, id).Execute()
+				return resp, err
+			},
+			Diagnostics: &resp.Diagnostics,
+		})
 	}
 
+	// Wait for the instance to be ready
 	waitForReady := func() (string, error) {
-		resp, hresp, err := client.InstancesAPI.GetInstance(ctx, plan.Id.ValueInt64()).Execute()
+		resp, hresp, err := client.InstancesAPI.GetInstance(ctx, instanceId).Execute()
 		if err != nil || hresp.StatusCode != http.StatusOK {
 			return "", backoff.Permanent(err)
 		}
@@ -262,20 +278,28 @@ func (g *Resource) Create(
 		resp.Diagnostics.AddError(
 			"create instance resource",
 			fmt.Sprintf(
-				"instance %d: provisioning failed current status is: %s",
-				plan.Id.ValueInt64(),
+				"instance %d: provisioning failed, current status is: %s",
+				instanceId,
 				status,
 			),
 		)
-	}
-
-	state, diag := getInstanceAsState(ctx, plan.Id.ValueInt64(), client, plan)
-	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
+		deleteOnError()
 		return
 	}
 
+	// Get the full instance state
+	state, diag := getInstanceAsState(ctx, instanceId, client, plan)
+	if diag.HasError() {
+		resp.Diagnostics.Append(diag...)
+		deleteOnError()
+		return
+	}
+
+	// ONLY NOW do we set state - everything succeeded!
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		// State setting failed (this is rare), still try to clean up
+		deleteOnError()
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -232,26 +232,8 @@ func (g *Resource) Create(
 		return
 	}
 
-	// OPTION 2: Don't set state until everything succeeds
 	// Store ID locally but NOT in state yet
 	instanceId := instance.Instance.GetId()
-
-	// Helper function to delete the instance if anything goes wrong
-	deleteOnError := func() {
-		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
-			ResourceType: "instance",
-			ResourceID:   instanceId,
-			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.InstancesAPI.DeleteInstance(ctx, id).Execute()
-				return resp, err
-			},
-			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.InstancesAPI.GetInstance(ctx, id).Execute()
-				return resp, err
-			},
-			Diagnostics: &resp.Diagnostics,
-		})
-	}
 
 	// Wait for the instance to be ready
 	waitForReady := func() (string, error) {
@@ -276,30 +258,47 @@ func (g *Resource) Create(
 		backoff.WithMaxElapsedTime(createTimeout),
 	); err != nil {
 		resp.Diagnostics.AddError(
-			"create instance resource",
-			fmt.Sprintf(
-				"instance %d: provisioning failed, current status is: %s",
-				instanceId,
-				status,
-			),
+			"instance provisioning failed",
+			fmt.Sprintf("Instance %d failed to reach running status. Current status: %s. Error: %v", instanceId, status, err),
 		)
-		deleteOnError()
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "instance",
+			ResourceID:   instanceId,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
-	// Get the full instance state
 	state, diag := getInstanceAsState(ctx, instanceId, client, plan)
 	if diag.HasError() {
 		resp.Diagnostics.Append(diag...)
-		deleteOnError()
+		resp.Diagnostics.AddError(
+			"failed to read instance state",
+			fmt.Sprintf("Instance %d was created but could not be read", instanceId),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "instance",
+			ResourceID:   instanceId,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
-	// ONLY NOW do we set state - everything succeeded!
+	// SUCCESS! Set the full state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		// State setting failed (this is rare), still try to clean up
-		deleteOnError()
+		resp.Diagnostics.AddError(
+			"failed to set instance state",
+			fmt.Sprintf("Instance %d was created but state could not be saved", instanceId),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "instance",
+			ResourceID:   instanceId,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -232,7 +232,7 @@ func (g *Resource) Create(
 		return
 	}
 
-	// Store ID locally but NOT in state yet
+	// Store ID locally but not in state yet
 	instanceId := instance.Instance.GetId()
 
 	// Helper to taint the resource state on an error after the POST request
@@ -268,8 +268,12 @@ func (g *Resource) Create(
 		backoff.WithMaxElapsedTime(createTimeout),
 	); err != nil {
 		resp.Diagnostics.AddError(
-			"instance provisioning failed",
-			fmt.Sprintf("Instance %d failed to reach running status. Current status: %s. Error: %v", instanceId, status, err),
+			"create instance resource",
+			fmt.Sprintf(
+				"instance %d: provisioning failed current status is: %s",
+				instanceId,
+				status,
+			),
 		)
 		taintResourceState(instanceId)
 
@@ -288,7 +292,6 @@ func (g *Resource) Create(
 		return
 	}
 
-	// SUCCESS! Set the full state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		resp.Diagnostics.AddError(

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -235,6 +235,16 @@ func (g *Resource) Create(
 	// Store ID locally but NOT in state yet
 	instanceId := instance.Instance.GetId()
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "instance",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	// Wait for the instance to be ready
 	waitForReady := func() (string, error) {
 		resp, hresp, err := client.InstancesAPI.GetInstance(ctx, instanceId).Execute()
@@ -261,12 +271,7 @@ func (g *Resource) Create(
 			"instance provisioning failed",
 			fmt.Sprintf("Instance %d failed to reach running status. Current status: %s. Error: %v", instanceId, status, err),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "instance",
-			ResourceID:   instanceId,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(instanceId)
 		return
 	}
 
@@ -277,12 +282,7 @@ func (g *Resource) Create(
 			"failed to read instance state",
 			fmt.Sprintf("Instance %d was created but could not be read", instanceId),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "instance",
-			ResourceID:   instanceId,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(instanceId)
 		return
 	}
 
@@ -293,12 +293,7 @@ func (g *Resource) Create(
 			"failed to set instance state",
 			fmt.Sprintf("Instance %d was created but state could not be saved", instanceId),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "instance",
-			ResourceID:   instanceId,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(instanceId)
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -235,9 +235,9 @@ func (g *Resource) Create(
 	// Store ID locally but NOT in state yet
 	instanceId := instance.Instance.GetId()
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "instance",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -271,7 +271,7 @@ func (g *Resource) Create(
 			"instance provisioning failed",
 			fmt.Sprintf("Instance %d failed to reach running status. Current status: %s. Error: %v", instanceId, status, err),
 		)
-		setPartialState(instanceId)
+		taintResourceState(instanceId)
 
 		return
 	}
@@ -283,7 +283,7 @@ func (g *Resource) Create(
 			"failed to read instance state",
 			fmt.Sprintf("Instance %d was created but could not be read", instanceId),
 		)
-		setPartialState(instanceId)
+		taintResourceState(instanceId)
 
 		return
 	}
@@ -295,7 +295,7 @@ func (g *Resource) Create(
 			"failed to set instance state",
 			fmt.Sprintf("Instance %d was created but state could not be saved", instanceId),
 		)
-		setPartialState(instanceId)
+		taintResourceState(instanceId)
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -272,6 +272,7 @@ func (g *Resource) Create(
 			fmt.Sprintf("Instance %d failed to reach running status. Current status: %s. Error: %v", instanceId, status, err),
 		)
 		setPartialState(instanceId)
+
 		return
 	}
 
@@ -283,6 +284,7 @@ func (g *Resource) Create(
 			fmt.Sprintf("Instance %d was created but could not be read", instanceId),
 		)
 		setPartialState(instanceId)
+
 		return
 	}
 
@@ -294,6 +296,7 @@ func (g *Resource) Create(
 			fmt.Sprintf("Instance %d was created but state could not be saved", instanceId),
 		)
 		setPartialState(instanceId)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/network/create.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create.go
@@ -281,6 +281,16 @@ func (r *Resource) Create(
 
 	id := *network.GetNetwork().Id
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "network",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	state, pdiags := getNetworkAsState(ctx, id, client, plan)
 	if pdiags.HasError() {
 		resp.Diagnostics.Append(pdiags...)
@@ -288,12 +298,7 @@ func (r *Resource) Create(
 			"failed to read network state",
 			fmt.Sprintf("Network %d was created but could not be read", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "network",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 
@@ -307,12 +312,7 @@ func (r *Resource) Create(
 			"failed to set network state",
 			fmt.Sprintf("Network %d was created but state could not be saved", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "network",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/network/create.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create.go
@@ -281,9 +281,9 @@ func (r *Resource) Create(
 
 	id := *network.GetNetwork().Id
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "network",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -298,7 +298,7 @@ func (r *Resource) Create(
 			"failed to read network state",
 			fmt.Sprintf("Network %d was created but could not be read", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -313,7 +313,7 @@ func (r *Resource) Create(
 			"failed to set network state",
 			fmt.Sprintf("Network %d was created but state could not be saved", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/network/create.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 func (r *Resource) Create(
@@ -279,12 +280,22 @@ func (r *Resource) Create(
 	}
 
 	id := *network.GetNetwork().Id
-	plan.Id = types.Int64Value(id)
 
-	// write id as soon as possible
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
+	// Helper function to delete the network if anything goes wrong
+	deleteOnError := func() {
+		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
+			ResourceType: "network",
+			ResourceID:   id,
+			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.NetworksAPI.DeleteNetwork(ctx, id).Execute()
+				return resp, err
+			},
+			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.NetworksAPI.GetNetwork(ctx, id).Execute()
+				return resp, err
+			},
+			Diagnostics: &resp.Diagnostics,
+		})
 	}
 
 	state, pdiags := getNetworkAsState(ctx, id, client, plan)
@@ -294,7 +305,7 @@ func (r *Resource) Create(
 			"create network resource",
 			fmt.Sprintf("network %d: failed to read from api", id),
 		)
-
+		deleteOnError()
 		return
 	}
 
@@ -303,4 +314,8 @@ func (r *Resource) Create(
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		deleteOnError()
+		return
+	}
 }

--- a/internal/framework/subproviders/morpheus/resources/network/create.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create.go
@@ -299,6 +299,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Network %d was created but could not be read", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 
@@ -313,6 +314,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Network %d was created but state could not be saved", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/network/create.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create.go
@@ -281,31 +281,19 @@ func (r *Resource) Create(
 
 	id := *network.GetNetwork().Id
 
-	// Helper function to delete the network if anything goes wrong
-	deleteOnError := func() {
-		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
-			ResourceType: "network",
-			ResourceID:   id,
-			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.NetworksAPI.DeleteNetwork(ctx, id).Execute()
-				return resp, err
-			},
-			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.NetworksAPI.GetNetwork(ctx, id).Execute()
-				return resp, err
-			},
-			Diagnostics: &resp.Diagnostics,
-		})
-	}
-
 	state, pdiags := getNetworkAsState(ctx, id, client, plan)
 	if pdiags.HasError() {
 		resp.Diagnostics.Append(pdiags...)
 		resp.Diagnostics.AddError(
-			"create network resource",
-			fmt.Sprintf("network %d: failed to read from api", id),
+			"failed to read network state",
+			fmt.Sprintf("Network %d was created but could not be read", id),
 		)
-		deleteOnError()
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "network",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
@@ -315,7 +303,16 @@ func (r *Resource) Create(
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		deleteOnError()
+		resp.Diagnostics.AddError(
+			"failed to set network state",
+			fmt.Sprintf("Network %d was created but state could not be saved", id),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "network",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -26,6 +26,16 @@ func (r *Resource) Create(
 		return
 	}
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "policy",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	name := plan.Name.ValueString()
 	addPolicy := sdk.NewAddPoliciesRequestPolicyWithDefaults()
 
@@ -128,12 +138,7 @@ func (r *Resource) Create(
 			"failed to read policy state",
 			fmt.Sprintf("Policy %d was created but could not be read", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "policy",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 
@@ -144,12 +149,7 @@ func (r *Resource) Create(
 			"failed to set policy state",
 			fmt.Sprintf("Policy %d was created but state could not be saved", id),
 		)
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "policy",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
+		setPartialState(id)
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -120,9 +120,9 @@ func (r *Resource) Create(
 
 	id := *policy.Policy.Id
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "policy",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -138,7 +138,7 @@ func (r *Resource) Create(
 			"failed to read policy state",
 			fmt.Sprintf("Policy %d was created but could not be read", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -150,7 +150,7 @@ func (r *Resource) Create(
 			"failed to set policy state",
 			fmt.Sprintf("Policy %d was created but state could not be saved", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -4,6 +4,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
@@ -119,34 +120,36 @@ func (r *Resource) Create(
 
 	id := *policy.Policy.Id
 
-	// Helper function to delete the policy if anything goes wrong
-	deleteOnError := func() {
-		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
-			ResourceType: "policy",
-			ResourceID:   id,
-			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.PoliciesAPI.RemovePolicies(ctx, id).Execute()
-				return resp, err
-			},
-			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-				_, resp, err := client.PoliciesAPI.GetPolicies(ctx, id).Execute()
-				return resp, err
-			},
-			Diagnostics: &resp.Diagnostics,
-		})
-	}
-
 	// Read the created policy to get full state
 	state, diags := getPolicyAsState(ctx, id, client, &plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
-		deleteOnError()
+		resp.Diagnostics.AddError(
+			"failed to read policy state",
+			fmt.Sprintf("Policy %d was created but could not be read", id),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "policy",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 
+	// Set the state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		deleteOnError()
+		resp.Diagnostics.AddError(
+			"failed to set policy state",
+			fmt.Sprintf("Policy %d was created but state could not be saved", id),
+		)
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "policy",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -139,6 +139,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Policy %d was created but could not be read", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 
@@ -150,6 +151,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Policy %d was created but state could not be saved", id),
 		)
 		setPartialState(id)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -26,16 +26,6 @@ func (r *Resource) Create(
 		return
 	}
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-			ResourceType: "policy",
-			ResourceID:   id,
-			StateWriter:  &resp.State,
-			Diagnostics:  &resp.Diagnostics,
-		})
-	}
-
 	name := plan.Name.ValueString()
 	addPolicy := sdk.NewAddPoliciesRequestPolicyWithDefaults()
 
@@ -129,6 +119,16 @@ func (r *Resource) Create(
 	}
 
 	id := *policy.Policy.Id
+
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "policy",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
 
 	// Read the created policy to get full state
 	state, diags := getPolicyAsState(ctx, id, client, &plan)

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 func (r *Resource) Create(
@@ -118,21 +118,35 @@ func (r *Resource) Create(
 	}
 
 	id := *policy.Policy.Id
-	plan.Id = types.Int64Value(id)
 
-	// Write id as soon as possible
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
+	// Helper function to delete the policy if anything goes wrong
+	deleteOnError := func() {
+		utils.CleanupResourceOnError(ctx, utils.CleanupConfig{
+			ResourceType: "policy",
+			ResourceID:   id,
+			DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.PoliciesAPI.RemovePolicies(ctx, id).Execute()
+				return resp, err
+			},
+			GetFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+				_, resp, err := client.PoliciesAPI.GetPolicies(ctx, id).Execute()
+				return resp, err
+			},
+			Diagnostics: &resp.Diagnostics,
+		})
 	}
 
 	// Read the created policy to get full state
 	state, diags := getPolicyAsState(ctx, id, client, &plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
-
+		deleteOnError()
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		deleteOnError()
+		return
+	}
 }

--- a/internal/framework/subproviders/morpheus/resources/policy/read.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/read.go
@@ -617,7 +617,7 @@ func getPolicyAsState(
 	if err != nil || hresp.StatusCode != http.StatusOK || policy == nil {
 		diags.AddError(
 			"populate policy resource",
-			fmt.Sprintf("policy %d GET failed", id)+errors.ErrMsg(err, hresp),
+			fmt.Sprintf("policy %d GET failed: ", id)+errors.ErrMsg(err, hresp),
 		)
 
 		return state, diags

--- a/internal/framework/subproviders/morpheus/resources/role/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/role/resource.go
@@ -19,6 +19,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -1457,6 +1458,16 @@ func (r *Resource) Create(
 	id := *role.GetRole().Id
 	plan.Id = types.Int64Value(id)
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "role",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	// write id as soon as possible
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -1470,6 +1481,7 @@ func (r *Resource) Create(
 			"create role resource",
 			fmt.Sprintf("role %d: failed to read from api", id),
 		)
+		setPartialState(id)
 
 		return
 	}
@@ -1541,6 +1553,7 @@ func (r *Resource) Create(
 			)
 			if diags.HasError() {
 				resp.Diagnostics.Append(diags...)
+				setPartialState(id)
 
 				return
 			}
@@ -1553,6 +1566,7 @@ func (r *Resource) Create(
 			)
 			if diags.HasError() {
 				resp.Diagnostics.Append(diags...)
+				setPartialState(id)
 
 				return
 			}
@@ -1575,6 +1589,7 @@ func (r *Resource) Create(
 						"create role resource",
 						fmt.Sprintf("role %d: permission with code %s not found", id, v.Code.String()),
 					)
+					setPartialState(id)
 
 					return
 				}
@@ -1587,6 +1602,7 @@ func (r *Resource) Create(
 			)
 			if diags.HasError() {
 				resp.Diagnostics.Append(diags...)
+				setPartialState(id)
 
 				return
 			}
@@ -1597,6 +1613,12 @@ func (r *Resource) Create(
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &apiState)...)
 	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(
+			"failed to set role state",
+			fmt.Sprintf("Role %d was created but state could not be saved", id),
+		)
+		setPartialState(id)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/role/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/role/resource.go
@@ -1458,9 +1458,9 @@ func (r *Resource) Create(
 	id := *role.GetRole().Id
 	plan.Id = types.Int64Value(id)
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "role",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -1481,7 +1481,7 @@ func (r *Resource) Create(
 			"create role resource",
 			fmt.Sprintf("role %d: failed to read from api", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -1553,7 +1553,7 @@ func (r *Resource) Create(
 			)
 			if diags.HasError() {
 				resp.Diagnostics.Append(diags...)
-				setPartialState(id)
+				taintResourceState(id)
 
 				return
 			}
@@ -1566,7 +1566,7 @@ func (r *Resource) Create(
 			)
 			if diags.HasError() {
 				resp.Diagnostics.Append(diags...)
-				setPartialState(id)
+				taintResourceState(id)
 
 				return
 			}
@@ -1589,7 +1589,7 @@ func (r *Resource) Create(
 						"create role resource",
 						fmt.Sprintf("role %d: permission with code %s not found", id, v.Code.String()),
 					)
-					setPartialState(id)
+					taintResourceState(id)
 
 					return
 				}
@@ -1602,7 +1602,7 @@ func (r *Resource) Create(
 			)
 			if diags.HasError() {
 				resp.Diagnostics.Append(diags...)
-				setPartialState(id)
+				taintResourceState(id)
 
 				return
 			}
@@ -1617,7 +1617,7 @@ func (r *Resource) Create(
 			"failed to set role state",
 			fmt.Sprintf("Role %d was created but state could not be saved", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/serviceplan/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/serviceplan/resource.go
@@ -485,9 +485,9 @@ func (r *Resource) Create(
 	id := *servicePlan.Id
 	plan.Id = types.Int64Value(id)
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "service_plan",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -508,7 +508,7 @@ func (r *Resource) Create(
 			"failed to read service plan state",
 			fmt.Sprintf("Service plan %d was created but could not be read", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -519,7 +519,7 @@ func (r *Resource) Create(
 			"failed to set service plan state",
 			fmt.Sprintf("Service plan %d was created but state could not be saved", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}

--- a/internal/framework/subproviders/morpheus/resources/serviceplan/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/serviceplan/resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -484,6 +485,16 @@ func (r *Resource) Create(
 	id := *servicePlan.Id
 	plan.Id = types.Int64Value(id)
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "service_plan",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	// write id as soon as possible
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -493,12 +504,23 @@ func (r *Resource) Create(
 	state, diags := getServicePlanAsState(ctx, id, client)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
+		resp.Diagnostics.AddError(
+			"failed to read service plan state",
+			fmt.Sprintf("Service plan %d was created but could not be read", id),
+		)
+		setPartialState(id)
 
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(
+			"failed to set service plan state",
+			fmt.Sprintf("Service plan %d was created but state could not be saved", id),
+		)
+		setPartialState(id)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/user/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/user/resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/convert"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -207,6 +208,16 @@ func (r *Resource) Create(
 	id := *user.GetUser().Id
 	plan.Id = types.Int64Value(id)
 
+	// Helper to set partial state on error
+	setPartialState := func(id int64) {
+		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+			ResourceType: "user",
+			ResourceID:   id,
+			StateWriter:  &resp.State,
+			Diagnostics:  &resp.Diagnostics,
+		})
+	}
+
 	// write id as soon as possible
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -220,6 +231,7 @@ func (r *Resource) Create(
 			"create user resource",
 			fmt.Sprintf("user %d: failed to read from api", id),
 		)
+		setPartialState(id)
 
 		return
 	}
@@ -231,6 +243,12 @@ func (r *Resource) Create(
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
+		resp.Diagnostics.AddError(
+			"failed to set user state",
+			fmt.Sprintf("User %d was created but state could not be saved", id),
+		)
+		setPartialState(id)
+
 		return
 	}
 }

--- a/internal/framework/subproviders/morpheus/resources/user/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/user/resource.go
@@ -208,9 +208,9 @@ func (r *Resource) Create(
 	id := *user.GetUser().Id
 	plan.Id = types.Int64Value(id)
 
-	// Helper to set partial state on error
-	setPartialState := func(id int64) {
-		utils.SetPartialState(ctx, utils.SetPartialStateConfig{
+	// Helper to taint the resource state on an error after the POST request
+	taintResourceState := func(id int64) {
+		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
 			ResourceType: "user",
 			ResourceID:   id,
 			StateWriter:  &resp.State,
@@ -231,7 +231,7 @@ func (r *Resource) Create(
 			"create user resource",
 			fmt.Sprintf("user %d: failed to read from api", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}
@@ -247,7 +247,7 @@ func (r *Resource) Create(
 			"failed to set user state",
 			fmt.Sprintf("User %d was created but state could not be saved", id),
 		)
-		setPartialState(id)
+		taintResourceState(id)
 
 		return
 	}

--- a/internal/framework/utils/resource_cleanup.go
+++ b/internal/framework/utils/resource_cleanup.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// SetPartialStateConfig holds configuration for setting partial state on error.
-type SetPartialStateConfig struct {
+// TaintResourceStateConfig holds configuration for tainting resource state on error.
+type TaintResourceStateConfig struct {
 	// ResourceType is the human-readable name of the resource (e.g. "instance", "cloud")
 	ResourceType string
 	// ResourceID is the ID of the resource that was created
@@ -28,8 +28,8 @@ type State interface {
 	SetAttribute(ctx context.Context, path path.Path, val any) diag.Diagnostics
 }
 
-// SetPartialState sets just the ID in state to mark the resource as tainted.
-func SetPartialState(ctx context.Context, config SetPartialStateConfig) {
+// TaintResourceState sets just the ID in state to mark the resource as tainted.
+func TaintResourceState(ctx context.Context, config TaintResourceStateConfig) {
 	tflog.Warn(ctx, fmt.Sprintf("%s %d created but encountered error - setting partial state with ID only",
 		config.ResourceType, config.ResourceID))
 

--- a/internal/framework/utils/resource_cleanup.go
+++ b/internal/framework/utils/resource_cleanup.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -124,61 +126,60 @@ func CleanupResourceOnError(ctx context.Context, config CleanupConfig) {
 
 // SetPartialStateConfig holds configuration for setting partial state on error.
 type SetPartialStateConfig struct {
-	// ResourceType is the human-readable name of the resource
+	// ResourceType is the human-readable name of the resource (e.g. "instance", "cloud")
 	ResourceType string
-	// ResourceID is the ID of the resource
+	// ResourceID is the ID of the resource that was created
 	ResourceID int64
-	// State is the state object to set (must have an Id field)
-	State any
-	// StateWriter is the response state to write to
-	StateWriter any // Should be *resource.CreateResponse.State or similar
-	// Diagnostics is where to add errors/warnings
+	// StateWriter is the response state to write to (resource.CreateResponse.State)
+	StateWriter State
+	// Diagnostics is where to add warnings (errors should already be added before calling this)
 	Diagnostics *diag.Diagnostics
-	// ErrorTitle is the title of the error to add
-	ErrorTitle string
-	// ErrorDetail is the detailed error message
-	ErrorDetail string
 }
 
-// SetStateSetter is an interface for setting state (implemented by resource.CreateResponse.State)
-type SetStateSetter interface {
+// State is an interface for state operations (implemented by resource.CreateResponse.State)
+type State interface {
 	Set(ctx context.Context, val any) diag.Diagnostics
+	SetAttribute(ctx context.Context, path path.Path, val any) diag.Diagnostics
 }
 
-// SetPartialStateAndError sets minimal state (just ID) and returns an error.
-// This implements "Option 3" - let Terraform handle cleanup by marking the resource as tainted.
+// SetPartialState sets just the ID in state to mark the resource as tainted.
+// This implements "Option 3" - let Terraform handle cleanup by tainting the resource.
+// Uses SetAttribute to set only the ID field, which works even when diagnostics has errors.
+//
+// Call this AFTER adding your error to diagnostics. This function only sets the ID and adds
+// a warning about the tainted resource - it does not add the error itself.
 //
 // Usage example:
 //
-//	partialState := InstanceModel{
-//	    Id: convert.Int64ToType(instanceId),
-//	    // All other fields will be null/zero
-//	}
-//	utils.SetPartialStateAndError(ctx, utils.SetPartialStateConfig{
+//	resp.Diagnostics.AddError(
+//	    "instance provisioning failed",
+//	    fmt.Sprintf("Instance %d failed to reach running status", instanceId),
+//	)
+//	utils.SetPartialState(ctx, utils.SetPartialStateConfig{
 //	    ResourceType: "instance",
-//	    ResourceID: instanceId,
-//	    State: &partialState,
-//	    StateWriter: resp.State,
-//	    Diagnostics: &resp.Diagnostics,
-//	    ErrorTitle: "instance provisioning failed",
-//	    ErrorDetail: fmt.Sprintf("Instance %d failed to reach running status", instanceId),
+//	    ResourceID:   instanceId,
+//	    StateWriter:  resp.State,
+//	    Diagnostics:  &resp.Diagnostics,
 //	})
-func SetPartialStateAndError(ctx context.Context, config SetPartialStateConfig) {
-	tflog.Warn(ctx, fmt.Sprintf("%s %d: %s - setting partial state with ID only",
-		config.ResourceType, config.ResourceID, config.ErrorTitle))
+//	return
+func SetPartialState(ctx context.Context, config SetPartialStateConfig) {
+	tflog.Warn(ctx, fmt.Sprintf("%s %d created but encountered error - setting partial state with ID only",
+		config.ResourceType, config.ResourceID))
 
-	// Set the partial state
-	if setter, ok := config.StateWriter.(SetStateSetter); ok {
-		setDiags := setter.Set(ctx, config.State)
-		config.Diagnostics.Append(setDiags...)
+	// Set ONLY the ID using SetAttribute - this works even when returning errors
+	// Unlike State.Set() which is ignored on error, SetAttribute can set individual fields
+	// IMPORTANT: Must convert int64 to types.Int64 - raw primitives don't work!
+	setDiags := config.StateWriter.SetAttribute(ctx, path.Root("id"), types.Int64Value(config.ResourceID))
+	config.Diagnostics.Append(setDiags...)
+	if setDiags.HasError() {
+		tflog.Error(ctx, fmt.Sprintf("Failed to set ID attribute: %v", setDiags))
+	} else {
+		tflog.Info(ctx, fmt.Sprintf("Successfully set ID attribute to %d", config.ResourceID))
 	}
-
-	// Add the original error
-	config.Diagnostics.AddError(config.ErrorTitle, config.ErrorDetail)
 
 	// Add helpful guidance to the user
 	config.Diagnostics.AddWarning(
-		fmt.Sprintf("%s partially created", config.ResourceType),
+		fmt.Sprintf("%s partially created", capitalize(config.ResourceType)),
 		fmt.Sprintf("%s %d was created but could not be fully configured. "+
 			"The resource has been marked as tainted. "+
 			"On the next 'terraform apply', Terraform will destroy and recreate this %s. "+

--- a/internal/framework/utils/resource_cleanup.go
+++ b/internal/framework/utils/resource_cleanup.go
@@ -34,8 +34,6 @@ func SetPartialState(ctx context.Context, config SetPartialStateConfig) {
 		config.ResourceType, config.ResourceID))
 
 	// Set ONLY the ID using SetAttribute - this works even when returning errors
-	// Unlike State.Set() which is ignored on error, SetAttribute can set individual fields
-	// IMPORTANT: Must convert int64 to types.Int64 - raw primitives don't work!
 	setDiags := config.StateWriter.SetAttribute(ctx, path.Root("id"), types.Int64Value(config.ResourceID))
 	config.Diagnostics.Append(setDiags...)
 	if setDiags.HasError() {

--- a/internal/framework/utils/resource_cleanup.go
+++ b/internal/framework/utils/resource_cleanup.go
@@ -1,0 +1,198 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// DeleteFunc defines a function that deletes a resource by ID.
+// It should return the HTTP response and any error encountered.
+type DeleteFunc func(ctx context.Context, id int64) (*http.Response, error)
+
+// GetFunc defines a function that retrieves a resource by ID.
+// It should return the HTTP response and any error encountered.
+type GetFunc func(ctx context.Context, id int64) (resp *http.Response, err error)
+
+// CleanupConfig holds configuration for resource cleanup on error.
+type CleanupConfig struct {
+	// ResourceType is the human-readable name of the resource (e.g., "instance", "network")
+	ResourceType string
+	// ResourceID is the ID of the resource to clean up
+	ResourceID int64
+	// DeleteFunc is the function that performs the deletion
+	DeleteFunc DeleteFunc
+	// GetFunc is the function that checks if the resource still exists
+	GetFunc GetFunc
+	// Timeout is how long to wait for cleanup (default: 10 minutes)
+	Timeout time.Duration
+	// Diagnostics is where to add warnings/errors during cleanup
+	Diagnostics *diag.Diagnostics
+}
+
+// CleanupResourceOnError attempts to delete a resource that was created but couldn't be fully configured.
+// This implements "Option 2" - clean up after ourselves by deleting partially-created resources.
+//
+// Usage example:
+//
+//	cleanup := utils.CleanupConfig{
+//	    ResourceType: "instance",
+//	    ResourceID: instanceId,
+//	    DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
+//	        _, resp, err := client.InstancesAPI.DeleteInstance(ctx, id).Execute()
+//	        return resp, err
+//	    },
+//	    GetFunc: func(ctx context.Context, id int64) (string, *http.Response, error) {
+//	        instance, resp, err := client.InstancesAPI.GetInstance(ctx, id).Execute()
+//	        if err != nil {
+//	            return "", resp, err
+//	        }
+//	        return instance.Instance.GetStatus(), resp, nil
+//	    },
+//	    Diagnostics: &resp.Diagnostics,
+//	}
+//	utils.CleanupResourceOnError(ctx, cleanup)
+func CleanupResourceOnError(ctx context.Context, config CleanupConfig) {
+	if config.Timeout == 0 {
+		config.Timeout = 10 * time.Minute
+	}
+
+	tflog.Warn(ctx, fmt.Sprintf("%s %d: creation failed, attempting cleanup by deleting",
+		config.ResourceType, config.ResourceID))
+
+	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), config.Timeout)
+	defer deleteCancel()
+
+	// Attempt to delete the resource
+	delResp, delErr := config.DeleteFunc(deleteCtx, config.ResourceID)
+	if delErr != nil || (delResp != nil && delResp.StatusCode != http.StatusOK) {
+		tflog.Error(ctx, fmt.Sprintf("%s %d: failed to delete during error cleanup: %v",
+			config.ResourceType, config.ResourceID, delErr))
+		config.Diagnostics.AddWarning(
+			fmt.Sprintf("failed to clean up %s after error", config.ResourceType),
+			fmt.Sprintf("%s %d was created but subsequent operations failed. "+
+				"Attempted to delete the %s but deletion also failed. "+
+				"You may need to manually delete %s %d. Error: %v",
+				capitalize(config.ResourceType), config.ResourceID,
+				config.ResourceType,
+				config.ResourceType, config.ResourceID, delErr),
+		)
+		return
+	}
+
+	// Wait for deletion to complete
+	waitForDelete := func() (string, error) {
+		getHttpResp, getErr := config.GetFunc(deleteCtx, config.ResourceID)
+		if getHttpResp != nil && getHttpResp.StatusCode == http.StatusNotFound {
+			// Resource is gone, success!
+			return "deleted", nil
+		}
+		if getErr != nil {
+			// Some other error, keep trying
+			return "", nil
+		}
+		// Resource still exists
+		return "exists", nil
+	}
+
+	if _, waitErr := backoff.Retry(
+		deleteCtx,
+		waitForDelete,
+		backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)),
+		backoff.WithMaxElapsedTime(config.Timeout),
+	); waitErr != nil {
+		tflog.Error(ctx, fmt.Sprintf("%s %d: timed out waiting for deletion during cleanup",
+			config.ResourceType, config.ResourceID))
+		config.Diagnostics.AddWarning(
+			fmt.Sprintf("failed to confirm %s deletion after error", config.ResourceType),
+			fmt.Sprintf("%s %d was created but subsequent operations failed. "+
+				"Deletion was initiated but we couldn't confirm completion. "+
+				"You may need to manually verify/delete %s %d.",
+				capitalize(config.ResourceType), config.ResourceID,
+				config.ResourceType, config.ResourceID),
+		)
+	} else {
+		tflog.Info(ctx, fmt.Sprintf("%s %d: successfully deleted during error cleanup",
+			config.ResourceType, config.ResourceID))
+	}
+}
+
+// SetPartialStateConfig holds configuration for setting partial state on error.
+type SetPartialStateConfig struct {
+	// ResourceType is the human-readable name of the resource
+	ResourceType string
+	// ResourceID is the ID of the resource
+	ResourceID int64
+	// State is the state object to set (must have an Id field)
+	State any
+	// StateWriter is the response state to write to
+	StateWriter any // Should be *resource.CreateResponse.State or similar
+	// Diagnostics is where to add errors/warnings
+	Diagnostics *diag.Diagnostics
+	// ErrorTitle is the title of the error to add
+	ErrorTitle string
+	// ErrorDetail is the detailed error message
+	ErrorDetail string
+}
+
+// SetStateSetter is an interface for setting state (implemented by resource.CreateResponse.State)
+type SetStateSetter interface {
+	Set(ctx context.Context, val any) diag.Diagnostics
+}
+
+// SetPartialStateAndError sets minimal state (just ID) and returns an error.
+// This implements "Option 3" - let Terraform handle cleanup by marking the resource as tainted.
+//
+// Usage example:
+//
+//	partialState := InstanceModel{
+//	    Id: convert.Int64ToType(instanceId),
+//	    // All other fields will be null/zero
+//	}
+//	utils.SetPartialStateAndError(ctx, utils.SetPartialStateConfig{
+//	    ResourceType: "instance",
+//	    ResourceID: instanceId,
+//	    State: &partialState,
+//	    StateWriter: resp.State,
+//	    Diagnostics: &resp.Diagnostics,
+//	    ErrorTitle: "instance provisioning failed",
+//	    ErrorDetail: fmt.Sprintf("Instance %d failed to reach running status", instanceId),
+//	})
+func SetPartialStateAndError(ctx context.Context, config SetPartialStateConfig) {
+	tflog.Warn(ctx, fmt.Sprintf("%s %d: %s - setting partial state with ID only",
+		config.ResourceType, config.ResourceID, config.ErrorTitle))
+
+	// Set the partial state
+	if setter, ok := config.StateWriter.(SetStateSetter); ok {
+		setDiags := setter.Set(ctx, config.State)
+		config.Diagnostics.Append(setDiags...)
+	}
+
+	// Add the original error
+	config.Diagnostics.AddError(config.ErrorTitle, config.ErrorDetail)
+
+	// Add helpful guidance to the user
+	config.Diagnostics.AddWarning(
+		fmt.Sprintf("%s partially created", config.ResourceType),
+		fmt.Sprintf("%s %d was created but could not be fully configured. "+
+			"The resource has been marked as tainted. "+
+			"On the next 'terraform apply', Terraform will destroy and recreate this %s. "+
+			"If you want to keep this %s, you can import it manually: "+
+			"'terraform import <resource_type>.<name> %d'",
+			capitalize(config.ResourceType), config.ResourceID,
+			config.ResourceType,
+			config.ResourceType, config.ResourceID),
+	)
+}
+
+func capitalize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return string(s[0]-32) + s[1:]
+}

--- a/internal/framework/utils/resource_cleanup.go
+++ b/internal/framework/utils/resource_cleanup.go
@@ -3,126 +3,12 @@ package utils
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"time"
 
-	"github.com/cenkalti/backoff/v5"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
-
-// DeleteFunc defines a function that deletes a resource by ID.
-// It should return the HTTP response and any error encountered.
-type DeleteFunc func(ctx context.Context, id int64) (*http.Response, error)
-
-// GetFunc defines a function that retrieves a resource by ID.
-// It should return the HTTP response and any error encountered.
-type GetFunc func(ctx context.Context, id int64) (resp *http.Response, err error)
-
-// CleanupConfig holds configuration for resource cleanup on error.
-type CleanupConfig struct {
-	// ResourceType is the human-readable name of the resource (e.g., "instance", "network")
-	ResourceType string
-	// ResourceID is the ID of the resource to clean up
-	ResourceID int64
-	// DeleteFunc is the function that performs the deletion
-	DeleteFunc DeleteFunc
-	// GetFunc is the function that checks if the resource still exists
-	GetFunc GetFunc
-	// Timeout is how long to wait for cleanup (default: 10 minutes)
-	Timeout time.Duration
-	// Diagnostics is where to add warnings/errors during cleanup
-	Diagnostics *diag.Diagnostics
-}
-
-// CleanupResourceOnError attempts to delete a resource that was created but couldn't be fully configured.
-// This implements "Option 2" - clean up after ourselves by deleting partially-created resources.
-//
-// Usage example:
-//
-//	cleanup := utils.CleanupConfig{
-//	    ResourceType: "instance",
-//	    ResourceID: instanceId,
-//	    DeleteFunc: func(ctx context.Context, id int64) (*http.Response, error) {
-//	        _, resp, err := client.InstancesAPI.DeleteInstance(ctx, id).Execute()
-//	        return resp, err
-//	    },
-//	    GetFunc: func(ctx context.Context, id int64) (string, *http.Response, error) {
-//	        instance, resp, err := client.InstancesAPI.GetInstance(ctx, id).Execute()
-//	        if err != nil {
-//	            return "", resp, err
-//	        }
-//	        return instance.Instance.GetStatus(), resp, nil
-//	    },
-//	    Diagnostics: &resp.Diagnostics,
-//	}
-//	utils.CleanupResourceOnError(ctx, cleanup)
-func CleanupResourceOnError(ctx context.Context, config CleanupConfig) {
-	if config.Timeout == 0 {
-		config.Timeout = 10 * time.Minute
-	}
-
-	tflog.Warn(ctx, fmt.Sprintf("%s %d: creation failed, attempting cleanup by deleting",
-		config.ResourceType, config.ResourceID))
-
-	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), config.Timeout)
-	defer deleteCancel()
-
-	// Attempt to delete the resource
-	delResp, delErr := config.DeleteFunc(deleteCtx, config.ResourceID)
-	if delErr != nil || (delResp != nil && delResp.StatusCode != http.StatusOK) {
-		tflog.Error(ctx, fmt.Sprintf("%s %d: failed to delete during error cleanup: %v",
-			config.ResourceType, config.ResourceID, delErr))
-		config.Diagnostics.AddWarning(
-			fmt.Sprintf("failed to clean up %s after error", config.ResourceType),
-			fmt.Sprintf("%s %d was created but subsequent operations failed. "+
-				"Attempted to delete the %s but deletion also failed. "+
-				"You may need to manually delete %s %d. Error: %v",
-				capitalize(config.ResourceType), config.ResourceID,
-				config.ResourceType,
-				config.ResourceType, config.ResourceID, delErr),
-		)
-		return
-	}
-
-	// Wait for deletion to complete
-	waitForDelete := func() (string, error) {
-		getHttpResp, getErr := config.GetFunc(deleteCtx, config.ResourceID)
-		if getHttpResp != nil && getHttpResp.StatusCode == http.StatusNotFound {
-			// Resource is gone, success!
-			return "deleted", nil
-		}
-		if getErr != nil {
-			// Some other error, keep trying
-			return "", nil
-		}
-		// Resource still exists
-		return "exists", nil
-	}
-
-	if _, waitErr := backoff.Retry(
-		deleteCtx,
-		waitForDelete,
-		backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)),
-		backoff.WithMaxElapsedTime(config.Timeout),
-	); waitErr != nil {
-		tflog.Error(ctx, fmt.Sprintf("%s %d: timed out waiting for deletion during cleanup",
-			config.ResourceType, config.ResourceID))
-		config.Diagnostics.AddWarning(
-			fmt.Sprintf("failed to confirm %s deletion after error", config.ResourceType),
-			fmt.Sprintf("%s %d was created but subsequent operations failed. "+
-				"Deletion was initiated but we couldn't confirm completion. "+
-				"You may need to manually verify/delete %s %d.",
-				capitalize(config.ResourceType), config.ResourceID,
-				config.ResourceType, config.ResourceID),
-		)
-	} else {
-		tflog.Info(ctx, fmt.Sprintf("%s %d: successfully deleted during error cleanup",
-			config.ResourceType, config.ResourceID))
-	}
-}
 
 // SetPartialStateConfig holds configuration for setting partial state on error.
 type SetPartialStateConfig struct {
@@ -143,25 +29,6 @@ type State interface {
 }
 
 // SetPartialState sets just the ID in state to mark the resource as tainted.
-// This implements "Option 3" - let Terraform handle cleanup by tainting the resource.
-// Uses SetAttribute to set only the ID field, which works even when diagnostics has errors.
-//
-// Call this AFTER adding your error to diagnostics. This function only sets the ID and adds
-// a warning about the tainted resource - it does not add the error itself.
-//
-// Usage example:
-//
-//	resp.Diagnostics.AddError(
-//	    "instance provisioning failed",
-//	    fmt.Sprintf("Instance %d failed to reach running status", instanceId),
-//	)
-//	utils.SetPartialState(ctx, utils.SetPartialStateConfig{
-//	    ResourceType: "instance",
-//	    ResourceID:   instanceId,
-//	    StateWriter:  resp.State,
-//	    Diagnostics:  &resp.Diagnostics,
-//	})
-//	return
 func SetPartialState(ctx context.Context, config SetPartialStateConfig) {
 	tflog.Warn(ctx, fmt.Sprintf("%s %d created but encountered error - setting partial state with ID only",
 		config.ResourceType, config.ResourceID))
@@ -179,21 +46,14 @@ func SetPartialState(ctx context.Context, config SetPartialStateConfig) {
 
 	// Add helpful guidance to the user
 	config.Diagnostics.AddWarning(
-		fmt.Sprintf("%s partially created", capitalize(config.ResourceType)),
+		fmt.Sprintf("%s partially created", config.ResourceType),
 		fmt.Sprintf("%s %d was created but could not be fully configured. "+
 			"The resource has been marked as tainted. "+
 			"On the next 'terraform apply', Terraform will destroy and recreate this %s. "+
 			"If you want to keep this %s, you can import it manually: "+
 			"'terraform import <resource_type>.<name> %d'",
-			capitalize(config.ResourceType), config.ResourceID,
+			config.ResourceType, config.ResourceID,
 			config.ResourceType,
 			config.ResourceType, config.ResourceID),
 	)
-}
-
-func capitalize(s string) string {
-	if len(s) == 0 {
-		return s
-	}
-	return string(s[0]-32) + s[1:]
 }


### PR DESCRIPTION
This commit introduces utility functions for assisting in removing resources should there
be any errors on creation to avoid dangling resources.
- Added the following functions to utils/resource_cleanup.go
  ~~- CleanupResourceOnError: cleans up the resource~~ - sticking with the tainting appraoch
  - TaintResourceState: taints the resource

TaintResourceState has been applied for all resources so that the resource is tainted should Create fail post-creation.
Also updated some errors to make it clearer that a resource has been created.