### PR TITLE
Restore original Network test configs in examples directory

### DIFF
--- a/examples/resources/hpe_morpheus_network/azure/resource.tf
+++ b/examples/resources/hpe_morpheus_network/azure/resource.tf
@@ -1,0 +1,118 @@
+variable "name" {
+  description = "Network name"
+  type        = string
+  default     = "terraform-network-all-attrs"
+}
+
+variable "description" {
+  description = "Network description"
+  type        = string
+  default     = "Network with all attributes set"
+}
+
+variable "cloud_id" {
+  description = "Cloud (zone) id"
+  type        = number
+  default     = 4617
+}
+
+variable "pool_id" {
+  description = "Network pool id"
+  type        = number
+  default     = 1
+}
+
+variable "group_id" {
+  description = "Group (site) id"
+  type        = number
+  default     = 1
+}
+
+variable "type_id" {
+  description = "Network type id"
+  type        = number
+  default     = 35
+}
+
+variable "cidr" {
+  description = "CIDR Network"
+  type        = string
+  default     = "10.100.0.0/16"
+}
+
+variable "visibility" {
+  description = "Network visibility"
+  type        = string
+  default     = "public"
+}
+
+variable "active" {
+  description = "Whether network is active"
+  type        = bool
+  default     = true
+}
+
+variable "dhcp_server" {
+  description = "Whether DHCP server is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "appliance_url_proxy_bypass" {
+  description = "Whether to bypass proxy for appliance URL"
+  type        = bool
+  default     = false
+}
+
+variable "config_resource_group_id" {
+  description = "Resource Group ID for network config"
+  type        = string
+  default     = "all-attrs-resource-group"
+}
+
+variable "config_subnet_name" {
+  description = "Subnet name for network config"
+  type        = string
+  default     = "all-attrs-subnet"
+}
+
+variable "config_subnet_cidr" {
+  description = "Subnet CIDR for network config"
+  type        = string
+  default     = "10.100.1.0/24"
+}
+
+variable "config_location" {
+  description = "Location for network config"
+  type        = string
+  default     = "eastus"
+}
+
+variable "config_additional_field" {
+  description = "Additional config field"
+  type        = string
+  default     = "test-value"
+}
+
+resource "hpe_morpheus_network" "all_attrs" {
+  name                       = var.name
+  description                = var.description
+  cloud_id                   = var.cloud_id
+  pool_id                    = var.pool_id
+  group_id                   = var.group_id
+  type_id                    = var.type_id
+  cidr                       = var.cidr
+  visibility                 = var.visibility
+  active                     = var.active
+  dhcp_server                = var.dhcp_server
+  appliance_url_proxy_bypass = var.appliance_url_proxy_bypass
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
+  config = {
+    "resourceGroupId" = var.config_resource_group_id
+    "subnetName"      = var.config_subnet_name
+    "subnetCidr"      = var.config_subnet_cidr
+    "location"        = var.config_location
+    "additionalField" = var.config_additional_field
+  }
+  tenant_ids = [1, 2, 3]
+}

--- a/examples/resources/hpe_morpheus_network/gcp/resource.tf
+++ b/examples/resources/hpe_morpheus_network/gcp/resource.tf
@@ -1,0 +1,104 @@
+variable "name" {
+  description = "Network name"
+  type        = string
+  default     = "TestAccMorpheusNetworkResourceCreateGcp"
+}
+
+variable "description" {
+  description = "Network description"
+  type        = string
+  default     = "GCP network"
+}
+
+variable "cloud_id" {
+  description = "Cloud (zone) id"
+  type        = number
+  default     = 6
+}
+
+variable "pool_id" {
+  description = "Network pool id"
+  type        = number
+  default     = 1
+}
+
+variable "group_id" {
+  description = "Group (site) id"
+  type        = number
+  default     = 8
+}
+
+variable "type_id" {
+  description = "Network type id"
+  type        = number
+  default     = 38
+}
+
+variable "cidr" {
+  description = "CIDR Network"
+  type        = string
+  default     = "10.0.0.0/8"
+}
+
+variable "zone_pool_id" {
+  description = "Zone pool id"
+  type        = number
+  default     = 85990
+}
+
+variable "config_mtu" {
+  description = "MTU setting for network config"
+  type        = string
+  default     = "1460"
+}
+
+variable "config_auto_create" {
+  description = "Auto create setting for network config"
+  type        = bool
+  default     = true
+}
+
+variable "active" {
+  description = "Whether network is active"
+  type        = bool
+  default     = true
+}
+
+variable "dhcp_server" {
+  description = "Whether DHCP server is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "appliance_url_proxy_bypass" {
+  description = "Whether to bypass proxy for appliance URL"
+  type        = bool
+  default     = true
+}
+
+variable "visibility" {
+  description = "Network visibility"
+  type        = string
+  default     = "private"
+}
+
+resource "hpe_morpheus_network" "gcp" {
+  name        = var.name
+  description = var.description
+  cloud_id    = var.cloud_id
+  pool_id     = var.pool_id
+  group_id    = var.group_id
+  type_id     = var.type_id
+  config = {
+    mtu        = var.config_mtu
+    autoCreate = var.config_auto_create
+  }
+  active                     = var.active
+  dhcp_server                = var.dhcp_server
+  appliance_url_proxy_bypass = var.appliance_url_proxy_bypass
+  tenant_ids                 = [1]
+  visibility                 = var.visibility
+  cidr                       = var.cidr
+  zone_pool_id               = var.zone_pool_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
+}

