### PR TITLE
Some instance docs updates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -288,8 +288,6 @@ In this release (v1.0.0) we have added the following data-source functionality:
   datastores.  This is an API bug which is being investigated.
 - `hpe_morpheus_policy resource` does not currently support the Backup Targets (`backupStorage`) policy type
   due to improper handling of the `backupStorageIds` attribute. This is an API bug which is being investigated.
-- `hpe_morpheus_instance` has issues with using the same `datastore_id` with multiple volumes, please use
-  a different `datastore_id` for each volume.
 - `hpe_morpheus_instance` updates fail when removing optional fields.
   This will be addressed in a future release.
 - `hpe_morpheus_instance` updates fail when removing `evars`.

--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -8,7 +8,7 @@ description: |-
 
 
 
-Instance is a virtual machine or container deployed and managed by HPE Morpheus.
+Instance is a virtual machine, bare metal machine or container deployed and managed by HPE Morpheus.
 Morpheus oversees its entire lifecycle, from initial provisioning to scaling, 
 monitoring, and eventual decommissioning.
 
@@ -34,6 +34,7 @@ the new settings but no `Morpheus` `Update` API calls will be made.  The default
 `read` and `update` is 45 minutes.<br><br>
 We've added a `connection_info` section (read-only) which contains the IP address(es) by which the instance
 can be accessed<br><br>
+The `datastore_auto_selection` attribute is not supported for BMaaS instances.<br><br>
 When creating an instance with network bonding and/or LAGs we cannot reconcile the created list of `network_interfaces`
 with the HCL supplied.  In these cases the `connection_info` section will contain IP address(es).  To access the full
 network configuration use the `hpe_morpheus_instance` `data-source` to read back the created instance.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -229,8 +229,6 @@ In this release (v1.0.0) we have added the following data-source functionality:
   datastores.  This is an API bug which is being investigated.
 - `hpe_morpheus_policy resource` does not currently support the Backup Targets (`backupStorage`) policy type
   due to improper handling of the `backupStorageIds` attribute. This is an API bug which is being investigated.
-- `hpe_morpheus_instance` has issues with using the same `datastore_id` with multiple volumes, please use
-  a different `datastore_id` for each volume.
 - `hpe_morpheus_instance` updates fail when removing optional fields.
   This will be addressed in a future release.
 - `hpe_morpheus_instance` updates fail when removing `evars`.

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -8,7 +8,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-Instance is a virtual machine or container deployed and managed by HPE Morpheus.
+Instance is a virtual machine, bare metal machine or container deployed and managed by HPE Morpheus.
 Morpheus oversees its entire lifecycle, from initial provisioning to scaling, 
 monitoring, and eventual decommissioning.
 
@@ -34,6 +34,7 @@ the new settings but no `Morpheus` `Update` API calls will be made.  The default
 `read` and `update` is 45 minutes.<br><br>
 We've added a `connection_info` section (read-only) which contains the IP address(es) by which the instance
 can be accessed<br><br>
+The `datastore_auto_selection` attribute is not supported for BMaaS instances.<br><br>
 When creating an instance with network bonding and/or LAGs we cannot reconcile the created list of `network_interfaces`
 with the HCL supplied.  In these cases the `connection_info` section will contain IP address(es).  To access the full
 network configuration use the `hpe_morpheus_instance` `data-source` to read back the created instance.


### PR DESCRIPTION
- Removed issue with repeated datastore-ids from release notes, since we're using repeated datastore-ids in our tests
- Added note on datastore_auto_selection for BMaaS
- Added bare metal machine to list of types of instance