### PR TITLE
sdkv2: Use unique code in instance_type test

### DIFF
--- a/internal/sdkv2/morpheus/resources/blueprint/morpheus_instance_type_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/blueprint/morpheus_instance_type_resource_test.go
@@ -51,6 +51,7 @@ func TestAccMorpheusInstanceTypeExampleOk(t *testing.T) {
 
 	resourceConfig, err := blueprint.RenderInstanceTypeConfig(t, map[string]string{
 		"Name": name,
+		"Code": strings.ToLower(name),
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This would previously use the same code as the example, causing subsequent runs after a test which hadn't its resources cleaned up to fail.
