### PR TITLE
Fix datastore and image nil hresp stack-trace

### DIFF
--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -145,7 +145,7 @@ func (r *Resource) Create(
 	waitForReady := func() (*sdk.GetDatastores200Response, error) {
 		response, hresp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
 		if err != nil {
-			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusOK {
+			if hresp == nil || hresp.StatusCode != http.StatusOK {
 				return nil, backoff.Permanent(err)
 			}
 		}

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_create.go
@@ -144,8 +144,10 @@ func (r *Resource) Create(
 	// Wait for the datastore to be ready
 	waitForReady := func() (*sdk.GetDatastores200Response, error) {
 		response, hresp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
-		if err != nil || hresp.StatusCode != http.StatusOK {
-			return nil, backoff.Permanent(err)
+		if err != nil {
+			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusOK {
+				return nil, backoff.Permanent(err)
+			}
 		}
 
 		status := response.GetDatastore().Status

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_delete.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_delete.go
@@ -45,7 +45,7 @@ func (r *Resource) Delete(
 	waitForReady := func() (int, error) {
 		_, hresp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
 		if err != nil {
-			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusNotFound {
+			if hresp == nil || hresp.StatusCode != http.StatusNotFound {
 				return 0, backoff.Permanent(err)
 			}
 		}

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_delete.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_delete.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package datastore
 
@@ -44,8 +44,10 @@ func (r *Resource) Delete(
 	// Wait for the datastore to be "not found" which means it has been deleted
 	waitForReady := func() (int, error) {
 		_, hresp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
-		if err != nil && hresp.StatusCode != http.StatusNotFound {
-			return hresp.StatusCode, backoff.Permanent(err)
+		if err != nil {
+			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusNotFound {
+				return 0, backoff.Permanent(err)
+			}
 		}
 
 		switch hresp.StatusCode {

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_update.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_update.go
@@ -167,7 +167,7 @@ func updateDatastore(
 	waitForReady := func() (string, error) {
 		response, hresp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
 		if err != nil {
-			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusOK {
+			if hresp == nil || hresp.StatusCode != http.StatusOK {
 				return "", backoff.Permanent(err)
 			}
 		}

--- a/internal/framework/subproviders/morpheus/resources/datastore/datastore_update.go
+++ b/internal/framework/subproviders/morpheus/resources/datastore/datastore_update.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package datastore
 
@@ -166,8 +166,10 @@ func updateDatastore(
 	// Wait for the datastore to be ready
 	waitForReady := func() (string, error) {
 		response, hresp, err := client.DatastoresAPI.GetDatastores(ctx, id).Execute()
-		if err != nil || hresp.StatusCode != http.StatusOK {
-			return "", backoff.Permanent(err)
+		if err != nil {
+			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusOK {
+				return "", backoff.Permanent(err)
+			}
 		}
 
 		status := response.GetDatastore().Status

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -270,7 +270,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	waitForReady := func() (string, error) {
 		resp, httpResp, err := client.LibraryAPI.GetVirtualImage(ctx, plan.Id.ValueInt64()).Execute()
 		if err != nil {
-			if httpResp == nil || httpResp != nil && httpResp.StatusCode != http.StatusOK {
+			if httpResp == nil || httpResp.StatusCode != http.StatusOK {
 				return "", backoff.Permanent(err)
 			}
 		}

--- a/internal/framework/subproviders/morpheus/resources/image/create.go
+++ b/internal/framework/subproviders/morpheus/resources/image/create.go
@@ -269,8 +269,10 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	waitForReady := func() (string, error) {
 		resp, httpResp, err := client.LibraryAPI.GetVirtualImage(ctx, plan.Id.ValueInt64()).Execute()
-		if err != nil || httpResp.StatusCode != http.StatusOK {
-			return "", backoff.Permanent(err)
+		if err != nil {
+			if httpResp == nil || httpResp != nil && httpResp.StatusCode != http.StatusOK {
+				return "", backoff.Permanent(err)
+			}
 		}
 
 		status := resp.VirtualImage.GetStatus()

--- a/internal/framework/subproviders/morpheus/resources/image/delete.go
+++ b/internal/framework/subproviders/morpheus/resources/image/delete.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package image
 

--- a/internal/framework/subproviders/morpheus/resources/image/delete.go
+++ b/internal/framework/subproviders/morpheus/resources/image/delete.go
@@ -45,8 +45,10 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	waitForDeleted := func() (*sdk.GetInstance200Response, error) {
 		_, httpResp, err := client.LibraryAPI.GetVirtualImage(ctx, id.ValueInt64()).Execute()
 		// 404 status code counts as a successful delete
-		if err != nil && httpResp.StatusCode != http.StatusNotFound {
-			return nil, backoff.Permanent(err)
+		if err != nil {
+			if httpResp == nil || httpResp != nil && httpResp.StatusCode != http.StatusNotFound {
+				return nil, backoff.Permanent(err)
+			}
 		}
 
 		return nil, nil

--- a/internal/framework/subproviders/morpheus/resources/image/delete.go
+++ b/internal/framework/subproviders/morpheus/resources/image/delete.go
@@ -46,7 +46,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		_, httpResp, err := client.LibraryAPI.GetVirtualImage(ctx, id.ValueInt64()).Execute()
 		// 404 status code counts as a successful delete
 		if err != nil {
-			if httpResp == nil || httpResp != nil && httpResp.StatusCode != http.StatusNotFound {
+			if httpResp == nil || httpResp.StatusCode != http.StatusNotFound {
 				return nil, backoff.Permanent(err)
 			}
 		}

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_create.go
@@ -258,7 +258,7 @@ func (g *Resource) Create(
 	waitForReady := func() (string, error) {
 		resp, hresp, err := client.InstancesAPI.GetInstance(ctx, instanceId).Execute()
 		if err != nil {
-			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusOK {
+			if hresp == nil || hresp.StatusCode != http.StatusOK {
 				return "", backoff.Permanent(err)
 			}
 		}

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_delete.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_delete.go
@@ -69,7 +69,7 @@ func (g *Resource) Delete(
 	waitForDeleted := func() (*sdk.GetInstance200Response, error) {
 		resp, hresp, err := client.InstancesAPI.GetInstance(ctx, data.Id.ValueInt64()).Execute()
 		if err != nil {
-			if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusNotFound {
+			if hresp == nil || hresp.StatusCode != http.StatusNotFound {
 				return nil, backoff.Permanent(err)
 			}
 		}

--- a/internal/framework/subproviders/morpheus/resources/instance/instance_update.go
+++ b/internal/framework/subproviders/morpheus/resources/instance/instance_update.go
@@ -208,7 +208,7 @@ func makeUpdateAPIcalls(
 		waitForReady := func() (string, error) {
 			resp, hresp, err := client.InstancesAPI.GetInstance(ctx, plan.Id.ValueInt64()).Execute()
 			if err != nil {
-				if hresp == nil || hresp != nil && hresp.StatusCode != http.StatusOK {
+				if hresp == nil || hresp.StatusCode != http.StatusOK {
 					return "", backoff.Permanent(err)
 				}
 			}


### PR DESCRIPTION
A stack-trace due to a nil httpResponse object has been observed in instance.  The same could occur for datastore and image.  This PR adds code to fix the issue for datastore and image.