### PR TITLE
Tidy formatting of RenderConfig functions

### DIFF
--- a/internal/sdkv2/morpheus/resources/automation/hpe_morpheus_execute_schedule_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/automation/hpe_morpheus_execute_schedule_resource_test.go
@@ -47,11 +47,9 @@ func TestAccMorpheusExecuteScheduleExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := automation.RenderExecuteScheduleConfig(
-		t,
-		name,
-		map[string]string{},
-	)
+	resourceConfig, err := automation.RenderExecuteScheduleConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/automation/morpheus_execute_schedule_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/automation/morpheus_execute_schedule_resource_example.go
@@ -13,15 +13,11 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_execute_schedule/resource.tf hpe_morpheus_execute_schedule_resource.tf.tmpl Name "Run daily at 7 AM" Description "This schedule runs daily at 7 AM Mountain Time" Enabled false TimeZone "America/Denver" Schedule "7 0 * * *"
 
-func RenderExecuteScheduleConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderExecuteScheduleConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":        name,
+		"Name":        "Example",
 		"Description": "This schedule runs daily at 7 AM Mountain Time",
 		"Enabled":     "false",
 		"TimeZone":    "America/Denver",
@@ -30,6 +26,11 @@ func RenderExecuteScheduleConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -43,10 +44,6 @@ func RenderExecuteScheduleConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"TimeZone", defaults["TimeZone"],
-		"Schedule", defaults["Schedule"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/automation/morpheus_scale_threshold_example.go
+++ b/internal/sdkv2/morpheus/resources/automation/morpheus_scale_threshold_example.go
@@ -13,15 +13,11 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_scale_threshold/resource.tf morpheus_scale_threshold_resource.tf.tmpl Name example_scale_threshold AutoUpscale true AutoDownscale true MinCount 1 MaxCount 3 EnableCpuThreshold true MinCpuPercentage 30.0 MaxCpuPercentage 75.0 EnableMemoryThreshold true MinMemoryPercentage 20.0 MaxMemoryPercentage 60.0 EnableDiskThreshold true MinDiskPercentage 25.0 MaxDiskPercentage 80.0
 
-func RenderScaleThresholdConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderScaleThresholdConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                  name,
+		"Name":                  "Example",
 		"AutoUpscale":           "true",
 		"AutoDownscale":         "true",
 		"MinCount":              "1",
@@ -37,8 +33,13 @@ func RenderScaleThresholdConfig(
 		"MaxDiskPercentage":     "80.0",
 	}
 
-	for k, v := range overrides {
-		defaults[k] = v
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -52,19 +53,6 @@ func RenderScaleThresholdConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"AutoUpscale", defaults["AutoUpscale"],
-		"AutoDownscale", defaults["AutoDownscale"],
-		"MinCount", defaults["MinCount"],
-		"MaxCount", defaults["MaxCount"],
-		"EnableCpuThreshold", defaults["EnableCpuThreshold"],
-		"MinCpuPercentage", defaults["MinCpuPercentage"],
-		"MaxCpuPercentage", defaults["MaxCpuPercentage"],
-		"EnableMemoryThreshold", defaults["EnableMemoryThreshold"],
-		"MinMemoryPercentage", defaults["MinMemoryPercentage"],
-		"MaxMemoryPercentage", defaults["MaxMemoryPercentage"],
-		"EnableDiskThreshold", defaults["EnableDiskThreshold"],
-		"MinDiskPercentage", defaults["MinDiskPercentage"],
-		"MaxDiskPercentage", defaults["MaxDiskPercentage"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/automation/morpheus_scale_threshold_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/automation/morpheus_scale_threshold_resource_test.go
@@ -25,11 +25,9 @@ func TestAccMorpheusScaleThresholdExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := automation.RenderScaleThresholdConfig(
-		t,
-		name,
-		map[string]string{},
-	)
+	resourceConfig, err := automation.RenderScaleThresholdConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/blueprint/morpheus_instance_type_example.go
+++ b/internal/sdkv2/morpheus/resources/blueprint/morpheus_instance_type_example.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
@@ -14,16 +13,12 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_instance_type/resource.tf morpheus_instance_type_resource.tf.tmpl Name "tf_example_instance" Code "tf_example_instance" Description "Terraform Example Instance Type" Labels "[\"demo\", \"instance\", \"terraform\"]" Category "web" Visibility "private" ImagePath "tfexample.png" ImageName "tfexample.png" Featured "false" EnableDeployments "true" EnableScaling "true" EnableSettings "true" EnvironmentPrefix "TFEXAMPLE_DEMO" OptionTypeIds "[1910, 1912]" EvarFirstName "first" EvarFirstValue "first" EvarFirstExport "true" EvarSecondName "second" EvarSecondMaskedValue "second" EvarSecondExport "false"
 
-func RenderInstanceTypeConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderInstanceTypeConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                  name,
-		"Code":                  strings.ToLower(name),
+		"Name":                  "Example",
+		"Code":                  "example",
 		"Description":           "Terraform Example Instance Type",
 		"Labels":                `["demo", "instance", "terraform"]`,
 		"Category":              "web",
@@ -44,8 +39,13 @@ func RenderInstanceTypeConfig(
 		"EvarSecondExport":      "false",
 	}
 
-	for k, v := range overrides {
-		defaults[k] = v
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -59,25 +59,6 @@ func RenderInstanceTypeConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Description", defaults["Description"],
-		"Labels", defaults["Labels"],
-		"Category", defaults["Category"],
-		"Visibility", defaults["Visibility"],
-		"ImagePath", defaults["ImagePath"],
-		"ImageName", defaults["ImageName"],
-		"Featured", defaults["Featured"],
-		"EnableDeployments", defaults["EnableDeployments"],
-		"EnableScaling", defaults["EnableScaling"],
-		"EnableSettings", defaults["EnableSettings"],
-		"EnvironmentPrefix", defaults["EnvironmentPrefix"],
-		"OptionTypeIds", defaults["OptionTypeIds"],
-		"EvarFirstName", defaults["EvarFirstName"],
-		"EvarFirstValue", defaults["EvarFirstValue"],
-		"EvarFirstExport", defaults["EvarFirstExport"],
-		"EvarSecondName", defaults["EvarSecondName"],
-		"EvarSecondMaskedValue", defaults["EvarSecondMaskedValue"],
-		"EvarSecondExport", defaults["EvarSecondExport"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/blueprint/morpheus_instance_type_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/blueprint/morpheus_instance_type_resource_test.go
@@ -49,7 +49,9 @@ func TestAccMorpheusInstanceTypeExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := blueprint.RenderInstanceTypeConfig(t, name, map[string]string{})
+	resourceConfig, err := blueprint.RenderInstanceTypeConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/catalogitem/morpheus_catalog_item_instance_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/catalogitem/morpheus_catalog_item_instance_resource_example.go
@@ -15,15 +15,11 @@ import (
 
 // RenderCatalogItemInstanceConfig generates a Terraform configuration for catalog item instance resource.
 // It accepts a name and a map of field overrides to customize the default values.
-func RenderCatalogItemInstanceConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderCatalogItemInstanceConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":        name,
+		"Name":        "Example",
 		"Config":      "{\"name\":\"test\"}",
 		"Content":     "{\"name\":\"test\"}",
 		"Description": "terraform example instance catalog item",
@@ -38,6 +34,11 @@ func RenderCatalogItemInstanceConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -49,14 +50,6 @@ func RenderCatalogItemInstanceConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Config", defaults["Config"],
-		"Content", defaults["Content"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Featured", defaults["Featured"],
-		"ImageName", defaults["ImageName"],
-		"ImagePath", defaults["ImagePath"],
-		"Visibility", defaults["Visibility"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/catalogitem/morpheus_catalog_item_instance_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/catalogitem/morpheus_catalog_item_instance_resource_test.go
@@ -48,7 +48,9 @@ func TestAccMorpheusCatalogItemInstanceExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := catalogitem.RenderCatalogItemInstanceConfig(t, name, map[string]string{})
+	resourceConfig, err := catalogitem.RenderCatalogItemInstanceConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/contact/contact_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/contact/contact_resource_test.go
@@ -48,7 +48,9 @@ func TestAccMorpheusContactExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := contact.RenderContactConfig(t, name, map[string]string{})
+	resourceConfig, err := contact.RenderContactConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/contact/morpheus_contact_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/contact/morpheus_contact_resource_example.go
@@ -15,21 +15,22 @@ import (
 
 // RenderContactConfig renders the contact resource configuration with
 // optional field overrides
-func RenderContactConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderContactConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":         name,
+		"Name":         "Example",
 		"EmailAddress": "tfcontact@demo.com",
 		"MobileNumber": "123-456-7890",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -43,8 +44,6 @@ func RenderContactConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"EmailAddress", defaults["EmailAddress"],
-		"MobileNumber", defaults["MobileNumber"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/credential/morpheus_credential_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/credential/morpheus_credential_resource_example.go
@@ -21,10 +21,7 @@ import (
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_credential/resource_email_private_key.tf credential_resource_email_private_key.tf.tmpl Name "tf_example_credential_email_private_key" Description "terraform credential example for email private key" Enabled "true" Type "email-private-key" Email "test@example.local" KeyPairId "33"
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_credential/resource_client_id_secret.tf credential_resource_client_id_secret.tf.tmpl Name "tf_example_credential_client_id_secret" Description "terraform credential example for client id secret" Enabled "true" Type "client-id-secret" ClientId "FIEFMIQNQ" ClientSecret "MMEWMIFINWEINFINE"
 
-func RenderCredentialTenantUsernameKeypairConfig(
-	t *testing.T,
-	overrides map[string]string,
-) (string, error) {
+func RenderCredentialTenantUsernameKeypairConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
@@ -40,6 +37,11 @@ func RenderCredentialTenantUsernameKeypairConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -51,20 +53,11 @@ func RenderCredentialTenantUsernameKeypairConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"Tenant", defaults["Tenant"],
-		"Username", defaults["Username"],
-		"KeyPairId", defaults["KeyPairId"],
+		args...,
 	)
 }
 
-func RenderCredentialClientIdSecretConfig(
-	t *testing.T,
-	overrides map[string]string,
-) (string, error) {
+func RenderCredentialClientIdSecretConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
@@ -79,6 +72,11 @@ func RenderCredentialClientIdSecretConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -90,19 +88,11 @@ func RenderCredentialClientIdSecretConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"ClientId", defaults["ClientId"],
-		"ClientSecret", defaults["ClientSecret"],
+		args...,
 	)
 }
 
-func RenderCredentialUsernameApiKeyConfig(
-	t *testing.T,
-	overrides map[string]string,
-) (string, error) {
+func RenderCredentialUsernameApiKeyConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
@@ -117,6 +107,11 @@ func RenderCredentialUsernameApiKeyConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -128,19 +123,11 @@ func RenderCredentialUsernameApiKeyConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"Username", defaults["Username"],
-		"ApiKey", defaults["ApiKey"],
+		args...,
 	)
 }
 
-func RenderCredentialUsernamePasswordKeypairConfig(
-	t *testing.T,
-	overrides map[string]string,
-) (string, error) {
+func RenderCredentialUsernamePasswordKeypairConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
@@ -156,6 +143,11 @@ func RenderCredentialUsernamePasswordKeypairConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -167,20 +159,11 @@ func RenderCredentialUsernamePasswordKeypairConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"Username", defaults["Username"],
-		"Password", defaults["Password"],
-		"KeyPairId", defaults["KeyPairId"],
+		args...,
 	)
 }
 
-func RenderCredentialAccessKeySecretConfig(
-	t *testing.T,
-	overrides map[string]string,
-) (string, error) {
+func RenderCredentialAccessKeySecretConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
@@ -195,6 +178,11 @@ func RenderCredentialAccessKeySecretConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -206,12 +194,7 @@ func RenderCredentialAccessKeySecretConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"AccessKey", defaults["AccessKey"],
-		"SecretKey", defaults["SecretKey"],
+		args...,
 	)
 }
 
@@ -229,6 +212,11 @@ func RenderCredentialApiKeyConfig(t *testing.T, overrides map[string]string) (st
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -240,18 +228,11 @@ func RenderCredentialApiKeyConfig(t *testing.T, overrides map[string]string) (st
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"ApiKey", defaults["ApiKey"],
+		args...,
 	)
 }
 
-func RenderCredentialUsernameKeypairConfig(
-	t *testing.T,
-	overrides map[string]string,
-) (string, error) {
+func RenderCredentialUsernameKeypairConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
@@ -266,6 +247,11 @@ func RenderCredentialUsernameKeypairConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -277,19 +263,11 @@ func RenderCredentialUsernameKeypairConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"Username", defaults["Username"],
-		"KeyPairId", defaults["KeyPairId"],
+		args...,
 	)
 }
 
-func RenderCredentialUsernamePasswordConfig(
-	t *testing.T,
-	overrides map[string]string,
-) (string, error) {
+func RenderCredentialUsernamePasswordConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
@@ -304,6 +282,11 @@ func RenderCredentialUsernamePasswordConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -315,19 +298,11 @@ func RenderCredentialUsernamePasswordConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"Username", defaults["Username"],
-		"Password", defaults["Password"],
+		args...,
 	)
 }
 
-func RenderCredentialEmailPrivateKeyConfig(
-	t *testing.T,
-	overrides map[string]string,
-) (string, error) {
+func RenderCredentialEmailPrivateKeyConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
@@ -342,6 +317,11 @@ func RenderCredentialEmailPrivateKeyConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -353,11 +333,6 @@ func RenderCredentialEmailPrivateKeyConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Enabled", defaults["Enabled"],
-		"Type", defaults["Type"],
-		"Email", defaults["Email"],
-		"KeyPairId", defaults["KeyPairId"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/cypher/hpe_morpheus_cypher_tfvars_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/cypher/hpe_morpheus_cypher_tfvars_resource_test.go
@@ -48,7 +48,9 @@ func TestAccMorpheusCypherTfvarsExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := cypher.RenderCypherTfvarsConfig(t, name, map[string]string{})
+	resourceConfig, err := cypher.RenderCypherTfvarsConfig(t, map[string]string{
+		"Key": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/cypher/morpheus_cypher_secret_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/cypher/morpheus_cypher_secret_resource_example.go
@@ -15,16 +15,12 @@ import (
 
 // RenderCypherSecretConfig generates a Terraform configuration
 // for the hpe_morpheus_cypher_secret resource from the template file.
-func RenderCypherSecretConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderCypherSecretConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	// Default field values
 	defaults := map[string]string{
-		"Key":   name,
+		"Key":   "Example",
 		"Value": "password123",
 		"Ttl":   "86400",
 	}
@@ -32,6 +28,11 @@ func RenderCypherSecretConfig(
 	// Apply overrides to defaults
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -42,10 +43,9 @@ func RenderCypherSecretConfig(
 	dir := filepath.Dir(filename)
 	templatePath := filepath.Join(dir, "morpheus_cypher_secret_resource_tf.tmpl")
 
-	return testhelpers.RenderExample(t,
+	return testhelpers.RenderExample(
+		t,
 		templatePath,
-		"Key", defaults["Key"],
-		"Value", defaults["Value"],
-		"Ttl", defaults["Ttl"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/cypher/morpheus_cypher_secret_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/cypher/morpheus_cypher_secret_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusCypherSecretExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := cypher.RenderCypherSecretConfig(t, name, nil)
+	resourceConfig, err := cypher.RenderCypherSecretConfig(t, map[string]string{
+		"Key": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/cypher/morpheus_cypher_tfvars_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/cypher/morpheus_cypher_tfvars_resource_example.go
@@ -13,21 +13,22 @@ import (
 
 //go:generate sh -c "go run ../../../../../cmd/render -out examples/resources/morpheus_cypher_tfvars/resource.tf hpe_morpheus_cypher_tfvars_resource.tf.tmpl Key securetfvars Value 'account=12345\npassword=supersecure' Ttl 86400"
 
-func RenderCypherTfvarsConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderCypherTfvarsConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Key":   name,
+		"Key":   "Example",
 		"Ttl":   "86400",
 		"Value": "account=12345\npassword=supersecure",
 	}
 
-	for k, v := range overrides {
-		defaults[k] = v
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -41,8 +42,6 @@ func RenderCypherTfvarsConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Key", defaults["Key"],
-		"Ttl", defaults["Ttl"],
-		"Value", defaults["Value"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/environment/morpheus_environment_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/environment/morpheus_environment_resource_example.go
@@ -15,21 +15,23 @@ import (
 
 // RenderEnvironmentConfig renders the environment resource configuration with default values
 // that can be overridden by providing a map of field name to value.
-func RenderEnvironmentConfig(t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderEnvironmentConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
 		"Active":      "true",
 		"Code":        "tfexample",
 		"Description": "Terraform Example",
-		"Name":        name,
+		"Name":        "Example",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -43,9 +45,6 @@ func RenderEnvironmentConfig(t *testing.T,
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Active", defaults["Active"],
-		"Code", defaults["Code"],
-		"Description", defaults["Description"],
-		"Name", defaults["Name"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/environment/morpheus_environment_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/environment/morpheus_environment_resource_test.go
@@ -48,7 +48,7 @@ func TestAccMorpheusEnvironmentExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := environment.RenderEnvironmentConfig(t, name, map[string]string{
+	resourceConfig, err := environment.RenderEnvironmentConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_ansible_tower_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_ansible_tower_resource_example.go
@@ -15,11 +15,11 @@ import (
 
 // RenderIntegrationAnsibleTowerConfig renders the Ansible Tower integration resource configuration
 // with default values that can be overridden via the overrides parameter.
-func RenderIntegrationAnsibleTowerConfig(t *testing.T, name string, overrides map[string]string) (string, error) {
+func RenderIntegrationAnsibleTowerConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":     name,
+		"Name":     "Example",
 		"Enabled":  "true",
 		"Url":      "https://ansibletower01.morpheusdata.com",
 		"Username": "admin",
@@ -29,6 +29,11 @@ func RenderIntegrationAnsibleTowerConfig(t *testing.T, name string, overrides ma
 	// Override defaults with provided values
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -42,10 +47,6 @@ func RenderIntegrationAnsibleTowerConfig(t *testing.T, name string, overrides ma
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Enabled", defaults["Enabled"],
-		"Url", defaults["Url"],
-		"Username", defaults["Username"],
-		"Password", defaults["Password"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_ansible_tower_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_ansible_tower_resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusIntegrationAnsibleTowerExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := integration.RenderIntegrationAnsibleTowerConfig(t, name, map[string]string{
+	resourceConfig, err := integration.RenderIntegrationAnsibleTowerConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_chef_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_chef_resource_example.go
@@ -15,11 +15,11 @@ import (
 
 // RenderIntegrationChefConfig generates a Terraform configuration for the Chef integration resource
 // using default values that can be overridden via the overrides map.
-func RenderIntegrationChefConfig(t *testing.T, name string, overrides map[string]string) (string, error) {
+func RenderIntegrationChefConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                     name,
+		"Name":                     "Example",
 		"Enabled":                  "true",
 		"Url":                      "https://chef.morpheusdata.com",
 		"Version":                  "15.9.38",
@@ -35,6 +35,11 @@ func RenderIntegrationChefConfig(t *testing.T, name string, overrides map[string
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -46,15 +51,6 @@ func RenderIntegrationChefConfig(t *testing.T, name string, overrides map[string
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Enabled", defaults["Enabled"],
-		"Url", defaults["Url"],
-		"Version", defaults["Version"],
-		"WindowsVersion", defaults["WindowsVersion"],
-		"WindowsMsiInstallUrl", defaults["WindowsMsiInstallUrl"],
-		"Organization", defaults["Organization"],
-		"Username", defaults["Username"],
-		"PrivateKey", defaults["PrivateKey"],
-		"OrganizationValidatorKey", defaults["OrganizationValidatorKey"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_chef_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_chef_resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusIntegrationChefExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := integration.RenderIntegrationChefConfig(t, name, map[string]string{
+	resourceConfig, err := integration.RenderIntegrationChefConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_docker_registry_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_docker_registry_resource_example.go
@@ -16,15 +16,11 @@ import (
 // RenderIntegrationDockerRegistryConfig renders the Docker Registry integration
 // resource configuration with the provided field overrides. Default values are used for any
 // fields not specified.
-func RenderIntegrationDockerRegistryConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderIntegrationDockerRegistryConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":     name,
+		"Name":     "Example",
 		"Enabled":  "true",
 		"Url":      "https://index.docker.io/v1/",
 		"Username": "admin",
@@ -34,6 +30,11 @@ func RenderIntegrationDockerRegistryConfig(
 	// Apply overrides
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -47,10 +48,6 @@ func RenderIntegrationDockerRegistryConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Enabled", defaults["Enabled"],
-		"Url", defaults["Url"],
-		"Username", defaults["Username"],
-		"Password", defaults["Password"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_docker_registry_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_docker_registry_resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusIntegrationDockerRegistryExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := integration.RenderIntegrationDockerRegistryConfig(t, name, map[string]string{
+	resourceConfig, err := integration.RenderIntegrationDockerRegistryConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_puppet_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_puppet_resource_example.go
@@ -13,11 +13,11 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_integration_puppet/resource.tf morpheus_integration_puppet_resource.tf.tmpl Name "tfexample puppet integration" Enabled true PuppetMasterHostname peserver01.morpheusdata.com AllowImmediateExecution true PuppetMasterSshUsername root PuppetMasterSshPassword password123
 
-func RenderIntegrationPuppetConfig(t *testing.T, name string, overrides map[string]string) (string, error) {
+func RenderIntegrationPuppetConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                    name,
+		"Name":                    "Example",
 		"Enabled":                 "true",
 		"PuppetMasterHostname":    "peserver01.morpheusdata.com",
 		"AllowImmediateExecution": "true",
@@ -27,6 +27,11 @@ func RenderIntegrationPuppetConfig(t *testing.T, name string, overrides map[stri
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -40,11 +45,6 @@ func RenderIntegrationPuppetConfig(t *testing.T, name string, overrides map[stri
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Enabled", defaults["Enabled"],
-		"PuppetMasterHostname", defaults["PuppetMasterHostname"],
-		"AllowImmediateExecution", defaults["AllowImmediateExecution"],
-		"PuppetMasterSshUsername", defaults["PuppetMasterSshUsername"],
-		"PuppetMasterSshPassword", defaults["PuppetMasterSshPassword"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_puppet_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_puppet_resource_test.go
@@ -27,7 +27,9 @@ func TestAccMorpheusIntegrationPuppetExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := integration.RenderIntegrationPuppetConfig(t, name, nil)
+	resourceConfig, err := integration.RenderIntegrationPuppetConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_servicenow_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_servicenow_resource_example.go
@@ -13,15 +13,11 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_integration_servicenow/resource.tf morpheus_integration_servicenow_resource.tf.tmpl Name "terraform servicenow integration" Enabled true Url "https://servicenowprod.service-now.com" Username "my-snow-username" Password "my-snow-password" DefaultCmdbBusinessClass "demo"
 
-func RenderIntegrationServicenowConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderIntegrationServicenowConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                     name,
+		"Name":                     "Example",
 		"Enabled":                  "true",
 		"Url":                      "https://servicenowprod.service-now.com",
 		"Username":                 "my-snow-username",
@@ -31,6 +27,11 @@ func RenderIntegrationServicenowConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -44,11 +45,6 @@ func RenderIntegrationServicenowConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Enabled", defaults["Enabled"],
-		"Url", defaults["Url"],
-		"Username", defaults["Username"],
-		"Password", defaults["Password"],
-		"DefaultCmdbBusinessClass", defaults["DefaultCmdbBusinessClass"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_servicenow_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_servicenow_resource_test.go
@@ -27,7 +27,9 @@ func TestAccMorpheusIntegrationServicenowExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := integration.RenderIntegrationServicenowConfig(t, name, nil)
+	resourceConfig, err := integration.RenderIntegrationServicenowConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource_example.go
@@ -15,12 +15,12 @@ import (
 
 // RenderIntegrationVroConfig generates a Terraform configuration for the VRO integration
 // resource. It accepts an optional map of field overrides to customize the default values.
-func RenderIntegrationVroConfig(t *testing.T, name string, overrides map[string]string) (string, error) {
+func RenderIntegrationVroConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	// Default field values
 	defaults := map[string]string{
-		"Name":     name,
+		"Name":     "Example",
 		"Enabled":  "true",
 		"Url":      "https://myvro/vco/api",
 		"Username": "my-vro-username",
@@ -34,6 +34,11 @@ func RenderIntegrationVroConfig(t *testing.T, name string, overrides map[string]
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -45,12 +50,6 @@ func RenderIntegrationVroConfig(t *testing.T, name string, overrides map[string]
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Enabled", defaults["Enabled"],
-		"Url", defaults["Url"],
-		"Username", defaults["Username"],
-		"Password", defaults["Password"],
-		"AuthType", defaults["AuthType"],
-		"Tenant", defaults["Tenant"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource_test.go
@@ -50,7 +50,7 @@ func TestAccMorpheusIntegrationVroExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := integration.RenderIntegrationVroConfig(t, name, map[string]string{
+	resourceConfig, err := integration.RenderIntegrationVroConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/license/morpheus_license_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/license/morpheus_license_resource_example.go
@@ -27,6 +27,11 @@ func RenderLicenseConfig(t *testing.T, overrides map[string]string) (string, err
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -38,7 +43,6 @@ func RenderLicenseConfig(t *testing.T, overrides map[string]string) (string, err
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Key",
-		defaults["Key"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/network/morpheus_ip_pool_ipv4_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/network/morpheus_ip_pool_ipv4_resource_example.go
@@ -15,14 +15,11 @@ import (
 
 // RenderIPPoolIPv4Config generates a Terraform configuration for hpe_morpheus_ip_pool_ipv4 resource.
 // It accepts an optional map of field overrides. If nil or empty, default values are used.
-func RenderIPPoolIPv4Config(t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderIPPoolIPv4Config(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":             name,
+		"Name":             "Example",
 		"StartingAddress1": "\"192.168.1.1\"",
 		"EndingAddress1":   "\"192.168.1.10\"",
 		"StartingAddress2": "\"10.0.0.1\"",
@@ -31,6 +28,11 @@ func RenderIPPoolIPv4Config(t *testing.T,
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -44,15 +46,6 @@ func RenderIPPoolIPv4Config(t *testing.T,
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name",
-		defaults["Name"],
-		"StartingAddress1",
-		defaults["StartingAddress1"],
-		"EndingAddress1",
-		defaults["EndingAddress1"],
-		"StartingAddress2",
-		defaults["StartingAddress2"],
-		"EndingAddress2",
-		defaults["EndingAddress2"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/network/morpheus_ip_pool_ipv4_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/network/morpheus_ip_pool_ipv4_resource_test.go
@@ -48,7 +48,7 @@ func TestAccMorpheusIpPoolIpv4ResourceExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := network.RenderIPPoolIPv4Config(t, name, map[string]string{
+	resourceConfig, err := network.RenderIPPoolIPv4Config(t, map[string]string{
 		"Name": "\"" + name + "\"",
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_api_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_api_resource_example.go
@@ -13,15 +13,11 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_option_list_api/resource.tf morpheus_option_list_api_resource.tf.tmpl Name tf_example_api_option_list Description "Terraform Morpheus API option list example" Visibility private OptionList instances TranslationScript "var i=0;\nresults = [];\nfor(i; i<data.length; i++) {\n  results.push({name: data[i].name, value: data[i].name});\n}"
 
-func RenderOptionListApiConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderOptionListApiConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":        name,
+		"Name":        "Example",
 		"Description": "Terraform Morpheus API option list example",
 		"Visibility":  "private",
 		"OptionList":  "instances",
@@ -31,6 +27,11 @@ func RenderOptionListApiConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -44,10 +45,6 @@ func RenderOptionListApiConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Visibility", defaults["Visibility"],
-		"OptionList", defaults["OptionList"],
-		"TranslationScript", defaults["TranslationScript"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_api_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_api_resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusOptionListApiExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := optionlist.RenderOptionListApiConfig(t, name, map[string]string{
+	resourceConfig, err := optionlist.RenderOptionListApiConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_manual_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_manual_resource_example.go
@@ -16,15 +16,11 @@ import (
 // RenderOptionListManualConfig generates a Terraform configuration for the
 // morpheus_option_list_manual resource. It accepts an optional map of field overrides to
 // customize the default values. Supported override keys: "Name", "Description", "Dataset", "RealTime"
-func RenderOptionListManualConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderOptionListManualConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":        name,
+		"Name":        "Example",
 		"Description": "Terraform manual option list example",
 		"Dataset": "[{\"name\": \"Level 1\",\"value\":\"level1\"},\n " +
 			"{\"name\": \"Level 2\",\"value\":\"level2\"},\n " +
@@ -35,6 +31,11 @@ func RenderOptionListManualConfig(
 	// Apply overrides
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	//nolint: lll
@@ -49,9 +50,6 @@ func RenderOptionListManualConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Dataset", defaults["Dataset"],
-		"RealTime", defaults["RealTime"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_manual_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_manual_resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusOptionListManualExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := optionlist.RenderOptionListManualConfig(t, name, map[string]string{
+	resourceConfig, err := optionlist.RenderOptionListManualConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_rest_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_rest_resource_example.go
@@ -18,15 +18,11 @@ import (
 // Supported override keys: "Name", "Description", "Visibility", "SourceUrl", "RealTime", "IgnoreSslErrors",
 // "SourceMethod", "InitialDataset", "TranslationScript", "SourceHeaderName1", "SourceHeaderValue1",
 // "SourceHeaderName2", "SourceHeaderValue2"
-func RenderOptionListRestConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderOptionListRestConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":            name,
+		"Name":            "Example",
 		"Description":     "Terraform REST option list example",
 		"Visibility":      "private",
 		"SourceUrl":       "https://api.github.com/repos/hashicorp/consul/releases",
@@ -50,6 +46,11 @@ func RenderOptionListRestConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	//nolint: lll
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
@@ -62,18 +63,6 @@ func RenderOptionListRestConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Visibility", defaults["Visibility"],
-		"SourceUrl", defaults["SourceUrl"],
-		"RealTime", defaults["RealTime"],
-		"IgnoreSslErrors", defaults["IgnoreSslErrors"],
-		"SourceMethod", defaults["SourceMethod"],
-		"InitialDataset", defaults["InitialDataset"],
-		"TranslationScript", defaults["TranslationScript"],
-		"SourceHeaderName1", defaults["SourceHeaderName1"],
-		"SourceHeaderValue1", defaults["SourceHeaderValue1"],
-		"SourceHeaderName2", defaults["SourceHeaderName2"],
-		"SourceHeaderValue2", defaults["SourceHeaderValue2"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_rest_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/morpheus_option_list_rest_resource_test.go
@@ -48,7 +48,7 @@ func TestAccMorpheusOptionListRestExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := optionlist.RenderOptionListRestConfig(t, name, map[string]string{
+	resourceConfig, err := optionlist.RenderOptionListRestConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_checkbox_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_checkbox_resource_example.go
@@ -17,14 +17,11 @@ import (
 // It accepts an optional map of field overrides to customize the default values.
 // Supported override keys: "Name", "Description", "Labels", "FieldName", "ExportMeta", "DependentField",
 // "VisibilityField", "RequireField", "ShowOnEdit", "Editable", "DisplayValueOnDetails", "FieldLabel", "DefaultChecked"
-func RenderOptionTypeCheckboxConfig(t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderOptionTypeCheckboxConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                  name,
+		"Name":                  "Example",
 		"Description":           "Terraform checkbox option type example",
 		"Labels":                "[\"demo\", \"terraform\"]",
 		"FieldName":             "checkbox_example",
@@ -44,6 +41,11 @@ func RenderOptionTypeCheckboxConfig(t *testing.T,
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -55,18 +57,6 @@ func RenderOptionTypeCheckboxConfig(t *testing.T,
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Labels", defaults["Labels"],
-		"FieldName", defaults["FieldName"],
-		"ExportMeta", defaults["ExportMeta"],
-		"DependentField", defaults["DependentField"],
-		"VisibilityField", defaults["VisibilityField"],
-		"RequireField", defaults["RequireField"],
-		"ShowOnEdit", defaults["ShowOnEdit"],
-		"Editable", defaults["Editable"],
-		"DisplayValueOnDetails", defaults["DisplayValueOnDetails"],
-		"FieldLabel", defaults["FieldLabel"],
-		"DefaultChecked", defaults["DefaultChecked"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_checkbox_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_checkbox_resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusOptionTypeCheckboxExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := optiontype.RenderOptionTypeCheckboxConfig(t, name, map[string]string{
+	resourceConfig, err := optiontype.RenderOptionTypeCheckboxConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_hidden_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_hidden_resource_example.go
@@ -18,11 +18,11 @@ import (
 // the default values. Supported override keys: "Name", "Description", "Labels", "FieldName",
 // "ExportMeta", "DependentField", "VisibilityField", "RequireField", "ShowOnEdit", "Editable",
 // "DisplayValueOnDetails", "DefaultValue"
-func RenderOptionTypeHiddenConfig(t *testing.T, name string, overrides map[string]string) (string, error) {
+func RenderOptionTypeHiddenConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                  name,
+		"Name":                  "Example",
 		"Description":           "Terraform hidden option type example",
 		"Labels":                `["demo","terraform"]`,
 		"FieldName":             "hidden_example",
@@ -41,6 +41,11 @@ func RenderOptionTypeHiddenConfig(t *testing.T, name string, overrides map[strin
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -52,17 +57,6 @@ func RenderOptionTypeHiddenConfig(t *testing.T, name string, overrides map[strin
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Labels", defaults["Labels"],
-		"FieldName", defaults["FieldName"],
-		"ExportMeta", defaults["ExportMeta"],
-		"DependentField", defaults["DependentField"],
-		"VisibilityField", defaults["VisibilityField"],
-		"RequireField", defaults["RequireField"],
-		"ShowOnEdit", defaults["ShowOnEdit"],
-		"Editable", defaults["Editable"],
-		"DisplayValueOnDetails", defaults["DisplayValueOnDetails"],
-		"DefaultValue", defaults["DefaultValue"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_hidden_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_hidden_resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusOptionTypeHiddenExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := optiontype.RenderOptionTypeHiddenConfig(t, name, map[string]string{
+	resourceConfig, err := optiontype.RenderOptionTypeHiddenConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_number_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_number_resource_example.go
@@ -19,11 +19,11 @@ import (
 // Supported override keys: "Name", "Description", "Labels", "FieldName", "ExportMeta",
 // "DependentField", "VisibilityField", "RequireField", "ShowOnEdit", "Editable",
 // "DisplayValueOnDetails", "FieldLabel", "Placeholder", "DefaultValue", "HelpBlock", "Required"
-func RenderOptionTypeNumberConfig(t *testing.T, name string, overrides map[string]string) (string, error) {
+func RenderOptionTypeNumberConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                  name,
+		"Name":                  "Example",
 		"Description":           "Terraform number option type example",
 		"Labels":                "[\"demo\", \"terraform\"]",
 		"FieldName":             "tfNumberExample",
@@ -46,6 +46,11 @@ func RenderOptionTypeNumberConfig(t *testing.T, name string, overrides map[strin
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -57,21 +62,6 @@ func RenderOptionTypeNumberConfig(t *testing.T, name string, overrides map[strin
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Labels", defaults["Labels"],
-		"FieldName", defaults["FieldName"],
-		"ExportMeta", defaults["ExportMeta"],
-		"DependentField", defaults["DependentField"],
-		"VisibilityField", defaults["VisibilityField"],
-		"RequireField", defaults["RequireField"],
-		"ShowOnEdit", defaults["ShowOnEdit"],
-		"Editable", defaults["Editable"],
-		"DisplayValueOnDetails", defaults["DisplayValueOnDetails"],
-		"FieldLabel", defaults["FieldLabel"],
-		"Placeholder", defaults["Placeholder"],
-		"DefaultValue", defaults["DefaultValue"],
-		"HelpBlock", defaults["HelpBlock"],
-		"Required", defaults["Required"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_number_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_number_resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusOptionTypeNumberExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := optiontype.RenderOptionTypeNumberConfig(t, name, map[string]string{
+	resourceConfig, err := optiontype.RenderOptionTypeNumberConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_password_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_password_resource_example.go
@@ -19,15 +19,11 @@ import (
 // Supported override keys: "Name", "Description", "Labels", "FieldName", "ExportMeta", "DependentField",
 // "VisibilityField", "RequireField", "ShowOnEdit", "Editable", "DisplayValueOnDetails", "FieldLabel",
 // "Placeholder", "DefaultValue", "HelpBlock", "Required", "VerifyPattern"
-func RenderOptionTypePasswordConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderOptionTypePasswordConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                  name,
+		"Name":                  "Example",
 		"Description":           "Terraform password option type example",
 		"Labels":                "[\"demo\", \"terraform\"]",
 		"FieldName":             "tfPasswordExample",
@@ -51,6 +47,11 @@ func RenderOptionTypePasswordConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -62,22 +63,6 @@ func RenderOptionTypePasswordConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Labels", defaults["Labels"],
-		"FieldName", defaults["FieldName"],
-		"ExportMeta", defaults["ExportMeta"],
-		"DependentField", defaults["DependentField"],
-		"VisibilityField", defaults["VisibilityField"],
-		"RequireField", defaults["RequireField"],
-		"ShowOnEdit", defaults["ShowOnEdit"],
-		"Editable", defaults["Editable"],
-		"DisplayValueOnDetails", defaults["DisplayValueOnDetails"],
-		"FieldLabel", defaults["FieldLabel"],
-		"Placeholder", defaults["Placeholder"],
-		"DefaultValue", defaults["DefaultValue"],
-		"HelpBlock", defaults["HelpBlock"],
-		"Required", defaults["Required"],
-		"VerifyPattern", defaults["VerifyPattern"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_password_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_password_resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusOptionTypePasswordExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := optiontype.RenderOptionTypePasswordConfig(t, name, map[string]string{"Name": name})
+	resourceConfig, err := optiontype.RenderOptionTypePasswordConfig(t, map[string]string{"Name": name})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_textarea_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_textarea_resource_example.go
@@ -13,11 +13,11 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_option_type_textarea/resource.tf morpheus_option_type_textarea_resource.tf.tmpl Name tf_example_textarea_option_type Description "Terraform text area option type example" Labels ["demo","terraform"] FieldName textareaExample ExportMeta true DependentField dependent_example VisibilityField visibility_example RequireField require_example ShowOnEdit true Editable true DisplayValueOnDetails true FieldLabel "Text Area Example" Rows 5 Placeholder "example text" DefaultValue example HelpBlock "Terraform text area option type example" Required true VerifyPattern "a\\\\D{4}"
 
-func RenderOptionTypeTextareaConfig(t *testing.T, name string, overrides map[string]string) (string, error) {
+func RenderOptionTypeTextareaConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                  name,
+		"Name":                  "Example",
 		"Description":           "Terraform text area option type example",
 		"Labels":                `["demo","terraform"]`,
 		"FieldName":             "textareaExample",
@@ -41,6 +41,11 @@ func RenderOptionTypeTextareaConfig(t *testing.T, name string, overrides map[str
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -49,25 +54,9 @@ func RenderOptionTypeTextareaConfig(t *testing.T, name string, overrides map[str
 	dir := filepath.Dir(filename)
 	templatePath := filepath.Join(dir, "morpheus_option_type_textarea_resource.tf.tmpl")
 
-	return testhelpers.RenderExample(t,
+	return testhelpers.RenderExample(
+		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Labels", defaults["Labels"],
-		"FieldName", defaults["FieldName"],
-		"ExportMeta", defaults["ExportMeta"],
-		"DependentField", defaults["DependentField"],
-		"VisibilityField", defaults["VisibilityField"],
-		"RequireField", defaults["RequireField"],
-		"ShowOnEdit", defaults["ShowOnEdit"],
-		"Editable", defaults["Editable"],
-		"DisplayValueOnDetails", defaults["DisplayValueOnDetails"],
-		"FieldLabel", defaults["FieldLabel"],
-		"Rows", defaults["Rows"],
-		"Placeholder", defaults["Placeholder"],
-		"DefaultValue", defaults["DefaultValue"],
-		"HelpBlock", defaults["HelpBlock"],
-		"Required", defaults["Required"],
-		"VerifyPattern", defaults["VerifyPattern"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_textarea_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/morpheus_option_type_textarea_resource_test.go
@@ -39,7 +39,7 @@ func TestAccMorpheusOptionTypeTextareaExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := optiontype.RenderOptionTypeTextareaConfig(t, name, map[string]string{
+	resourceConfig, err := optiontype.RenderOptionTypeTextareaConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/script/boot_script_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/script/boot_script_resource_test.go
@@ -51,7 +51,7 @@ func TestAccMorpheusBootScriptExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := script.RenderBootScriptConfig(t, name, map[string]string{
+	resourceConfig, err := script.RenderBootScriptConfig(t, map[string]string{
 		"Content": "ls",
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/script/morpheus_boot_script_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/script/morpheus_boot_script_resource_example.go
@@ -15,20 +15,21 @@ import (
 
 // RenderBootScriptConfig renders a Terraform configuration for boot_script resource.
 // It accepts a name and a map of overrides to customize the default field values.
-func RenderBootScriptConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderBootScriptConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":    name,
+		"Name":    "Example",
 		"Content": "ls",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -42,7 +43,6 @@ func RenderBootScriptConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Content", defaults["Content"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/script/morpheus_preseed_script_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/script/morpheus_preseed_script_resource_example.go
@@ -16,20 +16,21 @@ import (
 // RenderPreseedScriptConfig renders a Terraform configuration
 // for preseed_script resource.
 // It accepts a name and a map of overrides to customize the default field values.
-func RenderPreseedScriptConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderPreseedScriptConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":    name,
+		"Name":    "Example",
 		"Content": "ls",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -43,7 +44,6 @@ func RenderPreseedScriptConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Content", defaults["Content"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/script/morpheus_preseed_script_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/script/morpheus_preseed_script_resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusPreseedScriptExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := script.RenderPreseedScriptConfig(t, name, map[string]string{
+	resourceConfig, err := script.RenderPreseedScriptConfig(t, map[string]string{
 		"Content": "ls",
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/setting/morpheus_setting_guidance_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/setting/morpheus_setting_guidance_resource_example.go
@@ -31,6 +31,11 @@ func RenderSettingGuidanceConfig(t *testing.T, overrides map[string]string) (str
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -42,13 +47,6 @@ func RenderSettingGuidanceConfig(t *testing.T, overrides map[string]string) (str
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"PowerSettingsAverageCpu", defaults["PowerSettingsAverageCpu"],
-		"PowerSettingsMaximumCpu", defaults["PowerSettingsMaximumCpu"],
-		"PowerSettingsNetworkThreshold", defaults["PowerSettingsNetworkThreshold"],
-		"CpuUpsizeAverageCpu", defaults["CpuUpsizeAverageCpu"],
-		"CpuUpsizeMaximumCpu", defaults["CpuUpsizeMaximumCpu"],
-		"MemoryUpsizeMinimumFreeMemory", defaults["MemoryUpsizeMinimumFreeMemory"],
-		"MemoryDownsizeAverageFreeMemory", defaults["MemoryDownsizeAverageFreeMemory"],
-		"MemoryDownsizeMaximumFreeMemory", defaults["MemoryDownsizeMaximumFreeMemory"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/setting/morpheus_setting_guidance_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/setting/morpheus_setting_guidance_resource_test.go
@@ -5,7 +5,6 @@ package setting_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
@@ -22,9 +21,6 @@ func TestAccMorpheusSettingGuidanceExampleOk(t *testing.T) {
 	}
 
 	providerConfig := testhelpers.ProviderBlock()
-
-	name := acctest.RandomWithPrefix(t.Name())
-	_ = name // name is reserved for future use
 
 	resourceConfig, err := setting.RenderSettingGuidanceConfig(t, nil)
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/setting/morpheus_setting_provisioning_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/setting/morpheus_setting_provisioning_resource_example.go
@@ -33,6 +33,11 @@ func RenderSettingProvisioningConfig(t *testing.T, overrides map[string]string) 
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -44,15 +49,6 @@ func RenderSettingProvisioningConfig(t *testing.T, overrides map[string]string) 
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"AllowZoneSelection", defaults["AllowZoneSelection"],
-		"AllowHostSelection", defaults["AllowHostSelection"],
-		"RequireEnvironments", defaults["RequireEnvironments"],
-		"ShowPricing", defaults["ShowPricing"],
-		"HideDatastoreStats", defaults["HideDatastoreStats"],
-		"CrossTenantNamingPolicies", defaults["CrossTenantNamingPolicies"],
-		"CloudinitUsername", defaults["CloudinitUsername"],
-		"CloudinitPassword", defaults["CloudinitPassword"],
-		"WindowsPassword", defaults["WindowsPassword"],
-		"PxeRootPassword", defaults["PxeRootPassword"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_chef_bootstrap_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_chef_bootstrap_example.go
@@ -15,16 +15,12 @@ import (
 
 // RenderChefBootstrapConfig renders the task chef bootstrap
 // resource configuration with the provided overrides applied to default values.
-func RenderChefBootstrapConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderChefBootstrapConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            `"demo", "terraform"`,
 		"ChefServerId":      "9",
 		"Environment":       "dev",
@@ -44,6 +40,11 @@ func RenderChefBootstrapConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -55,20 +56,6 @@ func RenderChefBootstrapConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"ChefServerId", defaults["ChefServerId"],
-		"Environment", defaults["Environment"],
-		"RunList", defaults["RunList"],
-		"DataBagKey", defaults["DataBagKey"],
-		"DataBagKeyPath", defaults["DataBagKeyPath"],
-		"NodeName", defaults["NodeName"],
-		"NodeAttributes", defaults["NodeAttributes"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
-		"Visibility", defaults["Visibility"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_chef_bootstrap_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_chef_bootstrap_resource_test.go
@@ -48,11 +48,9 @@ func TestAccMorpheusTaskChefBootstrapExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderChefBootstrapConfig(
-		t,
-		name,
-		map[string]string{},
-	)
+	resourceConfig, err := task.RenderChefBootstrapConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_email_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_email_resource_example.go
@@ -15,15 +15,11 @@ import (
 //go:generate /bin/sh -c "go run ../../../../../cmd/render -out examples/resources/morpheus_task_email/resource_git.tf morpheus_task_email_resource_git.tf.tmpl Name tfexample_email_git Code tfexample_email_git Labels '[\"demo\",\"terraform\"]' EmailAddress '<%=instance.createdByEmail%>' Subject '<%=instance.hostname%> provisioning complete' Source repository ContentPath example.txt RepositoryId 1 VersionRef main SkipWrappedEmailTemplate false Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true"
 //go:generate /bin/sh -c "go run ../../../../../cmd/render -out examples/resources/morpheus_task_email/resource_url.tf morpheus_task_email_resource_url.tf.tmpl Name tfexample_email_url Code tfexample_email_url Labels '[\"demo\",\"terraform\"]' EmailAddress '<%=instance.createdByEmail%>' Subject '<%=instance.hostname%> provisioning complete' Source url ContentUrl https://example.com/example.txt SkipWrappedEmailTemplate false Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true"
 
-func RenderTaskEmailConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskEmailConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                     name,
+		"Name":                     "Example",
 		"Code":                     "tfexample_email",
 		"Labels":                   `["demo","terraform"]`,
 		"EmailAddress":             "<%=instance.createdByEmail%>",
@@ -41,6 +37,11 @@ func RenderTaskEmailConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -52,30 +53,15 @@ func RenderTaskEmailConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"EmailAddress", defaults["EmailAddress"],
-		"Subject", defaults["Subject"],
-		"Source", defaults["Source"],
-		"Content", defaults["Content"],
-		"SkipWrappedEmailTemplate", defaults["SkipWrappedEmailTemplate"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskEmailGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskEmailGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                     name,
+		"Name":                     "Example",
 		"Code":                     "tfexample_email_git",
 		"Labels":                   `["demo","terraform"]`,
 		"EmailAddress":             "<%=instance.createdByEmail%>",
@@ -95,6 +81,11 @@ func RenderTaskEmailGitConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -106,32 +97,15 @@ func RenderTaskEmailGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"EmailAddress", defaults["EmailAddress"],
-		"Subject", defaults["Subject"],
-		"Source", defaults["Source"],
-		"ContentPath", defaults["ContentPath"],
-		"RepositoryId", defaults["RepositoryId"],
-		"VersionRef", defaults["VersionRef"],
-		"SkipWrappedEmailTemplate", defaults["SkipWrappedEmailTemplate"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskEmailUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskEmailUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                     name,
+		"Name":                     "Example",
 		"Code":                     "tfexample_email_url",
 		"Labels":                   `["demo","terraform"]`,
 		"EmailAddress":             "<%=instance.createdByEmail%>",
@@ -149,6 +123,11 @@ func RenderTaskEmailUrlConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -160,17 +139,6 @@ func RenderTaskEmailUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"EmailAddress", defaults["EmailAddress"],
-		"Subject", defaults["Subject"],
-		"Source", defaults["Source"],
-		"ContentUrl", defaults["ContentUrl"],
-		"SkipWrappedEmailTemplate", defaults["SkipWrappedEmailTemplate"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_email_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_email_resource_git_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskEmailGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskEmailGitConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskEmailGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_email_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_email_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskEmailExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskEmailConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskEmailConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_email_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_email_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskEmailUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskEmailUrlConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskEmailUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_groovy_script_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_groovy_script_resource_example.go
@@ -15,16 +15,12 @@ import (
 //go:generate sh -c "go run ../../../../../cmd/render -out examples/resources/morpheus_task_groovy_script/resource_git.tf morpheus_task_groovy_script_resource_git.tf.tmpl Name tfexample_groovy_git Code tfexample_groovy_git Labels '[\"demo\",\"terraform\"]' SourceType repository ResultType json ScriptPath example.groovy VersionRef master RepositoryId 1 Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true"
 //go:generate sh -c "go run ../../../../../cmd/render -out examples/resources/morpheus_task_groovy_script/resource_url.tf morpheus_task_groovy_script_resource_url.tf.tmpl Name tfexample_groovy_url Code tfexample_groovy_url Labels '[\"demo\",\"terraform\"]' SourceType url ResultType json ScriptPath https://example.com/example.groovy Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true"
 
-func RenderTaskGroovyScriptConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskGroovyScriptConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "[\"demo\", \"terraform\"]",
 		"SourceType":        "local",
 		"ScriptContent":     "println \"hello\"",
@@ -38,6 +34,11 @@ func RenderTaskGroovyScriptConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -49,28 +50,16 @@ func RenderTaskGroovyScriptConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ScriptContent", defaults["ScriptContent"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskGroovyScriptGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskGroovyScriptGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "[\"demo\", \"terraform\"]",
 		"SourceType":        "repository",
 		"ResultType":        "json",
@@ -87,6 +76,11 @@ func RenderTaskGroovyScriptGitConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -98,31 +92,16 @@ func RenderTaskGroovyScriptGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"VersionRef", defaults["VersionRef"],
-		"RepositoryId", defaults["RepositoryId"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskGroovyScriptUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskGroovyScriptUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "[\"demo\", \"terraform\"]",
 		"SourceType":        "url",
 		"ResultType":        "json",
@@ -137,6 +116,11 @@ func RenderTaskGroovyScriptUrlConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -148,15 +132,6 @@ func RenderTaskGroovyScriptUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_groovy_script_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_groovy_script_resource_git_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskGroovyScriptGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskGroovyScriptGitConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskGroovyScriptGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_groovy_script_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_groovy_script_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskGroovyScriptExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskGroovyScriptConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskGroovyScriptConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_groovy_script_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_groovy_script_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskGroovyScriptUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskGroovyScriptUrlConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskGroovyScriptUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_javascript_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_javascript_resource_example.go
@@ -16,16 +16,12 @@ import (
 // RenderTaskJavascriptConfig generates a terraform configuration string
 // for task javascript resource.
 // It accepts a name and a map to override default field values.
-func RenderTaskJavascriptConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskJavascriptConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            `["demo","terraform"]`,
 		"ScriptContent":     `console.log("testing")`,
 		"Retryable":         "true",
@@ -36,6 +32,11 @@ func RenderTaskJavascriptConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -49,13 +50,6 @@ func RenderTaskJavascriptConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"ScriptContent", defaults["ScriptContent"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_javascript_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_javascript_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskJavascriptExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskJavascriptConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskJavascriptConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_powershell_script_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_powershell_script_resource_example.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
@@ -16,16 +15,12 @@ import (
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_task_powershell_script/resource_git.tf morpheus_task_powershell_script_resource_git.tf.tmpl Name tfexample_powershell_git Code tfexample_powershell_git Labels "\"demo\", \"terraform\"" SourceType repository ResultType json ScriptPath example.ps VersionRef master RepositoryId 1 ElevatedShell true Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_task_powershell_script/resource_url.tf morpheus_task_powershell_script_resource_url.tf.tmpl Name tfexample_powershell_url Code tfexample_powershell_url Labels "\"demo\", \"terraform\"" SourceType url ResultType json ScriptPath https://example.com/example.ps ElevatedShell true Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true
 
-func RenderTaskPowershellScriptConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskPowershellScriptConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            `"demo", "terraform"`,
 		"SourceType":        "local",
 		"ScriptContent":     `Write-Output \"testing\"`,
@@ -40,6 +35,11 @@ func RenderTaskPowershellScriptConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -51,29 +51,16 @@ func RenderTaskPowershellScriptConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ScriptContent", defaults["ScriptContent"],
-		"ElevatedShell", defaults["ElevatedShell"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskPowershellScriptGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskPowershellScriptGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              strings.ToLower(name),
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            `"demo", "terraform"`,
 		"SourceType":        "repository",
 		"ResultType":        "json",
@@ -91,6 +78,11 @@ func RenderTaskPowershellScriptGitConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -102,32 +94,16 @@ func RenderTaskPowershellScriptGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"VersionRef", defaults["VersionRef"],
-		"RepositoryId", defaults["RepositoryId"],
-		"ElevatedShell", defaults["ElevatedShell"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskPowershellScriptUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskPowershellScriptUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            `"demo", "terraform"`,
 		"SourceType":        "url",
 		"ResultType":        "json",
@@ -143,6 +119,11 @@ func RenderTaskPowershellScriptUrlConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -154,16 +135,6 @@ func RenderTaskPowershellScriptUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"ElevatedShell", defaults["ElevatedShell"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_powershell_script_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_powershell_script_resource_git_test.go
@@ -26,7 +26,9 @@ func TestAccMorpheusTaskPowershellScriptResourceGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskPowershellScriptGitConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskPowershellScriptGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_powershell_script_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_powershell_script_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskPowershellScriptResourceExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskPowershellScriptConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskPowershellScriptConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_powershell_script_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_powershell_script_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskPowershellScriptResourceUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskPowershellScriptUrlConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskPowershellScriptUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_python_script_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_python_script_resource_example.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
@@ -18,15 +17,12 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_task_python_script/resource_git.tf morpheus_task_python_script_resource_git.tf.tmpl Name tfexample_python_git Code tfexample_python_git Labels "[\"demo\", \"terraform\"]" SourceType repository ResultType json ScriptPath example.py VersionRef master RepositoryId 1 CommandArguments example AdditionalPackages pyyaml PythonBinary /usr/bin/python3 Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true
 
-func RenderTaskPythonScriptConfig(
-	t *testing.T, name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskPythonScriptConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":               name,
-		"Code":               strings.ToLower(name),
+		"Name":               "Example",
+		"Code":               "example",
 		"Labels":             "[\"demo\", \"terraform\"]",
 		"SourceType":         "local",
 		"ScriptContent":      "print('morpheus')\\nprint('python')",
@@ -43,6 +39,11 @@ func RenderTaskPythonScriptConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -54,31 +55,16 @@ func RenderTaskPythonScriptConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ScriptContent", defaults["ScriptContent"],
-		"CommandArguments", defaults["CommandArguments"],
-		"AdditionalPackages", defaults["AdditionalPackages"],
-		"PythonBinary", defaults["PythonBinary"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskPythonScriptUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskPythonScriptUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":               name,
-		"Code":               name,
+		"Name":               "Example",
+		"Code":               "example",
 		"Labels":             "[\"demo\", \"terraform\"]",
 		"SourceType":         "url",
 		"ResultType":         "json",
@@ -96,6 +82,11 @@ func RenderTaskPythonScriptUrlConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -107,32 +98,16 @@ func RenderTaskPythonScriptUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"CommandArguments", defaults["CommandArguments"],
-		"AdditionalPackages", defaults["AdditionalPackages"],
-		"PythonBinary", defaults["PythonBinary"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskPythonScriptGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskPythonScriptGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":               name,
-		"Code":               strings.ToLower(name),
+		"Name":               "Example",
+		"Code":               "example",
 		"Labels":             "[\"demo\", \"terraform\"]",
 		"SourceType":         "repository",
 		"ResultType":         "json",
@@ -152,6 +127,11 @@ func RenderTaskPythonScriptGitConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -163,20 +143,6 @@ func RenderTaskPythonScriptGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"VersionRef", defaults["VersionRef"],
-		"RepositoryId", defaults["RepositoryId"],
-		"CommandArguments", defaults["CommandArguments"],
-		"AdditionalPackages", defaults["AdditionalPackages"],
-		"PythonBinary", defaults["PythonBinary"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_python_script_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_python_script_resource_git_test.go
@@ -26,7 +26,9 @@ func TestAccMorpheusTaskPythonScriptGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskPythonScriptGitConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskPythonScriptGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_python_script_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_python_script_resource_test.go
@@ -26,7 +26,9 @@ func TestAccMorpheusTaskPythonScriptExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskPythonScriptConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskPythonScriptConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_python_script_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_python_script_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskPythonScriptUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskPythonScriptUrlConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskPythonScriptUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_restart_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_restart_resource_example.go
@@ -15,16 +15,12 @@ import (
 
 // RenderTaskRestartConfig renders the task restart resource configuration
 // with the provided name and field overrides.
-func RenderTaskRestartConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskRestartConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	// Default values
 	defaults := map[string]string{
-		"Name":              name,
+		"Name":              "Example",
 		"Code":              "tfexample_restart",
 		"Labels":            `["demo", "terraform"]`,
 		"Retryable":         "true",
@@ -38,6 +34,11 @@ func RenderTaskRestartConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -49,12 +50,6 @@ func RenderTaskRestartConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_ruby_script_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_ruby_script_resource_example.go
@@ -15,16 +15,12 @@ import (
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_task_ruby_script/resource_git.tf task_ruby_script_resource_git.tf.tmpl Name tfexample_ruby_git Code tfexample_ruby_git Labels "\"demo\", \"terraform\"" SourceType repository ResultType json ScriptPath example.rb VersionRef master RepositoryId 1 Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_task_ruby_script/resource_url.tf task_ruby_script_resource_url.tf.tmpl Name tfexample_ruby_url Code tfexample_ruby_url Labels "\"demo\", \"terraform\"" SourceType url ResultType json ScriptPath https://example.com/example.rb Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true
 
-func RenderTaskRubyScriptConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskRubyScriptConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "\"demo\", \"terraform\"",
 		"SourceType":        "local",
 		"ScriptContent":     "puts \"testing\"",
@@ -38,6 +34,11 @@ func RenderTaskRubyScriptConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -49,28 +50,16 @@ func RenderTaskRubyScriptConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ScriptContent", defaults["ScriptContent"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskRubyScriptGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskRubyScriptGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "\"demo\", \"terraform\"",
 		"SourceType":        "repository",
 		"ResultType":        "json",
@@ -87,6 +76,11 @@ func RenderTaskRubyScriptGitConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -98,31 +92,16 @@ func RenderTaskRubyScriptGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"VersionRef", defaults["VersionRef"],
-		"RepositoryId", defaults["RepositoryId"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskRubyScriptUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskRubyScriptUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "\"demo\", \"terraform\"",
 		"SourceType":        "url",
 		"ResultType":        "json",
@@ -137,6 +116,11 @@ func RenderTaskRubyScriptUrlConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -148,15 +132,6 @@ func RenderTaskRubyScriptUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_shell_script_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_shell_script_example.go
@@ -15,16 +15,12 @@ import (
 //go:generate sh -c "cd ../../../../../internal/sdkv2/morpheus/resources/task && go run ../../../../../cmd/render/main.go -out examples/resources/morpheus_task_shell_script/resource_git.tf morpheus_task_shell_script_resource_git.tf.tmpl Name tfexample_shell_git Code tfexample_shell_git Labels '[\"demo\", \"terraform\"]' SourceType repository ResultType json ScriptPath example.sh VersionRef master RepositoryId 1 Sudo true Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true"
 //go:generate sh -c "cd ../../../../../internal/sdkv2/morpheus/resources/task && go run ../../../../../cmd/render/main.go -out examples/resources/morpheus_task_shell_script/resource_url.tf morpheus_task_shell_script_resource_url.tf.tmpl Name tfexample_shell_url Code tfexample_shell_url Labels '[\"demo\", \"terraform\"]' SourceType url ResultType json ScriptPath https://example.com/example.sh Sudo true Retryable true RetryCount 1 RetryDelaySeconds 10 AllowCustomConfig true"
 
-func RenderTaskShellScriptConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskShellScriptConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "[\"demo\", \"terraform\"]",
 		"SourceType":        "local",
 		"ScriptContent":     "  echo \"testing\"",
@@ -39,6 +35,11 @@ func RenderTaskShellScriptConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -50,29 +51,16 @@ func RenderTaskShellScriptConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ScriptContent", defaults["ScriptContent"],
-		"Sudo", defaults["Sudo"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskShellScriptGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskShellScriptGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "[\"demo\", \"terraform\"]",
 		"SourceType":        "repository",
 		"ResultType":        "json",
@@ -90,6 +78,11 @@ func RenderTaskShellScriptGitConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -101,32 +94,16 @@ func RenderTaskShellScriptGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"VersionRef", defaults["VersionRef"],
-		"RepositoryId", defaults["RepositoryId"],
-		"Sudo", defaults["Sudo"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }
 
-func RenderTaskShellScriptUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskShellScriptUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":              name,
-		"Code":              name,
+		"Name":              "Example",
+		"Code":              "example",
 		"Labels":            "[\"demo\", \"terraform\"]",
 		"SourceType":        "url",
 		"ResultType":        "json",
@@ -142,6 +119,11 @@ func RenderTaskShellScriptUrlConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -153,16 +135,6 @@ func RenderTaskShellScriptUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Labels", defaults["Labels"],
-		"SourceType", defaults["SourceType"],
-		"ResultType", defaults["ResultType"],
-		"ScriptPath", defaults["ScriptPath"],
-		"Sudo", defaults["Sudo"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/morpheus_task_write_attributes_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/task/morpheus_task_write_attributes_resource_example.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
@@ -16,16 +15,12 @@ import (
 
 // RenderTaskWriteAttributesConfig generates a Terraform configuration for testing
 // the task_write_attributes resource. It accepts overrides to customize field values.
-func RenderTaskWriteAttributesConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderTaskWriteAttributesConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
-	code := strings.ToLower(name)
-
 	defaults := map[string]string{
+		"Name":              "Example",
+		"Code":              "example",
 		"Label1":            "demo",
 		"Label2":            "terraform",
 		"Attributes":        `{"demo":"test"}`,
@@ -40,6 +35,11 @@ func RenderTaskWriteAttributesConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -51,14 +51,6 @@ func RenderTaskWriteAttributesConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", name,
-		"Code", code,
-		"Label1", defaults["Label1"],
-		"Label2", defaults["Label2"],
-		"Attributes", defaults["Attributes"],
-		"Retryable", defaults["Retryable"],
-		"RetryCount", defaults["RetryCount"],
-		"RetryDelaySeconds", defaults["RetryDelaySeconds"],
-		"AllowCustomConfig", defaults["AllowCustomConfig"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/task/task_restart_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/task_restart_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskRestartExampleOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	resourceConfig, err := task.RenderTaskRestartConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskRestartConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/task_ruby_script_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/task/task_ruby_script_resource_git_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskRubyScriptGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskRubyScriptGitConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskRubyScriptGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/task_ruby_script_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/task_ruby_script_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskRubyScriptExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskRubyScriptConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskRubyScriptConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/task_ruby_script_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/task/task_ruby_script_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskRubyScriptUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskRubyScriptUrlConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskRubyScriptUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/task_shell_script_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/task/task_shell_script_resource_git_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskShellScriptResourceGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskShellScriptGitConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskShellScriptGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/task_shell_script_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/task_shell_script_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskShellScriptResourceExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskShellScriptConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskShellScriptConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/task_shell_script_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/task/task_shell_script_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusTaskShellScriptResourceUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskShellScriptUrlConfig(t, name, map[string]string{})
+	resourceConfig, err := task.RenderTaskShellScriptUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/task/task_write_attributes_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/task/task_write_attributes_resource_test.go
@@ -26,7 +26,9 @@ func TestAccMorpheusTaskWriteAttributesExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := task.RenderTaskWriteAttributesConfig(t, name, nil)
+	resourceConfig, err := task.RenderTaskWriteAttributesConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/cluster_package_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/template/cluster_package_resource_test.go
@@ -47,7 +47,9 @@ func TestAccMorpheusClusterPackageExampleOk(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())
-	resourceConfig, err := template.RenderClusterPackageConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderClusterPackageConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_cluster_package_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_cluster_package_resource_example.go
@@ -15,15 +15,11 @@ import (
 
 // RenderClusterPackageConfig generates a test configuration for cluster package resource.
 // It accepts a name and a map of field overrides to customize the default values.
-func RenderClusterPackageConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderClusterPackageConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":            name,
+		"Name":            "Example",
 		"Code":            "tf-example-cluster-package",
 		"Description":     "Terraform example cluster package",
 		"PackageVersion":  "1.2.3",
@@ -38,6 +34,11 @@ func RenderClusterPackageConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -49,14 +50,6 @@ func RenderClusterPackageConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"Description", defaults["Description"],
-		"PackageVersion", defaults["PackageVersion"],
-		"Type", defaults["Type"],
-		"PackageType", defaults["PackageType"],
-		"Enabled", defaults["Enabled"],
-		"RepeatInstall", defaults["RepeatInstall"],
-		"SpecTemplateIds", defaults["SpecTemplateIds"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/morpheus_file_template_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_file_template_resource_example.go
@@ -13,15 +13,11 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_file_template/resource.tf morpheus_file_template_resource.tf.tmpl Name tf-terraform-file-template Labels ["demo","template","terraform"] FileName tfcustom.cnf FilePath /etc/my.cnf.d Phase preProvision FileOwner root SettingName myCnf SettingCategory master
 
-func RenderFileTemplateConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderFileTemplateConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":            name,
+		"Name":            "Example",
 		"Labels":          `["demo", "template", "terraform"]`,
 		"FileName":        "tfcustom.cnf",
 		"FilePath":        "/etc/my.cnf.d",
@@ -36,6 +32,11 @@ func RenderFileTemplateConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -47,14 +48,6 @@ func RenderFileTemplateConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Labels", defaults["Labels"],
-		"FileName", defaults["FileName"],
-		"FilePath", defaults["FilePath"],
-		"Phase", defaults["Phase"],
-		"FileContent", defaults["FileContent"],
-		"FileOwner", defaults["FileOwner"],
-		"SettingName", defaults["SettingName"],
-		"SettingCategory", defaults["SettingCategory"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/morpheus_file_template_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_file_template_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusFileTemplateExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderFileTemplateConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderFileTemplateConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_script_template_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_script_template_example.go
@@ -14,15 +14,11 @@ import (
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_script_template/resource.tf morpheus_script_template_resource.tf.tmpl 'Name' 'tf-terraform-script-template' 'Labels' "[\"demo\", \"template\", \"terraform\"]" 'ScriptType' 'bash' 'ScriptPhase' 'provision' 'ScriptContent' "echo \"testing\"" 'RunAsUser' 'root' 'Sudo' 'true'
 
 // RenderScriptTemplateConfig renders the template with provided overrides
-func RenderScriptTemplateConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderScriptTemplateConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":          name,
+		"Name":          "Example",
 		"Labels":        "[\"demo\", \"template\", \"terraform\"]",
 		"ScriptType":    "bash",
 		"ScriptPhase":   "provision",
@@ -33,6 +29,11 @@ func RenderScriptTemplateConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -46,12 +47,6 @@ func RenderScriptTemplateConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Labels", defaults["Labels"],
-		"ScriptType", defaults["ScriptType"],
-		"ScriptPhase", defaults["ScriptPhase"],
-		"ScriptContent", defaults["ScriptContent"],
-		"RunAsUser", defaults["RunAsUser"],
-		"Sudo", defaults["Sudo"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/morpheus_script_template_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_script_template_resource_test.go
@@ -25,11 +25,9 @@ func TestAccMorpheusScriptTemplateExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderScriptTemplateConfig(
-		t,
-		name,
-		map[string]string{},
-	)
+	resourceConfig, err := template.RenderScriptTemplateConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_security_package_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_security_package_resource_example.go
@@ -13,15 +13,11 @@ import (
 
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_security_package/resource.tf morpheus_security_package_resource.tf.tmpl Name "tf_example_security_package" Description "Terraform security package example" Labels "[\"demo\", \"terraform\"]" Enabled true Url "https://github.com/ComplianceAsCode/content/releases/download/v0.1.59/scap-security-guide-0.1.59.zip"
 
-func RenderSecurityPackageConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSecurityPackageConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":        name,
+		"Name":        "Example",
 		"Description": "Terraform security package example",
 		"Labels":      "[\"demo\", \"terraform\"]",
 		"Enabled":     "true",
@@ -31,6 +27,11 @@ func RenderSecurityPackageConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -44,10 +45,6 @@ func RenderSecurityPackageConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Description", defaults["Description"],
-		"Labels", defaults["Labels"],
-		"Enabled", defaults["Enabled"],
-		"Url", defaults["Url"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/morpheus_security_package_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_security_package_resource_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSecurityPackageExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSecurityPackageConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderSecurityPackageConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_arm_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_arm_example.go
@@ -15,20 +15,21 @@ import (
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_spec_template_arm/resource_local.tf morpheus_spec_template_arm_resource_local.tf.tmpl Name tf-arm-spec-example-local SourceType local
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_spec_template_arm/resource_url.tf morpheus_spec_template_arm_resource_url.tf.tmpl Name tf-arm-spec-example-url SourceType url SpecPath http://example.com/spec.json
 
-func RenderSpecTemplateArmLocalConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateArmLocalConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":       name,
+		"Name":       "Example",
 		"SourceType": "local",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -42,26 +43,26 @@ func RenderSpecTemplateArmLocalConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
+		args...,
 	)
 }
 
-func RenderSpecTemplateArmUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateArmUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":       name,
+		"Name":       "Example",
 		"SourceType": "url",
 		"SpecPath":   "http://example.com/spec.json",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -75,21 +76,15 @@ func RenderSpecTemplateArmUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecPath", defaults["SpecPath"],
+		args...,
 	)
 }
 
-func RenderSpecTemplateArmGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateArmGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":         name,
+		"Name":         "Example",
 		"SourceType":   "repository",
 		"RepositoryId": "2",
 		"VersionRef":   "main",
@@ -98,6 +93,11 @@ func RenderSpecTemplateArmGitConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -111,10 +111,6 @@ func RenderSpecTemplateArmGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"RepositoryId", defaults["RepositoryId"],
-		"VersionRef", defaults["VersionRef"],
-		"SpecPath", defaults["SpecPath"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_arm_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_arm_resource_git_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateArmResourceGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateArmGitConfig(t, name, nil)
+	resourceConfig, err := template.RenderSpecTemplateArmGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_arm_resource_local_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_arm_resource_local_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateArmResourceLocalExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateArmLocalConfig(t, name, nil)
+	resourceConfig, err := template.RenderSpecTemplateArmLocalConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_arm_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_arm_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateArmResourceUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateArmUrlConfig(t, name, nil)
+	resourceConfig, err := template.RenderSpecTemplateArmUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_cloud_formation_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_cloud_formation_example.go
@@ -15,15 +15,11 @@ import (
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_spec_template_cloud_formation/resource_local.tf morpheus_spec_template_cloud_formation_resource_local.tf.tmpl Name tf_cloud_formation_spec_example_local SourceType local SpecContent "{\n  \"AWSTemplateFormatVersion\" : \"2010-09-09\",\n  \"Description\" : \"AWS CloudFormation Sample Template S3_Website_Bucket_With_Retain_On_Delete: Sample template showing how to create a publicly accessible S3 bucket configured for website access with a deletion policy of retain on delete. **WARNING** This template creates an S3 bucket that will NOT be deleted when the stack is deleted. You will be billed for the AWS resources used if you create a stack from this template.\",\n  \"Resources\" : {\n    \"S3Bucket\" : {\n      \"Type\" : \"AWS::S3::Bucket\",\n      \"Properties\" : {\n        \"AccessControl\" : \"PublicRead\",\n        \"WebsiteConfiguration\" : {\n          \"IndexDocument\" : \"index.html\",\n          \"ErrorDocument\" : \"error.html\"\n         }\n      },\n      \"DeletionPolicy\" : \"Retain\"\n    }\n  },\n\n  \"Outputs\" : {\n    \"WebsiteURL\" : {\n      \"Value\" : { \"Fn::GetAtt\" : [ \"S3Bucket\", \"WebsiteURL\" ] },\n      \"Description\" : \"URL for website hosted on S3\"\n    },\n    \"S3BucketSecureURL\" : {\n      \"Value\" : { \"Fn::Join\" : [ \"\", [ \"https://\", { \"Fn::GetAtt\" : [ \"S3Bucket\", \"DomainName\" ] } ] ] },\n      \"Description\" : \"Name of S3 bucket to hold website content\"\n    }\n  }\n}" CapabilityIam true CapabilityNamedIam true CapabilityAutoExpand true
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_spec_template_cloud_formation/resource_url.tf morpheus_spec_template_cloud_formation_resource_url.tf.tmpl Name tf_cloud_formation_spec_example_url SourceType url SpecPath http://example.com/spec.yaml CapabilityIam true CapabilityNamedIam true CapabilityAutoExpand true
 
-func RenderSpecTemplateCloudFormationLocalConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateCloudFormationLocalConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":       name,
+		"Name":       "Example",
 		"SourceType": "local",
 		"SpecContent": `{
   "AWSTemplateFormatVersion" : "2010-09-09",
@@ -66,6 +62,11 @@ func RenderSpecTemplateCloudFormationLocalConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -77,24 +78,15 @@ func RenderSpecTemplateCloudFormationLocalConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecContent", defaults["SpecContent"],
-		"CapabilityIam", defaults["CapabilityIam"],
-		"CapabilityNamedIam", defaults["CapabilityNamedIam"],
-		"CapabilityAutoExpand", defaults["CapabilityAutoExpand"],
+		args...,
 	)
 }
 
-func RenderSpecTemplateCloudFormationUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateCloudFormationUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                 name,
+		"Name":                 "Example",
 		"SourceType":           "url",
 		"SpecPath":             "http://example.com/spec.yaml",
 		"CapabilityIam":        "true",
@@ -104,6 +96,11 @@ func RenderSpecTemplateCloudFormationUrlConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -117,24 +114,15 @@ func RenderSpecTemplateCloudFormationUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecPath", defaults["SpecPath"],
-		"CapabilityIam", defaults["CapabilityIam"],
-		"CapabilityNamedIam", defaults["CapabilityNamedIam"],
-		"CapabilityAutoExpand", defaults["CapabilityAutoExpand"],
+		args...,
 	)
 }
 
-func RenderSpecTemplateCloudFormationGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateCloudFormationGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":                 name,
+		"Name":                 "Example",
 		"SourceType":           "repository",
 		"RepositoryId":         "2",
 		"VersionRef":           "main",
@@ -148,6 +136,11 @@ func RenderSpecTemplateCloudFormationGitConfig(
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -159,13 +152,6 @@ func RenderSpecTemplateCloudFormationGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"RepositoryId", defaults["RepositoryId"],
-		"VersionRef", defaults["VersionRef"],
-		"SpecPath", defaults["SpecPath"],
-		"CapabilityIam", defaults["CapabilityIam"],
-		"CapabilityNamedIam", defaults["CapabilityNamedIam"],
-		"CapabilityAutoExpand", defaults["CapabilityAutoExpand"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_cloud_formation_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_cloud_formation_resource_git_test.go
@@ -25,11 +25,9 @@ func TestAccMorpheusSpecTemplateCloudFormationResourceGitExampleOk(t *testing.T)
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateCloudFormationGitConfig(
-		t,
-		name,
-		map[string]string{},
-	)
+	resourceConfig, err := template.RenderSpecTemplateCloudFormationGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_cloud_formation_resource_local_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_cloud_formation_resource_local_test.go
@@ -25,11 +25,9 @@ func TestAccMorpheusSpecTemplateCloudFormationResourceLocalExampleOk(t *testing.
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateCloudFormationLocalConfig(
-		t,
-		name,
-		map[string]string{},
-	)
+	resourceConfig, err := template.RenderSpecTemplateCloudFormationLocalConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_cloud_formation_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_cloud_formation_resource_url_test.go
@@ -25,11 +25,9 @@ func TestAccMorpheusSpecTemplateCloudFormationResourceUrlExampleOk(t *testing.T)
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateCloudFormationUrlConfig(
-		t,
-		name,
-		map[string]string{},
-	)
+	resourceConfig, err := template.RenderSpecTemplateCloudFormationUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_helm_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_helm_resource_example.go
@@ -15,11 +15,7 @@ import (
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_spec_template_helm/resource_local.tf morpheus_spec_template_helm_resource_local.tf.tmpl Name tf-helm-spec-example-local SourceType local SpecContent "apiVersion: v1\nkind: Service\nmetadata:\nname: {{ template \"fullname\" . }}\nlabels:\n    chart: \"{{ .Chart.Name }}-{{ .Chart.Version | replace \"+\" \"_\" }}\"\nspec:\ntype: {{ .Values.service.type }}\nports:\n- port: {{ .Values.service.externalPort }}\n    targetPort: {{ .Values.service.internalPort }}\n    protocol: TCP\n    name: {{ .Values.service.name }}\nselector:\n    app: {{ template \"fullname\" . }}"
 //go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_spec_template_helm/resource_git.tf morpheus_spec_template_helm_resource_git.tf.tmpl Name tf-helm-spec-example-git SourceType repository RepositoryId 2 VersionRef main SpecPath ./spec.yaml
 
-func RenderSpecTemplateHelmLocalConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateHelmLocalConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaultSpecContent := "apiVersion: v1\nkind: Service\nmetadata:\nname: {{ template \"fullname\" . }}\n" +
@@ -29,13 +25,18 @@ func RenderSpecTemplateHelmLocalConfig(
 		"    name: {{ .Values.service.name }}\nselector:\n    app: {{ template \"fullname\" . }}"
 
 	defaults := map[string]string{
-		"Name":        name,
+		"Name":        "Example",
 		"SourceType":  "local",
 		"SpecContent": defaultSpecContent,
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -49,27 +50,26 @@ func RenderSpecTemplateHelmLocalConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecContent", defaults["SpecContent"],
+		args...,
 	)
 }
 
-func RenderSpecTemplateHelmUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateHelmUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":       name,
+		"Name":       "Example",
 		"SourceType": "url",
 		"SpecPath":   "http://example.com/chart.yaml",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -83,21 +83,15 @@ func RenderSpecTemplateHelmUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecPath", defaults["SpecPath"],
+		args...,
 	)
 }
 
-func RenderSpecTemplateHelmGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateHelmGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":         name,
+		"Name":         "Example",
 		"RepositoryId": "2",
 		"SourceType":   "repository",
 		"SpecPath":     "./spec.yaml",
@@ -106,6 +100,11 @@ func RenderSpecTemplateHelmGitConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -119,10 +118,6 @@ func RenderSpecTemplateHelmGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"RepositoryId", defaults["RepositoryId"],
-		"SourceType", defaults["SourceType"],
-		"SpecPath", defaults["SpecPath"],
-		"VersionRef", defaults["VersionRef"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_kubernetes_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_kubernetes_example.go
@@ -19,11 +19,7 @@ import (
 
 // RenderSpecTemplateKubernetesLocalConfig renders the configuration for the local
 // Kubernetes spec template resource. Pass overrides as a map to customize field values.
-func RenderSpecTemplateKubernetesLocalConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateKubernetesLocalConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaultSpecContent := `---
@@ -50,13 +46,18 @@ spec:
         - containerPort: 80`
 
 	defaults := map[string]string{
-		"Name":        name,
+		"Name":        "Example",
 		"SourceType":  "local",
 		"SpecContent": defaultSpecContent,
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -70,23 +71,17 @@ spec:
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecContent", defaults["SpecContent"],
+		args...,
 	)
 }
 
 // RenderSpecTemplateKubernetesGitConfig renders the configuration for the Git-based
 // Kubernetes spec template resource. Pass overrides as a map to customize field values.
-func RenderSpecTemplateKubernetesGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateKubernetesGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":         name,
+		"Name":         "Example",
 		"SourceType":   "repository",
 		"RepositoryId": "2",
 		"VersionRef":   "main",
@@ -95,6 +90,11 @@ func RenderSpecTemplateKubernetesGitConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -108,31 +108,28 @@ func RenderSpecTemplateKubernetesGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"RepositoryId", defaults["RepositoryId"],
-		"VersionRef", defaults["VersionRef"],
-		"SpecPath", defaults["SpecPath"],
+		args...,
 	)
 }
 
 // RenderSpecTemplateKubernetesUrlConfig renders the configuration for the URL-based
 // Kubernetes spec template resource. Pass overrides as a map to customize field values.
-func RenderSpecTemplateKubernetesUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateKubernetesUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":       name,
+		"Name":       "Example",
 		"SourceType": "url",
 		"SpecPath":   "http://example.com/spec.yaml",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -146,8 +143,6 @@ func RenderSpecTemplateKubernetesUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecPath", defaults["SpecPath"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_terraform_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/template/morpheus_spec_template_terraform_resource_example.go
@@ -17,15 +17,11 @@ import (
 
 // RenderSpecTemplateTerraformLocalConfig renders the Terraform config for
 // spec_template_terraform_resource_local tests
-func RenderSpecTemplateTerraformLocalConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateTerraformLocalConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":       name,
+		"Name":       "Example",
 		"SourceType": "local",
 		"SpecContent": `resource "aws_instance" "instance_1" {
   ami           = "ami-0b91a410940e82c54"
@@ -35,6 +31,11 @@ func RenderSpecTemplateTerraformLocalConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -48,23 +49,17 @@ func RenderSpecTemplateTerraformLocalConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecContent", defaults["SpecContent"],
+		args...,
 	)
 }
 
 // RenderSpecTemplateTerraformGitConfig renders the Terraform config for
 // spec_template_terraform_resource_git tests
-func RenderSpecTemplateTerraformGitConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateTerraformGitConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":         name,
+		"Name":         "Example",
 		"SourceType":   "repository",
 		"RepositoryId": "2",
 		"VersionRef":   "main",
@@ -73,6 +68,11 @@ func RenderSpecTemplateTerraformGitConfig(
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -86,31 +86,28 @@ func RenderSpecTemplateTerraformGitConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"RepositoryId", defaults["RepositoryId"],
-		"VersionRef", defaults["VersionRef"],
-		"SpecPath", defaults["SpecPath"],
+		args...,
 	)
 }
 
 // RenderSpecTemplateTerraformUrlConfig renders the Terraform config for
 // spec_template_terraform_resource_url tests
-func RenderSpecTemplateTerraformUrlConfig(
-	t *testing.T,
-	name string,
-	overrides map[string]string,
-) (string, error) {
+func RenderSpecTemplateTerraformUrlConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":       name,
+		"Name":       "Example",
 		"SourceType": "url",
 		"SpecPath":   "http://example.com/spec.tf",
 	}
 
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -124,8 +121,6 @@ func RenderSpecTemplateTerraformUrlConfig(
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"SourceType", defaults["SourceType"],
-		"SpecPath", defaults["SpecPath"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/template/spec_template_helm_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_helm_resource_git_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateHelmGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateHelmGitConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderSpecTemplateHelmGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/spec_template_helm_resource_local_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_helm_resource_local_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateHelmLocalExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateHelmLocalConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderSpecTemplateHelmLocalConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/spec_template_helm_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_helm_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateHelmUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateHelmUrlConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderSpecTemplateHelmUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/spec_template_kubernetes_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_kubernetes_resource_git_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateKubernetesResourceGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateKubernetesGitConfig(t, name, nil)
+	resourceConfig, err := template.RenderSpecTemplateKubernetesGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/spec_template_kubernetes_resource_local_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_kubernetes_resource_local_test.go
@@ -49,7 +49,7 @@ spec:
         - containerPort: 80
 `
 
-	resourceConfig, err := template.RenderSpecTemplateKubernetesLocalConfig(t, name, map[string]string{
+	resourceConfig, err := template.RenderSpecTemplateKubernetesLocalConfig(t, map[string]string{
 		"SpecContent": specContent,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/template/spec_template_kubernetes_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_kubernetes_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateKubernetesResourceUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateKubernetesUrlConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderSpecTemplateKubernetesUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/spec_template_terraform_resource_git_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_terraform_resource_git_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateTerraformResourceGitExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateTerraformGitConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderSpecTemplateTerraformGitConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/template/spec_template_terraform_resource_local_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_terraform_resource_local_test.go
@@ -31,7 +31,7 @@ func TestAccMorpheusSpecTemplateTerraformResourceLocalExampleOk(t *testing.T) {
 }
 `
 
-	resourceConfig, err := template.RenderSpecTemplateTerraformLocalConfig(t, name, map[string]string{
+	resourceConfig, err := template.RenderSpecTemplateTerraformLocalConfig(t, map[string]string{
 		"SpecContent": specContent,
 	})
 	if err != nil {

--- a/internal/sdkv2/morpheus/resources/template/spec_template_terraform_resource_url_test.go
+++ b/internal/sdkv2/morpheus/resources/template/spec_template_terraform_resource_url_test.go
@@ -25,7 +25,9 @@ func TestAccMorpheusSpecTemplateTerraformResourceUrlExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := template.RenderSpecTemplateTerraformUrlConfig(t, name, map[string]string{})
+	resourceConfig, err := template.RenderSpecTemplateTerraformUrlConfig(t, map[string]string{
+		"Name": name,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sdkv2/morpheus/resources/trust/morpheus_key_pair_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/trust/morpheus_key_pair_resource_example.go
@@ -49,6 +49,11 @@ func RenderKeyPairConfig(t *testing.T, overrides map[string]string) (string, err
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -60,8 +65,6 @@ func RenderKeyPairConfig(t *testing.T, overrides map[string]string) (string, err
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"PublicKey", defaults["PublicKey"],
-		"PrivateKey", defaults["PrivateKey"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/wiki/morpheus_wiki_page_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/wiki/morpheus_wiki_page_resource_example.go
@@ -15,18 +15,23 @@ import (
 
 // RenderWikiPageConfig generates a Terraform configuration for the wiki page resource.
 // It accepts a map of field overrides to customize default values.
-func RenderWikiPageConfig(t *testing.T, name string, overrides map[string]string) (string, error) {
+func RenderWikiPageConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	// Default field values
 	defaults := map[string]string{
-		"Name":     name,
+		"Name":     "Example",
 		"Category": "morpheus-terraform",
 	}
 
 	// Apply overrides
 	for key, value := range overrides {
 		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
 	}
 
 	// Get the directory where this source file is located
@@ -37,9 +42,9 @@ func RenderWikiPageConfig(t *testing.T, name string, overrides map[string]string
 	dir := filepath.Dir(filename)
 	templatePath := filepath.Join(dir, "morpheus_wiki_page_resource.tf.tmpl")
 
-	return testhelpers.RenderExample(t,
+	return testhelpers.RenderExample(
+		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Category", defaults["Category"],
+		args...,
 	)
 }

--- a/internal/sdkv2/morpheus/resources/wiki/morpheus_wiki_page_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/wiki/morpheus_wiki_page_resource_test.go
@@ -48,7 +48,7 @@ func TestAccMorpheusWikiPageExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := wiki.RenderWikiPageConfig(t, name, map[string]string{
+	resourceConfig, err := wiki.RenderWikiPageConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {


### PR DESCRIPTION
Tidies the formatting of the Render{Resource}Config functions by doing the following:

- Adopts a pattern of passing a variable `args []string` to `RenderExample`. `args` is built up by iterating over the `defaults` map of each render function. This avoids hardcoding the arguments to `RenderExample` and avoids developer error in maintaining a correct list of args for each function.

- Standardise formatting of function signature to be `(t *testing.T, overrides map[string]string) (string, error)`. This prevents stuttering of overriding the `name` which we had previously. Overriding `Name` now uses an `override` like any other overridden parameter.

- Update function invocations with new formatting (i.e. remove `name` from parameter list, make it an override).

- Use `Example` and `example` as default values for `Name` and `Code` respectively for each rendered config.

- Make function signatures all one line long.

- General tidy of formatting within functions for consistency.

- Small fixes in certain tests. `Cypher` render invocations previously used `Name` instead of `Key`. `Key` is correct for these functions.