--- a/examples/resources/hpe_morpheus_network/host/resource.tf
+++ b/examples/resources/hpe_morpheus_network/host/resource.tf
@@ -1,0 +1,82 @@
+variable "name" {
+  description = "Network name"
+  type        = string
+  default     = "terraform-host-network"
+}
+
+variable "description" {
+  description = "Network description"
+  type        = string
+  default     = "A test host network"
+}
+
+variable "cloud_id" {
+  description = "Cloud (zone) id"
+  type        = number
+  default     = 17
+}
+
+variable "pool_id" {
+  description = "Network pool id"
+  type        = number
+  default     = 1
+}
+
+variable "group_id" {
+  description = "Group (site) id"
+  type        = number
+  default     = 1
+}
+
+variable "type_id" {
+  description = "Network type id"
+  type        = number
+  default     = 1
+}
+
+variable "cidr" {
+  description = "CIDR Network"
+  type        = string
+  default     = "10.0.0.0/8"
+}
+
+variable "visibility" {
+  description = "Network visibility"
+  type        = string
+  default     = "private"
+}
+
+variable "active" {
+  description = "Whether network is active"
+  type        = bool
+  default     = true
+}
+
+variable "dhcp_server" {
+  description = "Whether DHCP server is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "appliance_url_proxy_bypass" {
+  description = "Whether to bypass proxy for appliance URL"
+  type        = bool
+  default     = true
+}
+
+resource "hpe_morpheus_network" "host" {
+  name                       = var.name
+  description                = var.description
+  cloud_id                   = var.cloud_id
+  pool_id                    = var.pool_id
+  group_id                   = var.group_id
+  type_id                    = var.type_id
+  config                     = {}
+  active                     = var.active
+  dhcp_server                = var.dhcp_server
+  appliance_url_proxy_bypass = var.appliance_url_proxy_bypass
+  tenant_ids                 = [1]
+  visibility                 = var.visibility
+  cidr                       = var.cidr
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
+}

--- a/examples/resources/hpe_morpheus_network/ovs_port_group/resource.tf
+++ b/examples/resources/hpe_morpheus_network/ovs_port_group/resource.tf
@@ -1,0 +1,107 @@
+variable "name" {
+  description = "Network name"
+  type        = string
+  default     = "Terraform OVS Port Group"
+}
+
+variable "description" {
+  description = "Network description"
+  type        = string
+  default     = "OVS Port Group network"
+}
+
+variable "cloud_id" {
+  description = "Cloud (zone) id"
+  type        = number
+  default     = 7714
+}
+
+variable "pool_id" {
+  description = "Network pool id"
+  type        = number
+  default     = 3251
+}
+
+variable "group_id" {
+  description = "Group (site) id"
+  type        = number
+  default     = 1
+}
+
+variable "type_id" {
+  description = "Network type id (OVS Port Group)"
+  type        = number
+  default     = 63
+}
+
+variable "cidr" {
+  description = "CIDR Network"
+  type        = string
+  default     = "10.32.148.0/22"
+}
+
+variable "zone_pool_id" {
+  description = "Zone pool id"
+  type        = number
+  default     = 62299
+}
+
+variable "vlan_id" {
+  description = "VLAN ID"
+  type        = number
+  default     = 43
+}
+
+variable "switch_id" {
+  description = "Switch ID for OVS network"
+  type        = string
+  default     = "Compute"
+}
+
+variable "active" {
+  description = "Whether network is active"
+  type        = bool
+  default     = true
+}
+
+variable "dhcp_server" {
+  description = "Whether DHCP server is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "appliance_url_proxy_bypass" {
+  description = "Whether to bypass proxy for appliance URL"
+  type        = bool
+  default     = true
+}
+
+variable "visibility" {
+  description = "Network visibility"
+  type        = string
+  default     = "public"
+}
+
+resource "hpe_morpheus_network" "ovs_port_group" {
+  name                       = var.name
+  description                = var.description
+  cloud_id                   = var.cloud_id
+  pool_id                    = var.pool_id
+  group_id                   = var.group_id
+  type_id                    = var.type_id
+  switch_id                  = var.switch_id
+  config                     = {}
+  active                     = var.active
+  dhcp_server                = var.dhcp_server
+  appliance_url_proxy_bypass = var.appliance_url_proxy_bypass
+  tenant_ids                 = [1]
+  visibility                 = var.visibility
+  cidr                       = var.cidr
+  zone_pool_id               = var.zone_pool_id
+  vlan_id                    = var.vlan_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
+
+  lifecycle {
+    ignore_changes = [name, display_name, description]
+  }
+}

