### PR TITLE
Morpheus to hpe migration guides

### DIFF
--- a/docs/guides/morpheus_instance_to_hpe_instance.md
+++ b/docs/guides/morpheus_instance_to_hpe_instance.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Migrate Morpheus Provider Instance to HPE Provider Instance"
+page_title: "Morpheus Instance to HPE Instance"
 subcategory: "Migration"
 ---
 

--- a/docs/guides/morpheus_instance_to_hpe_instance.md
+++ b/docs/guides/morpheus_instance_to_hpe_instance.md
@@ -1,16 +1,16 @@
 ---
-page_title: "Migrate Morpheus Instance to HPE Instance - terraform-provider-hpe"
+page_title: "Migrate Morpheus Provider Instance to hpe Provider Instance"
 subcategory: "Migration"
 ---
 
-# Migrate Morpheus Instance to HPE Instance
+# Migrate Morpheus Provider Instance to hpe Provider Instance
 
-This guide provides step-by-step instructions on how to migrate a Morpheus instance to an HPE instance using the `hpe_morpheus_instance` resource in Terraform.
+This guide provides step-by-step instructions on how to migrate a Morpheus provider instance to a hpe provider instance using the `hpe_morpheus_instance` resource in Terraform.
 The guide covers the following types of Morpheus instance:
 - VMware Virtual Machine
 - HVM Virtual Machine
 
