### PR TITLE
Tidy formatting of Framework RenderConfig functions

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_example.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_example.go
@@ -30,6 +30,11 @@ func RenderCloudConfig(t *testing.T, overrides map[string]string) (string, error
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -41,12 +46,7 @@ func RenderCloudConfig(t *testing.T, overrides map[string]string) (string, error
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"TenantId", defaults["TenantId"],
-		"GroupId", defaults["GroupId"],
-		"Code", defaults["Code"],
-		"Label", defaults["Label"],
-		"ApplianceUrl", defaults["ApplianceUrl"],
+		args...,
 	)
 }
 
@@ -66,6 +66,11 @@ func RenderCloudGenericConfig(t *testing.T, overrides map[string]string) (string
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -77,11 +82,6 @@ func RenderCloudGenericConfig(t *testing.T, overrides map[string]string) (string
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"TenantId", defaults["TenantId"],
-		"GroupId", defaults["GroupId"],
-		"Code", defaults["Code"],
-		"Label", defaults["Label"],
-		"ApplianceUrl", defaults["ApplianceUrl"],
+		args...,
 	)
 }

--- a/internal/framework/subproviders/morpheus/resources/group/group_example.go
+++ b/internal/framework/subproviders/morpheus/resources/group/group_example.go
@@ -27,6 +27,11 @@ func RenderGroupConfig(t *testing.T, overrides map[string]string) (string, error
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -38,9 +43,6 @@ func RenderGroupConfig(t *testing.T, overrides map[string]string) (string, error
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Location", defaults["Location"],
-		"Code", defaults["Code"],
-		"Label", defaults["Label"],
+		args...,
 	)
 }

--- a/internal/framework/subproviders/morpheus/resources/role/role_example.go
+++ b/internal/framework/subproviders/morpheus/resources/role/role_example.go
@@ -29,6 +29,11 @@ func RenderRoleUserConfig(t *testing.T, overrides map[string]string) (string, er
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -40,14 +45,7 @@ func RenderRoleUserConfig(t *testing.T, overrides map[string]string) (string, er
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name",
-		defaults["Name"],
-		"Multitenant",
-		defaults["Multitenant"],
-		"Description",
-		defaults["Description"],
-		"RoleType",
-		defaults["RoleType"],
+		args...,
 	)
 }
 
@@ -64,6 +62,11 @@ func RenderRoleTenantConfig(t *testing.T, overrides map[string]string) (string, 
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -75,11 +78,6 @@ func RenderRoleTenantConfig(t *testing.T, overrides map[string]string) (string, 
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name",
-		defaults["Name"],
-		"Description",
-		defaults["Description"],
-		"RoleType",
-		defaults["RoleType"],
+		args...,
 	)
 }

--- a/internal/framework/subproviders/morpheus/resources/serviceplan/service_plan_example.go
+++ b/internal/framework/subproviders/morpheus/resources/serviceplan/service_plan_example.go
@@ -33,6 +33,11 @@ func RenderServicePlanConfig(t *testing.T, overrides map[string]string) (string,
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -44,15 +49,6 @@ func RenderServicePlanConfig(t *testing.T, overrides map[string]string) (string,
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"Name", defaults["Name"],
-		"Code", defaults["Code"],
-		"SortOrder", defaults["SortOrder"],
-		"MaxMemory", defaults["MaxMemory"],
-		"MaxStorage", defaults["MaxStorage"],
-		"ProvisionTypeCode", defaults["ProvisionTypeCode"],
-		"CustomMaxStorage", defaults["CustomMaxStorage"],
-		"CoresPerSocket", defaults["CoresPerSocket"],
-		"ConfigRangesMinStorage", defaults["ConfigRangesMinStorage"],
-		"ConfigRangesMaxStorage", defaults["ConfigRangesMaxStorage"],
+		args...,
 	)
 }

--- a/internal/framework/subproviders/morpheus/resources/user/user_example.go
+++ b/internal/framework/subproviders/morpheus/resources/user/user_example.go
@@ -26,6 +26,11 @@ func RenderUserConfig(t *testing.T, overrides map[string]string) (string, error)
 		defaults[key] = value
 	}
 
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
 	// Get the directory where this source file is located
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -37,9 +42,6 @@ func RenderUserConfig(t *testing.T, overrides map[string]string) (string, error)
 	return testhelpers.RenderExample(
 		t,
 		templatePath,
-		"TenantId", defaults["TenantId"],
-		"Username", defaults["Username"],
-		"RoleIds", defaults["RoleIds"],
-		"LinuxKeyPairId", defaults["LinuxKeyPairId"],
+		args...,
 	)
 }


### PR DESCRIPTION
Similar to #744, tidy up Render{Resource}Config functions for framework resources.

Switches to the `args []string` pattern to avoid developer error in the calls to `RenderExample`.