--- a/examples/resources/hpe_morpheus_network/resource.tf
+++ b/examples/resources/hpe_morpheus_network/resource.tf
@@ -1,0 +1,108 @@
+variable "name" {
+  description = "Network name"
+  type        = string
+  default     = "terraform-aws-test"
+}
+
+variable "description" {
+  description = "Network description"
+  type        = string
+  default     = "AWS subnet"
+}
+
+variable "cloud_id" {
+  description = "Cloud (zone) id"
+  type        = number
+  default     = 207
+}
+
+variable "pool_id" {
+  description = "Network pool id"
+  type        = number
+  default     = 1
+}
+
+variable "group_id" {
+  description = "Group (site) id"
+  type        = number
+  default     = 1
+}
+
+variable "type_id" {
+  description = "Network type id"
+  type        = number
+  default     = 36
+}
+
+variable "cidr" {
+  description = "CIDR Network"
+  type        = string
+  default     = "10.200.99.0/24"
+}
+
+variable "zone_pool_id" {
+  description = "Zone pool id"
+  type        = number
+  default     = 12329
+}
+
+variable "config_assign_public_ip" {
+  description = "Assign public IP setting for network config"
+  type        = bool
+  default     = true
+}
+
+variable "config_availability_zone" {
+  description = "Availability zone setting for network config"
+  type        = string
+  default     = "us-west-1a"
+}
+
+variable "active" {
+  description = "Whether network is active"
+  type        = bool
+  default     = true
+}
+
+variable "dhcp_server" {
+  description = "Whether DHCP server is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "appliance_url_proxy_bypass" {
+  description = "Whether to bypass proxy for appliance URL"
+  type        = bool
+  default     = true
+}
+
+variable "visibility" {
+  description = "Network visibility"
+  type        = string
+  default     = "private"
+}
+
+resource "hpe_morpheus_network" "aws" {
+  name        = var.name
+  description = var.description
+  cloud_id    = var.cloud_id
+  pool_id     = var.pool_id
+  group_id    = var.group_id
+  type_id     = var.type_id
+  config = {
+    assignPublicIp   = var.config_assign_public_ip
+    availabilityZone = var.config_availability_zone
+  }
+  active                     = var.active
+  dhcp_server                = var.dhcp_server
+  appliance_url_proxy_bypass = var.appliance_url_proxy_bypass
+  tenant_ids                 = [1]
+  visibility                 = var.visibility
+  cidr                       = var.cidr
+  zone_pool_id               = var.zone_pool_id
+  labels                     = ["terraform", "acctest", "hpe_morpheus_network", "sweepable"]
+
+  lifecycle {
+    ignore_changes = [name, display_name, description]
+  }
+}

--- a/examples/resources/hpe_morpheus_network/variables.tf
+++ b/examples/resources/hpe_morpheus_network/variables.tf
@@ -1,0 +1,83 @@
+variable "name" {
+  description = "Network name"
+  type        = string
+  default     = "terraform-aws-test"
+}
+
+variable "description" {
+  description = "Network description"
+  type        = string
+  default     = "AWS subnet"
+}
+
+variable "cloud_id" {
+  description = "Cloud (zone) id"
+  type        = number
+  default     = 207
+}
+
+variable "pool_id" {
+  description = "Network pool id"
+  type        = number
+  default     = 1
+}
+
+variable "group_id" {
+  description = "Group (site) id"
+  type        = number
+  default     = 1
+}
+
+variable "type_id" {
+  description = "Network type id"
+  type        = number
+  default     = 36
+}
+
+variable "cidr" {
+  description = "CIDR Network"
+  type        = string
+  default     = "10.200.99.0/24"
+}
+
+variable "zone_pool_id" {
+  description = "Zone pool id"
+  type        = number
+  default     = 12329
+}
+
+variable "config_assign_public_ip" {
+  description = "Assign public IP setting for network config"
+  type        = bool
+  default     = true
+}
+
+variable "config_availability_zone" {
+  description = "Availability zone setting for network config"
+  type        = string
+  default     = "us-west-1a"
+}
+
+variable "active" {
+  description = "Whether network is active"
+  type        = bool
+  default     = true
+}
+
+variable "dhcp_server" {
+  description = "Whether DHCP server is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "appliance_url_proxy_bypass" {
+  description = "Whether to bypass proxy for appliance URL"
+  type        = bool
+  default     = true
+}
+
+variable "visibility" {
+  description = "Network visibility"
+  type        = string
+  default     = "private"
+}


### PR DESCRIPTION
Quick fix for the failing Network tests.

The paths that the tests read from hadn't yet been updated, so we'll just restore the original configs used for testing for now.

We can re-evaluate the test configs in combination with the rendered example configs at a later point.
