### PR TITLE
Fix race conditions when recording test results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ testacc:
 	env TF_ACC=1 \
 	go test -v -cover -count 1 -timeout 60m ./...
 
+collect-test-results:
+	./scripts/collect-test-results.bash
+
 docs:
 	go generate ./...
 	cd tools && go generate

--- a/internal/framework/subproviders/morpheus/testhelpers/qa_results.go
+++ b/internal/framework/subproviders/morpheus/testhelpers/qa_results.go
@@ -5,67 +5,58 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 )
 
-type TestResult struct {
+type testResult struct {
 	Status string `json:"status"`
 	Error  string `json:"error"`
 }
 
-var TestResults = make(map[string]TestResult)
+var (
+	testResults         = make(map[string]testResult)
+	m                   sync.Mutex
+	_, recordingEnabled = os.LookupEnv("RECORD_TEST_RESULTS")
+)
 
 func RecordResult(t *testing.T) {
-	if os.Getenv("RECORD_TEST_RESULTS") != "true" {
+	if !recordingEnabled {
 		return
 	}
 
+	m.Lock()
 	if t.Failed() {
-		TestResults[t.Name()] = TestResult{
+		testResults[t.Name()] = testResult{
 			Status: "Failed",
 			Error:  "Test " + t.Name() + "failed.",
 		}
 	} else if t.Skipped() {
-		TestResults[t.Name()] = TestResult{
+		testResults[t.Name()] = testResult{
 			Status: "Skipped",
 			Error:  "",
 		}
 	} else {
-		TestResults[t.Name()] = TestResult{
+		testResults[t.Name()] = testResult{
 			Status: "Passed",
 			Error:  "",
 		}
 	}
+	m.Unlock()
 }
 
 func WriteMergedResults() {
+	if !recordingEnabled {
+		return
+	}
+
 	rootOutputDir := filepath.Join("/tmp", "test_output")
-	outputFile := filepath.Join(rootOutputDir, "result.json")
-
-	existing := map[string]TestResult{}
-
-	// Try to read the existing file
-	data, err := os.ReadFile(outputFile)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("Error reading existing results file: %v", err)
-			os.Exit(1)
-		}
-	} else {
-		// File exists, parse the JSON data
-		if err := json.Unmarshal(data, &existing); err != nil {
-			log.Printf("Error parsing JSON from existing results file: %v", err)
-			os.Exit(1)
-		}
-	}
-
-	// Merge new results into existing map
-	for k, v := range TestResults {
-		existing[k] = v
-	}
+	outputFile := filepath.Join(rootOutputDir, acctest.RandomWithPrefix("test-result")+".result")
 
 	// Marshal the merged results
-	output, err := json.MarshalIndent(existing, "", "  ")
+	output, err := json.MarshalIndent(testResults, "", "  ")
 	if err != nil {
 		log.Printf("Error marshalling merged results: %v", err)
 		os.Exit(1)

--- a/scripts/collect-test-results.bash
+++ b/scripts/collect-test-results.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+TEST_DIR=/tmp/test_output
+
+# delete old test results
+rm -rf /tmp/test_output/result.json
+
+# do nothing if no test artifacts exist
+if ! find $TEST_DIR/*.result > /dev/null 2>&1; then
+    echo "No test artifacts found"
+    exit 0
+fi
+
+# merge all `.result` files into result.json
+jq -s add $TEST_DIR/*.result > $TEST_DIR/result.json
+
+# delete all intermediate files so we don't end up collecting old test data
+# next time we execute `collect-test-results`
+rm -rf /tmp/test_output/*.result


### PR DESCRIPTION
PR changes the code for recording test results to prevent a race condition.
Previously each test would attempt to read the `result.json` file and append new tests to it. This could cause errors if a different test binary was still in the middle of writing the results.

To fix this we make changes to the way tests are recorded:
- Each package under testing will produce its own test record files
- Test record files will only be produced when the `RECORD_TEST_RESULTS` env var is set
- After finishing tests `make collect-test-results` can be run to merge all separate test record files into a single JSON file

The PR also adds a sync.Mutex to control writes to the test results map to prevent concurrent map writes.
