### PR TITLE
Parity: workflows tests

### DIFF
--- a/docs/resources/morpheus_workflow_operational.md
+++ b/docs/resources/morpheus_workflow_operational.md
@@ -11,17 +11,13 @@ Provides a Morpheus operational workflow resource.
 ## Example Usage
 
 ```terraform
-resource "hpe_morpheus_workflow_operational" "tf_example_operational_workflow" {
+resource "hpe_morpheus_workflow_operational" "example" {
   name                = "tf_example_operational_workflow"
   description         = "Terraform operational workflow example"
   labels              = ["demo", "terraform"]
   platform            = "all"
   visibility          = "private"
   allow_custom_config = true
-  option_types = [
-    1730
-  ]
-  task_ids = [18]
 }
 ```
 

--- a/docs/resources/morpheus_workflow_provisioning.md
+++ b/docs/resources/morpheus_workflow_provisioning.md
@@ -11,16 +11,12 @@ Provides a Morpheus provisioning workflow resource.
 ## Example Usage
 
 ```terraform
-resource "hpe_morpheus_workflow_provisioning" "tf_example_provisioning_workflow" {
+resource "hpe_morpheus_workflow_provisioning" "example" {
   name        = "tf_example_provisioning_workflow"
   description = "Terraform provisioning workflow example"
   labels      = ["demo", "terraform"]
   platform    = "all"
   visibility  = "private"
-  task {
-    task_id    = 18
-    task_phase = "configure"
-  }
 }
 ```
 

