### PR TITLE
Bump legacy sdk: handle nil httpResp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HPE/terraform-provider-hpe
 go 1.24.1
 
 require (
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260121111707-f8f6ff481a3e
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e34cd02e9
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.12.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260121111707-f8f6ff481a3e h1:eBq61SG1LhH6KAXZcyMmRE5l7ZptOvc4d0jwubLXifU=
-github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260121111707-f8f6ff481a3e/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e34cd02e9 h1:5/U1k5ymjDdxnU//OloLug/xeDVwH6lqbCi75diQ5L4=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e34cd02e9/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.12.0 h1:G2e2q8gEpg/mdcmMMYG6hOqTT1An5lGUnZ48xjyOyr8=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.12.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
Bumps legacy sdk version. Run go mod tidy.

Fixes stack traces ocurring on a nil httpResp.
