### PR TITLE
Adding validation for VRO integration resource

### DIFF
--- a/docs/resources/morpheus_integration_vro.md
+++ b/docs/resources/morpheus_integration_vro.md
@@ -19,6 +19,7 @@ resource "hpe_morpheus_integration_vro" "tf_example_vro_integration" {
   password  = "my-vro-password"
   auth_type = "basic"
   tenant    = "vsphere.local"
+  auth_id   = "1"
 }
 ```
 

--- a/docs/resources/morpheus_integration_vro.md
+++ b/docs/resources/morpheus_integration_vro.md
@@ -29,14 +29,16 @@ resource "hpe_morpheus_integration_vro" "tf_example_vro_integration" {
 
 - `auth_type` (String) The authentication type for the vRO integration
 - `name` (String) The name of the vRO integration
-- `password` (String, Sensitive) The password of the account used to connect to vRO
-- `tenant` (String) The tenant of the account used to connect to vRO
 - `url` (String) The url of the vRO server
-- `username` (String) The username of the account used to connect to vRO
 
 ### Optional
 
+- `api_token` (String, Sensitive) The API token for vRO (required when auth_type is aria)
+- `auth_id` (String) The authentication ID for the vRO integration (required for non-aria auth types)
 - `enabled` (Boolean) Whether the vRO integration is enabled
+- `password` (String, Sensitive) The password of the account used to connect to vRO (required for non-aria auth types)
+- `tenant` (String) The tenant of the account used to connect to vRO (required for non-aria auth types)
+- `username` (String) The username of the account used to connect to vRO (required for non-aria auth types)
 
 ### Read-Only
 

--- a/examples/resources/morpheus_integration_vro/resource.tf
+++ b/examples/resources/morpheus_integration_vro/resource.tf
@@ -6,4 +6,5 @@ resource "hpe_morpheus_integration_vro" "tf_example_vro_integration" {
   password  = "my-vro-password"
   auth_type = "basic"
   tenant    = "vsphere.local"
+  auth_id   = "1"
 }

--- a/internal/sdkv2/morpheus/resources/integration/integration_vro.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_vro.go
@@ -70,7 +70,8 @@ func validateVROAuthConfig(ctx context.Context, d *schema.ResourceDiff, meta any
 		}
 
 		if username == "" || password == "" || tenant == "" || authId == "" {
-			return fmt.Errorf("the following fields are required when auth_type is not 'aria': username, password, tenant, auth_id")
+			return fmt.Errorf("the following fields are required when auth_type is not 'aria': " +
+				"username, password, tenant, auth_id")
 		}
 	}
 

--- a/internal/sdkv2/morpheus/resources/integration/integration_vro.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_vro.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"log"
 	"strings"
 
@@ -19,6 +20,44 @@ import (
 	morpheus "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
 )
 
+func validateVROAuthConfig(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+	authType := d.Get("auth_type").(string)
+
+	if authType == "aria" {
+		// For aria auth type, api_token is required
+		apiToken := d.Get("api_token").(string)
+		if apiToken == "" {
+			return fmt.Errorf("api_token is required when auth_type is 'aria'")
+		}
+	} else {
+		// For non-aria auth types, username, password, tenant, and auth_id are required
+		username := d.Get("username").(string)
+		password := d.Get("password").(string)
+		tenant := d.Get("tenant").(string)
+		authId := d.Get("auth_id").(string)
+
+		var missing []string
+		if username == "" {
+			missing = append(missing, "username")
+		}
+		if password == "" {
+			missing = append(missing, "password")
+		}
+		if tenant == "" {
+			missing = append(missing, "tenant")
+		}
+		if authId == "" {
+			missing = append(missing, "auth_id")
+		}
+
+		if len(missing) > 0 {
+			return fmt.Errorf("the following fields are required when auth_type is not 'aria': %s", strings.Join(missing, ", "))
+		}
+	}
+
+	return nil
+}
+
 func ResourceIntegrationVRO() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Provides a vRealize Orchestrator integration resource",
@@ -26,6 +65,7 @@ func ResourceIntegrationVRO() *schema.Resource {
 		ReadContext:   resourceIntegrationVRORead,
 		UpdateContext: resourceIntegrationVROUpdate,
 		DeleteContext: resourceIntegrationVRODelete,
+		CustomizeDiff: validateVROAuthConfig,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -53,17 +93,17 @@ func ResourceIntegrationVRO() *schema.Resource {
 				Type:         schema.TypeString,
 				Description:  "The authentication type for the vRO integration",
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"basic"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"basic", "aria", "oauth", "vra"}, false),
 			},
 			"username": {
 				Type:        schema.TypeString,
-				Description: "The username of the account used to connect to vRO",
-				Required:    true,
+				Description: "The username of the account used to connect to vRO (required for non-aria auth types)",
+				Optional:    true,
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Description: "The password of the account used to connect to vRO",
-				Required:    true,
+				Description: "The password of the account used to connect to vRO (required for non-aria auth types)",
+				Optional:    true,
 				Sensitive:   true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					h := sha256.New()
@@ -76,8 +116,8 @@ func ResourceIntegrationVRO() *schema.Resource {
 			},
 			"tenant": {
 				Type:        schema.TypeString,
-				Description: "The tenant of the account used to connect to vRO",
-				Required:    true,
+				Description: "The tenant of the account used to connect to vRO (required for non-aria auth types)",
+				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					h := sha256.New()
 					h.Write([]byte(new))
@@ -85,6 +125,18 @@ func ResourceIntegrationVRO() *schema.Resource {
 
 					return strings.EqualFold(old, sha256Hash)
 				},
+			},
+			"auth_id": {
+				Type:        schema.TypeString,
+				Description: "The authentication ID for the vRO integration (required for non-aria auth types)",
+				Optional:    true,
+				Computed:    true,
+			},
+			"api_token": {
+				Type:        schema.TypeString,
+				Description: "The API token for vRO (required when auth_type is aria)",
+				Optional:    true,
+				Sensitive:   true,
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -121,6 +173,14 @@ func resourceIntegrationVROCreate(ctx context.Context, d *schema.ResourceData, m
 
 	integration["type"] = "vro"
 
+	var authType string
+	if v, ok := d.Get("auth_type").(string); ok {
+		authType = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("auth_type", d.Get("auth_type")))
+	}
+	integration["authType"] = authType
+
 	var url string
 	if v, ok := d.Get("url").(string); ok {
 		url = v
@@ -129,39 +189,43 @@ func resourceIntegrationVROCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 	integration["serviceUrl"] = url
 
-	var username string
-	if v, ok := d.Get("username").(string); ok {
-		username = v
+	// Handle different auth types
+	if authType == "aria" {
+		// For aria auth type, use api_token
+		var apiToken string
+		if v, ok := d.Get("api_token").(string); ok {
+			apiToken = v
+		}
+		config := make(map[string]any)
+		config["apiToken"] = apiToken
+		integration["config"] = config
 	} else {
-		return diag.FromErr(helpers.TypeAssertFailError("username", d.Get("username")))
-	}
-	integration["serviceUsername"] = username
+		// For non-aria auth types (basic, oauth, vra), use username/password/tenant
+		var username string
+		if v, ok := d.Get("username").(string); ok {
+			username = v
+		}
+		integration["serviceUsername"] = username
 
-	var password string
-	if v, ok := d.Get("password").(string); ok {
-		password = v
-	} else {
-		return diag.FromErr(helpers.TypeAssertFailError("password", d.Get("password")))
-	}
-	integration["servicePassword"] = password
+		var password string
+		if v, ok := d.Get("password").(string); ok {
+			password = v
+		}
+		integration["servicePassword"] = password
 
-	var tenant string
-	if v, ok := d.Get("tenant").(string); ok {
-		tenant = v
-	} else {
-		return diag.FromErr(helpers.TypeAssertFailError("tenant", d.Get("tenant")))
-	}
-	integration["serviceToken"] = tenant
+		var tenant string
+		if v, ok := d.Get("tenant").(string); ok {
+			tenant = v
+		}
+		integration["serviceToken"] = tenant
 
-	integration["authId"] = ""
-
-	var authType string
-	if v, ok := d.Get("auth_type").(string); ok {
-		authType = v
-	} else {
-		return diag.FromErr(helpers.TypeAssertFailError("auth_type", d.Get("auth_type")))
+		var authId string
+		if v, ok := d.Get("auth_id").(string); ok {
+			authId = v
+		}
+		// For non-aria auth types, authId must be set (can be empty string for local credentials)
+		integration["authId"] = authId
 	}
-	integration["authType"] = authType
 
 	req := &morpheus.Request{
 		Body: map[string]any{

--- a/internal/sdkv2/morpheus/resources/integration/integration_vro.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_vro.go
@@ -21,20 +21,53 @@ import (
 )
 
 func validateVROAuthConfig(ctx context.Context, d *schema.ResourceDiff, meta any) error {
-	authType := d.Get("auth_type").(string)
+	var authType string
+	if v, ok := d.Get("auth_type").(string); ok {
+		authType = v
+	} else {
+		return fmt.Errorf("auth_type type assertion failed")
+	}
 
 	if authType == "aria" {
 		// For aria auth type, api_token is required
-		apiToken := d.Get("api_token").(string)
+		var apiToken string
+		if v, ok := d.Get("api_token").(string); ok {
+			apiToken = v
+		} else {
+			return fmt.Errorf("api_token type assertion failed")
+		}
 		if apiToken == "" {
 			return fmt.Errorf("api_token is required when auth_type is 'aria'")
 		}
 	} else {
 		// For non-aria auth types, username, password, tenant, and auth_id are required
-		username := d.Get("username").(string)
-		password := d.Get("password").(string)
-		tenant := d.Get("tenant").(string)
-		authId := d.Get("auth_id").(string)
+		var username string
+		if v, ok := d.Get("username").(string); ok {
+			username = v
+		} else {
+			return fmt.Errorf("username type assertion failed")
+		}
+		
+		var password string
+		if v, ok := d.Get("password").(string); ok {
+			password = v
+		} else {
+			return fmt.Errorf("password type assertion failed")
+		}
+		
+		var tenant string
+		if v, ok := d.Get("tenant").(string); ok {
+			tenant = v
+		} else {
+			return fmt.Errorf("tenant type assertion failed")
+		}
+		
+		var authId string
+		if v, ok := d.Get("auth_id").(string); ok {
+			authId = v
+		} else {
+			return fmt.Errorf("auth_id type assertion failed")
+		}
 
 		var missing []string
 		if username == "" {

--- a/internal/sdkv2/morpheus/resources/integration/integration_vro.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_vro.go
@@ -25,7 +25,7 @@ func validateVROAuthConfig(ctx context.Context, d *schema.ResourceDiff, meta any
 	if v, ok := d.Get("auth_type").(string); ok {
 		authType = v
 	} else {
-		return fmt.Errorf("auth_type type assertion failed")
+		return helpers.TypeAssertFailError("auth_type", d.Get("auth_type"))
 	}
 
 	if authType == "aria" {
@@ -34,7 +34,7 @@ func validateVROAuthConfig(ctx context.Context, d *schema.ResourceDiff, meta any
 		if v, ok := d.Get("api_token").(string); ok {
 			apiToken = v
 		} else {
-			return fmt.Errorf("api_token type assertion failed")
+			return helpers.TypeAssertFailError("api_token", d.Get("api_token"))
 		}
 		if apiToken == "" {
 			return fmt.Errorf("api_token is required when auth_type is 'aria'")
@@ -45,28 +45,28 @@ func validateVROAuthConfig(ctx context.Context, d *schema.ResourceDiff, meta any
 		if v, ok := d.Get("username").(string); ok {
 			username = v
 		} else {
-			return fmt.Errorf("username type assertion failed")
+			return helpers.TypeAssertFailError("username", d.Get("username"))
 		}
-		
+
 		var password string
 		if v, ok := d.Get("password").(string); ok {
 			password = v
 		} else {
-			return fmt.Errorf("password type assertion failed")
+			return helpers.TypeAssertFailError("password", d.Get("password"))
 		}
-		
+
 		var tenant string
 		if v, ok := d.Get("tenant").(string); ok {
 			tenant = v
 		} else {
-			return fmt.Errorf("tenant type assertion failed")
+			return helpers.TypeAssertFailError("tenant", d.Get("tenant"))
 		}
-		
+
 		var authId string
 		if v, ok := d.Get("auth_id").(string); ok {
 			authId = v
 		} else {
-			return fmt.Errorf("auth_id type assertion failed")
+			return helpers.TypeAssertFailError("auth_id", d.Get("auth_id"))
 		}
 
 		var missing []string

--- a/internal/sdkv2/morpheus/resources/integration/integration_vro.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_vro.go
@@ -69,22 +69,8 @@ func validateVROAuthConfig(ctx context.Context, d *schema.ResourceDiff, meta any
 			return helpers.TypeAssertFailError("auth_id", d.Get("auth_id"))
 		}
 
-		var missing []string
-		if username == "" {
-			missing = append(missing, "username")
-		}
-		if password == "" {
-			missing = append(missing, "password")
-		}
-		if tenant == "" {
-			missing = append(missing, "tenant")
-		}
-		if authId == "" {
-			missing = append(missing, "auth_id")
-		}
-
-		if len(missing) > 0 {
-			return fmt.Errorf("the following fields are required when auth_type is not 'aria': %s", strings.Join(missing, ", "))
+		if username == "" || password == "" || tenant == "" || authId == "" {
+			return fmt.Errorf("the following fields are required when auth_type is not 'aria': username, password, tenant, auth_id")
 		}
 	}
 

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource.tf.tmpl
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource.tf.tmpl
@@ -6,4 +6,5 @@ resource "hpe_morpheus_integration_vro" "tf_example_vro_integration" {
   password  = "{{.Password}}"
   auth_type = "{{.AuthType}}"
   tenant    = "{{.Tenant}}"
+  auth_id   = "{{.AuthId}}"
 }

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource_example.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource_example.go
@@ -11,7 +11,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
 )
 
-//go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_integration_vro/resource.tf morpheus_integration_vro_resource.tf.tmpl Name "tfexample vro" Enabled true Url https://myvro/vco/api Username my-vro-username Password my-vro-password AuthType basic Tenant vsphere.local
+//go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_integration_vro/resource.tf morpheus_integration_vro_resource.tf.tmpl Name "tfexample vro" Enabled true Url https://myvro/vco/api Username my-vro-username Password my-vro-password AuthType basic Tenant vsphere.local AuthId "1"
 
 // RenderIntegrationVroConfig generates a Terraform configuration for the VRO integration
 // resource. It accepts an optional map of field overrides to customize the default values.
@@ -27,6 +27,7 @@ func RenderIntegrationVroConfig(t *testing.T, overrides map[string]string) (stri
 		"Password": "my-vro-password",
 		"AuthType": "basic",
 		"Tenant":   "vsphere.local",
+		"AuthId":   "1",
 	}
 
 	// Apply overrides to defaults

--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_vro_resource_test.go
@@ -93,6 +93,11 @@ func TestAccMorpheusIntegrationVroExampleOk(t *testing.T) {
 			"tenant",
 			"vsphere.local",
 		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_integration_vro.tf_example_vro_integration",
+			"auth_id",
+			"1",
+		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)


### PR DESCRIPTION
Adding validation for VRO integration resource to avoid 400 errors. The required-ness of attributes here depends on the `auth_type` (which was previously only set to basic). This PR adds the other auth_types and includes validation to ensure
- api_token is set when auth_type is 'aria'
- username, password, tenant and auth_id are set otherwise.

This avoids confusing 400 errors.