### PR TITLE
Fixing space trimming issues across ported resources

### DIFF
--- a/internal/sdkv2/morpheus/helpers/diff_suppress_funcs.go
+++ b/internal/sdkv2/morpheus/helpers/diff_suppress_funcs.go
@@ -4,11 +4,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func SuppressEquivalentJSONDiffs(k, old, new string, d *schema.ResourceData) bool {
+	// First try simple whitespace-trimmed comparison
+	if strings.TrimSpace(old) == strings.TrimSpace(new) {
+		return true
+	}
+
+	// Trim whitespace before attempting JSON parsing
+	// This handles cases where JSON has leading/trailing whitespace
+	old = strings.TrimSpace(old)
+	new = strings.TrimSpace(new)
+
 	ob := bytes.NewBufferString("")
 	if err := json.Compact(ob, []byte(old)); err != nil {
 		return false

--- a/internal/sdkv2/morpheus/resources/blueprint/resource_app_blueprint_cloud_formation.go
+++ b/internal/sdkv2/morpheus/resources/blueprint/resource_app_blueprint_cloud_formation.go
@@ -96,7 +96,13 @@ func ResourceAppBlueprintCloudFormation() *schema.Resource {
 						blueprintContent = v
 					}
 
-					return strings.TrimSuffix(blueprintContent, "\n")
+					return strings.TrimSpace(blueprintContent)
+				},
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					old = strings.TrimSpace(old)
+					new = strings.TrimSpace(new)
+
+					return old == new
 				},
 			},
 			"working_path": {

--- a/internal/sdkv2/morpheus/resources/blueprint/resource_app_blueprint_kubernetes.go
+++ b/internal/sdkv2/morpheus/resources/blueprint/resource_app_blueprint_kubernetes.go
@@ -69,10 +69,16 @@ func ResourceAppBlueprintKubernetes() *schema.Resource {
 				Optional:    true,
 				StateFunc: func(val any) string {
 					if v, ok := val.(string); ok {
-						return strings.TrimSuffix(v, "\n")
+						return strings.TrimSpace(v)
 					}
 
 					return ""
+				},
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					old = strings.TrimSpace(old)
+					new = strings.TrimSpace(new)
+
+					return old == new
 				},
 			},
 			"working_path": {

--- a/internal/sdkv2/morpheus/resources/blueprint/resource_arm_app_blueprint.go
+++ b/internal/sdkv2/morpheus/resources/blueprint/resource_arm_app_blueprint.go
@@ -77,11 +77,12 @@ func ResourceAppBlueprintARM() *schema.Resource {
 				Optional:    true,
 				StateFunc: func(val any) string {
 					if v, ok := val.(string); ok {
-						return strings.TrimSuffix(v, "\n")
+						return strings.TrimSpace(v)
 					}
 
 					return ""
 				},
+				DiffSuppressFunc: helpers.SuppressEquivalentJSONDiffs,
 			},
 			"working_path": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/catalogitem/catalog_item_app_blueprint.go
+++ b/internal/sdkv2/morpheus/resources/catalogitem/catalog_item_app_blueprint.go
@@ -67,7 +67,13 @@ func ResourceCatalogItemAppBlueprint() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				StateFunc: func(val any) string {
-					return strings.TrimSuffix(val.(string), "\n")
+					return strings.TrimSpace(val.(string))
+				},
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					old = strings.TrimSpace(old)
+					new = strings.TrimSpace(new)
+
+					return old == new
 				},
 			},
 			"labels": {

--- a/internal/sdkv2/morpheus/resources/catalogitem/catalog_item_instance.go
+++ b/internal/sdkv2/morpheus/resources/catalogitem/catalog_item_instance.go
@@ -81,12 +81,17 @@ func ResourceCatalogItemInstance() *schema.Resource {
 				Computed:    true,
 				StateFunc: func(val any) string {
 					if v, ok := val.(string); ok {
-						return strings.TrimSuffix(v, "\n")
+						return strings.TrimSpace(v)
 					}
 
 					return ""
 				},
-				DiffSuppressFunc: helpers.SuppressEquivalentJSONDiffs,
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					old = strings.TrimSpace(old)
+					new = strings.TrimSpace(new)
+
+					return old == new
+				},
 			},
 			"config": {
 				Type:             schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/catalogitem/catalog_item_workflow.go
+++ b/internal/sdkv2/morpheus/resources/catalogitem/catalog_item_workflow.go
@@ -93,10 +93,16 @@ func resourceCatalogItemWorkflow() *schema.Resource {
 				Computed:    true,
 				StateFunc: func(val any) string {
 					if v, ok := val.(string); ok {
-						return strings.TrimSuffix(v, "\n")
+						return strings.TrimSpace(v)
 					}
 
 					return ""
+				},
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					old = strings.TrimSpace(old)
+					new = strings.TrimSpace(new)
+
+					return old == new
 				},
 			},
 			"option_type_ids": {

--- a/internal/sdkv2/morpheus/resources/optionlist/option_list_manual.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/option_list_manual.go
@@ -60,12 +60,12 @@ func ResourceOptionListManual() *schema.Resource {
 				Description: "The dataset for the manual option list",
 				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimRight(val.(string), "\n")
+					return strings.TrimSpace(val.(string))
 				},
 			},
 			"real_time": {

--- a/internal/sdkv2/morpheus/resources/optionlist/option_list_manual.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/option_list_manual.go
@@ -62,6 +62,7 @@ func ResourceOptionListManual() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldPayload := strings.TrimSpace(old)
 					newPayload := strings.TrimSpace(new)
+
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {

--- a/internal/sdkv2/morpheus/resources/optionlist/option_list_manual.go
+++ b/internal/sdkv2/morpheus/resources/optionlist/option_list_manual.go
@@ -59,8 +59,13 @@ func ResourceOptionListManual() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The dataset for the manual option list",
 				Optional:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
+					return oldPayload == newPayload
+				},
 				StateFunc: func(val any) string {
-					return strings.TrimSuffix(val.(string), "\n")
+					return strings.TrimRight(val.(string), "\n")
 				},
 			},
 			"real_time": {

--- a/internal/sdkv2/morpheus/resources/script/boot_script.go
+++ b/internal/sdkv2/morpheus/resources/script/boot_script.go
@@ -40,12 +40,12 @@ func ResourceBootScript() *schema.Resource {
 				Description: "The content of the boot script",
 				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {
-					payload := strings.TrimRight(v.(string), "\n")
+					payload := strings.TrimSpace(v.(string))
 
 					return payload
 				},

--- a/internal/sdkv2/morpheus/resources/script/boot_script.go
+++ b/internal/sdkv2/morpheus/resources/script/boot_script.go
@@ -39,8 +39,13 @@ func ResourceBootScript() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The content of the boot script",
 				Optional:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
+					return oldPayload == newPayload
+				},
 				StateFunc: func(v any) string {
-					payload := strings.TrimSuffix(v.(string), "\n")
+					payload := strings.TrimRight(v.(string), "\n")
 
 					return payload
 				},

--- a/internal/sdkv2/morpheus/resources/script/boot_script.go
+++ b/internal/sdkv2/morpheus/resources/script/boot_script.go
@@ -42,6 +42,7 @@ func ResourceBootScript() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldPayload := strings.TrimSpace(old)
 					newPayload := strings.TrimSpace(new)
+
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {

--- a/internal/sdkv2/morpheus/resources/script/preseed_script.go
+++ b/internal/sdkv2/morpheus/resources/script/preseed_script.go
@@ -40,14 +40,14 @@ func ResourcePreseedScript() *schema.Resource {
 				Description: "The content of the preseed script",
 				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {
 					var payload string
 					if vStr, ok := v.(string); ok {
-						payload = strings.TrimRight(vStr, "\n")
+						payload = strings.TrimSpace(vStr)
 					}
 
 					return payload

--- a/internal/sdkv2/morpheus/resources/script/preseed_script.go
+++ b/internal/sdkv2/morpheus/resources/script/preseed_script.go
@@ -39,10 +39,15 @@ func ResourcePreseedScript() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The content of the preseed script",
 				Optional:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
+					return oldPayload == newPayload
+				},
 				StateFunc: func(v any) string {
 					var payload string
 					if vStr, ok := v.(string); ok {
-						payload = strings.TrimSuffix(vStr, "\n")
+						payload = strings.TrimRight(vStr, "\n")
 					}
 
 					return payload

--- a/internal/sdkv2/morpheus/resources/script/preseed_script.go
+++ b/internal/sdkv2/morpheus/resources/script/preseed_script.go
@@ -42,6 +42,7 @@ func ResourcePreseedScript() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldPayload := strings.TrimSpace(old)
 					newPayload := strings.TrimSpace(new)
+
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_email.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_email.go
@@ -93,8 +93,13 @@ func ResourceTaskEmail() *schema.Resource {
 				Description: "The body of the email is HTML. Morpheus automation variables can be injected into the email body when needed. Used with a source type of local",
 				Optional:    true,
 				Computed:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
+					return oldPayload == newPayload
+				},
 				StateFunc: func(val any) string {
-					return strings.TrimSuffix(val.(string), "\n")
+					return strings.TrimRight(val.(string), "\n")
 				},
 			},
 			"skip_wrapped_email_template": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_email.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_email.go
@@ -96,6 +96,7 @@ func ResourceTaskEmail() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldPayload := strings.TrimSpace(old)
 					newPayload := strings.TrimSpace(new)
+
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_email.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_email.go
@@ -94,12 +94,12 @@ func ResourceTaskEmail() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimRight(val.(string), "\n")
+					return strings.TrimSpace(val.(string))
 				},
 			},
 			"skip_wrapped_email_template": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
@@ -67,13 +67,13 @@ func ResourceTaskGroovyScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimSuffix(old, "\n")
-					newPayload := strings.TrimSuffix(new, "\n")
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimSuffix(val.(string), "\n")
+					return strings.TrimRight(val.(string), "\n")
 				},
 			},
 			"script_path": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_groovy_script.go