--- a/examples/resources/morpheus_workflow_operational/resource.tf
+++ b/examples/resources/morpheus_workflow_operational/resource.tf
@@ -1,12 +1,8 @@
-resource "hpe_morpheus_workflow_operational" "tf_example_operational_workflow" {
+resource "hpe_morpheus_workflow_operational" "example" {
   name                = "tf_example_operational_workflow"
   description         = "Terraform operational workflow example"
   labels              = ["demo", "terraform"]
   platform            = "all"
   visibility          = "private"
   allow_custom_config = true
-  option_types = [
-    1730
-  ]
-  task_ids = [18]
 }

--- a/examples/resources/morpheus_workflow_provisioning/resource.tf
+++ b/examples/resources/morpheus_workflow_provisioning/resource.tf
@@ -1,11 +1,7 @@
-resource "hpe_morpheus_workflow_provisioning" "tf_example_provisioning_workflow" {
+resource "hpe_morpheus_workflow_provisioning" "example" {
   name        = "tf_example_provisioning_workflow"
   description = "Terraform provisioning workflow example"
   labels      = ["demo", "terraform"]
   platform    = "all"
   visibility  = "private"
-  task {
-    task_id    = 18
-    task_phase = "configure"
-  }
 }

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_operational_example.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_operational_example.go
@@ -1,0 +1,53 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package workflow
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
+)
+
+//go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_workflow_operational/resource.tf workflow_operational_resource.tf.tmpl Name tf_example_operational_workflow Description "Terraform operational workflow example" Labels "[\"demo\", \"terraform\"]" Platform all Visibility private AllowCustomConfig true
+
+// RenderWorkflowOperationalConfig generates a Terraform configuration for the workflow operational resource.
+// It accepts optional overrides for field values. Default values are used if not overridden.
+func RenderWorkflowOperationalConfig(t *testing.T, overrides map[string]string) (string, error) {
+	t.Helper()
+
+	defaults := map[string]string{
+		"Name":              "tf_example_operational_workflow",
+		"Description":       "Terraform operational workflow example",
+		"Labels":            "[\"demo\", \"terraform\"]",
+		"Platform":          "all",
+		"Visibility":        "private",
+		"AllowCustomConfig": "true",
+	}
+
+	// Apply overrides to defaults
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
+	// Get the directory where this source file is located
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to get current file path")
+	}
+	dir := filepath.Dir(filename)
+	templatePath := filepath.Join(dir, "workflow_operational_resource.tf.tmpl")
+
+	return testhelpers.RenderExample(
+		t,
+		templatePath,
+		args...,
+	)
+}

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_operational_resource.tf.tmpl
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_operational_resource.tf.tmpl
@@ -1,0 +1,8 @@
+resource "hpe_morpheus_workflow_operational" "example" {
+  name                = "{{.Name}}"
+  description         = "{{.Description}}"
+  labels              = {{.Labels}}
+  platform            = "{{.Platform}}"
+  visibility          = "{{.Visibility}}"
+  allow_custom_config = {{.AllowCustomConfig}}
+}

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_operational_test.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_operational_test.go
@@ -1,0 +1,96 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+package workflow_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
+	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus"
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/resources/workflow"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	testhelpers.WriteMergedResults()
+
+	os.Exit(code)
+}
+
+func TestAccMorpheusWorkflowOperationalExampleOk(t *testing.T) {
+	t.Parallel()
+
+	defer testhelpers.RecordResult(t)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig, err := workflow.RenderWorkflowOperationalConfig(t, map[string]string{
+		"Name": name,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_operational.example",
+			"name",
+			name,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_operational.example",
+			"description",
+			"Terraform operational workflow example",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_operational.example",
+			"labels.#",
+			"2",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_operational.example",
+			"platform",
+			"all",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_operational.example",
+			"visibility",
+			"private",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_operational.example",
+			"allow_custom_config",
+			"true",
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, nil, sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			// Apply
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+			},
+			// Plan after apply
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+		},
+	})
+}

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_operational_test.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_operational_test.go
@@ -60,6 +60,16 @@ func TestAccMorpheusWorkflowOperationalExampleOk(t *testing.T) {
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_workflow_operational.example",
+			"labels.0",
+			"demo",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_operational.example",
+			"labels.1",
+			"terraform",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_operational.example",
 			"platform",
 			"all",
 		),

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_provisioning_example.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_provisioning_example.go
@@ -1,0 +1,52 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package workflow
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
+)
+
+//go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_workflow_provisioning/resource.tf workflow_provisioning_resource.tf.tmpl Name "tf_example_provisioning_workflow" Description "Terraform provisioning workflow example" Labels "[\"demo\", \"terraform\"]" Platform "all" Visibility "private"
+
+// RenderWorkflowProvisioningConfig generates a Terraform configuration for the workflow provisioning resource.
+// It accepts optional overrides for field values. Default values are used if not overridden.
+func RenderWorkflowProvisioningConfig(t *testing.T, overrides map[string]string) (string, error) {
+	t.Helper()
+
+	defaults := map[string]string{
+		"Name":        "tf_example_provisioning_workflow",
+		"Description": "Terraform provisioning workflow example",
+		"Labels":      "[\"demo\", \"terraform\"]",
+		"Platform":    "all",
+		"Visibility":  "private",
+	}
+
+	// Apply overrides to defaults
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
+	// Get the directory where this source file is located
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to get current file path")
+	}
+	dir := filepath.Dir(filename)
+	templatePath := filepath.Join(dir, "workflow_provisioning_resource.tf.tmpl")
+
+	return testhelpers.RenderExample(
+		t,
+		templatePath,
+		args...,
+	)
+}

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_provisioning_resource.tf.tmpl
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_provisioning_resource.tf.tmpl
@@ -1,0 +1,7 @@
+resource "hpe_morpheus_workflow_provisioning" "example" {
+  name        = "{{.Name}}"
+  description = "{{.Description}}"
+  labels      = {{.Labels}}
+  platform    = "{{.Platform}}"
+  visibility  = "{{.Visibility}}"
+}

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_provisioning_test.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_provisioning_test.go
@@ -1,0 +1,83 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package workflow_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
+	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus"
+	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/resources/workflow"
+)
+
+func TestAccWorkflowProvisioningExampleOk(t *testing.T) {
+	t.Parallel()
+
+	defer testhelpers.RecordResult(t)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	name := acctest.RandomWithPrefix(t.Name())
+
+	resourceConfig, err := workflow.RenderWorkflowProvisioningConfig(t, map[string]string{
+		"Name": name,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_provisioning.example",
+			"name",
+			name,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_provisioning.example",
+			"description",
+			"Terraform provisioning workflow example",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_provisioning.example",
+			"labels.#",
+			"2",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_provisioning.example",
+			"platform",
+			"all",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_provisioning.example",
+			"visibility",
+			"private",
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			// Apply
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+			},
+			// Plan after apply
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+		},
+	})
+}

--- a/internal/sdkv2/morpheus/resources/workflow/workflow_provisioning_test.go
+++ b/internal/sdkv2/morpheus/resources/workflow/workflow_provisioning_test.go
@@ -52,6 +52,16 @@ func TestAccWorkflowProvisioningExampleOk(t *testing.T) {
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_workflow_provisioning.example",
+			"labels.0",
+			"demo",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_provisioning.example",
+			"labels.1",
+			"terraform",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_workflow_provisioning.example",
 			"platform",
 			"all",
 		),


### PR DESCRIPTION
Adds acceptance tests and generated example code for the resources `hpe_morpheus_workflow_operational` and `hpe_morpheus_workflow_provisioning`.
