### PR TITLE
Simplify setting SDKV2 tracing

### DIFF
--- a/internal/sdkv2/morpheus/config.go
+++ b/internal/sdkv2/morpheus/config.go
@@ -7,7 +7,6 @@ import (
 
 	sdklegacy "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 
 	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/httptrace"
 	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/client"
@@ -30,7 +29,6 @@ type Config struct {
 }
 
 func (c *Config) Client() (*sdklegacy.Client, diag.Diagnostics) {
-	debug := logging.IsDebugOrHigher() && httptrace.IsEnabled()
 	diags := diag.Diagnostics{}
 
 	if c.client == nil {
@@ -41,7 +39,7 @@ func (c *Config) Client() (*sdklegacy.Client, diag.Diagnostics) {
 			c.Password,
 			c.AccessToken,
 			sdklegacy.SkipLogin(),
-			sdklegacy.WithDebug(debug),
+			sdklegacy.WithDebug(httptrace.IsEnabled()),
 			sdklegacy.WithInsecure(c.Insecure),
 		)
 	}

--- a/internal/sdkv2/morpheus/config.go
+++ b/internal/sdkv2/morpheus/config.go
@@ -4,12 +4,12 @@ package morpheus
 
 import (
 	"context"
-	"os"
 
 	sdklegacy "github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 
+	"github.com/HPE/terraform-provider-hpe/internal/framework/subproviders/morpheus/httptrace"
 	"github.com/HPE/terraform-provider-hpe/internal/sdkv2/morpheus/client"
 )
 
@@ -30,7 +30,7 @@ type Config struct {
 }
 
 func (c *Config) Client() (*sdklegacy.Client, diag.Diagnostics) {
-	debug := logging.IsDebugOrHigher() && os.Getenv("MORPHEUS_API_HTTPTRACE") == "true"
+	debug := logging.IsDebugOrHigher() && httptrace.IsEnabled()
 	diags := diag.Diagnostics{}
 
 	if c.client == nil {


### PR DESCRIPTION
- `MORPHEUS_API_HTTPTRACE` is now required to be set to enable tracing for sdkv2 client - same as for framework client. It no longer needs to be explicitly set to `true`.
- We no longer require a `TF_LOG` level of debug or higher - we now get HTTP tracing with sdkv2 with `TF_LOG` level of `INFO` or higher.
