### PR TITLE
Documentation for Backup Targets (backupStorage) support in policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,8 +154,6 @@ In this release (v1.0.0) we have added the following data-source functionality:
 - `hpe_morpheus_datastore` data-source if a datastore with the specified name cannot be found (i.e. the corresponding
   list API request fails), the error message will indicate a 403 (Forbidden) even if the user has permission to list
   datastores.  This is an API bug which is being investigated.
-- `hpe_morpheus_policy` resource does not currently support the Backup Targets (`backupStorage`) policy type
-  due to improper handling of the `backupStorageIds` attribute. This is an API bug which is being investigated.
 - `hpe_morpheus_instance` updates fail when removing optional fields.
   This will be addressed in a future release.
 - `hpe_morpheus_instance` updates fail when removing `evars`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -286,8 +286,6 @@ In this release (v1.0.0) we have added the following data-source functionality:
 - `hpe_morpheus_datastore` data-source if a datastore with the specified name cannot be found (i.e. the corresponding
   list API request fails), the error message will indicate a 403 (Forbidden) even if the user has permission to list
   datastores.  This is an API bug which is being investigated.
-- `hpe_morpheus_policy resource` does not currently support the Backup Targets (`backupStorage`) policy type
-  due to improper handling of the `backupStorageIds` attribute. This is an API bug which is being investigated.
 - `hpe_morpheus_instance` updates fail when removing optional fields.
   This will be addressed in a future release.
 - `hpe_morpheus_instance` updates fail when removing `evars`.

