### PR TITLE
Fix stack trace from instance backoff code

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -257,14 +257,26 @@ func (g *Resource) Create(
 	// Wait for the instance to be ready
 	waitForReady := func() (string, error) {
 		resp, hresp, err := client.InstancesAPI.GetInstance(ctx, instanceId).Execute()
-		if err != nil || hresp.StatusCode != http.StatusOK {
-			return "", backoff.Permanent(err)
+		if err != nil {
+			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusOK {
+				return "", backoff.Permanent(err)
+			}
 		}
 
-		status := resp.Instance.GetStatus()
+		// Get instance
+		inst, ok := resp.GetInstanceOk()
+		if !ok || inst == nil {
+			return "", backoff.Permanent(fmt.Errorf("instance %d: GET returned empty instance", instanceId))
+		}
 
-		return status, checkStatusDone(
-			status,
+		// Get status
+		status, ok := inst.GetStatusOk()
+		if !ok || status == nil {
+			return "", backoff.Permanent(fmt.Errorf("instance %d: GET returned empty status", instanceId))
+		}
+
+		return *status, checkStatusDone(
+			*status,
 			CreateTargetStatuses,
 			CreateErrorStatuses,
 		)

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_delete.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_delete.go
@@ -68,8 +68,10 @@ func (g *Resource) Delete(
 
 	waitForDeleted := func() (*sdk.GetInstance200Response, error) {
 		resp, hresp, err := client.InstancesAPI.GetInstance(ctx, data.Id.ValueInt64()).Execute()
-		if err != nil && hresp.StatusCode != http.StatusNotFound {
-			return nil, backoff.Permanent(err)
+		if err != nil {
+			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusNotFound {
+				return nil, backoff.Permanent(err)
+			}
 		}
 
 		// 404 status code counts as a successful delete
@@ -77,10 +79,20 @@ func (g *Resource) Delete(
 			return nil, nil
 		}
 
-		status := resp.Instance.GetStatus()
+		// Get instance
+		instance, ok := resp.GetInstanceOk()
+		if !ok || instance == nil {
+			return nil, backoff.Permanent(fmt.Errorf("instance %d: GET returned empty instance", id))
+		}
+
+		// Get status
+		status, ok := instance.GetStatusOk()
+		if !ok || status == nil {
+			return nil, backoff.Permanent(fmt.Errorf("instance %d: GET returned empty status", id))
+		}
 
 		return resp, checkStatusDone(
-			status,
+			*status,
 			nil,
 			DeleteErrorStatuses,
 		)

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_update.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_update.go
@@ -207,14 +207,26 @@ func makeUpdateAPIcalls(
 
 		waitForReady := func() (string, error) {
 			resp, hresp, err := client.InstancesAPI.GetInstance(ctx, plan.Id.ValueInt64()).Execute()
-			if err != nil || hresp.StatusCode != http.StatusOK {
-				return "", backoff.Permanent(err)
+			if err != nil {
+				if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusOK {
+					return "", backoff.Permanent(err)
+				}
 			}
 
-			status := resp.Instance.GetStatus()
+			// Get instance
+			inst, ok := resp.GetInstanceOk()
+			if !ok || inst == nil {
+				return "", backoff.Permanent(fmt.Errorf("instance %d: GET returned empty instance", plan.Id.ValueInt64()))
+			}
 
-			return status, checkStatusDone(
-				status,
+			// Get status
+			status, ok := inst.GetStatusOk()
+			if !ok || status == nil {
+				return "", backoff.Permanent(fmt.Errorf("instance %d: GET returned empty status", plan.Id.ValueInt64()))
+			}
+
+			return *status, checkStatusDone(
+				*status,
 				UpdateTargetStatuses,
 				UpdateErrorStatuses,
 			)


### PR DESCRIPTION
QA testing has uncovered a situation where the instance Delete backoff code returned a stack-trace.  The issue seems to be that the response doesn't contain valid JSON so the code to extract the "status" stack-traces.  To fix this:
- we check that hresp is not nil before getting the status from it
- we add SDK GetInstanceOk() and GetStatusOk() to check that there is an instance record and within it a status to read
- if either function fails we raise a "Permanent" backoff error to terminate the backoff polling.

We've applied this logic to Create, Delete and Update.