### PR TITLE
Fix sdkv2 user_groups data source test

### DIFF
--- a/internal/sdkv2/morpheus/datasources/usergroup/user_groups_data-source_test.go
+++ b/internal/sdkv2/morpheus/datasources/usergroup/user_groups_data-source_test.go
@@ -3,6 +3,7 @@
 package usergroup_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -41,8 +42,9 @@ func TestAccMorpheusDataSourceUserGroupsExampleOk(t *testing.T) {
 	}
 
 	if currentDependency, err := user.RenderUserConfig(t, map[string]string{
-		"Name":    name,
-		"RoleIds": "resource.hpe_morpheus_role.example.id",
+		"Name":     name,
+		"Username": strings.ToLower(name),
+		"RoleIds":  "resource.hpe_morpheus_role.example.id",
 	}); err != nil {
 		t.Fatal(err)
 	} else {


### PR DESCRIPTION

This PR adds a username to `RenderUserConfig` to avoid a duplicate username failure