--- a/docs/resources/morpheus_policy.md
+++ b/docs/resources/morpheus_policy.md
@@ -23,7 +23,7 @@ Policies are different rules that can be applied to various Morpheus resources.
 - [Approve Reconfigure (reconfigureApproval)](#approve-reconfigure-reconfigureapproval) (uses [config_approval](#nestedatt--config_approval))
 - [Approve Workflow Execute (workflowApproval)](#approve-workflow-execute-workflowapproval) (uses [config_approval](#nestedatt--config_approval))
 - [Backup Creation (createBackup)](#backup-creation-createbackup) (uses [config_create_backup](#nestedatt--config_create_backup))
-- [Backup Targets (backupStorage)](#backup-targets-backupstorage) Not currently supported (uses [config_backup_storage](#nestedatt--config_backup_storage))
+- [Backup Targets (backupStorage)](#backup-targets-backupstorage) Supported for Morpheus 8.1.0 or later. (uses [config_backup_storage](#nestedatt--config_backup_storage))
 - [Budget (maxPrice)](#budget-maxprice) (uses [config_max_price](#nestedatt--config_max_price))
 - [Cluster Resource Name (serverNaming)](#cluster-resource-name-servernaming) (uses [config_server_naming](#nestedatt--config_server_naming))
 - [Cypher Access (cypher)](#cypher-access-cypher) (uses [config_cypher](#nestedatt--config_cypher))
@@ -201,7 +201,29 @@ resource "hpe_morpheus_policy" "backup_creation" {
 ```
 
 ### Backup Targets (backupStorage)
-Not currently supported
+
+```terraform
+# Backup Targets Policy - Restricts available backup storage targets
+# Allowed associated_resource_types: Group, Cloud, User, Global, Role
+# Tenant specification: NOT allowed (cannot specify tenants array)
+# Supported in Morpheus 8.1.0 or later (previous versions double nest the backupStorageIds attribute)
+resource "hpe_morpheus_policy" "backup_targets" {
+  name                     = "Backup Targets Policy"
+  description              = "Restrict available backup targets"
+  associated_resource_type = "User"
+  associated_resource_id   = 9969
+  enabled                  = true
+
+  policy_type = {
+    code = "backupStorage"
+  }
+
+  config = {
+    # Required
+    backupStorageIds = [5, 6] # Array of backup storage IDs to restrict available backup targets
+  }
+}
+```
 
 ### Budget (maxPrice)
 

--- a/examples/resources/hpe_morpheus_policy/policy_dynamic_backupStorage.tf
+++ b/examples/resources/hpe_morpheus_policy/policy_dynamic_backupStorage.tf
@@ -1,19 +1,20 @@
-# # Backup Targets Policy - Restricts available backup storage targets
+# Backup Targets Policy - Restricts available backup storage targets
 # Allowed associated_resource_types: Group, Cloud, User, Global, Role
 # Tenant specification: NOT allowed (cannot specify tenants array)
-# resource "hpe_morpheus_policy" "backup_targets" {
-#   name                     = "Backup Targets Policy"
-#   description              = "Restrict available backup targets"
-#   associated_resource_type = "User"
-#   associated_resource_id   = 9969
-#   enabled                  = true
-#
-#   policy_type = {
-#     code = "backupStorage"
-#   }
-#
-#   config = {
-#     # Required
-#     backupStorageIds = [5, 6] # Array of backup storage IDs to restrict available backup targets
-#   }
-# }
+# Supported in Morpheus 8.1.0 or later (previous versions double nest the backupStorageIds attribute)
+resource "hpe_morpheus_policy" "backup_targets" {
+  name                     = "Backup Targets Policy"
+  description              = "Restrict available backup targets"
+  associated_resource_type = "User"
+  associated_resource_id   = 9969
+  enabled                  = true
+
+  policy_type = {
+    code = "backupStorage"
+  }
+
+  config = {
+    # Required
+    backupStorageIds = [5, 6] # Array of backup storage IDs to restrict available backup targets
+  }
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -227,8 +227,6 @@ In this release (v1.0.0) we have added the following data-source functionality:
 - `hpe_morpheus_datastore` data-source if a datastore with the specified name cannot be found (i.e. the corresponding
   list API request fails), the error message will indicate a 403 (Forbidden) even if the user has permission to list
   datastores.  This is an API bug which is being investigated.
-- `hpe_morpheus_policy resource` does not currently support the Backup Targets (`backupStorage`) policy type
-  due to improper handling of the `backupStorageIds` attribute. This is an API bug which is being investigated.
 - `hpe_morpheus_instance` updates fail when removing optional fields.
   This will be addressed in a future release.
 - `hpe_morpheus_instance` updates fail when removing `evars`.

--- a/templates/resources/morpheus_policy.md.tmpl
+++ b/templates/resources/morpheus_policy.md.tmpl
@@ -23,7 +23,7 @@ Policies are different rules that can be applied to various Morpheus resources.
 - [Approve Reconfigure (reconfigureApproval)](#approve-reconfigure-reconfigureapproval) (uses [config_approval](#nestedatt--config_approval))
 - [Approve Workflow Execute (workflowApproval)](#approve-workflow-execute-workflowapproval) (uses [config_approval](#nestedatt--config_approval))
 - [Backup Creation (createBackup)](#backup-creation-createbackup) (uses [config_create_backup](#nestedatt--config_create_backup))
-- [Backup Targets (backupStorage)](#backup-targets-backupstorage) Not currently supported (uses [config_backup_storage](#nestedatt--config_backup_storage))
+- [Backup Targets (backupStorage)](#backup-targets-backupstorage) Supported for Morpheus 8.1.0 or later. (uses [config_backup_storage](#nestedatt--config_backup_storage))
 - [Budget (maxPrice)](#budget-maxprice) (uses [config_max_price](#nestedatt--config_max_price))
 - [Cluster Resource Name (serverNaming)](#cluster-resource-name-servernaming) (uses [config_server_naming](#nestedatt--config_server_naming))
 - [Cypher Access (cypher)](#cypher-access-cypher) (uses [config_cypher](#nestedatt--config_cypher))
@@ -78,7 +78,8 @@ Policies are different rules that can be applied to various Morpheus resources.
 {{ tffile "examples/resources/hpe_morpheus_policy/policy_dynamic_createBackup.tf" }}
 
 ### Backup Targets (backupStorage)
-Not currently supported
+
+{{ tffile "examples/resources/hpe_morpheus_policy/policy_dynamic_backupStorage.tf" }}
 
 ### Budget (maxPrice)
 


### PR DESCRIPTION
Updating documentation to reflect that Backup Targets (backupStorage) is now supported in the hpe_morpheus_policy resource for Morpheus 8.1.0 or later. This was previously marked as unsupported (despite being implemented) due to an API bug that has since been resolved as of Morpheus 8.1.0.
- Updated CHANGELOG.md and index.md.tmpl to remove the known issue.
- Updated morpheus_policy.md.tmpl to indicate support for Backup Targets (backupStorage) and included (and uncommented) example configuration file.
- Ran make docs