### PR TITLE
Update render path of Instance Terraform template

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -35,7 +35,7 @@ resource "hpe_morpheus_instance" "example" {
   name             = "TestInstance"
   cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
   layout_id        = 5385                                 # Single KVM VM
-  instance_type_id = 9                  # (HVM) mvm-cluster
+  instance_type_id = 9                                    # (HVM) mvm-cluster
   layout_size      = 1
 
   group_id = 1

--- a/examples/resources/morpheus_instance/example.tf
+++ b/examples/resources/morpheus_instance/example.tf
@@ -11,7 +11,7 @@ resource "hpe_morpheus_instance" "example" {
   name             = "TestInstance"
   cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
   layout_id        = 5385                                 # Single KVM VM
-  instance_type_id = 9                  # (HVM) mvm-cluster
+  instance_type_id = 9                                    # (HVM) mvm-cluster
   layout_size      = 1
 
   group_id = 1

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_example.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_example.go
@@ -1,0 +1,5 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package instance
+
+//go:generate go run ../../../../../../cmd/render -out examples/resources/morpheus_instance/example.tf example.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"

--- a/internal/framework/subproviders/morpheus/resources/instance/resource_test.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/resource_test.go
@@ -1,7 +1,5 @@
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
-//go:generate go run ../../../../../../cmd/render example.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
-
 package instance_test
 
 import (

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -21,6 +21,6 @@ supported.
 
 ## Example Usage
 
-{{ tffile "internal/framework/subproviders/morpheus/resources/instance/example.tf" }}
+{{ tffile "examples/resources/morpheus_instance/example.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Updates the path where the instance example gets rendered to `examples/resources/morpheus_instance`.

Adds an `instance_example.go` file to hold the `go:generate` statement.

This is for uniformity with other resources.
