### PR TITLE
Add `allow_custom_config` to task resource

### DIFF
--- a/docs/resources/morpheus_task.md
+++ b/docs/resources/morpheus_task.md
@@ -33,8 +33,9 @@ resource "hpe_morpheus_task" "example_task" {
     else_operational_workflow_name = "Test 2"
   }
 
-  execute_target = "local"
-  retryable      = false
+  execute_target      = "local"
+  retryable           = false
+  allow_custom_config = true
 }
 ```
 
@@ -66,6 +67,7 @@ resource "hpe_morpheus_task" "example_task" {
 
 ### Optional
 
+- `allow_custom_config` (Boolean) When enabled, a text area is provided at Task execution time to allow the user to pass extra variables or specify extra configuration
 - `code` (String) A unique code for the task
 - `config` (Dynamic) Configuration object. Settings vary by type.
 - `config_conditional_workflow` (Attributes) (see [below for nested schema](#nestedatt--config_conditional_workflow))
@@ -78,8 +80,6 @@ resource "hpe_morpheus_task" "example_task" {
 
 ### Read-Only
 
-- `account_id` (Number)
-- `allow_custom_config` (Boolean)
 - `id` (Number) The ID of this resource.
 
 <a id="nestedatt--config_conditional_workflow"></a>

--- a/examples/resources/morpheus_task/example_conditional_workflow.tf
+++ b/examples/resources/morpheus_task/example_conditional_workflow.tf
@@ -16,6 +16,7 @@ resource "hpe_morpheus_task" "example_task" {
     else_operational_workflow_name = "Test 2"
   }
 
-  execute_target = "local"
-  retryable      = false
+  execute_target      = "local"
+  retryable           = false
+  allow_custom_config = true
 }

--- a/internal/framework/subproviders/morpheus/resources/task/create.go
+++ b/internal/framework/subproviders/morpheus/resources/task/create.go
@@ -29,6 +29,11 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	addTaskReq := sdk.NewAddTasksRequestWithDefaults()
 
+	// allow_custom_config
+	if !plan.AllowCustomConfig.IsNull() && !plan.AllowCustomConfig.IsUnknown() {
+		addTaskReq.Task.SetAllowCustomConfig(plan.AllowCustomConfig.ValueBool())
+	}
+
 	// code
 	if !plan.Code.IsNull() && !plan.Code.IsUnknown() {
 		addTaskReq.Task.SetCode(plan.Code.ValueString())

--- a/internal/framework/subproviders/morpheus/resources/task/example_conditional_workflow.tf.tmpl
+++ b/internal/framework/subproviders/morpheus/resources/task/example_conditional_workflow.tf.tmpl
@@ -18,4 +18,5 @@ resource "hpe_morpheus_task" "example_task" {
 
     execute_target = "local"
     retryable = false
+    allow_custom_config = true
 }

--- a/internal/framework/subproviders/morpheus/resources/task/read.go
+++ b/internal/framework/subproviders/morpheus/resources/task/read.go
@@ -64,6 +64,10 @@ func getTaskAsState(
 	}
 
 	task := taskResp.GetTask()
+
+	// allow_custom_config
+	state.AllowCustomConfig = convert.BoolToType(task.AllowCustomConfig)
+
 	// code
 	state.Code = convert.StrToType(task.Code.Get())
 

--- a/internal/framework/subproviders/morpheus/resources/task/schema_gen.go
+++ b/internal/framework/subproviders/morpheus/resources/task/schema_gen.go
@@ -26,11 +26,11 @@ import (
 func TaskResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"account_id": schema.Int64Attribute{
-				Computed: true,
-			},
 			"allow_custom_config": schema.BoolAttribute{
-				Computed: true,
+				Optional:            true,
+				Computed:            true,
+				Description:         "When enabled, a text area is provided at Task execution time to allow the user to pass extra variables or specify extra configuration",
+				MarkdownDescription: "When enabled, a text area is provided at Task execution time to allow the user to pass extra variables or specify extra configuration",
 			},
 			"code": schema.StringAttribute{
 				Optional:            true,
@@ -172,7 +172,6 @@ func TaskResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TaskModel struct {
-	AccountId                 types.Int64                    `tfsdk:"account_id"`
 	AllowCustomConfig         types.Bool                     `tfsdk:"allow_custom_config"`
 	Code                      types.String                   `tfsdk:"code"`
 	Config                    types.Dynamic                  `tfsdk:"config"`

--- a/internal/framework/subproviders/morpheus/resources/task/task_test.go
+++ b/internal/framework/subproviders/morpheus/resources/task/task_test.go
@@ -76,6 +76,11 @@ func TestAccMorpheusTaskExampleConditionalOk(t *testing.T) {
 			"config_conditional_workflow.else_operational_workflow_id",
 			"91",
 		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"allow_custom_config",
+			"true",
+		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
@@ -145,6 +150,11 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 			"config_conditional_workflow.else_operational_workflow_id",
 			"91",
 		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"allow_custom_config",
+			"false",
+		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
@@ -194,6 +204,7 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 
 						execute_target = "local"
 						retryable = false
+						allow_custom_config = false
 					}`,
 			},
 			// check if changing task_type_code requires replace

--- a/internal/framework/subproviders/morpheus/resources/task/update.go
+++ b/internal/framework/subproviders/morpheus/resources/task/update.go
@@ -44,6 +44,11 @@ func (r *Resource) Update(
 	updateRequest := sdk.NewUpdateTasksRequestWithDefaults()
 	updateTask := sdk.NewUpdateTasksRequestTaskWithDefaults()
 
+	// allow_custom_config
+	if !plan.AllowCustomConfig.IsNull() && !plan.AllowCustomConfig.IsUnknown() {
+		updateTask.SetAllowCustomConfig(plan.AllowCustomConfig.ValueBool())
+	}
+
 	// code
 	if !plan.Code.IsNull() && !plan.Code.IsUnknown() {
 		updateTask.SetCode(plan.Code.ValueString())


### PR DESCRIPTION
This option enables users to specify custom configs when manually executing a task.

Drive-by: removes `AccountId` which was leftover in `schema_gen.go` by accident.
