### PR TITLE
Rename cluster_mks_vsphere to cluster_hks_vsphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ In this release (v1.0.0) we have added the following resource functionality:
 - hpe_morpheus_catalog_item_instance
 - hpe_morpheus_catalog_item_workflow
 - hpe_morpheus_cluster_layout
-- hpe_morpheus_cluster_mks_vsphere
+- hpe_morpheus_cluster_hks_vsphere
 - hpe_morpheus_cluster_package
 - hpe_morpheus_contact
 - hpe_morpheus_credential
@@ -189,7 +189,6 @@ In this release (v0.4.0) we have added the following data-source functionality:
 
 ## New known issues
 
-
 ## Known issues from previous releases
 
 - `hpe_morpheus_datastore` data-source if a datastore with the specified name cannot be found (i.e. the corresponding
@@ -341,4 +340,3 @@ In this release (v0.1.0) the following data sources have been added:
 - hpe_morpheus_user will force recreation if an attribute is updated
 - There are intermittent issues with the provider failing to authenticate, a 500 error is returned from the Morpheus API.
   If this happens please retry the operation.  This is being investigated.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,7 +142,7 @@ In this release (v1.0.0) we have added the following resource functionality:
 - hpe_morpheus_catalog_item_instance
 - hpe_morpheus_catalog_item_workflow
 - hpe_morpheus_cluster_layout
-- hpe_morpheus_cluster_mks_vsphere
+- hpe_morpheus_cluster_hks_vsphere
 - hpe_morpheus_cluster_package
 - hpe_morpheus_contact
 - hpe_morpheus_credential
@@ -442,7 +442,7 @@ Morpheus resources and data sources are covered by a single `hpe` resource or da
 | morpheus_typeahead_option_type            | hpe_morpheus_option_type_typeahead            |
 | morpheus_user_group                       | hpe_morpheus_user_group                       |
 | morpheus_vro_integration                  | hpe_morpheus_integration_vro                  |
-| morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_mks_vsphere              |
+| morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_hks_vsphere              |
 | morpheus_wiki_page                        | hpe_morpheus_wiki_page                        |
 | morpheus_workflow_catalog_item            | hpe_morpheus_catalog_item_workflow            |
 | morpheus_workflow_job                     | hpe_morpheus_job_workflow                     |

--- a/docs/resources/morpheus_cluster_hks_vsphere.md
+++ b/docs/resources/morpheus_cluster_hks_vsphere.md
@@ -1,13 +1,13 @@
 ---
-page_title: "hpe_morpheus_cluster_mks_vsphere Resource - terraform-provider-hpe"
+page_title: "hpe_morpheus_cluster_hks_vsphere Resource - terraform-provider-hpe"
 subcategory: "morpheus"
 description: |-
-  Provides an Morpheus Kubernetes Service (MKS) cluster on VMware vSphere resource
+  Provides a HPE Kubernetes Service (HKS) cluster on VMware vSphere cloud
 ---
 
-# hpe_morpheus_cluster_mks_vsphere (Resource)
+# hpe_morpheus_cluster_hks_vsphere (Resource)
 
-Provides an Morpheus Kubernetes Service (MKS) cluster on VMware vSphere resource
+Provides a HPE Kubernetes Service (HKS) cluster on VMware vSphere cloud
 
 ## Notes
 
@@ -17,11 +17,11 @@ Sometimes updating the number of worker nodes may fail unexpectedly and the new 
 ## Example Usage
 
 ```terraform
-resource "hpe_morpheus_cluster_mks_vsphere" "example" {
+resource "hpe_morpheus_cluster_hks_vsphere" "example" {
   name                    = "tfvsphere"
   resource_prefix         = "vmpre"
   hostname_prefix         = "ospre"
-  description             = "Terraform MKS cluster example"
+  description             = "Terraform HKS cluster example"
   cloud_id                = data.hpe_morpheus_cloud.morpheus_vsphere.id
   group_id                = data.hpe_morpheus_group.morpheus_lab.id
   cluster_layout_id       = 1070
@@ -46,7 +46,7 @@ resource "hpe_morpheus_cluster_mks_vsphere" "example" {
     }
 
     tags = {
-      "app" = "mksmaster"
+      "app" = "hksmaster"
     }
   }
 
@@ -76,7 +76,7 @@ resource "hpe_morpheus_cluster_mks_vsphere" "example" {
     }
 
     tags = {
-      "app" = "mksworker"
+      "app" = "hksworker"
     }
   }
 }
@@ -205,5 +205,5 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-terraform import hpe_morpheus_cluster_mks_vsphere.tf_example_vsphere_mks_cluster 1
+terraform import hpe_morpheus_cluster_hks_vsphere.tf_example_vsphere_hks_cluster 1
 ```

--- a/examples/resources/morpheus_cluster_hks_vsphere/import.sh
+++ b/examples/resources/morpheus_cluster_hks_vsphere/import.sh
@@ -1,0 +1,1 @@
+terraform import hpe_morpheus_cluster_hks_vsphere.tf_example_vsphere_hks_cluster 1

--- a/examples/resources/morpheus_cluster_hks_vsphere/resource.tf
+++ b/examples/resources/morpheus_cluster_hks_vsphere/resource.tf
@@ -1,8 +1,8 @@
-resource "hpe_morpheus_cluster_mks_vsphere" "example" {
+resource "hpe_morpheus_cluster_hks_vsphere" "example" {
   name                    = "tfvsphere"
   resource_prefix         = "vmpre"
   hostname_prefix         = "ospre"
-  description             = "Terraform MKS cluster example"
+  description             = "Terraform HKS cluster example"
   cloud_id                = data.hpe_morpheus_cloud.morpheus_vsphere.id
   group_id                = data.hpe_morpheus_group.morpheus_lab.id
   cluster_layout_id       = 1070
@@ -27,7 +27,7 @@ resource "hpe_morpheus_cluster_mks_vsphere" "example" {
     }
 
     tags = {
-      "app" = "mksmaster"
+      "app" = "hksmaster"
     }
   }
 
@@ -57,7 +57,7 @@ resource "hpe_morpheus_cluster_mks_vsphere" "example" {
     }
 
     tags = {
-      "app" = "mksworker"
+      "app" = "hksworker"
     }
   }
 }

