### PR TITLE
Skip docker registry integration test

### DIFF
--- a/internal/sdkv2/morpheus/resources/integration/morpheus_integration_docker_registry_resource_test.go
+++ b/internal/sdkv2/morpheus/resources/integration/morpheus_integration_docker_registry_resource_test.go
@@ -21,6 +21,8 @@ func TestAccMorpheusIntegrationDockerRegistryExampleOk(t *testing.T) {
 		t.Skip("Skipping slow test in short mode")
 	}
 
+	t.Skip("Skipping due to missing infrastructure in test environment")
+
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())


### PR DESCRIPTION

We are skipping this test for now due to a lack of test resources