@@ -67,13 +67,13 @@ func ResourceTaskGroovyScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimRight(val.(string), "\n")
+					return strings.TrimSpace(val.(string))
 				},
 			},
 			"script_path": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
@@ -75,13 +75,13 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimSuffix(old, "\n")
-					newPayload := strings.TrimSuffix(new, "\n")
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimSuffix(val.(string), "\n")
+					return strings.TrimRight(val.(string), "\n")
 				},
 			},
 			"script_path": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_powershell_script.go
@@ -75,13 +75,13 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimRight(val.(string), "\n")
+					return strings.TrimSpace(val.(string))
 				},
 			},
 			"script_path": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
@@ -66,13 +66,13 @@ func ResourceTaskPythonScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimRight(val.(string), "\n")
+					return strings.TrimSpace(val.(string))
 				},
 			},
 			"script_path": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_python_script.go
@@ -66,13 +66,13 @@ func ResourceTaskPythonScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimSpace(old)
-					newPayload := strings.TrimSpace(new)
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimSpace(val.(string))
+					return strings.TrimRight(val.(string), "\n")
 				},
 			},
 			"script_path": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
@@ -63,13 +63,13 @@ func ResourceTaskRubyScript() *schema.Resource {
 				Description: "The content of the ruby script. Used when the local source type is specified",
 				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimSuffix(old, "\n")
-					newPayload := strings.TrimSuffix(new, "\n")
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimSuffix(val.(string), "\n")
+					return strings.TrimRight(val.(string), "\n")
 				},
 			},
 			"script_path": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_ruby_script.go
