### PR TITLE
Fixing option_type_text and option_type_textarea

### DIFF
--- a/docs/resources/morpheus_option_type_text.md
+++ b/docs/resources/morpheus_option_type_text.md
@@ -37,6 +37,8 @@ resource "hpe_morpheus_option_type_text" "tf_example_text_option_type" {
 
 ### Required
 
+- `field_label` (String) The label associated with the field in the UI
+- `field_name` (String) The field name of the text option type
 - `name` (String) The name of the text option type
 
 ### Optional
@@ -47,8 +49,6 @@ resource "hpe_morpheus_option_type_text" "tf_example_text_option_type" {
 - `display_value_on_details` (Boolean) Display the selected value of the text option type on the associated resource's details page
 - `editable` (Boolean) Whether the value of the option type can be edited after the initial request
 - `export_meta` (Boolean) Whether to export the text option type as a tag
-- `field_label` (String) The label associated with the field in the UI
-- `field_name` (String) The field name of the text option type
 - `help_block` (String) Text that provides additional details about the use of the option type
 - `labels` (Set of String) The organization labels associated with the option type (Only supported on Morpheus 5.5.3 or higher)
 - `placeholder` (String) Text in the field used as a placeholder for example purposes

--- a/docs/resources/morpheus_option_type_textarea.md
+++ b/docs/resources/morpheus_option_type_textarea.md
@@ -38,6 +38,8 @@ resource "hpe_morpheus_option_type_textarea" "tf_example_textarea_option_type" {
 
 ### Required
 
+- `field_label` (String) The label associated with the field in the UI
+- `field_name` (String) The field name of the textarea option type
 - `name` (String) The name of the textarea option type
 
 ### Optional
@@ -48,8 +50,6 @@ resource "hpe_morpheus_option_type_textarea" "tf_example_textarea_option_type" {
 - `display_value_on_details` (Boolean) Display the selected value of the radio list option type on the associated resource's details page
 - `editable` (Boolean) Whether the value of the option type can be edited after the initial request
 - `export_meta` (Boolean) Whether to export the textarea option type as a tag
-- `field_label` (String) The label associated with the field in the UI
-- `field_name` (String) The field name of the textarea option type
 - `help_block` (String) Text that provides additional details about the use of the option type
 - `labels` (Set of String) The organization labels associated with the option type (Only supported on Morpheus 5.5.3 or higher)
 - `placeholder` (String) Text in the field used as a placeholder for example purposes

--- a/internal/sdkv2/morpheus/resources/optiontype/option_type_text.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/option_type_text.go
@@ -50,8 +50,7 @@ func ResourceOptionTypeText() *schema.Resource {
 			"field_name": {
 				Type:        schema.TypeString,
 				Description: "The field name of the text option type",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"export_meta": {
 				Type:        schema.TypeBool,
@@ -98,8 +97,7 @@ func ResourceOptionTypeText() *schema.Resource {
 			"field_label": {
 				Type:        schema.TypeString,
 				Description: "The label associated with the field in the UI",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"placeholder": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/optiontype/option_type_textarea.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/option_type_textarea.go
@@ -50,8 +50,7 @@ func ResourceOptionTypeTextarea() *schema.Resource {
 			"field_name": {
 				Type:        schema.TypeString,
 				Description: "The field name of the textarea option type",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"export_meta": {
 				Type:        schema.TypeBool,
@@ -98,8 +97,7 @@ func ResourceOptionTypeTextarea() *schema.Resource {
 			"field_label": {
 				Type:        schema.TypeString,
 				Description: "The label associated with the field in the UI",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"rows": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Adding fieldName and fieldLabel as required attributes for both hpe_morpheus_option_type_textarea and hpe_morpheus_option_type_text as they throw a 400 otherwise:
```
"success":false,"errors":{"fieldLabel":"fieldLabel is required","fieldName":"fieldName is required"}
```