### PR TITLE
Return warning string from sdkv2 client if morpheus block missing

### DIFF
--- a/internal/sdkv2/morpheus/provider.go
+++ b/internal/sdkv2/morpheus/provider.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package morpheus
 
@@ -292,7 +292,19 @@ func providerSchemaMorpheus() *schema.Schema {
 }
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	morpheusConfig := d.Get("morpheus").([]interface{})[0].(map[string]interface{})
+	morph, ok := d.GetOk("morpheus")
+	if !ok {
+		return `Morpheus resource or data source present, but possible missing morpheus provider block.
+ 
+ provider "hpe" {
+   morpheus { <- missing or duplicate?
+     url = "https://example.com"
+   }
+ }
+`, nil
+	}
+
+	morpheusConfig := morph.([]interface{})[0].(map[string]interface{})
 
 	config := Config{
 		Url:         morpheusConfig["url"].(string),


### PR DESCRIPTION
In this PR we change the sdkv2 client initialisation so that if the morpheus block isn't present the client is simply a string containing a warning that the morpheus block is missing.  This way if any sdkv2 resources or data-sources are executed the warning string will be emitted as part of the error returned when the client type assertion fails.