### PR TITLE
Fixing plan-level validation across ported resources

### DIFF
--- a/docs/resources/morpheus_cluster_package.md
+++ b/docs/resources/morpheus_cluster_package.md
@@ -33,6 +33,7 @@ resource "hpe_morpheus_cluster_package" "tf_example_cluster_package" {
 - `name` (String) The name of the cluster package
 - `package_type` (String) A one word descriptor of package, such as calico, rook, prometheus, etc.
 - `package_version` (String) The version of the cluster package
+- `spec_template_ids` (List of Number) A list of spec template ids associated with the cluster package
 - `type` (String) The package category type (apps, custom, ingress, logging, monitoring, morpheus, network, serviceMesh, storage)
 
 ### Optional
@@ -40,7 +41,6 @@ resource "hpe_morpheus_cluster_package" "tf_example_cluster_package" {
 - `description` (String) The description of the cluster package
 - `enabled` (Boolean) Whether the cluster package is enabled
 - `repeat_install` (Boolean) Whether to support the reinstallation of the package
-- `spec_template_ids` (List of Number) A list of spec template ids associated with the cluster package
 
 ### Read-Only
 

--- a/docs/resources/morpheus_environment.md
+++ b/docs/resources/morpheus_environment.md
@@ -24,12 +24,12 @@ resource "hpe_morpheus_environment" "tf_example_environment" {
 
 ### Required
 
+- `code` (String) The code of the environment
 - `name` (String) The name of the environment
 
 ### Optional
 
 - `active` (Boolean) Whether the environment is enabled or not
-- `code` (String) The code of the environment
 - `description` (String) The description of the environment
 - `visibility` (String) Whether the environment is visible in sub-tenants or not
 

--- a/docs/resources/morpheus_integration_servicenow.md
+++ b/docs/resources/morpheus_integration_servicenow.md
@@ -39,9 +39,7 @@ resource "hpe_morpheus_integration_servicenow" "tf_example_servicenow_integratio
 ### Required
 
 - `name` (String) The name of the ServiceNow integration
-- `password` (String, Sensitive) The password of the account used to connect to ServiceNow
 - `url` (String) The url of the ServiceNow instance
-- `username` (String) The username of the account used to connect to ServiceNow
 
 ### Optional
 
@@ -50,6 +48,8 @@ resource "hpe_morpheus_integration_servicenow" "tf_example_servicenow_integratio
 - `credential_id` (Number) The id of the credential store entry used for authentication
 - `default_cmdb_business_class` (String) The default ServiceNow table that records are written to if they aren't explicitly defined
 - `enabled` (Boolean) Whether the SerivceNow integration is enabled
+- `password` (String, Sensitive) The password of the account used to connect to ServiceNow
+- `username` (String) The username of the account used to connect to ServiceNow
 
 ### Read-Only
 

--- a/docs/resources/morpheus_integration_servicenow.md
+++ b/docs/resources/morpheus_integration_servicenow.md
@@ -39,7 +39,9 @@ resource "hpe_morpheus_integration_servicenow" "tf_example_servicenow_integratio
 ### Required
 
 - `name` (String) The name of the ServiceNow integration
+- `password` (String, Sensitive) The password of the account used to connect to ServiceNow
 - `url` (String) The url of the ServiceNow instance
+- `username` (String) The username of the account used to connect to ServiceNow
 
 ### Optional
 
@@ -48,8 +50,6 @@ resource "hpe_morpheus_integration_servicenow" "tf_example_servicenow_integratio
 - `credential_id` (Number) The id of the credential store entry used for authentication
 - `default_cmdb_business_class` (String) The default ServiceNow table that records are written to if they aren't explicitly defined
 - `enabled` (Boolean) Whether the SerivceNow integration is enabled
-- `password` (String, Sensitive) The password of the account used to connect to ServiceNow
-- `username` (String) The username of the account used to connect to ServiceNow
 
 ### Read-Only
 

--- a/internal/sdkv2/morpheus/resources/compute/resource_pool_group.go
+++ b/internal/sdkv2/morpheus/resources/compute/resource_pool_group.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package compute
 

--- a/internal/sdkv2/morpheus/resources/compute/resource_pool_group.go
+++ b/internal/sdkv2/morpheus/resources/compute/resource_pool_group.go
@@ -445,7 +445,7 @@ func resourceResourcePoolGroupUpdate(ctx context.Context, d *schema.ResourceData
 
 	req := &morpheus.Request{
 		Body: map[string]any{
-			"resourceResourcePoolGroup": map[string]any{
+			"resourcePoolGroup": map[string]any{
 				"name":        name,
 				"description": description,
 				"mode":        mode,
@@ -479,8 +479,8 @@ func resourceResourcePoolGroupUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(helpers.NotFoundInResponseError("ResourcePoolGroup"))
 	}
 
-	resourceResourcePoolGroup := result.ResourcePoolGroup
-	d.SetId(convert.Int64ToString(resourceResourcePoolGroup.ID))
+	resourcePoolGroup := result.ResourcePoolGroup
+	d.SetId(convert.Int64ToString(resourcePoolGroup.ID))
 
 	return resourceResourcePoolGroupRead(ctx, d, meta)
 }

--- a/internal/sdkv2/morpheus/resources/environment/environment.go
+++ b/internal/sdkv2/morpheus/resources/environment/environment.go
@@ -49,8 +49,7 @@ func ResourceEnvironment() *schema.Resource {
 			"code": {
 				Type:        schema.TypeString,
 				Description: "The code of the environment",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 			"visibility": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/environment/environment.go
+++ b/internal/sdkv2/morpheus/resources/environment/environment.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package environment
 

--- a/internal/sdkv2/morpheus/resources/form/form.go
+++ b/internal/sdkv2/morpheus/resources/form/form.go
@@ -918,8 +918,6 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 		} else {
 			return diag.FromErr(helpers.TypeAssertFailError("labels", attr))
 		}
-	} else {
-		return diag.FromErr(helpers.TypeAssertFailError("labels", d.Get("labels")))
 	}
 
 	var code string

--- a/internal/sdkv2/morpheus/resources/form/form.go
+++ b/internal/sdkv2/morpheus/resources/form/form.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package form
 

--- a/internal/sdkv2/morpheus/resources/integration/integration_ansible_tower.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_ansible_tower.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"log"
 	"strings"
 
@@ -22,6 +23,35 @@ const (
 	credentialTypeLocal            = "local"
 )
 
+func validateAnsibleTowerAuth(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+	var credentialID int
+	if v, ok := d.Get("credential_id").(int); ok {
+		credentialID = v
+	} else {
+		return helpers.TypeAssertFailError("credential_id", d.Get("credential_id"))
+	}
+
+	var username string
+	if v, ok := d.Get("username").(string); ok {
+		username = v
+	} else {
+		return helpers.TypeAssertFailError("username", d.Get("username"))
+	}
+
+	var password string
+	if v, ok := d.Get("password").(string); ok {
+		password = v
+	} else {
+		return helpers.TypeAssertFailError("password", d.Get("password"))
+	}
+
+	if credentialID == 0 && (username == "" || password == "") {
+		return fmt.Errorf("either credential_id must be provided, or both username and password must be provided")
+	}
+
+	return nil
+}
+
 func ResourceIntegrationAnsibleTower() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Provides an Ansible Tower integration resource",
@@ -29,6 +59,7 @@ func ResourceIntegrationAnsibleTower() *schema.Resource {
 		ReadContext:   resourceIntegrationAnsibleTowerRead,
 		UpdateContext: resourceIntegrationAnsibleTowerUpdate,
 		DeleteContext: resourceIntegrationAnsibleTowerDelete,
+		CustomizeDiff: validateAnsibleTowerAuth,
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/internal/sdkv2/morpheus/resources/integration/integration_ansible_tower.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_ansible_tower.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package integration
 

--- a/internal/sdkv2/morpheus/resources/integration/integration_servicenow.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_servicenow.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -18,6 +19,35 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/helpers"
 )
 
+func validateServiceNowAuth(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+	var credentialID int
+	if v, ok := d.Get("credential_id").(int); ok {
+		credentialID = v
+	} else {
+		return helpers.TypeAssertFailError("credential_id", d.Get("credential_id"))
+	}
+
+	var username string
+	if v, ok := d.Get("username").(string); ok {
+		username = v
+	} else {
+		return helpers.TypeAssertFailError("username", d.Get("username"))
+	}
+
+	var password string
+	if v, ok := d.Get("password").(string); ok {
+		password = v
+	} else {
+		return helpers.TypeAssertFailError("password", d.Get("password"))
+	}
+
+	if credentialID == 0 && (username == "" || password == "") {
+		return fmt.Errorf("either credential_id must be provided, or both username and password must be provided")
+	}
+
+	return nil
+}
+
 func ResourceIntegrationServiceNow() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Provides a ServiceNow integration resource",
@@ -25,6 +55,7 @@ func ResourceIntegrationServiceNow() *schema.Resource {
 		ReadContext:   resourceIntegrationServiceNowRead,
 		UpdateContext: resourceIntegrationServiceNowUpdate,
 		DeleteContext: resourceIntegrationServiceNowDelete,
+		CustomizeDiff: validateServiceNowAuth,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -56,15 +87,17 @@ func ResourceIntegrationServiceNow() *schema.Resource {
 				ConflictsWith: []string{"username", "password"},
 			},
 			"username": {
-				Type:        schema.TypeString,
-				Description: "The username of the account used to connect to ServiceNow",
-				Required:    true,
+				Type:          schema.TypeString,
+				Description:   "The username of the account used to connect to ServiceNow",
+				Optional:      true,
+				ConflictsWith: []string{"credential_id"},
 			},
 			"password": {
-				Type:        schema.TypeString,
-				Description: "The password of the account used to connect to ServiceNow",
-				Required:    true,
-				Sensitive:   true,
+				Type:          schema.TypeString,
+				Description:   "The password of the account used to connect to ServiceNow",
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"credential_id"},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					h := sha256.New()
 					h.Write([]byte(new))

--- a/internal/sdkv2/morpheus/resources/integration/integration_servicenow.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_servicenow.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package integration
 

--- a/internal/sdkv2/morpheus/resources/integration/integration_servicenow.go
+++ b/internal/sdkv2/morpheus/resources/integration/integration_servicenow.go
@@ -58,12 +58,12 @@ func ResourceIntegrationServiceNow() *schema.Resource {
 			"username": {
 				Type:        schema.TypeString,
 				Description: "The username of the account used to connect to ServiceNow",
-				Optional:    true,
+				Required:    true,
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Description: "The password of the account used to connect to ServiceNow",
-				Optional:    true,
+				Required:    true,
 				Sensitive:   true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					h := sha256.New()

--- a/internal/sdkv2/morpheus/resources/template/cluster_package.go
+++ b/internal/sdkv2/morpheus/resources/template/cluster_package.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package template
 

--- a/internal/sdkv2/morpheus/resources/template/cluster_package.go
+++ b/internal/sdkv2/morpheus/resources/template/cluster_package.go
@@ -76,7 +76,7 @@ func ResourceClusterPackage() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "A list of spec template ids associated with the cluster package",
 				Elem:        &schema.Schema{Type: schema.TypeInt},
-				Optional:    true,
+				Required:    true,
 			},
 		},
 		Importer: &schema.ResourceImporter{


### PR DESCRIPTION
Adding various requireds and plan validation across resources ported from `terraform-provider-morpheus`. This includes fixing any obvious errors when just running each configuration with just their required attributes.

This includes:
- For `hpe_morpheus_integration_servicenow` and `hpe_morpheus_integration_ansible_tower` - a username and password *or* a credential id must be provided or else the resource will 400. This has been added as validation.
- An internal logic error causing a TypeAssertion error whenever a `hpe_morpheus_form` is created without labels (which should be optional) has been resolved.
- A typo in the API structure for `hpe_morpheus_resource_pool_group` has been resolved.
- Various requireds have been added:
	- `code` for `hpe_morpheus_environment` has been marked as required as it 400s otherwise.
	- `spec_template_ids` for `hpe_morpheus_cluster_package` has been marked as it 400s otherwise.