### PR TITLE
Fix broken network tests

### DIFF
--- a/examples/resources/hpe_morpheus_network/azure/resource.tf
+++ b/examples/resources/hpe_morpheus_network/azure/resource.tf
@@ -19,7 +19,7 @@ variable "cloud_id" {
 variable "pool_id" {
   description = "Network pool id"
   type        = number
-  default     = 1
+  default     = 6446
 }
 
 variable "group_id" {

--- a/examples/resources/hpe_morpheus_network/gcp/resource.tf
+++ b/examples/resources/hpe_morpheus_network/gcp/resource.tf
@@ -19,7 +19,7 @@ variable "cloud_id" {
 variable "pool_id" {
   description = "Network pool id"
   type        = number
-  default     = 1
+  default     = 6446
 }
 
 variable "group_id" {

--- a/examples/resources/hpe_morpheus_network/host/resource.tf
+++ b/examples/resources/hpe_morpheus_network/host/resource.tf
@@ -19,7 +19,7 @@ variable "cloud_id" {
 variable "pool_id" {
   description = "Network pool id"
   type        = number
-  default     = 1
+  default     = 6446
 }
 
 variable "group_id" {

--- a/examples/resources/hpe_morpheus_network/resource.tf
+++ b/examples/resources/hpe_morpheus_network/resource.tf
@@ -19,7 +19,7 @@ variable "cloud_id" {
 variable "pool_id" {
   description = "Network pool id"
   type        = number
-  default     = 1
+  default     = 6446
 }
 
 variable "group_id" {

--- a/examples/resources/hpe_morpheus_network/variables.tf
+++ b/examples/resources/hpe_morpheus_network/variables.tf
@@ -19,7 +19,7 @@ variable "cloud_id" {
 variable "pool_id" {
   description = "Network pool id"
   type        = number
-  default     = 1
+  default     = 6446
 }
 
 variable "group_id" {

--- a/internal/framework/subproviders/morpheus/resources/network/create_test.go
+++ b/internal/framework/subproviders/morpheus/resources/network/create_test.go
@@ -79,7 +79,7 @@ variable "cidr" {
 
 resource "hpe_morpheus_network" "foo" {
   active   = true
-  pool_id     = 1
+  pool_id     = 6446
   tenant_ids = [1,2]
   name     = var.name
   cloud_id = var.cloud_id
@@ -189,7 +189,7 @@ func TestAccMorpheusNetworkResourceCreateAllAttrsOk(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.all_attrs", "cloud_id", "4617"),
 					resource.TestCheckResourceAttr(
-						"hpe_morpheus_network.all_attrs", "pool_id", "1"),
+						"hpe_morpheus_network.all_attrs", "pool_id", "6446"),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.all_attrs", "group_id", "1"),
 					resource.TestCheckResourceAttr(
@@ -293,7 +293,7 @@ func TestAccMorpheusNetworkResourceCreateHostConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.host", "cloud_id", "17"),
 					resource.TestCheckResourceAttr(
-						"hpe_morpheus_network.host", "pool_id", "1"),
+						"hpe_morpheus_network.host", "pool_id", "6446"),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.host", "group_id", "1"),
 					resource.TestCheckResourceAttr(
@@ -372,7 +372,7 @@ func TestAccMorpheusNetworkResourceCreateAWSExample(t *testing.T) {
 						"hpe_morpheus_network.aws", "cloud_id",
 						"207"),
 					resource.TestCheckResourceAttr(
-						"hpe_morpheus_network.aws", "pool_id", "1"),
+						"hpe_morpheus_network.aws", "pool_id", "6446"),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.aws", "group_id", "1"),
 					resource.TestCheckResourceAttr(
@@ -473,7 +473,7 @@ func TestAccMorpheusNetworkResourceCreateGcp(t *testing.T) {
 						"hpe_morpheus_network.gcp", "cloud_id", "6",
 					),
 					resource.TestCheckResourceAttr(
-						"hpe_morpheus_network.gcp", "pool_id", "1",
+						"hpe_morpheus_network.gcp", "pool_id", "6446",
 					),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.gcp", "group_id", "8",
@@ -539,6 +539,8 @@ func TestAccMorpheusNetworkResourceCreateOVSPortGroup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
+
+	t.Skip("Skipping due to missing infrastructure in test environment")
 
 	// nolint: goconst
 	providerConfig := testhelpers.ProviderBlock()

--- a/internal/framework/subproviders/morpheus/resources/network/import_test.go
+++ b/internal/framework/subproviders/morpheus/resources/network/import_test.go
@@ -50,7 +50,7 @@ variable "cloud_id" {
 variable "pool_id" {
   description = "Network pool id"
   type        = number
-  default     = 1
+  default     = 6446
 }
 
 variable "group_id" {
@@ -178,7 +178,7 @@ destroy = false
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_network.net1",
 			"pool_id",
-			"1",
+			"6446",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_network.net1",

--- a/internal/framework/subproviders/morpheus/resources/network/update_test.go
+++ b/internal/framework/subproviders/morpheus/resources/network/update_test.go
@@ -51,7 +51,7 @@ variable "cloud_id" {
 variable "pool_id" {
   description = "Network pool id"
   type        = number
-  default     = 1
+  default     = 6446
 }
 
 variable "group_id" {
@@ -164,7 +164,7 @@ resource "hpe_morpheus_network" "foo" {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_network.foo",
 			"pool_id",
-			"1",
+			"6446",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_network.foo",
@@ -267,7 +267,7 @@ resource "hpe_morpheus_network" "foo" {
 				Config: baseConfigText,
 				ConfigVariables: config.Variables{
 					"name":    config.StringVariable(uniqueName),
-					"pool_id": config.IntegerVariable(2), // CHANGED
+					"pool_id": config.IntegerVariable(5958), // CHANGED
 				},
 				ExpectNonEmptyPlan: true,
 				PlanOnly:           true,
@@ -325,7 +325,7 @@ resource "hpe_morpheus_network" "foo" {
 					// Keep original name
 					"name":        config.StringVariable(uniqueName),
 					"description": config.StringVariable("Comprehensive update test"),
-					"pool_id":     config.IntegerVariable(2),
+					"pool_id":     config.IntegerVariable(5958),
 					// Keep original CIDR
 					"cidr":                       config.StringVariable("10.50.0.0/16"),
 					"visibility":                 config.StringVariable("public"),
@@ -343,7 +343,7 @@ resource "hpe_morpheus_network" "foo" {
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.foo", "description", "Comprehensive update test"),
 					resource.TestCheckResourceAttr(
-						"hpe_morpheus_network.foo", "pool_id", "2"),
+						"hpe_morpheus_network.foo", "pool_id", "5958"),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network.foo", "cidr", "10.50.0.0/16"), // CIDR unchanged
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
- Updates the network pool ID used in testing to one that exists - the pools with IDs 1 and 2 used previously were deleted.

- Skip added to the OVS Port Group create test as infrastructure to support this test no longer exists.

We will revist these tests to decouple them from specific test hardware.
