### PR TITLE
Emit SDK error on datastore create retry loop read

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -167,10 +167,23 @@ func (r *Resource) Create(
 			status = r.GetDatastore().Status
 		}
 
-		resp.Diagnostics.AddError(
-			"datastore provisioning failed",
-			fmt.Sprintf("Datastore %d failed to reach provisioned status. Current status: %v", id, status),
-		)
+		// Unwrap the error to get the API/SDK error message if present
+		var errUnwrapped error
+		if r == nil {
+			errUnwrapped = errors.Unwrap(err)
+		}
+
+		if errUnwrapped != nil {
+			resp.Diagnostics.AddError(
+				"datastore provisioning failed",
+				fmt.Sprintf("Datastore %d failed to reach provisioned status: %v", id, errUnwrapped),
+			)
+		} else {
+			resp.Diagnostics.AddError(
+				"datastore provisioning failed",
+				fmt.Sprintf("Datastore %d failed to reach provisioned status. Current status: %v", id, status),
+			)
+		}
 		taintResourceState(id)
 
 		return

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -176,12 +176,12 @@ func (r *Resource) Create(
 		if errUnwrapped != nil {
 			resp.Diagnostics.AddError(
 				"datastore provisioning failed",
-				fmt.Sprintf("Datastore %d failed to reach provisioned status: %s", id, errUnwrapped),
+				fmt.Sprintf("Datastore %d failed to reach provisioned status: %v", id, errUnwrapped),
 			)
 		} else {
 			resp.Diagnostics.AddError(
 				"datastore provisioning failed",
-				fmt.Sprintf("Datastore %d failed to reach provisioned status. Current status: %v", id, status),
+				fmt.Sprintf("Datastore %d failed to reach provisioned status. Current status: %s", id, status),
 			)
 		}
 		taintResourceState(id)

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -176,7 +176,7 @@ func (r *Resource) Create(
 		if errUnwrapped != nil {
 			resp.Diagnostics.AddError(
 				"datastore provisioning failed",
-				fmt.Sprintf("Datastore %d failed to reach provisioned status: %v", id, errUnwrapped),
+				fmt.Sprintf("Datastore %d failed to reach provisioned status: %s", id, errUnwrapped),
 			)
 		} else {
 			resp.Diagnostics.AddError(


### PR DESCRIPTION
We've seen situations where a datastore create fails but the status in the error message is blank.  This suggests that the SDK call in the retry look to get the datastore failed.  If this happens we unwrap the error to obtain the underlying SDK error and add it to the returned error message.