@@ -63,13 +63,13 @@ func ResourceTaskRubyScript() *schema.Resource {
 				Description: "The content of the ruby script. Used when the local source type is specified",
 				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
-					return strings.TrimRight(val.(string), "\n")
+					return strings.TrimSpace(val.(string))
 				},
 			},
 			"script_path": {

--- a/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
@@ -74,14 +74,14 @@ func ResourceTaskShellScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
 					if str, ok := val.(string); ok {
-						return strings.TrimRight(str, "\n")
+						return strings.TrimSpace(str)
 					}
 
 					return ""

--- a/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
+++ b/internal/sdkv2/morpheus/resources/task/resource_task_shell_script.go
@@ -74,14 +74,14 @@ func ResourceTaskShellScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimSuffix(old, "\n")
-					newPayload := strings.TrimSuffix(new, "\n")
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
 
 					return oldPayload == newPayload
 				},
 				StateFunc: func(val any) string {
 					if str, ok := val.(string); ok {
-						return strings.TrimSuffix(str, "\n")
+						return strings.TrimRight(str, "\n")
 					}
 
 					return ""

--- a/internal/sdkv2/morpheus/resources/template/resource_arm_spec_template.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_arm_spec_template.go
@@ -50,7 +50,7 @@ func ResourceSpecTemplateARM() *schema.Resource {
 				Optional:    true,
 				StateFunc: func(val any) string {
 					if v, ok := val.(string); ok {
-						return strings.TrimSuffix(v, "\n")
+						return strings.TrimSpace(v)
 					}
 
 					return ""

--- a/internal/sdkv2/morpheus/resources/template/resource_file_template.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_file_template.go
@@ -67,8 +67,8 @@ func ResourceFileTemplate() *schema.Resource {
 				Description: "The content of the file template",
 				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {
@@ -76,7 +76,7 @@ func ResourceFileTemplate() *schema.Resource {
 					if str, ok := v.(string); ok {
 						payload = str
 					}
-					payload = strings.TrimRight(payload, "\n")
+					payload = strings.TrimSpace(payload)
 
 					return payload
 				},

--- a/internal/sdkv2/morpheus/resources/template/resource_file_template.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_file_template.go
@@ -69,6 +69,7 @@ func ResourceFileTemplate() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldPayload := strings.TrimSpace(old)
 					newPayload := strings.TrimSpace(new)
+
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {

--- a/internal/sdkv2/morpheus/resources/template/resource_file_template.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_file_template.go
@@ -66,12 +66,17 @@ func ResourceFileTemplate() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The content of the file template",
 				Optional:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
+					return oldPayload == newPayload
+				},
 				StateFunc: func(v any) string {
 					var payload string
 					if str, ok := v.(string); ok {
 						payload = str
 					}
-					payload = strings.TrimSuffix(payload, "\n")
+					payload = strings.TrimRight(payload, "\n")
 
 					return payload
 				},

--- a/internal/sdkv2/morpheus/resources/template/resource_script_template.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_script_template.go
@@ -64,9 +64,14 @@ func ResourceScriptTemplate() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The content of the script template",
 				Optional:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
+					return oldPayload == newPayload
+				},
 				StateFunc: func(v any) string {
 					if str, ok := v.(string); ok {
-						return strings.TrimSuffix(str, "\n")
+						return strings.TrimRight(str, "\n")
 					}
 
 					return ""

--- a/internal/sdkv2/morpheus/resources/template/resource_script_template.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_script_template.go
@@ -67,6 +67,7 @@ func ResourceScriptTemplate() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldPayload := strings.TrimSpace(old)
 					newPayload := strings.TrimSpace(new)
+
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {

--- a/internal/sdkv2/morpheus/resources/template/resource_script_template.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_script_template.go
@@ -65,13 +65,13 @@ func ResourceScriptTemplate() *schema.Resource {
 				Description: "The content of the script template",
 				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {
 					if str, ok := v.(string); ok {
-						return strings.TrimRight(str, "\n")
+						return strings.TrimSpace(str)
 					}
 
 					return ""

--- a/internal/sdkv2/morpheus/resources/template/resource_spec_template_cloud_formation.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_spec_template_cloud_formation.go
@@ -50,12 +50,19 @@ func ResourceSpecTemplateCloudFormation() *schema.Resource {
 				Optional:    true,
 				StateFunc: func(val any) string {
 					if v, ok := val.(string); ok {
-						return strings.TrimRight(v, "\n")
+						return strings.TrimSpace(v)
 					}
 
 					return ""
 				},
-				DiffSuppressFunc: helpers.SuppressEquivalentJSONDiffs,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// First try simple whitespace-trimmed comparison (works for YAML)
+					if strings.TrimSpace(old) == strings.TrimSpace(new) {
+						return true
+					}
+					// Fall back to JSON comparison for JSON templates
+					return helpers.SuppressEquivalentJSONDiffs(k, old, new, d)
+				},
 			},
 			"spec_path": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/template/resource_spec_template_cloud_formation.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_spec_template_cloud_formation.go
@@ -50,7 +50,7 @@ func ResourceSpecTemplateCloudFormation() *schema.Resource {
 				Optional:    true,
 				StateFunc: func(val any) string {
 					if v, ok := val.(string); ok {
-						return strings.TrimSuffix(v, "\n")
+						return strings.TrimRight(v, "\n")
 					}
 
 					return ""

--- a/internal/sdkv2/morpheus/resources/template/resource_spec_template_cloud_formation.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_spec_template_cloud_formation.go
@@ -55,14 +55,7 @@ func ResourceSpecTemplateCloudFormation() *schema.Resource {
 
 					return ""
 				},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// First try simple whitespace-trimmed comparison (works for YAML)
-					if strings.TrimSpace(old) == strings.TrimSpace(new) {
-						return true
-					}
-					// Fall back to JSON comparison for JSON templates
-					return helpers.SuppressEquivalentJSONDiffs(k, old, new, d)
-				},
+				DiffSuppressFunc: helpers.SuppressEquivalentJSONDiffs,
 			},
 			"spec_path": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/template/resource_spec_template_helm.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_spec_template_helm.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -47,13 +48,19 @@ func ResourceSpecTemplateHelm() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The content of the helm spec template. Used when the local source type is specified",
 				Optional:    true,
-				// StateFunc: func(val any) string {
-				// 	if v, ok := val.(string); ok {
-				// 		return strings.TrimSpace(v)
-				// 	}
-				//
-				// 	return ""
-				// },
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					old = strings.TrimSpace(old)
+					new = strings.TrimSpace(new)
+
+					return old == new
+				},
+				StateFunc: func(val any) string {
+					if v, ok := val.(string); ok {
+						return strings.TrimSpace(v)
+					}
+
+					return ""
+				},
 			},
 			"spec_path": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/template/resource_spec_template_helm.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_spec_template_helm.go
@@ -49,7 +49,7 @@ func ResourceSpecTemplateHelm() *schema.Resource {
 				Optional:    true,
 				// StateFunc: func(val any) string {
 				// 	if v, ok := val.(string); ok {
-				// 		return strings.TrimSuffix(v, "\n")
+				// 		return strings.TrimSpace(v)
 				// 	}
 				//
 				// 	return ""

--- a/internal/sdkv2/morpheus/resources/template/resource_spec_template_kubernetes.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_spec_template_kubernetes.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -47,13 +48,19 @@ func ResourceSpecTemplateKubernetes() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The content of the kubernetes spec template. Used when the local source type is specified",
 				Optional:    true,
-				// StateFunc: func(val any) string {
-				// 	if v, ok := val.(string); ok {
-				// 		return strings.TrimSpace(v)
-				// 	}
-				//
-				// 	return ""
-				// },
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					old = strings.TrimSpace(old)
+					new = strings.TrimSpace(new)
+
+					return old == new
+				},
+				StateFunc: func(val any) string {
+					if v, ok := val.(string); ok {
+						return strings.TrimSpace(v)
+					}
+
+					return ""
+				},
 			},
 			"spec_path": {
 				Type:        schema.TypeString,

--- a/internal/sdkv2/morpheus/resources/template/resource_spec_template_kubernetes.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_spec_template_kubernetes.go
@@ -49,7 +49,7 @@ func ResourceSpecTemplateKubernetes() *schema.Resource {
 				Optional:    true,
 				// StateFunc: func(val any) string {
 				// 	if v, ok := val.(string); ok {
-				// 		return strings.TrimSuffix(v, "\n")
+				// 		return strings.TrimSpace(v)
 				// 	}
 				//
 				// 	return ""

--- a/internal/sdkv2/morpheus/resources/template/resource_spec_template_terraform.go
+++ b/internal/sdkv2/morpheus/resources/template/resource_spec_template_terraform.go
@@ -51,7 +51,7 @@ func ResourceSpecTemplateTerraform() *schema.Resource {
 				Computed:    true,
 				StateFunc: func(val any) string {
 					if v, ok := val.(string); ok {
-						return strings.TrimSuffix(v, "\n")
+						return strings.TrimSpace(v)
 					}
 
 					return ""

--- a/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
+++ b/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
@@ -46,8 +46,8 @@ func ResourceWikiPage() *schema.Resource {
 				Description: "The content of the wiki page",
 				Optional:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldPayload := strings.TrimRight(old, "\n")
-					newPayload := strings.TrimRight(new, "\n")
+					oldPayload := strings.TrimSpace(old)
+					newPayload := strings.TrimSpace(new)
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {
@@ -55,7 +55,7 @@ func ResourceWikiPage() *schema.Resource {
 					if strVal, ok := v.(string); ok {
 						payload = strVal
 					}
-					payload = strings.TrimRight(payload, "\n")
+					payload = strings.TrimSpace(payload)
 
 					return payload
 				},

--- a/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
+++ b/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
@@ -45,12 +45,17 @@ func ResourceWikiPage() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The content of the wiki page",
 				Optional:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldPayload := strings.TrimRight(old, "\n")
+					newPayload := strings.TrimRight(new, "\n")
+					return oldPayload == newPayload
+				},
 				StateFunc: func(v any) string {
 					var payload string
 					if strVal, ok := v.(string); ok {
 						payload = strVal
 					}
-					payload = strings.TrimSuffix(payload, "\n")
+					payload = strings.TrimRight(payload, "\n")
 
 					return payload
 				},

--- a/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
+++ b/internal/sdkv2/morpheus/resources/wiki/wiki_page.go
@@ -48,6 +48,7 @@ func ResourceWikiPage() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldPayload := strings.TrimSpace(old)
 					newPayload := strings.TrimSpace(new)
+
 					return oldPayload == newPayload
 				},
 				StateFunc: func(v any) string {


### PR DESCRIPTION
This PR stops issues with in-place updates across various resources ported over from `terraform_provider_morpheus`.

Previously - most of these resources used `TrimSuffix` instead of `TrimSpace` for DiffSuppress - causing each of them to have issues when multiple newlines lead or trailed the input.

The resources in question have been tested via doing an apply and then planning - observing any in-place updates and ensuring these are resolved after repeating the process.
