### PR TITLE
Fixing required fields for option types.

### DIFF
--- a/docs/resources/morpheus_option_type_hidden.md
+++ b/docs/resources/morpheus_option_type_hidden.md
@@ -32,6 +32,7 @@ resource "hpe_morpheus_option_type_hidden" "tf_example_hidden_option_type" {
 
 ### Required
 
+- `field_name` (String) The field name of the hidden option type
 - `name` (String) The name of the hidden option type
 
 ### Optional
@@ -42,7 +43,6 @@ resource "hpe_morpheus_option_type_hidden" "tf_example_hidden_option_type" {
 - `display_value_on_details` (Boolean) Display the selected value of the number option type on the associated resource's details page
 - `editable` (Boolean) Whether the value of the option type can be edited after the initial request
 - `export_meta` (Boolean) Whether to export the hidden option type as a tag
-- `field_name` (String) The field name of the hidden option type
 - `labels` (Set of String) The organization labels associated with the option type (Only supported on Morpheus 5.5.3 or higher)
 - `require_field` (String) The field or code used to trigger the requirement of this field
 - `show_on_edit` (Boolean) Whether the option type will display in the edit section of the provisioned resource

--- a/docs/resources/morpheus_option_type_number.md
+++ b/docs/resources/morpheus_option_type_number.md
@@ -36,6 +36,8 @@ resource "hpe_morpheus_option_type_number" "tf_example_number_option_type" {
 
 ### Required
 
+- `field_label` (String) The label associated with the field in the UI
+- `field_name` (String) The field name of the number option type
 - `name` (String) The name of the number option type
 
 ### Optional
@@ -46,8 +48,6 @@ resource "hpe_morpheus_option_type_number" "tf_example_number_option_type" {
 - `display_value_on_details` (Boolean) Display the selected value of the number option type on the associated resource's details page
 - `editable` (Boolean) Whether the value of the option type can be edited after the initial request
 - `export_meta` (Boolean) Whether to export the number option type as a tag
-- `field_label` (String) The label associated with the field in the UI
-- `field_name` (String) The field name of the number option type
 - `help_block` (String) Text that provides additional details about the use of the option type
 - `labels` (Set of String) The organization labels associated with the option type (Only supported on Morpheus 5.5.3 or higher)
 - `placeholder` (String) Text in the field used as a placeholder for example purposes

--- a/docs/resources/morpheus_option_type_password.md
+++ b/docs/resources/morpheus_option_type_password.md
@@ -37,6 +37,8 @@ resource "hpe_morpheus_option_type_password" "tf_example_password_option_type" {
 
 ### Required
 
+- `field_label` (String) The label associated with the field in the UI
+- `field_name` (String) The field name of the password option type
 - `name` (String) The name of the password option type
 
 ### Optional
@@ -47,8 +49,6 @@ resource "hpe_morpheus_option_type_password" "tf_example_password_option_type" {
 - `display_value_on_details` (Boolean) Display the selected value of the password option type on the associated resource's details page
 - `editable` (Boolean) Whether the value of the option type can be edited after the initial request
 - `export_meta` (Boolean) Whether to export the password option type as a tag
-- `field_label` (String) The label associated with the field in the UI
-- `field_name` (String) The field name of the password option type
 - `help_block` (String) Password that provides additional details about the use of the option type
 - `labels` (Set of String) The organization labels associated with the option type (Only supported on Morpheus 5.5.3 or higher)
 - `placeholder` (String) Password in the field used as a placeholder for example purposes

--- a/docs/resources/morpheus_option_type_radio_list.md
+++ b/docs/resources/morpheus_option_type_radio_list.md
@@ -36,7 +36,10 @@ resource "hpe_morpheus_option_type_radio_list" "example" {
 
 ### Required
 
+- `field_label` (String) The label associated with the field in the UI
+- `field_name` (String) The field name of the radio list option type
 - `name` (String) The name of the radio list option type
+- `option_list_id` (Number) The ID of the associated option list
 
 ### Optional
 
@@ -46,11 +49,8 @@ resource "hpe_morpheus_option_type_radio_list" "example" {
 - `display_value_on_details` (Boolean) Display the selected value of the radio list option type on the associated resource's details page
 - `editable` (Boolean) Whether the value of the option type can be edited after the initial request
 - `export_meta` (Boolean) Whether to export the radio list option type as a tag
-- `field_label` (String) The label associated with the field in the UI
-- `field_name` (String) The field name of the radio list option type
 - `help_block` (String) Text that provides additional details about the use of the option type
 - `labels` (Set of String) The organization labels associated with the option type(Only supported on Morpheus 5.5.3 or higher)
-- `option_list_id` (Number) The ID of the associated option list
 - `require_field` (String) The field or code used to trigger the required status of the field
 - `required` (Boolean) Whether the option type is required
 - `show_on_edit` (Boolean) Whether the option type will display in the edit section of the provisioned resource

--- a/docs/resources/morpheus_option_type_select_list.md
+++ b/docs/resources/morpheus_option_type_select_list.md
@@ -36,7 +36,10 @@ resource "hpe_morpheus_option_type_select_list" "example" {
 
 ### Required
 
+- `field_label` (String) The label associated with the field in the UI
+- `field_name` (String) The field name of the select list option type
 - `name` (String) The name of the select list option type
+- `option_list_id` (Number) The ID of the associated option list
 
 ### Optional
 
@@ -46,11 +49,8 @@ resource "hpe_morpheus_option_type_select_list" "example" {
 - `display_value_on_details` (Boolean) Display the selected value of the text option type on the associated resource's details page
 - `editable` (Boolean) Whether the value of the option type can be edited after the initial request
 - `export_meta` (Boolean) Whether to export the select list option type as a tag
-- `field_label` (String) The label associated with the field in the UI
-- `field_name` (String) The field name of the select list option type
 - `help_block` (String) Text that provides additional details about the use of the option type
 - `labels` (Set of String) The organization labels associated with the option type (Only supported on Morpheus 5.5.3 or higher)
-- `option_list_id` (Number) The ID of the associated option list
 - `require_field` (String) The field or code used to determine whether the field is required or not
 - `required` (Boolean) Whether the option type is required
 - `show_on_edit` (Boolean) Whether the option type will display in the edit section of the provisioned resource

--- a/docs/resources/morpheus_option_type_typeahead.md
+++ b/docs/resources/morpheus_option_type_typeahead.md
@@ -38,7 +38,10 @@ resource "hpe_morpheus_option_type_typeahead" "example" {
 
 ### Required
 
+- `field_label` (String) The label associated with the field in the UI
+- `field_name` (String) The field name of the typeahead option type
 - `name` (String) The name of the typeahead option type
+- `option_list_id` (Number) The ID of the associated option list
 
 ### Optional
 
@@ -49,11 +52,8 @@ resource "hpe_morpheus_option_type_typeahead" "example" {
 - `display_value_on_details` (Boolean) Display the selected value of the typeahead option type on the associated resource's details page
 - `editable` (Boolean) Whether the value of the option type can be edited after the initial request
 - `export_meta` (Boolean) Whether to export the typeahead option type as a tag
-- `field_label` (String) The label associated with the field in the UI
-- `field_name` (String) The field name of the typeahead option type
 - `help_block` (String) Text that provides additional details about the use of the option type
 - `labels` (Set of String) The organization labels associated with the option type (Only supported on Morpheus 5.5.3 or higher)
-- `option_list_id` (Number) The ID of the associated option list
 - `placeholder` (String) Text in the field used as a placeholder for example purposes
 - `require_field` (String) The field or code used to trigger the requirement of this field
 - `required` (Boolean) Whether the option type is required

--- a/internal/sdkv2/morpheus/resources/optiontype/option_type_hidden.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/option_type_hidden.go
@@ -49,8 +49,7 @@ func ResourceOptionTypeHidden() *schema.Resource {
 			"field_name": {
 				Type:        schema.TypeString,
 				Description: "The field name of the hidden option type",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"export_meta": {
 				Type:        schema.TypeBool,

--- a/internal/sdkv2/morpheus/resources/optiontype/option_type_number.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/option_type_number.go
@@ -50,8 +50,7 @@ func ResourceOptionTypeNumber() *schema.Resource {
 			"field_name": {
 				Type:        schema.TypeString,
 				Description: "The field name of the number option type",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"export_meta": {
 				Type:        schema.TypeBool,
@@ -98,8 +97,7 @@ func ResourceOptionTypeNumber() *schema.Resource {
 			"field_label": {
 				Type:        schema.TypeString,
 				Description: "The label associated with the field in the UI",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"placeholder": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/optiontype/option_type_password.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/option_type_password.go
@@ -50,8 +50,7 @@ func ResourceOptionTypePassword() *schema.Resource {
 			"field_name": {
 				Type:        schema.TypeString,
 				Description: "The field name of the password option type",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"export_meta": {
 				Type:        schema.TypeBool,
@@ -98,8 +97,7 @@ func ResourceOptionTypePassword() *schema.Resource {
 			"field_label": {
 				Type:        schema.TypeString,
 				Description: "The label associated with the field in the UI",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"placeholder": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/optiontype/option_type_radio_list.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/option_type_radio_list.go
@@ -50,8 +50,7 @@ func ResourceOptionTypeRadioList() *schema.Resource {
 			"field_name": {
 				Type:        schema.TypeString,
 				Description: "The field name of the radio list option type",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"export_meta": {
 				Type:        schema.TypeBool,
@@ -98,8 +97,7 @@ func ResourceOptionTypeRadioList() *schema.Resource {
 			"field_label": {
 				Type:        schema.TypeString,
 				Description: "The label associated with the field in the UI",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"default_value": {
 				Type:        schema.TypeString,
@@ -122,8 +120,7 @@ func ResourceOptionTypeRadioList() *schema.Resource {
 			"option_list_id": {
 				Type:        schema.TypeInt,
 				Description: "The ID of the associated option list",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/sdkv2/morpheus/resources/optiontype/option_type_select_list.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/option_type_select_list.go
@@ -49,8 +49,7 @@ func ResourceOptionTypeSelectList() *schema.Resource {
 			"field_name": {
 				Type:        schema.TypeString,
 				Description: "The field name of the select list option type",
-				Optional:    true,
-				Default:     false,
+				Required:    true,
 			},
 			"export_meta": {
 				Type:        schema.TypeBool,
@@ -94,7 +93,7 @@ func ResourceOptionTypeSelectList() *schema.Resource {
 			"field_label": {
 				Type:        schema.TypeString,
 				Description: "The label associated with the field in the UI",
-				Optional:    true,
+				Required:    true,
 			},
 			"default_value": {
 				Type:        schema.TypeString,
@@ -115,7 +114,7 @@ func ResourceOptionTypeSelectList() *schema.Resource {
 			"option_list_id": {
 				Type:        schema.TypeInt,
 				Description: "The ID of the associated option list",
-				Optional:    true,
+				Required:    true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/sdkv2/morpheus/resources/optiontype/option_type_typeahead.go
+++ b/internal/sdkv2/morpheus/resources/optiontype/option_type_typeahead.go
@@ -55,8 +55,7 @@ func ResourceOptionTypeTypeahead() *schema.Resource {
 			"field_name": {
 				Type:        schema.TypeString,
 				Description: "The field name of the typeahead option type",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"export_meta": {
 				Type:        schema.TypeBool,
@@ -103,8 +102,7 @@ func ResourceOptionTypeTypeahead() *schema.Resource {
 			"field_label": {
 				Type:        schema.TypeString,
 				Description: "The label associated with the field in the UI",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"placeholder": {
 				Type:        schema.TypeString,
@@ -127,8 +125,7 @@ func ResourceOptionTypeTypeahead() *schema.Resource {
 			"option_list_id": {
 				Type:        schema.TypeInt,
 				Description: "The ID of the associated option list",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"allow_multiple_selections": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Some fields that are validated as required in the API are marked as optional in the Terraform schema. This commit updates those fields to be marked as required in the schema to ensure proper validation during plan and apply phases.
- Set field_name and field_label as required for each option type (these are required with the exception of the hidden type which omits the field_label attribute).
- For lists (radio_list, select_list, typeahead), set option_list_id as required.

Some notes:
- If option_list_id points to an option list that does not exist, the request will 400 with the following error:
```
optionList.name is required, optionList.account is required
```
  This is currently withheld from the user - and the error is somewhat unclear (implying that these attributes are required for the request rather than the option list needing to exist). However, this is outside the scope of this PR.