-We strongly recommend that users familiarize themselves with the [importing existing resources](https://developer.hashicorp.com/terraform/language/import)
+We strongly recommend that users familiarise themselves with the [importing existing resources](https://developer.hashicorp.com/terraform/language/import)
 documentation provided by HashiCorp before proceeding with the migration process.
 
 The following instructions describe importing a single Morpheus instance.
@@ -64,6 +64,12 @@ The process involves the following steps:
    ```bash
    $ terraform plan -var-file local_test.tfvars -generate-config-out=generated_instance_example.tf
    ```
+   This is the content of `locat_test.tfvars`:
+   ```HCL
+   morpheus_url     = < url >
+   password         = < password >
+   username         = < username >
+   ```
 1. Review the generated file `generated_instance_example.tf` and make any necessary adjustments as explained in the following sections.
 1. Once satisfied with the generated file, proceed to the actual migration by running `terraform apply` in the test directory.
    ```bash
@@ -101,18 +107,10 @@ The process involves the following steps:
    │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
    ```
 1. Remove the relevant `import` block from the configuration file
-1. Check that a subsequent `terraform plan` will complete successfully and show no changes - ignore the warning about provider development overrides,
-   that is because in my testing I am using a locally built version of the provider:
+1. Check that a subsequent `terraform plan` will complete successfully and show no changes:
    ```bash
    $ terraform plan -var-file local_test.tfvars
-   ╷
-   │ Warning: Provider development overrides are in effect
-   │ 
-   │ The following provider development overrides are set in the CLI configuration:
-   │  - hpe/hpe in /Users/eamonn/go/bin
-   │ 
-   │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
-   ╵
+   
    hpe_morpheus_instance.example: Refreshing state... [name=EOTVMWareInstance-2]
    
    No changes. Your infrastructure matches the configuration.

--- a/docs/guides/morpheus_instance_to_hpe_instance.md
+++ b/docs/guides/morpheus_instance_to_hpe_instance.md
@@ -299,7 +299,7 @@ The following changes are needed:
 - Change the `noAgent` block to `noAgent = true` which is the setting in the `Bool` field of the block
 - Change the `resourcePoolId` block to `resourcePoolId = "pool-62299"` which is the value in the `String` field of the block
 
-### VMware Specific Adjustments
+## VMware Specific Adjustments
 After step 5 above, the generated file `generated_instance_example.tf` will need some adjustments specific to VMware instances.
 This is an example generated file for an VMware instance:
 ```HCL

--- a/docs/guides/morpheus_instance_to_hpe_instance.md
+++ b/docs/guides/morpheus_instance_to_hpe_instance.md
@@ -1,0 +1,457 @@
+---
+page_title: "Migrate Morpheus Instance to HPE Instance - terraform-provider-hpe"
+subcategory: "Migration"
+---
+
+# Migrate Morpheus Instance to HPE Instance
+
+This guide provides step-by-step instructions on how to migrate a Morpheus instance to an HPE instance using the `hpe_morpheus_instance` resource in Terraform.
+The guide covers the following types of Morpheus instance:
+- VMware Virtual Machine
+- HVM Virtual Machine
+
+We strongly recommend that users familiarize themselves with the [importing existing resources](https://developer.hashicorp.com/terraform/language/import)
+documentation provided by HashiCorp before proceeding with the migration process.
+
+The following instructions describe importing a single Morpheus instance.
+
+The process involves the following steps:
+1. Do a trial run of the migration in a separate directory
+1. Get the Morpheus ID of the instance to be migrated
+1. In the test directory create a Terraform configuration file with an `import` block for the instance, the block will look like this:
+   ```HCL
+   import {
+     id = 125623
+     to = hpe_morpheus_instance.example
+   }
+   ```
+1. Create a Terraform configuration file with a `provider` and `terraform` block, for example:
+   ```HCL
+   terraform {
+     required_providers {
+       hpe = {
+         source  = "HPE/hpe"
+         version = "= 1.0.0"
+       }
+     }
+   }
+   
+   provider "hpe" {
+     morpheus {
+       url      = var.morpheus_url
+       username = var.username
+       password = var.password
+     }
+   }
+   ```
+   Note that the above example includes some variable definitions, which are in another configuration file:
+   ```HCL
+    variable "morpheus_url" {
+      type = string
+    }
+    
+    variable "username" {
+      type = string
+    }
+    
+    variable "password" {
+      type      = string
+      sensitive = true
+    }
+   ```
+1. With these configuration files in place run `terraform plan` to generate a file with draft HCL to be used for the actual import,
+   the variable file `local_test.tfvars` contains the actual values for the variables defined in the configuration file.
+   ```bash
+   $ terraform plan -var-file local_test.tfvars -generate-config-out=generated_instance_example.tf
+   ```
+1. Review the generated file `generated_instance_example.tf` and make any necessary adjustments as explained in the following sections.
+1. Once satisfied with the generated file, proceed to the actual migration by running `terraform apply` in the test directory.
+   ```bash
+   $ terraform apply -var-file local_test.tfvars
+   ```
+1. Terraform will report errors related to the `network_interface` block, which is expected.  These errors will look similar to
+   the following:
+   ```bash
+   Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
+   hpe_morpheus_instance.example: Importing... [id=125623]
+   hpe_morpheus_instance.example: Import complete [id=125623]
+   hpe_morpheus_instance.example: Modifying... [name=EOTVMWareInstance-2]
+   ╷
+   │ Error: Provider produced inconsistent result after apply
+   │ 
+   │ When applying changes to hpe_morpheus_instance.example_vmware, provider "provider[\"registry.terraform.io/hpe/hpe\"]" produced an unexpected new value: .network_interfaces[0].name: was null, but now
+   │ cty.StringVal("eth0").
+   │ 
+   │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
+   ╵
+   ╷
+   │ Error: Provider produced inconsistent result after apply
+   │ 
+   │ When applying changes to hpe_morpheus_instance.example_vmware, provider "provider[\"registry.terraform.io/hpe/hpe\"]" produced an unexpected new value: .network_interfaces[0].primary_interface: was null, but
+   │ now cty.True.
+   │ 
+   │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
+   ╵
+   ╷
+   │ Error: Provider produced inconsistent result after apply
+   │ 
+   │ When applying changes to hpe_morpheus_instance.example_vmware, provider "provider[\"registry.terraform.io/hpe/hpe\"]" produced an unexpected new value: .network_interfaces[0].ip_address: was
+   │ cty.StringVal(""), but now cty.StringVal("10.32.151.143").
+   │ 
+   │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
+   ```
+1. Remove the relevant `import` block from the configuration file
+1. Check that a subsequent `terraform plan` will complete successfully and show no changes - ignore the warning about provider development overrides,
+   that is because in my testing I am using a locally built version of the provider:
+   ```bash
+   $ terraform plan -var-file local_test.tfvars
+   ╷
+   │ Warning: Provider development overrides are in effect
+   │ 
+   │ The following provider development overrides are set in the CLI configuration:
+   │  - hpe/hpe in /Users/eamonn/go/bin
+   │ 
+   │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
+   ╵
+   hpe_morpheus_instance.example: Refreshing state... [name=EOTVMWareInstance-2]
+   
+   No changes. Your infrastructure matches the configuration.
+   
+   Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
+   ```
+1. Once the test migration is successful, you can use the generated configuration file along with the `import` block in
+    your actual working directory to perform the migration, repeating the `terraform apply` step as needed.  Note that you
+    will see the same expected errors related to the `network_interface` block during the apply step.
+
+## HVM Specific Adjustments
+
+After step 5 above, the generated file `generated_instance_example.tf` will need some adjustments specific to HVM instances.
+This is an example generated file for an HVM instance:
+```HCL
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "125624"
+resource "hpe_morpheus_instance" "example_hvm" {
+  cloud_id = 7714
+  config = {
+    backup = {
+      AdditionalProperties = {
+        jobName     = ""
+        jobSchedule = 2
+        name        = ""
+      }
+      CreateBackup       = null
+      JobAction          = "new"
+      JobRetentionCount  = "3"
+      ProviderBackupType = 14
+    }
+    createBackup         = true
+    createUser           = false
+    customOptions        = {}
+    kvmHostId            = 346676
+    layoutSize           = 1
+    memoryDisplay        = "MB"
+    nestedVirtualization = "off"
+    noAgent = {
+      Bool   = true
+      String = null
+    }
+    poolProviderType = "mvm"
+    resourcePoolId = {
+      Int64  = null
+      String = "pool-62299"
+    }
+  }
+  evars            = null
+  group_id         = 1
+  instance_context = "dev"
+  instance_type_id = 9
+  layout_id        = 5385
+  layout_size      = 1
+  name             = "EOTTestInstance-2"
+  network_interfaces = [
+    {
+      child_virtual_networks = [
+        {
+          ip_address       = null
+          ip_mode          = null
+          ip_pool          = 3251
+          network_group_id = null
+          network_id       = 103481
+          network_type_id  = null
+        },
+      ]
+      ip_address       = null
+      ip_mode          = null
+      ip_pool          = 3251
+      network_group_id = null
+      network_id       = 103481
+      network_type_id  = null
+    },
+    {
+      child_virtual_networks = null
+      ip_address             = null
+      ip_mode                = null
+      ip_pool                = null
+      network_group_id       = null
+      network_id             = 103482
+      network_type_id        = null
+    },
+  ]
+  plan_id = 173
+  ports   = null
+  tags = [
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "managed_by"
+      value = "terraform"
+    },
+    {
+      name  = "terraform"
+      value = "true"
+    },
+  ]
+  task_set_id = null
+  timeouts    = null
+  volumes = [
+    {
+      controller_mount_point   = "1133003:0:9:0"
+      datastore_auto_selection = null
+      datastore_id             = 38658
+      name                     = "root"
+      root_volume              = true
+      size                     = 10
+      size_id                  = null
+      storage_type_id          = 1
+    },
+    {
+      controller_mount_point   = "1133003:0:9:1"
+      datastore_auto_selection = null
+      datastore_id             = 38658
+      name                     = "data"
+      root_volume              = false
+      size                     = 10
+      size_id                  = null
+      storage_type_id          = 1
+    },
+  ]
+}
+```
+
+### `config` Block
+
+This block will need to be edited to match the desired configuration for a HVM instance, which looks like this:
+```HCL
+  config = {
+    resourcePoolId       = "pool-62299"
+    poolProviderType     = "mvm"
+    nestedVirtualization = "off"
+    noAgent              = false
+    createUser           = true
+  }
+```
+
+This is the generated `config` block
+```HCL
+  config = {
+    backup = {
+      AdditionalProperties = {
+        jobName     = ""
+        jobSchedule = 2
+        name        = ""
+      }
+      CreateBackup       = null
+      JobAction          = "new"
+      JobRetentionCount  = "3"
+      ProviderBackupType = 14
+    }
+    createBackup         = true
+    createUser           = false
+    customOptions        = {}
+    kvmHostId            = 346676
+    layoutSize           = 1
+    memoryDisplay        = "MB"
+    nestedVirtualization = "off"
+    noAgent = {
+      Bool   = true
+      String = null
+    }
+    poolProviderType = "mvm"
+    resourcePoolId = {
+      Int64  = null
+      String = "pool-62299"
+    }
+  }
+```
+
+The following changes are needed:
+- Remove the entire `backup` block
+- Remove the `createBackup` line
+- Remove the `customOptions` line
+- Remove the `layoutSize` line
+- Remove the `memoryDisplay` line
+- Change the `noAgent` block to `noAgent = true` which is the setting in the `Bool` field of the block
+- Change the `resourcePoolId` block to `resourcePoolId = "pool-62299"` which is the value in the `String` field of the block
+
+### VMware Specific Adjustments
+After step 5 above, the generated file `generated_instance_example.tf` will need some adjustments specific to VMware instances.
+This is an example generated file for an VMware instance:
+```HCL
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "125623"
+resource "hpe_morpheus_instance" "example_vmware" {
+   cloud_id = 2
+   config = {
+      backup = {
+         AdditionalProperties = {
+            jobName = ""
+            name    = ""
+         }
+         CreateBackup       = null
+         JobAction          = "new"
+         JobRetentionCount  = null
+         ProviderBackupType = 50
+      }
+      createBackup         = true
+      createUser           = false
+      customOptions        = {}
+      layoutSize           = 1
+      memoryDisplay        = "MB"
+      nestedVirtualization = "off"
+      noAgent = {
+         Bool   = true
+         String = null
+      }
+      resourcePoolId = {
+         Int64  = null
+         String = "pool-1"
+      }
+      vmwareFolderId = "group-v79"
+   }
+   evars            = null
+   group_id         = 28
+   instance_context = "dev"
+   instance_type_id = 9
+   layout_id        = 1108
+   layout_size      = 1
+   name             = "EOTVMWareInstance-2"
+   network_interfaces = [
+      {
+         child_virtual_networks = null
+         ip_address             = null
+         ip_mode                = null
+         ip_pool                = 3251
+         network_group_id       = null
+         network_id             = 86657
+         network_type_id        = null
+      },
+   ]
+   plan_id = 241
+   ports   = null
+   tags = [
+      {
+         name  = "acctest"
+         value = "true"
+      },
+      {
+         name  = "hpe_morpheus_instance"
+         value = "true"
+      },
+      {
+         name  = "managed_by"
+         value = "terraform"
+      },
+      {
+         name  = "terraform"
+         value = "true"
+      },
+   ]
+   task_set_id = null
+   timeouts    = null
+   volumes = [
+      {
+         controller_mount_point   = "1133000:0:4:0"
+         datastore_auto_selection = null
+         datastore_id             = 1
+         name                     = "root"
+         root_volume              = true
+         size                     = 10
+         size_id                  = null
+         storage_type_id          = 1
+      },
+      {
+         controller_mount_point   = "1133000:0:4:1"
+         datastore_auto_selection = null
+         datastore_id             = 1
+         name                     = "data"
+         root_volume              = false
+         size                     = 10
+         size_id                  = null
+         storage_type_id          = 1
+      },
+   ]
+}
+```
+
+### `config` Block
+
+This block will need to be edited to match the desired configuration for a VMware instance, which looks like this:
+```HCL
+  config = {
+   createUser           = false
+   nestedVirtualization = "off"
+   noAgent = true
+   resourcePoolId = "pool-1"
+   vmwareFolderId = "group-v79"
+}
+```
+
+This is the generated `config` block
+```HCL
+  config = {
+    backup = {
+      AdditionalProperties = {
+        jobName = ""
+        name    = ""
+      }
+      CreateBackup       = null
+      JobAction          = "new"
+      JobRetentionCount  = null
+      ProviderBackupType = 50
+    }
+    createBackup         = true
+    createUser           = false
+    customOptions        = {}
+    layoutSize           = 1
+    memoryDisplay        = "MB"
+    nestedVirtualization = "off"
+    noAgent = {
+      Bool   = true
+      String = null
+    }
+    resourcePoolId = {
+      Int64  = null
+      String = "pool-1"
+    }
+    vmwareFolderId = "group-v79"
+  }
+```
+
+The following changes are needed:
+- Remove the entire `backup` block
+- Remove the `createBackup` line
+- Remove the `customOptions` line
+- Remove the `layoutSize` line
+- Remove the `memoryDisplay` line
+- Change the `noAgent` block to `noAgent = true` which is the setting in the `Bool` field of the block
+- Change the `resourcePoolId` block to `resourcePoolId = "pool-1"` which is the value in the `String` field of the block

--- a/docs/guides/morpheus_instance_to_hpe_instance.md
+++ b/docs/guides/morpheus_instance_to_hpe_instance.md
@@ -1,11 +1,11 @@
 ---
-page_title: "Migrate Morpheus Provider Instance to hpe Provider Instance"
+page_title: "Migrate Morpheus Provider Instance to HPE Provider Instance"
 subcategory: "Migration"
 ---
 
-# Migrate Morpheus Provider Instance to hpe Provider Instance
+# Migrate Morpheus Provider Instance to HPE Provider Instance
 
-This guide provides step-by-step instructions on how to migrate a Morpheus provider instance to a hpe provider instance using the `hpe_morpheus_instance` resource in Terraform.
+This guide provides step-by-step instructions on how to migrate a Morpheus provider instance to a HPE provider instance using the `hpe_morpheus_instance` resource in Terraform.
 The guide covers the following types of Morpheus instance:
 - VMware Virtual Machine
 - HVM Virtual Machine

--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -1,18 +1,18 @@
 ---
-page_title: "Migrate Morpheus Provider Resources to hpe Provider Resources"
+page_title: "Migrate Morpheus Provider Resources to HPE Provider Resources"
 subcategory: "Migration"
 ---
 
-# Migrate Morpheus Provider Resources to hpe Provider Resources
+# Migrate Morpheus Provider Resources to HPE Provider Resources
 
-To migrate resources from the Morpheus Terraform provider to the hpe Terraform provider the basic principle is to
-import the existing Morpheus resources created with the Morpheus provider into the hpe provider. HashiCorp documentation
+To migrate resources from the Morpheus Terraform provider to the HPE Terraform provider the basic principle is to
+import the existing Morpheus resources created with the Morpheus provider into the HPE provider. HashiCorp documentation
 on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
 
 -> The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
-requires provider support for the `List` RPC.  The hpe provider does not currently support `List`, this is something that we
+requires provider support for the `List` RPC.  The HPE provider does not currently support `List`, this is something that we
 are considering for a future release.<br><br>
-Note that some resources in the Morpheus provider have been converted to a more generalised resource in the hpe provider.
+Note that some resources in the Morpheus provider have been converted to a more generalised resource in the HPE provider.
 See below for details.
 
 ## Import Blocks
@@ -40,9 +40,9 @@ In addition to the import blocks resource definitions must be supplied.  In gene
 definitions to consider:
 
 ### Identical Schema
-The following table lists the resources that have identical schema between the Morpheus and hpe providers.
+The following table lists the resources that have identical schema between the Morpheus and HPE providers.
 
-| Morpheus Provider Resource Name           | hpe Provider Resource Name                    |
+| Morpheus Provider Resource Name           | HPE Provider Resource Name                    |
 |-------------------------------------------|-----------------------------------------------|
 | morpheus_active_directory_identity_source | hpe_morpheus_identity_source_active_directory |
 | morpheus_ansible_integration              | hpe_morpheus_integration_ansible              |
@@ -134,14 +134,14 @@ The following table lists the resources that have identical schema between the M
 | morpheus_write_attributes_task            | hpe_morpheus_task_write_attributes            |
 
 For these resources we can simply copy the resource definition from the Morpheus provider config and change the resource
-type to the corresponding hpe provider resource type.  This needs to be done manually for each resource.  Then an
-import block must be added for each hpe resource to import the existing Morpheus resource.
+type to the corresponding HPE provider resource type.  This needs to be done manually for each resource.  Then an
+import block must be added for each HPE resource to import the existing Morpheus resource.
 
 ### Different Schema
-Some resources have differences in schema between the Morpheus and hpe providers.  These resources are generalised
-in the hpe provider and several Morpheus provider resources map to a single hpe provider resource:
+Some resources have differences in schema between the Morpheus and HPE providers.  These resources are generalised
+in the HPE provider and several Morpheus provider resources map to a single HPE provider resource:
 
-| Morpheus Provider Resource Name | hpe Provider Resource Name |
+| Morpheus Provider Resource Name | HPE Provider Resource Name |
 |---------------------------------|----------------------------|
 | morpheus_aws_cloud | hpe_morpheus_cloud |
 | morpheus_azure_cloud | hpe_morpheus_cloud |
@@ -177,7 +177,7 @@ in the hpe provider and several Morpheus provider resources map to a single hpe 
 | morpheus_tenant_role | hpe_morpheus_role |
 | morpheus_user_role | hpe_morpheus_role |
 
-For these resources terraform can be used to generate the hpe resource definition.  Examples of this process for `hpe_morpheus_instance`
+For these resources terraform can be used to generate the HPE resource definition.  Examples of this process for `hpe_morpheus_instance`
 are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for
 multiple resources at once depending on the number of `import` blocks that are specified.  We recommend generating, editing
 and testing the configuration(s) in a separate directory before using them in your main Terraform configuration.

--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -1,0 +1,183 @@
+---
+page_title: "Migrate Morpheus Resources to HPE Resources - terraform-provider-hpe"
+subcategory: "Migration"
+---
+
+# Migrate Morpheus Resources to HPE Resources
+
+To migrate resources from the Morpheus Terraform provider to the HPE Terraform provider the basic principle is to
+import the existing Morpheus resources created with the Morpheus provider into the HPE provider. HashiCorp documentation
+on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
+
+-> The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
+requires provider support for the `List` RPC.  The hpe provider does not currently support `List`, this is something that we
+are considering for a future release.
+
+## Import Blocks
+To import resources we recommend the use of [import blocks](https://developer.hashicorp.com/terraform/language/block/import)
+Simple import blocks that specify just an ID and a resource address can be used, and multiple import blocks can be specified,
+for example:
+```HCL
+import {
+  id = 125623
+  to = hpe_morpheus_instance.example_vmware
+}
+
+import {
+  id = 125624
+  to = hpe_morpheus_instance.example_hvm
+}
+```
+
+Once resource definitions are supplied a `terraform apply` will import the resources into the state file.  After the
+import ensure that a `terraform plan` shows no changes.  If there are changes then the resource definitions need to be
+adjusted to match the existing resources.
+
+## Resource Definitions
+In addition to the import blocks resource definitions must be supplied.  In general there are two categories of resource
+definitions to consider:
+
+### Identical Schema
+The following table lists the resources that have identical schema between the Morpheus and HPE providers.
+
+| Morpheus Provider Resource Name           | hpe Provider Resource Name                    |
+|-------------------------------------------|-----------------------------------------------|
+| morpheus_active_directory_identity_source | hpe_morpheus_identity_source_active_directory |
+| morpheus_ansible_integration              | hpe_morpheus_integration_ansible              |
+| morpheus_ansible_playbook_task            | hpe_morpheus_task_ansible_playbook            |
+| morpheus_ansible_tower_integration        | hpe_morpheus_integration_ansible_tower        |
+| morpheus_ansible_tower_task               | hpe_morpheus_task_ansible_tower               |
+| morpheus_api_option_list                  | hpe_morpheus_option_list_api                  |
+| morpheus_app_blueprint_catalog_item       | hpe_morpheus_catalog_item_app_blueprint       |
+| morpheus_appliance_setting                | hpe_morpheus_setting_appliance                |
+| morpheus_arm_app_blueprint                | hpe_morpheus_app_blueprint_arm                |
+| morpheus_arm_spec_template                | hpe_morpheus_spec_template_arm                |
+| morpheus_backup_setting                   | hpe_morpheus_setting_backup                   |
+| morpheus_boot_script                      | hpe_morpheus_boot_script                      |
+| morpheus_checkbox_option_type             | hpe_morpheus_option_type_checkbox             |
+| morpheus_chef_bootstrap_task              | hpe_morpheus_task_chef_bootstrap              |
+| morpheus_chef_integration                 | hpe_morpheus_integration_chef                 |
+| morpheus_cloud_formation_app_blueprint    | hpe_morpheus_app_blueprint_cloud_formation    |
+| morpheus_cloud_formation_spec_template    | hpe_morpheus_spec_template_cloud_formation    |
+| morpheus_cluster_layout                   | hpe_morpheus_cluster_layout                   |
+| morpheus_cluster_package                  | hpe_morpheus_cluster_package                  |
+| morpheus_contact                          | hpe_morpheus_contact                          |
+| morpheus_credential                       | hpe_morpheus_credential                       |
+| morpheus_cypher_secret                    | hpe_morpheus_cypher_secret                    |
+| morpheus_cypher_tfvars                    | hpe_morpheus_cypher_tfvars                    |
+| morpheus_docker_registry_integration      | hpe_morpheus_integration_docker_registry      |
+| morpheus_email_task                       | hpe_morpheus_task_email                       |
+| morpheus_environment                      | hpe_morpheus_environment                      |
+| morpheus_execute_schedule                 | hpe_morpheus_execute_schedule                 |
+| morpheus_file_template                    | hpe_morpheus_file_template                    |
+| morpheus_form                             | hpe_morpheus_form                             |
+| morpheus_git_integration                  | hpe_morpheus_integration_git                  |
+| morpheus_groovy_script_task               | hpe_morpheus_task_groovy_script               |
+| morpheus_guidance_setting                 | hpe_morpheus_setting_guidance                 |
+| morpheus_helm_app_blueprint               | hpe_morpheus_app_blueprint_helm               |
+| morpheus_helm_spec_template               | hpe_morpheus_spec_template_helm               |
+| morpheus_hidden_option_type               | hpe_morpheus_option_type_hidden               |
+| morpheus_instance_catalog_item            | hpe_morpheus_catalog_item_instance            |
+| morpheus_instance_layout                  | hpe_morpheus_instance_type_layout             |
+| morpheus_instance_type                    | hpe_morpheus_instance_type                    |
+| morpheus_ipv4_ip_pool                     | hpe_morpheus_ip_pool_ipv4                     |
+| morpheus_javascript_task                  | hpe_morpheus_task_javascript                  |
+| morpheus_key_pairs                        | hpe_morpheus_key_pair                         |
+| morpheus_kubernetes_app_blueprint         | hpe_morpheus_app_blueprint_kubernetes         |
+| morpheus_kubernetes_spec_template         | hpe_morpheus_spec_template_kubernetes         |
+| morpheus_library_script_task              | hpe_morpheus_task_library_script              |
+| morpheus_library_template_task            | hpe_morpheus_task_library_template            |
+| morpheus_license                          | hpe_morpheus_license                          |
+| morpheus_manual_option_list               | hpe_morpheus_option_list_manual               |
+| morpheus_monitoring_setting               | hpe_morpheus_setting_monitoring               |
+| morpheus_nested_workflow_task             | hpe_morpheus_task_nested_workflow             |
+| morpheus_network_domain                   | hpe_morpheus_network_domain                   |
+| morpheus_node_type                        | hpe_morpheus_node_type                        |
+| morpheus_number_option_type               | hpe_morpheus_option_type_number               |
+| morpheus_operational_workflow             | hpe_morpheus_workflow_operational             |
+| morpheus_password_option_type             | hpe_morpheus_option_type_password             |
+| morpheus_powershell_script_task           | hpe_morpheus_task_powershell_script           |
+| morpheus_preseed_script                   | hpe_morpheus_preseed_script                   |
+| morpheus_price                            | hpe_morpheus_price                            |
+| morpheus_price_set                        | hpe_morpheus_price_set                        |
+| morpheus_provisioning_setting             | hpe_morpheus_setting_provisioning             |
+| morpheus_provisioning_workflow            | hpe_morpheus_workflow_provisioning            |
+| morpheus_puppet_integration               | hpe_morpheus_integration_puppet               |
+| morpheus_python_script_task               | hpe_morpheus_task_python_script               |
+| morpheus_radio_list_option_type           | hpe_morpheus_option_type_radio_list           |
+| morpheus_resource_pool_group              | hpe_morpheus_resource_pool_group              |
+| morpheus_rest_option_list                 | hpe_morpheus_option_list_rest                 |
+| morpheus_restart_task                     | hpe_morpheus_task_restart                     |
+| morpheus_ruby_script_task                 | hpe_morpheus_task_ruby_script                 |
+| morpheus_saml_identity_source             | hpe_morpheus_identity_source_saml             |
+| morpheus_scale_threshold                  | hpe_morpheus_scale_threshold                  |
+| morpheus_script_template                  | hpe_morpheus_script_template                  |
+| morpheus_security_package                 | hpe_morpheus_security_package                 |
+| morpheus_select_list_option_type          | hpe_morpheus_option_type_select_list          |
+| morpheus_servicenow_integration           | hpe_morpheus_integration_servicenow           |
+| morpheus_shell_script_task                | hpe_morpheus_task_shell_script                |
+| morpheus_task_job                         | hpe_morpheus_job_task                         |
+| morpheus_tenant                           | hpe_morpheus_tenant                           |
+| morpheus_terraform_app_blueprint          | hpe_morpheus_app_blueprint_terraform          |
+| morpheus_terraform_spec_template          | hpe_morpheus_spec_template_terraform          |
+| morpheus_text_option_type                 | hpe_morpheus_option_type_text                 |
+| morpheus_textarea_option_type             | hpe_morpheus_option_type_textarea             |
+| morpheus_typeahead_option_type            | hpe_morpheus_option_type_typeahead            |
+| morpheus_user_group                       | hpe_morpheus_user_group                       |
+| morpheus_vro_integration                  | hpe_morpheus_integration_vro                  |
+| morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_hks_vsphere              |
+| morpheus_wiki_page                        | hpe_morpheus_wiki_page                        |
+| morpheus_workflow_catalog_item            | hpe_morpheus_catalog_item_workflow            |
+| morpheus_workflow_job                     | hpe_morpheus_job_workflow                     |
+| morpheus_write_attributes_task            | hpe_morpheus_task_write_attributes            |
+
+For these resources we can simply copy the resource definition from the Morpheus provider config and change the resource
+type to the corresponding HPE provider resource type.  This needs to be done manually for each resource.  Then an
+import block must be added for each hpe resource to import the existing Morpheus resource.
+
+We are considering the possibility of writing a tool to automate this process for these resources in the future.
+
+### Different Schema
+Some resources have differences in schema between the Morpheus and HPE providers.  These resources are `generalised`
+in the hpe provider and several Morpheus provider resources map to a single hpe provider resource:
+
+| Morpheus Provider Resource Name | hpe Provider Resource Name |
+|---------------------------------|----------------------------|
+| morpheus_aws_cloud | hpe_morpheus_cloud |
+| morpheus_azure_cloud | hpe_morpheus_cloud |
+| morpheus_standard_cloud | hpe_morpheus_cloud |
+| morpheus_vsphere_cloud | hpe_morpheus_cloud |
+| morpheus_vsphere_cloud_datastore_configuration | hpe_morpheus_datastore |
+| morpheus_aws_instance | hpe_morpheus_instance |
+| morpheus_mvm_instance | hpe_morpheus_instance |
+| morpheus_vsphere_instance | hpe_morpheus_instance |
+| morpheus_backup_creation_policy | hpe_morpheus_policy |
+| morpheus_budget_policy | hpe_morpheus_policy |
+| morpheus_cluster_resource_name_policy | hpe_morpheus_policy |
+| morpheus_cypher_access_policy | hpe_morpheus_policy |
+| morpheus_delayed_delete_policy | hpe_morpheus_policy |
+| morpheus_delete_approval_policy | hpe_morpheus_policy |
+| morpheus_hostname_policy | hpe_morpheus_policy |
+| morpheus_instance_name_policy | hpe_morpheus_policy |
+| morpheus_max_containers_policy | hpe_morpheus_policy |
+| morpheus_max_cores_policy | hpe_morpheus_policy |
+| morpheus_max_hosts_policy | hpe_morpheus_policy |
+| morpheus_max_memory_policy | hpe_morpheus_policy |
+| morpheus_max_storage_policy | hpe_morpheus_policy |
+| morpheus_max_vms_policy | hpe_morpheus_policy |
+| morpheus_motd_policy | hpe_morpheus_policy |
+| morpheus_network_quota_policy | hpe_morpheus_policy |
+| morpheus_power_schedule_policy | hpe_morpheus_policy |
+| morpheus_provision_approval_policy | hpe_morpheus_policy |
+| morpheus_router_quota_policy | hpe_morpheus_policy |
+| morpheus_tag_policy | hpe_morpheus_policy |
+| morpheus_user_creation_policy | hpe_morpheus_policy |
+| morpheus_user_group_creation_policy | hpe_morpheus_policy |
+| morpheus_workflow_policy | hpe_morpheus_policy |
+| morpheus_tenant_role | hpe_morpheus_role |
+| morpheus_user_role | hpe_morpheus_role |
+
+For these resources terraform can be used to generate the hpe resource definition.  Examples of this process for `hpe_morpheus_instance`
+are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for
+multiple resources at once depending on the number of `import` blocks that are specified.  We recommend generating, editing
+and testing the configuration(s) in a separate directory before using them in your main terraform configuration.

--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Migrate Morpheus Provider Resources to HPE Provider Resources"
+page_title: "Morpheus to HPE"
 subcategory: "Migration"
 ---
 

--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -1,17 +1,19 @@
 ---
-page_title: "Migrate Morpheus Resources to HPE Resources - terraform-provider-hpe"
+page_title: "Migrate Morpheus Provider Resources to hpe Provider Resources"
 subcategory: "Migration"
 ---
 
-# Migrate Morpheus Resources to HPE Resources
+# Migrate Morpheus Provider Resources to hpe Provider Resources
 
-To migrate resources from the Morpheus Terraform provider to the HPE Terraform provider the basic principle is to
-import the existing Morpheus resources created with the Morpheus provider into the HPE provider. HashiCorp documentation
+To migrate resources from the Morpheus Terraform provider to the hpe Terraform provider the basic principle is to
+import the existing Morpheus resources created with the Morpheus provider into the hpe provider. HashiCorp documentation
 on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
 
 -> The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
 requires provider support for the `List` RPC.  The hpe provider does not currently support `List`, this is something that we
-are considering for a future release.
+are considering for a future release.<br><br>
+Note that some resources in the Morpheus provider have been converted to a more generalised resource in the hpe provider.
+See below for details.
 
 ## Import Blocks
 To import resources we recommend the use of [import blocks](https://developer.hashicorp.com/terraform/language/block/import)
@@ -38,7 +40,7 @@ In addition to the import blocks resource definitions must be supplied.  In gene
 definitions to consider:
 
 ### Identical Schema
-The following table lists the resources that have identical schema between the Morpheus and HPE providers.
+The following table lists the resources that have identical schema between the Morpheus and hpe providers.
 
 | Morpheus Provider Resource Name           | hpe Provider Resource Name                    |
 |-------------------------------------------|-----------------------------------------------|
@@ -132,13 +134,11 @@ The following table lists the resources that have identical schema between the M
 | morpheus_write_attributes_task            | hpe_morpheus_task_write_attributes            |
 
 For these resources we can simply copy the resource definition from the Morpheus provider config and change the resource
-type to the corresponding HPE provider resource type.  This needs to be done manually for each resource.  Then an
+type to the corresponding hpe provider resource type.  This needs to be done manually for each resource.  Then an
 import block must be added for each hpe resource to import the existing Morpheus resource.
 
-We are considering the possibility of writing a tool to automate this process for these resources in the future.
-
 ### Different Schema
-Some resources have differences in schema between the Morpheus and HPE providers.  These resources are `generalised`
+Some resources have differences in schema between the Morpheus and hpe providers.  These resources are generalised
 in the hpe provider and several Morpheus provider resources map to a single hpe provider resource:
 
 | Morpheus Provider Resource Name | hpe Provider Resource Name |
@@ -180,4 +180,4 @@ in the hpe provider and several Morpheus provider resources map to a single hpe 
 For these resources terraform can be used to generate the hpe resource definition.  Examples of this process for `hpe_morpheus_instance`
 are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for
 multiple resources at once depending on the number of `import` blocks that are specified.  We recommend generating, editing
-and testing the configuration(s) in a separate directory before using them in your main terraform configuration.
+and testing the configuration(s) in a separate directory before using them in your main Terraform configuration.

--- a/templates/guides/morpheus_instance_to_hpe_instance.md
+++ b/templates/guides/morpheus_instance_to_hpe_instance.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Migrate Morpheus Provider Instance to HPE Provider Instance"
+page_title: "Morpheus Instance to HPE Instance"
 subcategory: "Migration"
 ---
 

--- a/templates/guides/morpheus_instance_to_hpe_instance.md
+++ b/templates/guides/morpheus_instance_to_hpe_instance.md
@@ -299,7 +299,7 @@ The following changes are needed:
 - Change the `noAgent` block to `noAgent = true` which is the setting in the `Bool` field of the block
 - Change the `resourcePoolId` block to `resourcePoolId = "pool-62299"` which is the value in the `String` field of the block
 
-### VMware Specific Adjustments
+## VMware Specific Adjustments
 After step 5 above, the generated file `generated_instance_example.tf` will need some adjustments specific to VMware instances.
 This is an example generated file for an VMware instance:
 ```HCL

--- a/templates/guides/morpheus_instance_to_hpe_instance.md
+++ b/templates/guides/morpheus_instance_to_hpe_instance.md
@@ -1,0 +1,457 @@
+---
+page_title: "Migrate Morpheus Provider Instance to HPE Provider Instance"
+subcategory: "Migration"
+---
+
+# Migrate Morpheus Instance to HPE Instance
+
+This guide provides step-by-step instructions on how to migrate a Morpheus instance to an HPE instance using the `hpe_morpheus_instance` resource in Terraform.
+The guide covers the following types of Morpheus instance:
+- VMware Virtual Machine
+- HVM Virtual Machine
+
+We strongly recommend that users familiarize themselves with the [importing existing resources](https://developer.hashicorp.com/terraform/language/import)
+documentation provided by HashiCorp before proceeding with the migration process.
+
+The following instructions describe importing a single Morpheus instance.
+
+The process involves the following steps:
+1. Do a trial run of the migration in a separate directory
+1. Get the Morpheus ID of the instance to be migrated
+1. In the test directory create a Terraform configuration file with an `import` block for the instance, the block will look like this:
+   ```HCL
+   import {
+     id = 125623
+     to = hpe_morpheus_instance.example
+   }
+   ```
+1. Create a Terraform configuration file with a `provider` and `terraform` block, for example:
+   ```HCL
+   terraform {
+     required_providers {
+       hpe = {
+         source  = "HPE/hpe"
+         version = "= 1.0.0"
+       }
+     }
+   }
+   
+   provider "hpe" {
+     morpheus {
+       url      = var.morpheus_url
+       username = var.username
+       password = var.password
+     }
+   }
+   ```
+   Note that the above example includes some variable definitions, which are in another configuration file:
+   ```HCL
+    variable "morpheus_url" {
+      type = string
+    }
+    
+    variable "username" {
+      type = string
+    }
+    
+    variable "password" {
+      type      = string
+      sensitive = true
+    }
+   ```
+1. With these configuration files in place run `terraform plan` to generate a file with draft HCL to be used for the actual import,
+   the variable file `local_test.tfvars` contains the actual values for the variables defined in the configuration file.
+   ```bash
+   $ terraform plan -var-file local_test.tfvars -generate-config-out=generated_instance_example.tf
+   ```
+1. Review the generated file `generated_instance_example.tf` and make any necessary adjustments as explained in the following sections.
+1. Once satisfied with the generated file, proceed to the actual migration by running `terraform apply` in the test directory.
+   ```bash
+   $ terraform apply -var-file local_test.tfvars
+   ```
+1. Terraform will report errors related to the `network_interface` block, which is expected.  These errors will look similar to
+   the following:
+   ```bash
+   Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
+   hpe_morpheus_instance.example: Importing... [id=125623]
+   hpe_morpheus_instance.example: Import complete [id=125623]
+   hpe_morpheus_instance.example: Modifying... [name=EOTVMWareInstance-2]
+   ╷
+   │ Error: Provider produced inconsistent result after apply
+   │ 
+   │ When applying changes to hpe_morpheus_instance.example_vmware, provider "provider[\"registry.terraform.io/hpe/hpe\"]" produced an unexpected new value: .network_interfaces[0].name: was null, but now
+   │ cty.StringVal("eth0").
+   │ 
+   │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
+   ╵
+   ╷
+   │ Error: Provider produced inconsistent result after apply
+   │ 
+   │ When applying changes to hpe_morpheus_instance.example_vmware, provider "provider[\"registry.terraform.io/hpe/hpe\"]" produced an unexpected new value: .network_interfaces[0].primary_interface: was null, but
+   │ now cty.True.
+   │ 
+   │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
+   ╵
+   ╷
+   │ Error: Provider produced inconsistent result after apply
+   │ 
+   │ When applying changes to hpe_morpheus_instance.example_vmware, provider "provider[\"registry.terraform.io/hpe/hpe\"]" produced an unexpected new value: .network_interfaces[0].ip_address: was
+   │ cty.StringVal(""), but now cty.StringVal("10.32.151.143").
+   │ 
+   │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
+   ```
+1. Remove the relevant `import` block from the configuration file
+1. Check that a subsequent `terraform plan` will complete successfully and show no changes - ignore the warning about provider development overrides,
+   that is because in my testing I am using a locally built version of the provider:
+   ```bash
+   $ terraform plan -var-file local_test.tfvars
+   ╷
+   │ Warning: Provider development overrides are in effect
+   │ 
+   │ The following provider development overrides are set in the CLI configuration:
+   │  - hpe/hpe in /Users/eamonn/go/bin
+   │ 
+   │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
+   ╵
+   hpe_morpheus_instance.example: Refreshing state... [name=EOTVMWareInstance-2]
+   
+   No changes. Your infrastructure matches the configuration.
+   
+   Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
+   ```
+1. Once the test migration is successful, you can use the generated configuration file along with the `import` block in
+    your actual working directory to perform the migration, repeating the `terraform apply` step as needed.  Note that you
+    will see the same expected errors related to the `network_interface` block during the apply step.
+
+## HVM Specific Adjustments
+
+After step 5 above, the generated file `generated_instance_example.tf` will need some adjustments specific to HVM instances.
+This is an example generated file for an HVM instance:
+```HCL
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "125624"
+resource "hpe_morpheus_instance" "example_hvm" {
+  cloud_id = 7714
+  config = {
+    backup = {
+      AdditionalProperties = {
+        jobName     = ""
+        jobSchedule = 2
+        name        = ""
+      }
+      CreateBackup       = null
+      JobAction          = "new"
+      JobRetentionCount  = "3"
+      ProviderBackupType = 14
+    }
+    createBackup         = true
+    createUser           = false
+    customOptions        = {}
+    kvmHostId            = 346676
+    layoutSize           = 1
+    memoryDisplay        = "MB"
+    nestedVirtualization = "off"
+    noAgent = {
+      Bool   = true
+      String = null
+    }
+    poolProviderType = "mvm"
+    resourcePoolId = {
+      Int64  = null
+      String = "pool-62299"
+    }
+  }
+  evars            = null
+  group_id         = 1
+  instance_context = "dev"
+  instance_type_id = 9
+  layout_id        = 5385
+  layout_size      = 1
+  name             = "EOTTestInstance-2"
+  network_interfaces = [
+    {
+      child_virtual_networks = [
+        {
+          ip_address       = null
+          ip_mode          = null
+          ip_pool          = 3251
+          network_group_id = null
+          network_id       = 103481
+          network_type_id  = null
+        },
+      ]
+      ip_address       = null
+      ip_mode          = null
+      ip_pool          = 3251
+      network_group_id = null
+      network_id       = 103481
+      network_type_id  = null
+    },
+    {
+      child_virtual_networks = null
+      ip_address             = null
+      ip_mode                = null
+      ip_pool                = null
+      network_group_id       = null
+      network_id             = 103482
+      network_type_id        = null
+    },
+  ]
+  plan_id = 173
+  ports   = null
+  tags = [
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "managed_by"
+      value = "terraform"
+    },
+    {
+      name  = "terraform"
+      value = "true"
+    },
+  ]
+  task_set_id = null
+  timeouts    = null
+  volumes = [
+    {
+      controller_mount_point   = "1133003:0:9:0"
+      datastore_auto_selection = null
+      datastore_id             = 38658
+      name                     = "root"
+      root_volume              = true
+      size                     = 10
+      size_id                  = null
+      storage_type_id          = 1
+    },
+    {
+      controller_mount_point   = "1133003:0:9:1"
+      datastore_auto_selection = null
+      datastore_id             = 38658
+      name                     = "data"
+      root_volume              = false
+      size                     = 10
+      size_id                  = null
+      storage_type_id          = 1
+    },
+  ]
+}
+```
+
+### `config` Block
+
+This block will need to be edited to match the desired configuration for a HVM instance, which looks like this:
+```HCL
+  config = {
+    resourcePoolId       = "pool-62299"
+    poolProviderType     = "mvm"
+    nestedVirtualization = "off"
+    noAgent              = false
+    createUser           = true
+  }
+```
+
+This is the generated `config` block
+```HCL
+  config = {
+    backup = {
+      AdditionalProperties = {
+        jobName     = ""
+        jobSchedule = 2
+        name        = ""
+      }
+      CreateBackup       = null
+      JobAction          = "new"
+      JobRetentionCount  = "3"
+      ProviderBackupType = 14
+    }
+    createBackup         = true
+    createUser           = false
+    customOptions        = {}
+    kvmHostId            = 346676
+    layoutSize           = 1
+    memoryDisplay        = "MB"
+    nestedVirtualization = "off"
+    noAgent = {
+      Bool   = true
+      String = null
+    }
+    poolProviderType = "mvm"
+    resourcePoolId = {
+      Int64  = null
+      String = "pool-62299"
+    }
+  }
+```
+
+The following changes are needed:
+- Remove the entire `backup` block
+- Remove the `createBackup` line
+- Remove the `customOptions` line
+- Remove the `layoutSize` line
+- Remove the `memoryDisplay` line
+- Change the `noAgent` block to `noAgent = true` which is the setting in the `Bool` field of the block
+- Change the `resourcePoolId` block to `resourcePoolId = "pool-62299"` which is the value in the `String` field of the block
+
+### VMware Specific Adjustments
+After step 5 above, the generated file `generated_instance_example.tf` will need some adjustments specific to VMware instances.
+This is an example generated file for an VMware instance:
+```HCL
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "125623"
+resource "hpe_morpheus_instance" "example_vmware" {
+   cloud_id = 2
+   config = {
+      backup = {
+         AdditionalProperties = {
+            jobName = ""
+            name    = ""
+         }
+         CreateBackup       = null
+         JobAction          = "new"
+         JobRetentionCount  = null
+         ProviderBackupType = 50
+      }
+      createBackup         = true
+      createUser           = false
+      customOptions        = {}
+      layoutSize           = 1
+      memoryDisplay        = "MB"
+      nestedVirtualization = "off"
+      noAgent = {
+         Bool   = true
+         String = null
+      }
+      resourcePoolId = {
+         Int64  = null
+         String = "pool-1"
+      }
+      vmwareFolderId = "group-v79"
+   }
+   evars            = null
+   group_id         = 28
+   instance_context = "dev"
+   instance_type_id = 9
+   layout_id        = 1108
+   layout_size      = 1
+   name             = "EOTVMWareInstance-2"
+   network_interfaces = [
+      {
+         child_virtual_networks = null
+         ip_address             = null
+         ip_mode                = null
+         ip_pool                = 3251
+         network_group_id       = null
+         network_id             = 86657
+         network_type_id        = null
+      },
+   ]
+   plan_id = 241
+   ports   = null
+   tags = [
+      {
+         name  = "acctest"
+         value = "true"
+      },
+      {
+         name  = "hpe_morpheus_instance"
+         value = "true"
+      },
+      {
+         name  = "managed_by"
+         value = "terraform"
+      },
+      {
+         name  = "terraform"
+         value = "true"
+      },
+   ]
+   task_set_id = null
+   timeouts    = null
+   volumes = [
+      {
+         controller_mount_point   = "1133000:0:4:0"
+         datastore_auto_selection = null
+         datastore_id             = 1
+         name                     = "root"
+         root_volume              = true
+         size                     = 10
+         size_id                  = null
+         storage_type_id          = 1
+      },
+      {
+         controller_mount_point   = "1133000:0:4:1"
+         datastore_auto_selection = null
+         datastore_id             = 1
+         name                     = "data"
+         root_volume              = false
+         size                     = 10
+         size_id                  = null
+         storage_type_id          = 1
+      },
+   ]
+}
+```
+
+### `config` Block
+
+This block will need to be edited to match the desired configuration for a VMware instance, which looks like this:
+```HCL
+  config = {
+   createUser           = false
+   nestedVirtualization = "off"
+   noAgent = true
+   resourcePoolId = "pool-1"
+   vmwareFolderId = "group-v79"
+}
+```
+
+This is the generated `config` block
+```HCL
+  config = {
+    backup = {
+      AdditionalProperties = {
+        jobName = ""
+        name    = ""
+      }
+      CreateBackup       = null
+      JobAction          = "new"
+      JobRetentionCount  = null
+      ProviderBackupType = 50
+    }
+    createBackup         = true
+    createUser           = false
+    customOptions        = {}
+    layoutSize           = 1
+    memoryDisplay        = "MB"
+    nestedVirtualization = "off"
+    noAgent = {
+      Bool   = true
+      String = null
+    }
+    resourcePoolId = {
+      Int64  = null
+      String = "pool-1"
+    }
+    vmwareFolderId = "group-v79"
+  }
+```
+
+The following changes are needed:
+- Remove the entire `backup` block
+- Remove the `createBackup` line
+- Remove the `customOptions` line
+- Remove the `layoutSize` line
+- Remove the `memoryDisplay` line
+- Change the `noAgent` block to `noAgent = true` which is the setting in the `Bool` field of the block
+- Change the `resourcePoolId` block to `resourcePoolId = "pool-1"` which is the value in the `String` field of the block

--- a/templates/guides/morpheus_instance_to_hpe_instance.md
+++ b/templates/guides/morpheus_instance_to_hpe_instance.md
@@ -1,16 +1,16 @@
 ---
-page_title: "Migrate Morpheus Provider Instance to HPE Provider Instance"
+page_title: "Migrate Morpheus Provider Instance to hpe Provider Instance"
 subcategory: "Migration"
 ---
 
-# Migrate Morpheus Instance to HPE Instance
+# Migrate Morpheus Provider Instance to hpe Provider Instance
 
-This guide provides step-by-step instructions on how to migrate a Morpheus instance to an HPE instance using the `hpe_morpheus_instance` resource in Terraform.
+This guide provides step-by-step instructions on how to migrate a Morpheus provider instance to a hpe provider instance using the `hpe_morpheus_instance` resource in Terraform.
 The guide covers the following types of Morpheus instance:
 - VMware Virtual Machine
 - HVM Virtual Machine
 
-We strongly recommend that users familiarize themselves with the [importing existing resources](https://developer.hashicorp.com/terraform/language/import)
+We strongly recommend that users familiarise themselves with the [importing existing resources](https://developer.hashicorp.com/terraform/language/import)
 documentation provided by HashiCorp before proceeding with the migration process.
 
 The following instructions describe importing a single Morpheus instance.
@@ -64,6 +64,12 @@ The process involves the following steps:
    ```bash
    $ terraform plan -var-file local_test.tfvars -generate-config-out=generated_instance_example.tf
    ```
+   This is the content of `locat_test.tfvars`:
+   ```HCL
+   morpheus_url     = < url >
+   password         = < password >
+   username         = < username >
+   ```
 1. Review the generated file `generated_instance_example.tf` and make any necessary adjustments as explained in the following sections.
 1. Once satisfied with the generated file, proceed to the actual migration by running `terraform apply` in the test directory.
    ```bash
@@ -101,18 +107,10 @@ The process involves the following steps:
    │ This is a bug in the provider, which should be reported in the provider's own issue tracker.
    ```
 1. Remove the relevant `import` block from the configuration file
-1. Check that a subsequent `terraform plan` will complete successfully and show no changes - ignore the warning about provider development overrides,
-   that is because in my testing I am using a locally built version of the provider:
+1. Check that a subsequent `terraform plan` will complete successfully and show no changes:
    ```bash
    $ terraform plan -var-file local_test.tfvars
-   ╷
-   │ Warning: Provider development overrides are in effect
-   │ 
-   │ The following provider development overrides are set in the CLI configuration:
-   │  - hpe/hpe in /Users/eamonn/go/bin
-   │ 
-   │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
-   ╵
+   
    hpe_morpheus_instance.example: Refreshing state... [name=EOTVMWareInstance-2]
    
    No changes. Your infrastructure matches the configuration.

--- a/templates/guides/morpheus_instance_to_hpe_instance.md
+++ b/templates/guides/morpheus_instance_to_hpe_instance.md
@@ -1,11 +1,11 @@
 ---
-page_title: "Migrate Morpheus Provider Instance to hpe Provider Instance"
+page_title: "Migrate Morpheus Provider Instance to HPE Provider Instance"
 subcategory: "Migration"
 ---
 
-# Migrate Morpheus Provider Instance to hpe Provider Instance
+# Migrate Morpheus Provider Instance to HPE Provider Instance
 
-This guide provides step-by-step instructions on how to migrate a Morpheus provider instance to a hpe provider instance using the `hpe_morpheus_instance` resource in Terraform.
+This guide provides step-by-step instructions on how to migrate a Morpheus provider instance to a HPE provider instance using the `hpe_morpheus_instance` resource in Terraform.
 The guide covers the following types of Morpheus instance:
 - VMware Virtual Machine
 - HVM Virtual Machine

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -5,13 +5,15 @@ subcategory: "Migration"
 
 # Migrate Morpheus Provider Resources to hpe Provider Resources
 
-To migrate resources from the Morpheus Terraform provider to the HPE Terraform provider the basic principle is to
-import the existing Morpheus resources created with the Morpheus provider into the HPE provider. HashiCorp documentation
+To migrate resources from the Morpheus Terraform provider to the hpe Terraform provider the basic principle is to
+import the existing Morpheus resources created with the Morpheus provider into the hpe provider. HashiCorp documentation
 on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
 
 -> The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
 requires provider support for the `List` RPC.  The hpe provider does not currently support `List`, this is something that we
-are considering for a future release.
+are considering for a future release.<br><br>
+Note that some resources in the Morpheus provider have been converted to a more generalised resource in the hpe provider.
+See below for details.
 
 ## Import Blocks
 To import resources we recommend the use of [import blocks](https://developer.hashicorp.com/terraform/language/block/import)
@@ -38,7 +40,7 @@ In addition to the import blocks resource definitions must be supplied.  In gene
 definitions to consider:
 
 ### Identical Schema
-The following table lists the resources that have identical schema between the Morpheus and HPE providers.
+The following table lists the resources that have identical schema between the Morpheus and hpe providers.
 
 | Morpheus Provider Resource Name           | hpe Provider Resource Name                    |
 |-------------------------------------------|-----------------------------------------------|
@@ -132,13 +134,11 @@ The following table lists the resources that have identical schema between the M
 | morpheus_write_attributes_task            | hpe_morpheus_task_write_attributes            |
 
 For these resources we can simply copy the resource definition from the Morpheus provider config and change the resource
-type to the corresponding HPE provider resource type.  This needs to be done manually for each resource.  Then an
+type to the corresponding hpe provider resource type.  This needs to be done manually for each resource.  Then an
 import block must be added for each hpe resource to import the existing Morpheus resource.
 
-We are considering the possibility of writing a tool to automate this process for these resources in the future.
-
 ### Different Schema
-Some resources have differences in schema between the Morpheus and HPE providers.  These resources are `generalised`
+Some resources have differences in schema between the Morpheus and hpe providers.  These resources are generalised
 in the hpe provider and several Morpheus provider resources map to a single hpe provider resource:
 
 | Morpheus Provider Resource Name | hpe Provider Resource Name |
@@ -180,4 +180,4 @@ in the hpe provider and several Morpheus provider resources map to a single hpe 
 For these resources terraform can be used to generate the hpe resource definition.  Examples of this process for `hpe_morpheus_instance`
 are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for
 multiple resources at once depending on the number of `import` blocks that are specified.  We recommend generating, editing
-and testing the configuration(s) in a separate directory before using them in your main terraform configuration.
+and testing the configuration(s) in a separate directory before using them in your main Terraform configuration.

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -1,18 +1,18 @@
 ---
-page_title: "Migrate Morpheus Provider Resources to hpe Provider Resources"
+page_title: "Migrate Morpheus Provider Resources to HPE Provider Resources"
 subcategory: "Migration"
 ---
 
-# Migrate Morpheus Provider Resources to hpe Provider Resources
+# Migrate Morpheus Provider Resources to HPE Provider Resources
 
-To migrate resources from the Morpheus Terraform provider to the hpe Terraform provider the basic principle is to
-import the existing Morpheus resources created with the Morpheus provider into the hpe provider. HashiCorp documentation
+To migrate resources from the Morpheus Terraform provider to the HPE Terraform provider the basic principle is to
+import the existing Morpheus resources created with the Morpheus provider into the HPE provider. HashiCorp documentation
 on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
 
 -> The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
-requires provider support for the `List` RPC.  The hpe provider does not currently support `List`, this is something that we
+requires provider support for the `List` RPC.  The HPE provider does not currently support `List`, this is something that we
 are considering for a future release.<br><br>
-Note that some resources in the Morpheus provider have been converted to a more generalised resource in the hpe provider.
+Note that some resources in the Morpheus provider have been converted to a more generalised resource in the HPE provider.
 See below for details.
 
 ## Import Blocks
@@ -40,9 +40,9 @@ In addition to the import blocks resource definitions must be supplied.  In gene
 definitions to consider:
 
 ### Identical Schema
-The following table lists the resources that have identical schema between the Morpheus and hpe providers.
+The following table lists the resources that have identical schema between the Morpheus and HPE providers.
 
-| Morpheus Provider Resource Name           | hpe Provider Resource Name                    |
+| Morpheus Provider Resource Name           | HPE Provider Resource Name                    |
 |-------------------------------------------|-----------------------------------------------|
 | morpheus_active_directory_identity_source | hpe_morpheus_identity_source_active_directory |
 | morpheus_ansible_integration              | hpe_morpheus_integration_ansible              |
@@ -134,14 +134,14 @@ The following table lists the resources that have identical schema between the M
 | morpheus_write_attributes_task            | hpe_morpheus_task_write_attributes            |
 
 For these resources we can simply copy the resource definition from the Morpheus provider config and change the resource
-type to the corresponding hpe provider resource type.  This needs to be done manually for each resource.  Then an
-import block must be added for each hpe resource to import the existing Morpheus resource.
+type to the corresponding HPE provider resource type.  This needs to be done manually for each resource.  Then an
+import block must be added for each HPE resource to import the existing Morpheus resource.
 
 ### Different Schema
-Some resources have differences in schema between the Morpheus and hpe providers.  These resources are generalised
-in the hpe provider and several Morpheus provider resources map to a single hpe provider resource:
+Some resources have differences in schema between the Morpheus and HPE providers.  These resources are generalised
+in the HPE provider and several Morpheus provider resources map to a single HPE provider resource:
 
-| Morpheus Provider Resource Name | hpe Provider Resource Name |
+| Morpheus Provider Resource Name | HPE Provider Resource Name |
 |---------------------------------|----------------------------|
 | morpheus_aws_cloud | hpe_morpheus_cloud |
 | morpheus_azure_cloud | hpe_morpheus_cloud |
@@ -177,7 +177,7 @@ in the hpe provider and several Morpheus provider resources map to a single hpe 
 | morpheus_tenant_role | hpe_morpheus_role |
 | morpheus_user_role | hpe_morpheus_role |
 
-For these resources terraform can be used to generate the hpe resource definition.  Examples of this process for `hpe_morpheus_instance`
+For these resources terraform can be used to generate the HPE resource definition.  Examples of this process for `hpe_morpheus_instance`
 are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for
 multiple resources at once depending on the number of `import` blocks that are specified.  We recommend generating, editing
 and testing the configuration(s) in a separate directory before using them in your main Terraform configuration.

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -1,0 +1,183 @@
+---
+page_title: "Migrate Morpheus Provider Resources to hpe Provider Resources"
+subcategory: "Migration"
+---
+
+# Migrate Morpheus Provider Resources to hpe Provider Resources
+
+To migrate resources from the Morpheus Terraform provider to the HPE Terraform provider the basic principle is to
+import the existing Morpheus resources created with the Morpheus provider into the HPE provider. HashiCorp documentation
+on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
+
+-> The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
+requires provider support for the `List` RPC.  The hpe provider does not currently support `List`, this is something that we
+are considering for a future release.
+
+## Import Blocks
+To import resources we recommend the use of [import blocks](https://developer.hashicorp.com/terraform/language/block/import)
+Simple import blocks that specify just an ID and a resource address can be used, and multiple import blocks can be specified,
+for example:
+```HCL
+import {
+  id = 125623
+  to = hpe_morpheus_instance.example_vmware
+}
+
+import {
+  id = 125624
+  to = hpe_morpheus_instance.example_hvm
+}
+```
+
+Once resource definitions are supplied a `terraform apply` will import the resources into the state file.  After the
+import ensure that a `terraform plan` shows no changes.  If there are changes then the resource definitions need to be
+adjusted to match the existing resources.
+
+## Resource Definitions
+In addition to the import blocks resource definitions must be supplied.  In general there are two categories of resource
+definitions to consider:
+
+### Identical Schema
+The following table lists the resources that have identical schema between the Morpheus and HPE providers.
+
+| Morpheus Provider Resource Name           | hpe Provider Resource Name                    |
+|-------------------------------------------|-----------------------------------------------|
+| morpheus_active_directory_identity_source | hpe_morpheus_identity_source_active_directory |
+| morpheus_ansible_integration              | hpe_morpheus_integration_ansible              |
+| morpheus_ansible_playbook_task            | hpe_morpheus_task_ansible_playbook            |
+| morpheus_ansible_tower_integration        | hpe_morpheus_integration_ansible_tower        |
+| morpheus_ansible_tower_task               | hpe_morpheus_task_ansible_tower               |
+| morpheus_api_option_list                  | hpe_morpheus_option_list_api                  |
+| morpheus_app_blueprint_catalog_item       | hpe_morpheus_catalog_item_app_blueprint       |
+| morpheus_appliance_setting                | hpe_morpheus_setting_appliance                |
+| morpheus_arm_app_blueprint                | hpe_morpheus_app_blueprint_arm                |
+| morpheus_arm_spec_template                | hpe_morpheus_spec_template_arm                |
+| morpheus_backup_setting                   | hpe_morpheus_setting_backup                   |
+| morpheus_boot_script                      | hpe_morpheus_boot_script                      |
+| morpheus_checkbox_option_type             | hpe_morpheus_option_type_checkbox             |
+| morpheus_chef_bootstrap_task              | hpe_morpheus_task_chef_bootstrap              |
+| morpheus_chef_integration                 | hpe_morpheus_integration_chef                 |
+| morpheus_cloud_formation_app_blueprint    | hpe_morpheus_app_blueprint_cloud_formation    |
+| morpheus_cloud_formation_spec_template    | hpe_morpheus_spec_template_cloud_formation    |
+| morpheus_cluster_layout                   | hpe_morpheus_cluster_layout                   |
+| morpheus_cluster_package                  | hpe_morpheus_cluster_package                  |
+| morpheus_contact                          | hpe_morpheus_contact                          |
+| morpheus_credential                       | hpe_morpheus_credential                       |
+| morpheus_cypher_secret                    | hpe_morpheus_cypher_secret                    |
+| morpheus_cypher_tfvars                    | hpe_morpheus_cypher_tfvars                    |
+| morpheus_docker_registry_integration      | hpe_morpheus_integration_docker_registry      |
+| morpheus_email_task                       | hpe_morpheus_task_email                       |
+| morpheus_environment                      | hpe_morpheus_environment                      |
+| morpheus_execute_schedule                 | hpe_morpheus_execute_schedule                 |
+| morpheus_file_template                    | hpe_morpheus_file_template                    |
+| morpheus_form                             | hpe_morpheus_form                             |
+| morpheus_git_integration                  | hpe_morpheus_integration_git                  |
+| morpheus_groovy_script_task               | hpe_morpheus_task_groovy_script               |
+| morpheus_guidance_setting                 | hpe_morpheus_setting_guidance                 |
+| morpheus_helm_app_blueprint               | hpe_morpheus_app_blueprint_helm               |
+| morpheus_helm_spec_template               | hpe_morpheus_spec_template_helm               |
+| morpheus_hidden_option_type               | hpe_morpheus_option_type_hidden               |
+| morpheus_instance_catalog_item            | hpe_morpheus_catalog_item_instance            |
+| morpheus_instance_layout                  | hpe_morpheus_instance_type_layout             |
+| morpheus_instance_type                    | hpe_morpheus_instance_type                    |
+| morpheus_ipv4_ip_pool                     | hpe_morpheus_ip_pool_ipv4                     |
+| morpheus_javascript_task                  | hpe_morpheus_task_javascript                  |
+| morpheus_key_pairs                        | hpe_morpheus_key_pair                         |
+| morpheus_kubernetes_app_blueprint         | hpe_morpheus_app_blueprint_kubernetes         |
+| morpheus_kubernetes_spec_template         | hpe_morpheus_spec_template_kubernetes         |
+| morpheus_library_script_task              | hpe_morpheus_task_library_script              |
+| morpheus_library_template_task            | hpe_morpheus_task_library_template            |
+| morpheus_license                          | hpe_morpheus_license                          |
+| morpheus_manual_option_list               | hpe_morpheus_option_list_manual               |
+| morpheus_monitoring_setting               | hpe_morpheus_setting_monitoring               |
+| morpheus_nested_workflow_task             | hpe_morpheus_task_nested_workflow             |
+| morpheus_network_domain                   | hpe_morpheus_network_domain                   |
+| morpheus_node_type                        | hpe_morpheus_node_type                        |
+| morpheus_number_option_type               | hpe_morpheus_option_type_number               |
+| morpheus_operational_workflow             | hpe_morpheus_workflow_operational             |
+| morpheus_password_option_type             | hpe_morpheus_option_type_password             |
+| morpheus_powershell_script_task           | hpe_morpheus_task_powershell_script           |
+| morpheus_preseed_script                   | hpe_morpheus_preseed_script                   |
+| morpheus_price                            | hpe_morpheus_price                            |
+| morpheus_price_set                        | hpe_morpheus_price_set                        |
+| morpheus_provisioning_setting             | hpe_morpheus_setting_provisioning             |
+| morpheus_provisioning_workflow            | hpe_morpheus_workflow_provisioning            |
+| morpheus_puppet_integration               | hpe_morpheus_integration_puppet               |
+| morpheus_python_script_task               | hpe_morpheus_task_python_script               |
+| morpheus_radio_list_option_type           | hpe_morpheus_option_type_radio_list           |
+| morpheus_resource_pool_group              | hpe_morpheus_resource_pool_group              |
+| morpheus_rest_option_list                 | hpe_morpheus_option_list_rest                 |
+| morpheus_restart_task                     | hpe_morpheus_task_restart                     |
+| morpheus_ruby_script_task                 | hpe_morpheus_task_ruby_script                 |
+| morpheus_saml_identity_source             | hpe_morpheus_identity_source_saml             |
+| morpheus_scale_threshold                  | hpe_morpheus_scale_threshold                  |
+| morpheus_script_template                  | hpe_morpheus_script_template                  |
+| morpheus_security_package                 | hpe_morpheus_security_package                 |
+| morpheus_select_list_option_type          | hpe_morpheus_option_type_select_list          |
+| morpheus_servicenow_integration           | hpe_morpheus_integration_servicenow           |
+| morpheus_shell_script_task                | hpe_morpheus_task_shell_script                |
+| morpheus_task_job                         | hpe_morpheus_job_task                         |
+| morpheus_tenant                           | hpe_morpheus_tenant                           |
+| morpheus_terraform_app_blueprint          | hpe_morpheus_app_blueprint_terraform          |
+| morpheus_terraform_spec_template          | hpe_morpheus_spec_template_terraform          |
+| morpheus_text_option_type                 | hpe_morpheus_option_type_text                 |
+| morpheus_textarea_option_type             | hpe_morpheus_option_type_textarea             |
+| morpheus_typeahead_option_type            | hpe_morpheus_option_type_typeahead            |
+| morpheus_user_group                       | hpe_morpheus_user_group                       |
+| morpheus_vro_integration                  | hpe_morpheus_integration_vro                  |
+| morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_hks_vsphere              |
+| morpheus_wiki_page                        | hpe_morpheus_wiki_page                        |
+| morpheus_workflow_catalog_item            | hpe_morpheus_catalog_item_workflow            |
+| morpheus_workflow_job                     | hpe_morpheus_job_workflow                     |
+| morpheus_write_attributes_task            | hpe_morpheus_task_write_attributes            |
+
+For these resources we can simply copy the resource definition from the Morpheus provider config and change the resource
+type to the corresponding HPE provider resource type.  This needs to be done manually for each resource.  Then an
+import block must be added for each hpe resource to import the existing Morpheus resource.
+
+We are considering the possibility of writing a tool to automate this process for these resources in the future.
+
+### Different Schema
+Some resources have differences in schema between the Morpheus and HPE providers.  These resources are `generalised`
+in the hpe provider and several Morpheus provider resources map to a single hpe provider resource:
+
+| Morpheus Provider Resource Name | hpe Provider Resource Name |
+|---------------------------------|----------------------------|
+| morpheus_aws_cloud | hpe_morpheus_cloud |
+| morpheus_azure_cloud | hpe_morpheus_cloud |
+| morpheus_standard_cloud | hpe_morpheus_cloud |
+| morpheus_vsphere_cloud | hpe_morpheus_cloud |
+| morpheus_vsphere_cloud_datastore_configuration | hpe_morpheus_datastore |
+| morpheus_aws_instance | hpe_morpheus_instance |
+| morpheus_mvm_instance | hpe_morpheus_instance |
+| morpheus_vsphere_instance | hpe_morpheus_instance |
+| morpheus_backup_creation_policy | hpe_morpheus_policy |
+| morpheus_budget_policy | hpe_morpheus_policy |
+| morpheus_cluster_resource_name_policy | hpe_morpheus_policy |
+| morpheus_cypher_access_policy | hpe_morpheus_policy |
+| morpheus_delayed_delete_policy | hpe_morpheus_policy |
+| morpheus_delete_approval_policy | hpe_morpheus_policy |
+| morpheus_hostname_policy | hpe_morpheus_policy |
+| morpheus_instance_name_policy | hpe_morpheus_policy |
+| morpheus_max_containers_policy | hpe_morpheus_policy |
+| morpheus_max_cores_policy | hpe_morpheus_policy |
+| morpheus_max_hosts_policy | hpe_morpheus_policy |
+| morpheus_max_memory_policy | hpe_morpheus_policy |
+| morpheus_max_storage_policy | hpe_morpheus_policy |
+| morpheus_max_vms_policy | hpe_morpheus_policy |
+| morpheus_motd_policy | hpe_morpheus_policy |
+| morpheus_network_quota_policy | hpe_morpheus_policy |
+| morpheus_power_schedule_policy | hpe_morpheus_policy |
+| morpheus_provision_approval_policy | hpe_morpheus_policy |
+| morpheus_router_quota_policy | hpe_morpheus_policy |
+| morpheus_tag_policy | hpe_morpheus_policy |
+| morpheus_user_creation_policy | hpe_morpheus_policy |
+| morpheus_user_group_creation_policy | hpe_morpheus_policy |
+| morpheus_workflow_policy | hpe_morpheus_policy |
+| morpheus_tenant_role | hpe_morpheus_role |
+| morpheus_user_role | hpe_morpheus_role |
+
+For these resources terraform can be used to generate the hpe resource definition.  Examples of this process for `hpe_morpheus_instance`
+are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for
+multiple resources at once depending on the number of `import` blocks that are specified.  We recommend generating, editing
+and testing the configuration(s) in a separate directory before using them in your main terraform configuration.

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Migrate Morpheus Provider Resources to HPE Provider Resources"
+page_title: "Morpheus to HPE"
 subcategory: "Migration"
 ---
 


### PR DESCRIPTION
We add two documents to templates/guides and to docs/guides which will
be rendered under the "Migration" heading on the registry docs landing
page.  We will need to add to these documents over time.