### PR TITLE
Add a custom type for TrimmedStrings

### DIFF
--- a/internal/framework/customtypes/trimmed_string_type.go
+++ b/internal/framework/customtypes/trimmed_string_type.go
@@ -1,0 +1,72 @@
+package customtypes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ basetypes.StringTypable = (*TrimmedStringType)(nil)
+
+// TrimmedStringType is a custom String type which ignores differences in
+// leading and trailing whitespace
+type TrimmedStringType struct {
+	basetypes.StringType
+}
+
+// String returns a human readable string of the type name.
+func (t TrimmedStringType) String() string {
+	return "customtypes.TrimmedStringType"
+}
+
+// ValueType returns the Value type.
+func (t TrimmedStringType) ValueType(ctx context.Context) attr.Value {
+	return TrimmedString{}
+}
+
+// Equal returns true if the given type is equivalent.
+func (t TrimmedStringType) Equal(o attr.Type) bool {
+	other, ok := o.(TrimmedStringType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+// ValueFromString returns a StringValuable type given a StringValue.
+func (t TrimmedStringType) ValueFromString(
+	ctx context.Context,
+	in basetypes.StringValue,
+) (basetypes.StringValuable, diag.Diagnostics) {
+	return TrimmedString{
+		StringValue: in,
+	}, nil
+}
+
+// ValueFromTerraform returns a Value given a tftypes.Value.  This is meant to
+// convert the tftypes.Value into a more convenient Go type for the provider to
+// consume the data with.
+func (t TrimmedStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}

--- a/internal/framework/customtypes/trimmed_string_type_test.go
+++ b/internal/framework/customtypes/trimmed_string_type_test.go
@@ -1,0 +1,114 @@
+package customtypes_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/customtypes"
+)
+
+func TestTrimmedStringType_ValueFromTerraform(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      tftypes.Value
+		want    attr.Value
+		wantErr bool
+	}{
+		{
+			name:    "String",
+			in:      tftypes.NewValue(tftypes.String, "test string"),
+			want:    customtypes.NewTrimmedStringValue("test string"),
+			wantErr: false,
+		},
+		{
+			name:    "StringWithNewlines",
+			in:      tftypes.NewValue(tftypes.String, "\r\n\r\nnewline\r\ntest\r\n\r\n"),
+			want:    customtypes.NewTrimmedStringValue("\r\n\r\nnewline\r\ntest\r\n\r\n"),
+			wantErr: false,
+		},
+		{
+			name:    "IncorrectTypeMap",
+			in:      tftypes.NewValue(tftypes.Map{}, map[string]tftypes.Value{}),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "IncorrectTypeNumber",
+			in:      tftypes.NewValue(tftypes.Number, 1),
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tr customtypes.TrimmedStringType
+			got, gotErr := tr.ValueFromTerraform(context.Background(), tt.in)
+			fmt.Println(gotErr)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("ValueFromTerraform() failed: %v", gotErr)
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Fatal("ValueFromTerraform() succeeded unexpectedly")
+			}
+
+			if got != tt.want {
+				t.Errorf("ValueFromTerraform() = %v(%[1]T), want %v(%[2]T)", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimmedStringType_Equal(t *testing.T) {
+	tests := []struct {
+		name  string
+		value customtypes.TrimmedStringType
+		in    attr.Type
+		want  bool
+	}{
+		{
+			name: "Equal",
+			value: customtypes.TrimmedStringType{
+				StringType: basetypes.StringType{},
+			},
+			in: customtypes.TrimmedStringType{
+				StringType: basetypes.StringType{},
+			},
+			want: true,
+		},
+		{
+			name: "NotEqualBasetypeString",
+			value: customtypes.TrimmedStringType{
+				StringType: basetypes.StringType{},
+			},
+			in:   basetypes.StringType{},
+			want: false,
+		},
+		{
+			name: "NotEqualBasetypeInt64",
+			value: customtypes.TrimmedStringType{
+				StringType: basetypes.StringType{},
+			},
+			in:   basetypes.Int64Type{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.value.Equal(tt.in)
+			if got != tt.want {
+				t.Errorf("Equal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/framework/customtypes/trimmed_string_value.go
+++ b/internal/framework/customtypes/trimmed_string_value.go
@@ -1,0 +1,95 @@
+package customtypes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	_ basetypes.StringValuable                   = (*TrimmedString)(nil)
+	_ basetypes.StringValuableWithSemanticEquals = (*TrimmedString)(nil)
+)
+
+type TrimmedString struct {
+	basetypes.StringValue
+}
+
+// Type returns a TrimmedStringType.
+func (v TrimmedString) Type(_ context.Context) attr.Type {
+	return TrimmedStringType{}
+}
+
+// Equal returns true if the given value is equivalent.
+func (v TrimmedString) Equal(o attr.Value) bool {
+	other, ok := o.(TrimmedString)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+// StringSemanticEquals returns true if the given strings are equal once the
+// leading and trailing whtiespace is removed
+func (v TrimmedString) StringSemanticEquals(
+	_ context.Context,
+	newValuable basetypes.StringValuable,
+) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(TrimmedString)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
+
+		return false, diags
+	}
+
+	newTrimmed := strings.TrimSpace(newValue.ValueString())
+	vTrimmed := strings.TrimSpace(v.ValueString())
+
+	return newTrimmed == vTrimmed, diags
+}
+
+// NewNormalizedNull creates a Normalized with a null value. Determine whether
+// the value is null via IsNull method.
+func NewTrimmedStringNull() TrimmedString {
+	return TrimmedString{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+// NewTrimmedStringUnknown creates a Normalized with an unknown value. Determine
+// whether the value is unknown via IsUnknown method.
+func NewTrimmedStringUnknown() TrimmedString {
+	return TrimmedString{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+// NewTrimmedStringValue creates a Normalized with a known value. Access the
+// value via ValueString method.
+func NewTrimmedStringValue(value string) TrimmedString {
+	return TrimmedString{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}
+
+// NewTrimmedStringPointerValue creates a Normalized with a null value if nil or
+// a known value. Access the value via ValueStringPointer method.
+func NewTrimmedStringPointerValue(value *string) TrimmedString {
+	return TrimmedString{
+		StringValue: basetypes.NewStringPointerValue(value),
+	}
+}

--- a/internal/framework/customtypes/trimmed_string_value_test.go
+++ b/internal/framework/customtypes/trimmed_string_value_test.go
@@ -1,0 +1,114 @@
+package customtypes_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/HPE/terraform-provider-hpe/internal/framework/customtypes"
+)
+
+func TestNewTrimmedStringValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  customtypes.TrimmedString
+	}{
+		{
+			name:  "NormalString",
+			value: "test",
+			want: customtypes.TrimmedString{
+				StringValue: basetypes.NewStringValue("test"),
+			},
+		},
+		{
+			name:  "MultilineString",
+			value: "\nnewline\ntest\n",
+			want: customtypes.TrimmedString{
+				StringValue: basetypes.NewStringValue("\nnewline\ntest\n"),
+			},
+		},
+		{
+			name:  "EmptyString",
+			value: "",
+			want: customtypes.TrimmedString{
+				StringValue: basetypes.NewStringValue(""),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := customtypes.NewTrimmedStringValue(tt.value)
+			if !got.Equal(tt.want) {
+				t.Errorf("NewTrimmedStringValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimmedString_StringSemanticEquals(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       customtypes.TrimmedString
+		newValuable basetypes.StringValuable
+		want        bool
+		wantErr     bool
+	}{
+		{
+			name:        "Newlines",
+			value:       customtypes.NewTrimmedStringValue("\n\n\nnewline\ntest\n\n\n"),
+			newValuable: customtypes.NewTrimmedStringValue("newline\ntest"),
+			want:        true,
+			wantErr:     false,
+		},
+		{
+			name:        "ReturnNewline",
+			value:       customtypes.NewTrimmedStringValue("\r\nnewline\r\ntest\r\n\r\n"),
+			newValuable: customtypes.NewTrimmedStringValue("newline\r\ntest"),
+			want:        true,
+			wantErr:     false,
+		},
+		{
+			name:        "Spaces",
+			value:       customtypes.NewTrimmedStringValue("  newline\r\ntest  "),
+			newValuable: customtypes.NewTrimmedStringValue("newline\r\ntest"),
+			want:        true,
+			wantErr:     false,
+		},
+		{
+			name:        "NoWhitespace",
+			value:       customtypes.NewTrimmedStringValue("newline\ntest"),
+			newValuable: customtypes.NewTrimmedStringValue("newline\ntest"),
+			want:        true,
+			wantErr:     false,
+		},
+		{
+			name:        "StringValue",
+			value:       customtypes.NewTrimmedStringValue("newline\ntest"),
+			newValuable: basetypes.NewStringValue("test"),
+			want:        false,
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := tt.value.StringSemanticEquals(context.Background(), tt.newValuable)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("StringSemanticEquals() failed: %v", gotErr)
+				}
+
+				return
+			}
+
+			if tt.wantErr {
+				t.Fatal("StringSemanticEquals() succeeded unexpectedly")
+			}
+
+			if got != tt.want {
+				t.Errorf("StringSemanticEquals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a new custom type which ignores the differences in leading and trailing whitespace in String attributes.

The custom type implements the `basetypes.StringValuableWithSemanticEquals` interface which
allows implementing custom logic for semantic equality. In this case the implementation uses
`strings.TrimSpace()` to avoid drift detection where an API may have trimmed whitespace from
the input.
