### PR TITLE
Add instance datasource tests

### DIFF
--- a/internal/framework/subproviders/morpheus/datasources/instance/instance_test.go
+++ b/internal/framework/subproviders/morpheus/datasources/instance/instance_test.go
@@ -1,0 +1,208 @@
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+//go:generate go run ../../../../../../cmd/render example-id.tf.tmpl Id 99
+//go:generate go run ../../../../../../cmd/render example-name.tf.tmpl Name "HVM Instance"
+package instance_test
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/provider"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus"
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	testhelpers.WriteMergedResults()
+	os.Exit(code)
+}
+
+func newProviderWithError() (tfprotov6.ProviderServer, error) {
+	providerInstance := provider.New("test", morpheus.New())()
+
+	return providerserver.NewProtocol6WithError(providerInstance)()
+}
+
+var testAccProtoV6ProviderFactories = map[string]func() (
+	tfprotov6.ProviderServer, error,
+){
+	"hpe": newProviderWithError,
+}
+
+// Combining tests for both ID and Name under the same function as instance
+// creation can be time consuming, so we only want to create one instance.
+func TestAccMorpheusInstanceDatasourceByIdAndName(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	name := acctest.RandomWithPrefix(t.Name())
+	instanceTypeID := "9"
+	resourcePool := "pool-62299"
+	resourceConfig, err := testhelpers.RenderExample(t, "../../resources/instance/example.tf.tmpl",
+		"Name", name,
+		"InstanceType", instanceTypeID,
+		"ResourcePool", resourcePool,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataSourceConfigWithId, err := testhelpers.RenderExample(t,
+		"example-id.tf.tmpl", "Id", "hpe_morpheus_instance.example.id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataSourceConfigWithName, err := testhelpers.RenderExample(t,
+		"example-name.tf.tmpl", "Name", name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check some random fields to make sure we get the expected data from the
+	// datasource
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_instance.example",
+			"name",
+			name,
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_instance.example",
+			"config.noAgent",
+			"true",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_instance.example",
+			"config.resourcePoolId",
+			resourcePool,
+		),
+		testhelpers.CheckResourceAttrEqual(
+			"data.hpe_morpheus_instance.example", "instance_type.id",
+			"hpe_morpheus_instance.example", "instance_type_id",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_instance.example",
+			"instance_type.id",
+			instanceTypeID,
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_instance.example",
+			"container_details.#",
+			"1",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_instance.example",
+			"container_details.0.server.agent_installed",
+			"false",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_instance.example",
+			"container_details.0.server.resource_pool_id",
+			strings.TrimPrefix(resourcePool, "pool-"),
+		),
+		testhelpers.CheckResourceAttrEqual(
+			"data.hpe_morpheus_instance.example", "container_details.0.server.container_plan.id",
+			"hpe_morpheus_instance.example", "plan_id",
+		),
+		resource.TestCheckResourceAttr(
+			"data.hpe_morpheus_instance.example",
+			"volumes.#",
+			"3",
+		),
+		testhelpers.CheckResourceAttrEqual(
+			"data.hpe_morpheus_instance.example", "volumes.0.datastore_id",
+			"hpe_morpheus_instance.example", "volumes.0.datastore_id",
+		),
+		testhelpers.CheckResourceAttrEqual(
+			"data.hpe_morpheus_instance.example", "interfaces.0.network.id",
+			"hpe_morpheus_instance.example", "network_interfaces.0.network_id",
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + resourceConfig,
+			},
+			{
+				Config: providerConfig + resourceConfig + dataSourceConfigWithId,
+				Check:  checkFn,
+			},
+			{
+				Config: providerConfig + resourceConfig + dataSourceConfigWithName,
+				Check:  checkFn,
+			},
+		},
+	})
+}
+
+// this should fail due to a conflict between id and name
+func TestAccMorpheusInstanceDatasourceBothAttrs(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	dataSourceConfig := `
+data "hpe_morpheus_instance" "test" {
+  name = "Example Instance"
+  id = 5
+}
+`
+
+	errMatch := regexp.MustCompile("Attribute \"(.*)\" cannot be specified when \"id\" is specified")
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + dataSourceConfig,
+				ExpectError: errMatch,
+			},
+		},
+	})
+}
+
+// this should fail due to id or name being required
+func TestAccMorpheusInstanceDatasourceNoAttrs(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	dataSourceConfig := `
+data "hpe_morpheus_instance" "test" {
+}
+`
+
+	errMatch := regexp.MustCompile("At least one attribute out of (.*) must be specified")
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + dataSourceConfig,
+				ExpectError: errMatch,
+			},
+		},
+	})
+}

--- a/internal/framework/subproviders/morpheus/datasources/instance/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/datasources/instance/schema_gen.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/morpheusvalidators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -905,6 +906,7 @@ func InstanceDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed: true,
 				Validators: []validator.Int64{
 					int64validator.AtLeastOneOf(path.Expressions{path.MatchRoot("id"), path.MatchRoot("name")}...),
+					int64validator.ConflictsWith(path.Expressions{path.MatchRoot("name")}...),
 				},
 			},
 			"instance_context": schema.StringAttribute{
@@ -1140,6 +1142,9 @@ func InstanceDataSourceSchema(ctx context.Context) schema.Schema {
 			"name": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{path.MatchRoot("id")}...),
+				},
 			},
 			"network_level": schema.StringAttribute{
 				Computed: true,

--- a/internal/framework/subproviders/morpheus/testhelpers/attrcheck.go
+++ b/internal/framework/subproviders/morpheus/testhelpers/attrcheck.go
@@ -1,0 +1,59 @@
+package testhelpers
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func getResourceAttribute(s *terraform.State, name, key string) (string, error) {
+	// these bits are copied from terraform-plugin-testing/helper/resource/testing.go
+	ms := s.RootModule()
+	rs, ok := ms.Resources[name]
+	if !ok {
+		return "", fmt.Errorf("Not found: %s in %s", name, ms.Path)
+	}
+
+	is := rs.Primary
+	if is == nil {
+		return "", fmt.Errorf("No primary instance: %s in %s", name, ms.Path)
+	}
+
+	v, ok := is.Attributes[key]
+	if !ok {
+		return "", nil
+	}
+
+	return v, nil
+}
+
+// CheckResourceAttrEqual checks if two attributes contain equal values
+//
+// resource[A/B] specifies the name of the resource from which to extract the
+// attribute
+//
+// attr[A/B] specifies the name of the attribute belonging to matching resource
+func CheckResourceAttrEqual(resourceA, attrA, resourceB, attrB string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attrAValue, err := getResourceAttribute(s, resourceA, attrA)
+		if err != nil {
+			return err
+		}
+
+		attrBValue, err := getResourceAttribute(s, resourceB, attrB)
+		if err != nil {
+			return err
+		}
+
+		if attrAValue == attrBValue {
+			return nil
+		}
+
+		return fmt.Errorf(
+			"attribute '%s.%s' value '%s' does not much attribute '%s.%s' value '%s'",
+			resourceA, attrA, attrAValue,
+			resourceB, attrB, attrBValue,
+		)
+	}
+}


### PR DESCRIPTION
Adds tests for the instance datasource.

Also adds a helper function that allows comparing values from attributes belonging to separate resources.
This is useful for datasource testing where we can compare datasource outputs against a resource configuration.
