### PR TITLE
Fix inconsistencies in tainting resource PR

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package cloud
 

--- a/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
+++ b/internal/framework/subproviders/morpheus/resources/cloud/cloud_create.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 
@@ -211,6 +212,7 @@ func (r *Resource) Create(
 	}
 
 	id := *cloud.GetZone().Id
+	plan.Id = types.Int64Value(id)
 
 	// Helper to taint the resource state on an error after the POST request
 	taintResourceState := func(id int64) {

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/cenkalti/backoff/v5"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
 )
@@ -126,6 +127,9 @@ func (r *Resource) Create(
 
 		return
 	}
+
+	// Set the resource ID
+	plan.Id = types.Int64Value(id)
 
 	// Helper to taint the resource state on an error after the POST request
 	taintResourceState := func(id int64) {

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package image
 

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -231,6 +231,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	imageId := image.VirtualImage.GetId()
+	plan.Id = convert.Int64ToType(image.VirtualImage.Id)
 
 	// Helper to taint the resource state on an error after the POST request
 	taintResourceState := func(id int64) {

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -230,7 +230,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	imageId := image.VirtualImage.GetId()
 	plan.Id = convert.Int64ToType(image.VirtualImage.Id)
 
 	// Helper to taint the resource state on an error after the POST request
@@ -241,19 +240,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			StateWriter:  &resp.State,
 			Diagnostics:  &resp.Diagnostics,
 		})
-	}
-
-	// Set state
-	plan.Id = convert.Int64ToType(&imageId)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		resp.Diagnostics.AddError(
-			"failed to set initial image state",
-			fmt.Sprintf("Image %d was created but state could not be saved", imageId),
-		)
-		taintResourceState(imageId)
-
-		return
 	}
 
 	// rough template for what needs to be done to support file uploading

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -234,6 +234,7 @@ func (g *Resource) Create(
 	}
 
 	// Store ID locally but not in state yet
+	plan.Id = convert.Int64ToType(instance.Instance.Id)
 	instanceId := instance.Instance.GetId()
 
 	// Helper to taint the resource state on an error after the POST request

--- a/internal/framework/subproviders/morpheus/resources/network/create.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package network
 

--- a/internal/framework/subproviders/morpheus/resources/network/create.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create.go
@@ -280,6 +280,7 @@ func (r *Resource) Create(
 	}
 
 	id := *network.GetNetwork().Id
+	plan.Id = types.Int64Value(id)
 
 	// Helper to taint the resource state on an error after the POST request
 	taintResourceState := func(id int64) {

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package policy
 

--- a/internal/framework/subproviders/morpheus/resources/policy/create.go
+++ b/internal/framework/subproviders/morpheus/resources/policy/create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/errors"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/utils"
@@ -119,6 +120,7 @@ func (r *Resource) Create(
 	}
 
 	id := *policy.Policy.Id
+	plan.Id = types.Int64Value(id)
 
 	// Helper to taint the resource state on an error after the POST request
 	taintResourceState := func(id int64) {

--- a/internal/framework/subproviders/morpheus/resources/role/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/role/resource.go
@@ -1468,12 +1468,6 @@ func (r *Resource) Create(
 		})
 	}
 
-	// write id as soon as possible
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	apiState, diags := getRoleAsState(ctx, id, client)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/internal/framework/subproviders/morpheus/resources/serviceplan/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/serviceplan/resource.go
@@ -495,12 +495,6 @@ func (r *Resource) Create(
 		})
 	}
 
-	// write id as soon as possible
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	state, diags := getServicePlanAsState(ctx, id, client)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/internal/framework/subproviders/morpheus/resources/user/resource.go
+++ b/internal/framework/subproviders/morpheus/resources/user/resource.go
@@ -218,12 +218,6 @@ func (r *Resource) Create(
 		})
 	}
 
-	// write id as soon as possible
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	state, pdiags := getUserAsState(ctx, id, client)
 	if pdiags.HasError() {
 		resp.Diagnostics.Append(pdiags...)


### PR DESCRIPTION
In https://github.com/HPE/terraform-provider-hpe/pull/739 - some resources had the following line removed to accomodate not setting ID in state:
```
plan.Id = types.Int64Value(id)
```

In hindsight - there is not reason why we can't set the ID in plan as the actual lines where state was set early have been removed:
```
// write id as soon as possible
resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
if resp.Diagnostics.HasError() {
    return
}
```

Since removing this inadvertently caused an issue with datastore - this PR adds this line back to all create functions for consistency and to minimize any functional changes among CREATE functions as part of the previous PR.

The above lines setting state "as soon as possible" have also been removed from image, role, service plan and user resources.