### PR TITLE
Fix sdkv2 hpe_morpheus_network_subnet data source test

### DIFF
--- a/internal/sdkv2/morpheus/datasources/network/network_subnet_data-source_test.go
+++ b/internal/sdkv2/morpheus/datasources/network/network_subnet_data-source_test.go
@@ -5,7 +5,6 @@ package network_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus"
@@ -23,35 +22,31 @@ func TestAccMorpheusDataSourceNetworkSubnetExampleOk(t *testing.T) {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	t.Skip("Skipping due to missing infrastructure in test environment")
-	// Unable to create networks in the VM - need to investigate if it's possible
-
 	providerConfig := testhelpers.ProviderBlock()
 
-	name := acctest.RandomWithPrefix(t.Name())
+	name := "VM Network"
 
 	var dependenciesConfig string
 
 	datasourceConfig, err := dsnetwork.RenderNetworkSubnetConfig(t, map[string]string{
-		"Name": name,
+		"Name":      "\"" + name + "\"",
+		"NetworkId": "2",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Log(providerConfig + dependenciesConfig + datasourceConfig)
-
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(
 			"data.hpe_morpheus_network_subnet.example",
 			"name",
-			"TF Example Network Subnet",
+			name,
 		),
 
 		resource.TestCheckResourceAttr(
 			"data.hpe_morpheus_network_subnet.example",
 			"network_id",
-			"166333",
+			"2",
 		),
 	}
 
@@ -60,7 +55,7 @@ func TestAccMorpheusDataSourceNetworkSubnetExampleOk(t *testing.T) {
 		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
 		Steps: []resource.TestStep{
 			{
-				Config:             providerConfig + dependenciesConfig + datasourceConfig,
+				Config:             providerConfig + "\n" + dependenciesConfig + "\n" + datasourceConfig,
 				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
 			},


### PR DESCRIPTION
This PR re-enables the hpe_morpheus_network_subnet test because
there is now enough infrastructure in place on `zodiac-morpheus-now` to support it.

Currently it is using hard-coded values of resources created via the UI