--- a/examples/resources/morpheus_cluster_mks_vsphere/import.sh
+++ b/examples/resources/morpheus_cluster_mks_vsphere/import.sh
@@ -1,1 +1,0 @@
-terraform import hpe_morpheus_cluster_mks_vsphere.tf_example_vsphere_mks_cluster 1

--- a/internal/sdkv2/morpheus/provider.go
+++ b/internal/sdkv2/morpheus/provider.go
@@ -81,7 +81,7 @@ func Provider() *schema.Provider {
 			"hpe_morpheus_catalog_item_instance":            catalogitem.ResourceCatalogItemInstance(),
 			"hpe_morpheus_catalog_item_workflow":            catalogitem.ResourceCatalogItemWorkflow(),
 			"hpe_morpheus_cluster_layout":                   blueprint.ResourceClusterLayout(),
-			"hpe_morpheus_cluster_mks_vsphere":              cluster.ResourceClusterMKSVSphere(),
+			"hpe_morpheus_cluster_hks_vsphere":              cluster.ResourceClusterHKSVSphere(),
 			"hpe_morpheus_cluster_package":                  template.ResourceClusterPackage(),
 			"hpe_morpheus_contact":                          contact.ResourceContact(),
 			"hpe_morpheus_credential":                       credential.ResourceCredential(),

--- a/internal/sdkv2/morpheus/resources/cluster/cluster_hks_vsphere_example.go
+++ b/internal/sdkv2/morpheus/resources/cluster/cluster_hks_vsphere_example.go
@@ -11,18 +11,18 @@ import (
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/testhelpers"
 )
 
-//go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_cluster_mks_vsphere/resource.tf cluster_mks_vsphere_resource.tf.tmpl Name "tfvsphere" ResourcePrefix "vmpre" HostnamePrefix "ospre" Description "Terraform MKS cluster example" CloudId "data.hpe_morpheus_cloud.morpheus_vsphere.id" GroupId "data.hpe_morpheus_group.morpheus_lab.id" ClusterLayoutId "1070" PodCidr "172.20.0.0/16" ServiceCidr "172.30.0.0/16" ClusterRepoAccountId "1" MasterNodePoolPlanId "data.hpe_morpheus_service_plan.master_nodes.id" MasterNodePoolResourcePoolId "data.hpe_morpheus_resource_pool.vsphere_resource_pool.id" MasterNodePoolNetworkInterfaceNetworkId "data.hpe_morpheus_network.vm_network.id" MasterNodePoolStorageVolumeRoot "true" MasterNodePoolStorageVolumeSize "20" MasterNodePoolStorageVolumeName "root" MasterNodePoolStorageVolumeStorageType "1" MasterNodePoolStorageVolumeDatastoreId "9" MasterNodePoolTagsApp "mksmaster" WorkerNodePoolCount "3" WorkerNodePoolPlanId "data.hpe_morpheus_service_plan.worker_nodes.id" WorkerNodePoolResourcePoolId "data.hpe_morpheus_resource_pool.vsphere_resource_pool.id" WorkerNodePoolNetworkInterfaceNetworkId "data.hpe_morpheus_network.vm_network.id" WorkerNodePoolStorageVolume0Root "true" WorkerNodePoolStorageVolume0Size "20" WorkerNodePoolStorageVolume0Name "root" WorkerNodePoolStorageVolume0StorageType "1" WorkerNodePoolStorageVolume0DatastoreId "2" WorkerNodePoolStorageVolume1Root "false" WorkerNodePoolStorageVolume1Size "20" WorkerNodePoolStorageVolume1Name "data" WorkerNodePoolStorageVolume1StorageType "1" WorkerNodePoolStorageVolume1DatastoreId "2" WorkerNodePoolTagsApp "mksworker"
+//go:generate go run ../../../../../cmd/render -out examples/resources/morpheus_cluster_hks_vsphere/resource.tf cluster_hks_vsphere_resource.tf.tmpl Name "tfvsphere" ResourcePrefix "vmpre" HostnamePrefix "ospre" Description "Terraform HKS cluster example" CloudId "data.hpe_morpheus_cloud.morpheus_vsphere.id" GroupId "data.hpe_morpheus_group.morpheus_lab.id" ClusterLayoutId "1070" PodCidr "172.20.0.0/16" ServiceCidr "172.30.0.0/16" ClusterRepoAccountId "1" MasterNodePoolPlanId "data.hpe_morpheus_service_plan.master_nodes.id" MasterNodePoolResourcePoolId "data.hpe_morpheus_resource_pool.vsphere_resource_pool.id" MasterNodePoolNetworkInterfaceNetworkId "data.hpe_morpheus_network.vm_network.id" MasterNodePoolStorageVolumeRoot "true" MasterNodePoolStorageVolumeSize "20" MasterNodePoolStorageVolumeName "root" MasterNodePoolStorageVolumeStorageType "1" MasterNodePoolStorageVolumeDatastoreId "9" MasterNodePoolTagsApp "hksmaster" WorkerNodePoolCount "3" WorkerNodePoolPlanId "data.hpe_morpheus_service_plan.worker_nodes.id" WorkerNodePoolResourcePoolId "data.hpe_morpheus_resource_pool.vsphere_resource_pool.id" WorkerNodePoolNetworkInterfaceNetworkId "data.hpe_morpheus_network.vm_network.id" WorkerNodePoolStorageVolume0Root "true" WorkerNodePoolStorageVolume0Size "20" WorkerNodePoolStorageVolume0Name "root" WorkerNodePoolStorageVolume0StorageType "1" WorkerNodePoolStorageVolume0DatastoreId "2" WorkerNodePoolStorageVolume1Root "false" WorkerNodePoolStorageVolume1Size "20" WorkerNodePoolStorageVolume1Name "data" WorkerNodePoolStorageVolume1StorageType "1" WorkerNodePoolStorageVolume1DatastoreId "2" WorkerNodePoolTagsApp "hksworker"
 
-// RenderClusterMksVsphereConfig generates a Terraform configuration for the cluster_mks_vsphere resource.
+// RenderClusterHKSVsphereConfig generates a Terraform configuration for the cluster_hks_vsphere resource.
 // It accepts optional overrides for field values. Default values are used if not overridden.
-func RenderClusterMksVsphereConfig(t *testing.T, overrides map[string]string) (string, error) {
+func RenderClusterHKSVsphereConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
 		"Name":                         "tfvsphere",
 		"ResourcePrefix":               "vmpre",
 		"HostnamePrefix":               "ospre",
-		"Description":                  "Terraform MKS cluster example",
+		"Description":                  "Terraform HKS cluster example",
 		"CloudId":                      "data.hpe_morpheus_cloud.morpheus_vsphere.id",
 		"GroupId":                      "data.hpe_morpheus_group.morpheus_lab.id",
 		"ClusterLayoutId":              "1070",
@@ -38,7 +38,7 @@ func RenderClusterMksVsphereConfig(t *testing.T, overrides map[string]string) (s
 		"MasterNodePoolStorageVolumeName":         "root",
 		"MasterNodePoolStorageVolumeStorageType":  "1",
 		"MasterNodePoolStorageVolumeDatastoreId":  "9",
-		"MasterNodePoolTagsApp":                   "mksmaster",
+		"MasterNodePoolTagsApp":                   "hksmaster",
 		"WorkerNodePoolCount":                     "3",
 		"WorkerNodePoolPlanId":                    "data.hpe_morpheus_service_plan.worker_nodes.id",
 		"WorkerNodePoolResourcePoolId":            "data.hpe_morpheus_resource_pool.vsphere_resource_pool.id",
@@ -53,7 +53,7 @@ func RenderClusterMksVsphereConfig(t *testing.T, overrides map[string]string) (s
 		"WorkerNodePoolStorageVolume1Name":        "data",
 		"WorkerNodePoolStorageVolume1StorageType": "1",
 		"WorkerNodePoolStorageVolume1DatastoreId": "2",
-		"WorkerNodePoolTagsApp":                   "mksworker",
+		"WorkerNodePoolTagsApp":                   "hksworker",
 	}
 
 	// Apply overrides to defaults
@@ -72,7 +72,7 @@ func RenderClusterMksVsphereConfig(t *testing.T, overrides map[string]string) (s
 		return "", fmt.Errorf("unable to get current file path")
 	}
 	dir := filepath.Dir(filename)
-	templatePath := filepath.Join(dir, "cluster_mks_vsphere_resource.tf.tmpl")
+	templatePath := filepath.Join(dir, "cluster_hks_vsphere_resource.tf.tmpl")
 
 	return testhelpers.RenderExample(
 		t,

--- a/internal/sdkv2/morpheus/resources/cluster/cluster_hks_vsphere_resource.tf.tmpl
+++ b/internal/sdkv2/morpheus/resources/cluster/cluster_hks_vsphere_resource.tf.tmpl
@@ -1,4 +1,4 @@
-resource "hpe_morpheus_cluster_mks_vsphere" "example" {
+resource "hpe_morpheus_cluster_hks_vsphere" "example" {
   name                    = "{{.Name}}"
   resource_prefix         = "{{.ResourcePrefix}}"
   hostname_prefix         = "{{.HostnamePrefix}}"

--- a/internal/sdkv2/morpheus/resources/cluster/cluster_hks_vsphere_test.go
+++ b/internal/sdkv2/morpheus/resources/cluster/cluster_hks_vsphere_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func TestAccClusterMksVsphereExampleOk(t *testing.T) {
+func TestAccClusterHKSVsphereExampleOk(t *testing.T) {
 	t.Parallel()
 
 	defer testhelpers.RecordResult(t)
@@ -36,7 +36,7 @@ func TestAccClusterMksVsphereExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
-	resourceConfig, err := cluster.RenderClusterMksVsphereConfig(t, map[string]string{
+	resourceConfig, err := cluster.RenderClusterHKSVsphereConfig(t, map[string]string{
 		"Name": name,
 	})
 	if err != nil {
@@ -78,171 +78,171 @@ func TestAccClusterMksVsphereExampleOk(t *testing.T) {
 
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"name",
 			name,
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"resource_prefix",
 			"vmpre",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"hostname_prefix",
 			"ospre",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"description",
-			"Terraform MKS cluster example",
+			"Terraform HKS cluster example",
 		),
 		resource.TestCheckResourceAttrSet(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"cloud_id",
 		),
 		resource.TestCheckResourceAttrSet(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"group_id",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"cluster_layout_id",
 			"1070",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"pod_cidr",
 			"172.20.0.0/16",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"service_cidr",
 			"172.30.0.0/16",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"cluster_repo_account_id",
 			"1",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.plan_id",
 			"244",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.resource_pool_id",
 			"5",
 		),
 		resource.TestCheckResourceAttrSet(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.network_interface.0.network_id",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.storage_volume.0.root",
 			"true",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.storage_volume.0.size",
 			"20",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.storage_volume.0.name",
 			"root",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.storage_volume.0.storage_type",
 			"1",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.storage_volume.0.datastore_id",
 			"9",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"master_node_pool.0.tags.app",
-			"mksmaster",
+			"hksmaster",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.count",
 			"3",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.plan_id",
 			"244",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.resource_pool_id",
 			"5",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.network_interface.0.network_id",
 			"86657",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.0.root",
 			"true",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.0.size",
 			"20",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.0.name",
 			"root",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.0.storage_type",
 			"1",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.0.datastore_id",
 			"2",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.1.root",
 			"false",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.1.size",
 			"20",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.1.name",
 			"data",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.1.storage_type",
 			"1",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.storage_volume.1.datastore_id",
 			"2",
 		),
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_cluster_mks_vsphere.example",
+			"hpe_morpheus_cluster_hks_vsphere.example",
 			"worker_node_pool.0.tags.app",
-			"mksworker",
+			"hksworker",
 		),
 	}
 

--- a/internal/sdkv2/morpheus/resources/cluster/resource_cluster_hks_vsphere.go
+++ b/internal/sdkv2/morpheus/resources/cluster/resource_cluster_hks_vsphere.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	minimumMKSWorkerNodes = 3
+	minimumHKSWorkerNodes = 3
 	pollIntervalSeconds   = 10
 
 	statusCancelled      = "cancelled"
@@ -54,24 +54,24 @@ func validateCountDiagFunc(i interface{}, _ cty.Path) diag.Diagnostics {
 		return diag.FromErr(helpers.TypeAssertFailError("count", i))
 	}
 
-	if count < minimumMKSWorkerNodes {
-		return diag.Errorf("count must be a minimum of %d, count is %d", minimumMKSWorkerNodes, count)
+	if count < minimumHKSWorkerNodes {
+		return diag.Errorf("count must be a minimum of %d, count is %d", minimumHKSWorkerNodes, count)
 	}
 
 	return nil
 }
 
 func defaultCountFunc() (interface{}, error) {
-	return minimumMKSWorkerNodes, nil
+	return minimumHKSWorkerNodes, nil
 }
 
-func ResourceClusterMKSVSphere() *schema.Resource {
+func ResourceClusterHKSVSphere() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Provides an Morpheus Kubernetes Service (MKS) cluster on VMware vSphere resource",
-		CreateContext: resourceClusterMKSVSphereCreate,
-		ReadContext:   resourceClusterMKSVSphereRead,
-		UpdateContext: resourceClusterMKSVSphereUpdate,
-		DeleteContext: resourceClusterMKSVSphereDelete,
+		Description:   "Provides a HPE Kubernetes Service (HKS) cluster on VMware vSphere cloud",
+		CreateContext: resourceClusterHKSVSphereCreate,
+		ReadContext:   resourceClusterHKSVSphereRead,
+		UpdateContext: resourceClusterHKSVSphereUpdate,
+		DeleteContext: resourceClusterHKSVSphereDelete,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(45 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
@@ -451,7 +451,7 @@ func filterOutClusterWorkersByStatus(workers []morpheus.ClusterWorker, status st
 	return filteredWorkers
 }
 
-func resourceClusterMKSVSphereCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterHKSVSphereCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -803,7 +803,7 @@ func resourceClusterMKSVSphereCreate(ctx context.Context, d *schema.ResourceData
 
 	// Successfully created resource, now set id
 	d.SetId(convert.Int64ToString(cluster.ID))
-	diags = append(diags, resourceClusterMKSVSphereRead(ctx, d, meta)...)
+	diags = append(diags, resourceClusterHKSVSphereRead(ctx, d, meta)...)
 
 	// Fail the cluster deployment if the cluster status is in a failed state
 	if clusterStatus == statusFailed {
@@ -813,7 +813,7 @@ func resourceClusterMKSVSphereCreate(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceClusterMKSVSphereRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterHKSVSphereRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -1152,7 +1152,7 @@ func doClusterWorkerDelete(ctx context.Context, client *morpheus.Client, cluster
 	return nil
 }
 
-func resourceClusterMKSVSphereUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterHKSVSphereUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert
@@ -1256,10 +1256,10 @@ func resourceClusterMKSVSphereUpdate(ctx context.Context, d *schema.ResourceData
 		log.Printf("API RESPONSE: %s", resp)
 	}
 
-	return resourceClusterMKSVSphereRead(ctx, d, meta)
+	return resourceClusterHKSVSphereRead(ctx, d, meta)
 }
 
-func resourceClusterMKSVSphereDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterHKSVSphereDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var client *morpheus.Client
 	if clientAssert, ok := meta.(*morpheus.Client); ok {
 		client = clientAssert

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -83,7 +83,7 @@ In this release (v1.0.0) we have added the following resource functionality:
 - hpe_morpheus_catalog_item_instance
 - hpe_morpheus_catalog_item_workflow
 - hpe_morpheus_cluster_layout
-- hpe_morpheus_cluster_mks_vsphere
+- hpe_morpheus_cluster_hks_vsphere
 - hpe_morpheus_cluster_package
 - hpe_morpheus_contact
 - hpe_morpheus_credential
@@ -383,7 +383,7 @@ Morpheus resources and data sources are covered by a single `hpe` resource or da
 | morpheus_typeahead_option_type            | hpe_morpheus_option_type_typeahead            |
 | morpheus_user_group                       | hpe_morpheus_user_group                       |
 | morpheus_vro_integration                  | hpe_morpheus_integration_vro                  |
-| morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_mks_vsphere              |
+| morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_hks_vsphere              |
 | morpheus_wiki_page                        | hpe_morpheus_wiki_page                        |
 | morpheus_workflow_catalog_item            | hpe_morpheus_catalog_item_workflow            |
 | morpheus_workflow_job                     | hpe_morpheus_job_workflow                     |

--- a/templates/resources/morpheus_cluster_hks_vsphere.md.tmpl
+++ b/templates/resources/morpheus_cluster_hks_vsphere.md.tmpl
@@ -16,7 +16,7 @@ Sometimes updating the number of worker nodes may fail unexpectedly and the new 
 
 ## Example Usage
 
-{{tffile "examples/resources/morpheus_cluster_mks_vsphere/resource.tf"}}
+{{tffile "examples/resources/morpheus_cluster_hks_vsphere/resource.tf"}}
 
 {{ .SchemaMarkdown | trimspace }}
 
@@ -24,4 +24,4 @@ Sometimes updating the number of worker nodes may fail unexpectedly and the new 
 
 Import is supported using the following syntax:
 
-{{codefile "shell" "examples/resources/morpheus_cluster_mks_vsphere/import.sh" }}
+{{codefile "shell" "examples/resources/morpheus_cluster_hks_vsphere/import.sh" }}


### PR DESCRIPTION

This PR renames the `hpe_morpheus_cluster_mks_vsphere` resource to
`hpe_morpheus_cluster_hks_vsphere` to align with the new naming scheme
being introduced in Morpheus 8.1.0
