### PR TITLE
Fix bug in datastore create retry

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package datastore
 
@@ -127,8 +127,6 @@ func (r *Resource) Create(
 		return
 	}
 
-	// Set the resource ID locally but NOT in state yet
-
 	// Helper to taint the resource state on an error after the POST request
 	taintResourceState := func(id int64) {
 		utils.TaintResourceState(ctx, utils.TaintResourceStateConfig{
@@ -141,7 +139,7 @@ func (r *Resource) Create(
 
 	// Wait for the datastore to be ready
 	waitForReady := func() (*sdk.GetDatastores200Response, error) {
-		response, hresp, err := client.DatastoresAPI.GetDatastores(ctx, plan.Id.ValueInt64()).Execute()
+		response, hresp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
 		if err != nil || hresp.StatusCode != http.StatusOK {
 			return nil, backoff.Permanent(err)
 		}


### PR DESCRIPTION
We were using an id of 0 when reading the created datastore as opposed to the actual id.