### PR TITLE
Increase sdkv2 client timeout to 1 minute

### DIFF
--- a/internal/sdkv2/morpheus/client/client.go
+++ b/internal/sdkv2/morpheus/client/client.go
@@ -54,7 +54,7 @@ func NewLegacyClient(
 
 	c.HTTPClient = &http.Client{
 		Transport: authRoundTripper,
-		Timeout:   15 * time.Second,
+		Timeout:   1 * time.Minute,
 	}
 
 	return c


### PR DESCRIPTION
This should help to alleviate timeout issues we were seeing on certain endpoints, e.g. `DELETE` to `/api/clusters/{id}/servers/{id}` (from `hpe_morpheus_cluster_mks_vsphere` cluster worker node count resize).
