### PR TITLE
Add instance resource static config for HVM and VMware

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -12,7 +12,10 @@ Instance is a virtual machine, bare metal machine or container deployed and mana
 Morpheus oversees its entire lifecycle, from initial provisioning to scaling, 
 monitoring, and eventual decommissioning.
 
--> Currently HVM, VMware and BMaaS instances are supported. Some general issues<br>
+-> Currently HVM, VMware and BMaaS instances are supported.  We have static `config` schema for the following:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- HVM: `config_hvm`<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- VMware: `config_vmware`<br><br>
+Some general issues<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- With Morpheus versions prior to 8.0.11, make sure the root volume is the first defined.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- The addition and removal of volumes is not supported during updates.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Updates fail when removing optional fields.<br>
@@ -39,9 +42,9 @@ When creating an instance with network bonding and/or LAGs we cannot reconcile t
 with the HCL supplied.  In these cases the `connection_info` section will contain IP address(es).  To access the full
 network configuration use the `hpe_morpheus_instance` `data-source` to read back the created instance.
 
--> The following examples all have the following settings in their `config` blocks:<br>
-&nbsp;&nbsp;&nbsp;&nbsp;- `noAgent` is set to `false`<br>
-&nbsp;&nbsp;&nbsp;&nbsp;- `createUser` is set to `true`<br><br>
+-> Some of the examples below have the following settings in their `config` blocks:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- `no_agent` in static config (equivalent to `noAgent` in dynamic config) is set to `true`<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- `create_user` in static config (equivalent to `createUser` in dynamic config) is set to `false`<br><br>
 These settings can be changed as required.
 
 ## HVM Instance
@@ -112,12 +115,11 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "pool-62299"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = true
-    createUser           = false
+  config_hvm = {
+    resource_pool_id      = "pool-62299"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
   }
 }
 ```
@@ -207,12 +209,11 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "pool-62299"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = false
-    createUser           = true
+  config_hvm = {
+    resource_pool_id      = "pool-62299"
+    nested_virtualization = "off"
+    no_agent              = false
+    create_user           = true
   }
 }
 ```
@@ -291,12 +292,11 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "pool-62299"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = false
-    createUser           = true
+  config_hvm = {
+    resource_pool_id      = "pool-62299"
+    nested_virtualization = "off"
+    no_agent              = false
+    create_user           = true
   }
 
   timeouts = {
@@ -381,12 +381,12 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "pool-1"
-    nestedVirtualization = "off"
-    noAgent              = true
-    createUser           = false
-    vmwareFolderID       = "group-v79"
+  config_vmware = {
+    resource_pool_id      = "pool-1"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
+    vmware_folder_id      = "group-v79"
   }
 
   timeouts = {
@@ -532,6 +532,8 @@ The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" ca
 
 - `cloud_id` (Number) The Cloud ID to provision the instance onto.
 - `config` (Dynamic) Configuration object. Settings vary by type.
+- `config_hvm` (Attributes) Configuration options for HVM instances. (see [below for nested schema](#nestedatt--config_hvm))
+- `config_vmware` (Attributes) Configuration options for VMware instances. (see [below for nested schema](#nestedatt--config_vmware))
 - `evars` (Attributes Set) Environment Variables, an array of objects that have name and value. (see [below for nested schema](#nestedatt--evars))
 - `instance_context` (String) Environment
 - `layout_size` (Number) Apply a multiply factor of containers/vms within the instance.
@@ -586,6 +588,36 @@ Read-Only:
 - `name` (String) The name of the interface, e.g. 'eth0', 'eth1'
 - `primary_interface` (Boolean) Is this interface the 'primary interface'?
 
+
+
+<a id="nestedatt--config_hvm"></a>
+### Nested Schema for `config_hvm`
+
+Required:
+
+- `resource_pool_id` (String) The id of the resource group to be used, can be prefixed with 'pool-'.  A resource pool group can be specified instead by prefixing its ID wih 'poolGroup-'.
+
+Optional:
+
+- `create_user` (Boolean) Whether to create a user when provisioning the instance.  The default is 'false'
+- `kvm_host_id` (Number) The id of the KVM host to use for provisioning.
+- `nested_virtualization` (String) Enable nested virtualization on the instance. Can be 'on' or 'off'. The default is 'off'.
+- `no_agent` (Boolean) Whether to skip installing the Morpheus agent on the instance.  The default is 'true'
+
+
+<a id="nestedatt--config_vmware"></a>
+### Nested Schema for `config_vmware`
+
+Required:
+
+- `resource_pool_id` (String) The id of the resource group to be used, can be prefixed with 'pool-'.  A resource pool group can be specified instead by prefixing its ID wih 'poolGroup-'.
+- `vmware_folder_id` (String) VMware folder external ID.
+
+Optional:
+
+- `create_user` (Boolean) Whether to create a user when provisioning the instance.  The default is 'false'
+- `nested_virtualization` (String) Enable nested virtualization on the instance. Can be 'on' or 'off'. The default is 'off'.
+- `no_agent` (Boolean) Whether to skip installing the Morpheus agent on the instance.  The default is 'true'
 
 
 <a id="nestedatt--evars"></a>

--- a/morpheus/framework/resources/instance/example.tf
+++ b/morpheus/framework/resources/instance/example.tf
@@ -63,11 +63,10 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "pool-62299"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = true
-    createUser           = false
+  config_hvm = {
+    resource_pool_id      = "pool-62299"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
   }
 }

--- a/morpheus/framework/resources/instance/example.tf.tmpl
+++ b/morpheus/framework/resources/instance/example.tf.tmpl
@@ -63,11 +63,10 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "{{.ResourcePool}}"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = true
-    createUser           = false
+  config_hvm = {
+    resource_pool_id      = "{{.ResourcePool}}"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
   }
 }

--- a/morpheus/framework/resources/instance/example_timeouts.tf
+++ b/morpheus/framework/resources/instance/example_timeouts.tf
@@ -63,12 +63,11 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "pool-62299"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = false
-    createUser           = true
+  config_hvm = {
+    resource_pool_id      = "pool-62299"
+    nested_virtualization = "off"
+    no_agent              = false
+    create_user           = true
   }
 
   timeouts = {

--- a/morpheus/framework/resources/instance/example_timeouts.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_timeouts.tf.tmpl
@@ -63,12 +63,11 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "{{.ResourcePool}}"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = false
-    createUser           = true
+  config_hvm = {
+    resource_pool_id      = "{{.ResourcePool}}"
+    nested_virtualization = "off"
+    no_agent              = false
+    create_user           = true
   }
 
   timeouts = {

--- a/morpheus/framework/resources/instance/example_twonetworks.tf
+++ b/morpheus/framework/resources/instance/example_twonetworks.tf
@@ -77,11 +77,10 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "pool-62299"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = false
-    createUser           = true
+  config_hvm = {
+    resource_pool_id      = "pool-62299"
+    nested_virtualization = "off"
+    no_agent              = false
+    create_user           = true
   }
 }

--- a/morpheus/framework/resources/instance/example_twonetworks.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_twonetworks.tf.tmpl
@@ -77,11 +77,10 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "{{.ResourcePool}}"
-    poolProviderType     = "mvm"
-    nestedVirtualization = "off"
-    noAgent              = false
-    createUser           = true
+  config_hvm = {
+    resource_pool_id      = "{{.ResourcePool}}"
+    nested_virtualization = "off"
+    no_agent              = false
+    create_user           = true
   }
 }

--- a/morpheus/framework/resources/instance/example_vmware.tf
+++ b/morpheus/framework/resources/instance/example_vmware.tf
@@ -68,12 +68,12 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "pool-1"
-    nestedVirtualization = "off"
-    noAgent              = true
-    createUser           = false
-    vmwareFolderID       = "group-v79"
+  config_vmware = {
+    resource_pool_id      = "pool-1"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
+    vmware_folder_id      = "group-v79"
   }
 
   timeouts = {

--- a/morpheus/framework/resources/instance/example_vmware.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_vmware.tf.tmpl
@@ -68,12 +68,12 @@ resource "hpe_morpheus_instance" "example" {
     }
   ]
 
-  config = {
-    resourcePoolId       = "{{.ResourcePool}}"
-    nestedVirtualization = "off"
-    noAgent              = true
-    createUser           = false
-    vmwareFolderID       = "group-v79"
+  config_vmware = {
+    resource_pool_id      = "{{.ResourcePool}}"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
+    vmware_folder_id      = "group-v79"
   }
 
   timeouts = {

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -79,8 +79,38 @@ func (g *Resource) Create(
 	}
 
 	// config
-	configMap := make(map[string]any)
-	if !plan.Config.IsNull() {
+	switch {
+	// HVM config
+	case !plan.ConfigHvm.IsNull() && !plan.ConfigHvm.IsUnknown():
+		// The provisionTypeCode default is "mvm" which is the code for the HVM provisioning type.
+		configHvm := sdk.NewHVMInstanceConfigurationWithDefaults()
+		configHvm.SetCreateUser(plan.ConfigHvm.CreateUser.ValueBool())
+		configHvm.SetNestedVirtualization(plan.ConfigHvm.NestedVirtualization.ValueString())
+		configHvm.SetNoAgent(plan.ConfigHvm.NoAgent.ValueBool())
+		configHvm.SetResourcePoolId(plan.ConfigHvm.ResourcePoolId.ValueString())
+		if !plan.ConfigHvm.KvmHostId.IsNull() {
+			configHvm.SetKvmHostId(plan.ConfigHvm.KvmHostId.ValueInt64())
+		}
+
+		reqInstance.Config = sdk.AddInstanceRequestConfig{
+			HVMInstanceConfiguration: configHvm,
+		}
+
+	// VMware config
+	case !plan.ConfigVmware.IsNull() && !plan.ConfigVmware.IsUnknown():
+		configVMware := sdk.NewVMWareInstanceConfiguration1WithDefaults()
+		configVMware.SetNestedVirtualization(plan.ConfigVmware.NestedVirtualization.ValueString())
+		configVMware.SetCreateUser(plan.ConfigVmware.CreateUser.ValueBool())
+		configVMware.SetNoAgent(plan.ConfigVmware.NoAgent.ValueBool())
+		configVMware.SetResourcePoolId(plan.ConfigVmware.ResourcePoolId.ValueString())
+		configVMware.SetVmwareFolderId(plan.ConfigVmware.VmwareFolderId.ValueString())
+
+		reqInstance.Config = sdk.AddInstanceRequestConfig{
+			VMWareInstanceConfiguration1: configVMware,
+		}
+
+	// Generic config
+	case !plan.Config.IsNull() && !plan.Config.IsUnknown():
 		configValue := plan.Config.UnderlyingValue()
 		configAny, err := convert.ValueToAny(ctx, configValue)
 		if err != nil {
@@ -92,6 +122,7 @@ func (g *Resource) Create(
 
 			return
 		}
+		configMap := make(map[string]any)
 		configDataMap, ok := configAny.(map[string]any)
 		if ok {
 			configMap = configDataMap
@@ -101,9 +132,10 @@ func (g *Resource) Create(
 				"could not parse config value",
 			)
 		}
-	}
-	reqInstance.Config = sdk.AddInstanceRequestConfig{
-		MapmapOfStringAny: &configMap,
+
+		reqInstance.Config = sdk.AddInstanceRequestConfig{
+			MapmapOfStringAny: &configMap,
+		}
 	}
 
 	// evars

--- a/morpheus/framework/resources/instance/instance_delete.go
+++ b/morpheus/framework/resources/instance/instance_delete.go
@@ -55,7 +55,8 @@ func (g *Resource) Delete(
 		return
 	}
 
-	deleteReq := client.InstancesAPI.DeleteInstance(ctx, id.ValueInt64()).Force("true")
+	deleteReq := client.InstancesAPI.DeleteInstance(ctx, id.ValueInt64()).Force("on").
+		RemoveVolumes("on").ReleaseEIPs("on").ReleaseFloatingIps("on")
 	_, hresp, err := deleteReq.Execute()
 	if err != nil || hresp.StatusCode != http.StatusOK {
 		resp.Diagnostics.AddError(

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -23,6 +23,14 @@ import (
 	"github.com/HPE/terraform-provider-hpe/utils/convert"
 )
 
+const (
+	hvmCode    = "mvm-cluster"
+	kvmCode    = "kvm"
+	vmwareCode = "vmware"
+)
+
+type apiConfigType = sdk.GetInstance200ResponseInstanceConfig
+
 // Read implements resource.Resource.
 func (g *Resource) Read(
 	ctx context.Context,
@@ -90,18 +98,53 @@ func getInstanceAsState(
 
 	// config
 	state.Config = types.DynamicNull()
+	state.ConfigHvm = NewConfigHvmValueNull()
+	state.ConfigVmware = NewConfigVmwareValueNull()
 
-	if plan.Name.IsNull() || plan.Name.IsUnknown() {
+	switch {
+	case plan.Name.IsNull() || plan.Name.IsUnknown():
 		// on import, always read the config from the API
-		if apiConfig, ok := instance.GetConfigOk(); ok {
-			config, cdiags := getInstanceConfig(ctx, id, apiConfig)
+		code, apiConfig, gdiags := getCodeAndConfig(id, instance)
+		diags.Append(gdiags...)
+		if diags.HasError() {
+			return state, diags
+		}
+
+		switch *code {
+		case hvmCode:
+			configHvm, cdiags := getInstanceHVMConfig(id, apiConfig)
+			diags.Append(cdiags...)
+			if diags.HasError() {
+				return state, diags
+			}
+			state.ConfigHvm = configHvm
+
+		case vmwareCode:
+			configVMware, cdiags := getInstanceVMwareConfig(id, apiConfig)
+			diags.Append(cdiags...)
+			if diags.HasError() {
+				return state, diags
+			}
+			state.ConfigVmware = configVMware
+
+		default:
+			config, cdiags := getInstanceConfigGeneric(ctx, id, apiConfig)
 			diags.Append(cdiags...)
 			if diags.HasError() {
 				return state, diags
 			}
 			state.Config = config
+
 		}
-	} else if !plan.Config.IsNull() && !plan.Config.IsUnknown() {
+
+	// For normal reads, use the config from the plan if it's set.
+	case !plan.ConfigHvm.IsNull() && !plan.ConfigHvm.IsUnknown():
+		state.ConfigHvm = plan.ConfigHvm
+
+	case !plan.ConfigVmware.IsNull() && !plan.ConfigVmware.IsUnknown():
+		state.ConfigVmware = plan.ConfigVmware
+
+	case !plan.Config.IsNull() && !plan.Config.IsUnknown():
 		state.Config = plan.Config
 	}
 
@@ -232,10 +275,292 @@ func getInstanceAsState(
 	return state, diags
 }
 
-func getInstanceConfig(
+// getInstanceVMwareConfig builds the config_vmware block from the API response for vmware instances
+func getInstanceVMwareConfig(
+	id int64,
+	apiConfig *apiConfigType,
+) (ConfigVmwareValue, diag.Diagnostics) {
+	configVmware := ConfigVmwareValue{}
+
+	// CreateUser
+	createUser, cdiags := getCreateUser(id, apiConfig)
+	if cdiags.HasError() {
+		return configVmware, cdiags
+	}
+
+	// NoAgent
+	noAgent, ndiags := getNoAgent(id, apiConfig)
+	if ndiags.HasError() {
+		return configVmware, ndiags
+	}
+
+	// NestedVirtualization
+	nestedVirtualization, ndiags := getNestedVirtualization(id, apiConfig)
+	if ndiags.HasError() {
+		return configVmware, ndiags
+	}
+
+	// ResourcePoolId
+	resourcePoolId, rdiags := getResourcePoolId(id, apiConfig)
+	if rdiags.HasError() {
+		return configVmware, rdiags
+	}
+
+	// VMwareFolderId
+	folderId, fdiags := getVMwareFolderId(id, apiConfig)
+	if fdiags.HasError() {
+		return configVmware, fdiags
+	}
+
+	configVmware.CreateUser = convert.BoolToType(createUser)
+	configVmware.NoAgent = convert.BoolToType(noAgent)
+	configVmware.NestedVirtualization = convert.StrToType(nestedVirtualization)
+	configVmware.ResourcePoolId = convert.StrToType(resourcePoolId)
+	configVmware.VmwareFolderId = convert.StrToType(folderId)
+	configVmware.state = attr.ValueStateKnown
+
+	return configVmware, diag.Diagnostics{}
+}
+
+// getInstanceHVMConfig builds the config_hvm block from the API response for hvm instances
+func getInstanceHVMConfig(
+	id int64,
+	apiConfig *apiConfigType,
+) (ConfigHvmValue, diag.Diagnostics) {
+	configHvm := ConfigHvmValue{}
+
+	// CreateUser
+	createUser, cdiags := getCreateUser(id, apiConfig)
+	if cdiags.HasError() {
+		return configHvm, cdiags
+	}
+
+	// NoAgent
+	noAgent, ndiags := getNoAgent(id, apiConfig)
+	if ndiags.HasError() {
+		return configHvm, ndiags
+	}
+
+	// NestedVirtualization
+	nestedVirtualization, ndiags := getNestedVirtualization(id, apiConfig)
+	if ndiags.HasError() {
+		return configHvm, ndiags
+	}
+
+	// ResourcePoolId
+	resourcePoolId, rdiags := getResourcePoolId(id, apiConfig)
+	if rdiags.HasError() {
+		return configHvm, rdiags
+	}
+
+	// KvmHostId
+	kvmHostId, _ := apiConfig.GetKvmHostIdOk()
+
+	configHvm.CreateUser = convert.BoolToType(createUser)
+	configHvm.NoAgent = convert.BoolToType(noAgent)
+	configHvm.NestedVirtualization = convert.StrToType(nestedVirtualization)
+	configHvm.ResourcePoolId = convert.StrToType(resourcePoolId)
+	configHvm.KvmHostId = convert.Int64ToType(kvmHostId)
+	configHvm.state = attr.ValueStateKnown
+
+	return configHvm, diag.Diagnostics{}
+}
+
+func getCreateUser(
+	id int64,
+	apiConfig *apiConfigType,
+) (*bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	createUser, ok := apiConfig.GetCreateUserOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get config createUser", id),
+		)
+
+		return nil, diags
+	}
+
+	return createUser, nil
+}
+
+func getNoAgent(
+	id int64,
+	apiConfig *apiConfigType,
+) (*bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	noAgent, ok := apiConfig.GetNoAgentOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get config noAgent", id),
+		)
+
+		return nil, diags
+
+	}
+
+	return noAgent.Bool, nil
+}
+
+func getNestedVirtualization(
+	id int64,
+	apiConfig *apiConfigType,
+) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	nestedVirtualization, ok := apiConfig.GetNestedVirtualizationOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get config nestedVirtualization", id),
+		)
+
+		return nil, diags
+	}
+
+	return nestedVirtualization, nil
+}
+
+func getResourcePoolId(
+	id int64,
+	apiConfig *apiConfigType,
+) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	resourcePoolId, ok := apiConfig.GetResourcePoolIdOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get config resourcePoolId", id),
+		)
+
+		return nil, diags
+	}
+
+	return resourcePoolId.String, nil
+}
+
+func getVMwareFolderId(
+	id int64,
+	apiConfig *apiConfigType,
+) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	folderId, ok := apiConfig.GetVmwareFolderIdOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get config vmwareFolderId", id),
+		)
+
+		return nil, diags
+	}
+
+	return folderId, nil
+}
+
+// getCodeAndConfig returns the "code" for the instance and the config struct from the API response
+// The code is the layout provision type code for non-HVM clusters, and the cluster type code for HVM clusters.
+func getCodeAndConfig(
+	id int64,
+	instance sdk.GetInstance200ResponseInstance,
+) (*string, *apiConfigType, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Get layout first
+	layout, ok := instance.GetLayoutOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get layout", id),
+		)
+
+		return nil, nil, diags
+	}
+
+	provisionTypeCode, ok := layout.GetProvisionTypeCodeOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get layout provision type code", id),
+		)
+	}
+
+	var code string
+	switch *provisionTypeCode {
+	case kvmCode:
+		// If it's a kvm cluster, we need to check the cluster type code to see if it's actually an hvm cluster.
+		// This is because the API returns "kvm" as the provision type code for both kvm and hvm clusters,
+		// and we need to check the cluster type code to differentiate between them.
+		cluster, ok := instance.GetClusterOk()
+		if !ok {
+			code = kvmCode
+
+			break
+		}
+
+		clusterCode, cdiags := getClusterCode(id, cluster)
+		if cdiags.HasError() {
+			diags.Append(cdiags...)
+
+			return nil, nil, diags
+		}
+
+		code = *clusterCode
+
+	default:
+		code = *provisionTypeCode
+	}
+
+	apiConfig, ok := instance.GetConfigOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get instance config", id),
+		)
+
+		return nil, nil, diags
+	}
+
+	return &code, apiConfig, diags
+}
+
+// getClusterCode returns the cluster type code for an instance if the cluster information is present
+// in the API response
+func getClusterCode(
+	id int64,
+	cluster *sdk.GetInstance200ResponseInstanceCluster,
+) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	clusterType, ok := cluster.GetTypeOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get cluster type", id),
+		)
+
+		return nil, diags
+	}
+
+	clusterCode, ok := clusterType.GetCodeOk()
+	if !ok {
+		diags.AddError(
+			"populate instance resource",
+			fmt.Sprintf("instance %d GET failed to get cluster type code", id),
+		)
+
+		return nil, diags
+
+	}
+
+	return clusterCode, diags
+}
+
+// getInstanceConfigGeneric converts the instance config from the API response to a generic dynamic config
+// for unknown instance types
+func getInstanceConfigGeneric(
 	ctx context.Context,
 	id int64,
-	apiConfig *sdk.GetInstance200ResponseInstanceConfig,
+	apiConfig *apiConfigType,
 ) (types.Dynamic, diag.Diagnostics) {
 	var diags diag.Diagnostics
 

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -5,16 +5,17 @@ package instance
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	morpheusvalidators "github.com/HPE/terraform-provider-hpe/utils/validators"
+	"github.com/HPE/terraform-provider-hpe/utils/validators"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -27,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -46,7 +48,107 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Configuration object. Settings vary by type.",
 				MarkdownDescription: "Configuration object. Settings vary by type.",
 				Validators: []validator.Dynamic{
-					morpheusvalidators.ValidObjectMap(),
+					validators.ValidObjectMap(),
+					dynamicvalidator.AtLeastOneOf(path.Expressions{path.MatchRoot("config"), path.MatchRoot("config_hvm"), path.MatchRoot("config_vmware")}...),
+					dynamicvalidator.ConflictsWith(path.Expressions{path.MatchRoot("config_hvm"), path.MatchRoot("config_vmware")}...),
+				},
+			},
+			"config_hvm": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"create_user": schema.BoolAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Whether to create a user when provisioning the instance.  The default is 'false'",
+						MarkdownDescription: "Whether to create a user when provisioning the instance.  The default is 'false'",
+						Default:             booldefault.StaticBool(false),
+					},
+					"kvm_host_id": schema.Int64Attribute{
+						Optional:            true,
+						Description:         "The id of the KVM host to use for provisioning.",
+						MarkdownDescription: "The id of the KVM host to use for provisioning.",
+					},
+					"nested_virtualization": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Enable nested virtualization on the instance. Can be 'on' or 'off'. The default is 'off'.",
+						MarkdownDescription: "Enable nested virtualization on the instance. Can be 'on' or 'off'. The default is 'off'.",
+						Validators: []validator.String{
+							stringvalidator.OneOf("on", "off"),
+						},
+						Default: stringdefault.StaticString("off"),
+					},
+					"no_agent": schema.BoolAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Whether to skip installing the Morpheus agent on the instance.  The default is 'true'",
+						MarkdownDescription: "Whether to skip installing the Morpheus agent on the instance.  The default is 'true'",
+						Default:             booldefault.StaticBool(true),
+					},
+					"resource_pool_id": schema.StringAttribute{
+						Required:            true,
+						Description:         "The id of the resource group to be used, can be prefixed with 'pool-'.  A resource pool group can be specified instead by prefixing its ID wih 'poolGroup-'.",
+						MarkdownDescription: "The id of the resource group to be used, can be prefixed with 'pool-'.  A resource pool group can be specified instead by prefixing its ID wih 'poolGroup-'.",
+					},
+				},
+				CustomType: ConfigHvmType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigHvmValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Description:         "Configuration options for HVM instances.",
+				MarkdownDescription: "Configuration options for HVM instances.",
+				Validators: []validator.Object{
+					objectvalidator.ConflictsWith(path.Expressions{path.MatchRoot("config"), path.MatchRoot("config_vmware")}...),
+				},
+			},
+			"config_vmware": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"create_user": schema.BoolAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Whether to create a user when provisioning the instance.  The default is 'false'",
+						MarkdownDescription: "Whether to create a user when provisioning the instance.  The default is 'false'",
+						Default:             booldefault.StaticBool(false),
+					},
+					"nested_virtualization": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Enable nested virtualization on the instance. Can be 'on' or 'off'. The default is 'off'.",
+						MarkdownDescription: "Enable nested virtualization on the instance. Can be 'on' or 'off'. The default is 'off'.",
+						Validators: []validator.String{
+							stringvalidator.OneOf("on", "off"),
+						},
+						Default: stringdefault.StaticString("off"),
+					},
+					"no_agent": schema.BoolAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Whether to skip installing the Morpheus agent on the instance.  The default is 'true'",
+						MarkdownDescription: "Whether to skip installing the Morpheus agent on the instance.  The default is 'true'",
+						Default:             booldefault.StaticBool(true),
+					},
+					"resource_pool_id": schema.StringAttribute{
+						Required:            true,
+						Description:         "The id of the resource group to be used, can be prefixed with 'pool-'.  A resource pool group can be specified instead by prefixing its ID wih 'poolGroup-'.",
+						MarkdownDescription: "The id of the resource group to be used, can be prefixed with 'pool-'.  A resource pool group can be specified instead by prefixing its ID wih 'poolGroup-'.",
+					},
+					"vmware_folder_id": schema.StringAttribute{
+						Required:            true,
+						Description:         "VMware folder external ID.",
+						MarkdownDescription: "VMware folder external ID.",
+					},
+				},
+				CustomType: ConfigVmwareType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ConfigVmwareValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Description:         "Configuration options for VMware instances.",
+				MarkdownDescription: "Configuration options for VMware instances.",
+				Validators: []validator.Object{
+					objectvalidator.ConflictsWith(path.Expressions{path.MatchRoot("config"), path.MatchRoot("config_hvm")}...),
 				},
 			},
 			"connection_info": schema.ListAttribute{
@@ -502,24 +604,1130 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type InstanceModel struct {
-	CloudId           types.Int64    `tfsdk:"cloud_id"`
-	Config            types.Dynamic  `tfsdk:"config"`
-	ConnectionInfo    types.List     `tfsdk:"connection_info"`
-	Evars             types.Set      `tfsdk:"evars"`
-	GroupId           types.Int64    `tfsdk:"group_id"`
-	Id                types.Int64    `tfsdk:"id"`
-	InstanceContext   types.String   `tfsdk:"instance_context"`
-	InstanceTypeId    types.Int64    `tfsdk:"instance_type_id"`
-	LayoutId          types.Int64    `tfsdk:"layout_id"`
-	LayoutSize        types.Int64    `tfsdk:"layout_size"`
-	Name              types.String   `tfsdk:"name"`
-	NetworkInterfaces types.List     `tfsdk:"network_interfaces"`
-	PlanId            types.Int64    `tfsdk:"plan_id"`
-	Ports             types.Set      `tfsdk:"ports"`
-	Tags              types.Set      `tfsdk:"tags"`
-	TaskSetId         types.Int64    `tfsdk:"task_set_id"`
-	Timeouts          timeouts.Value `tfsdk:"timeouts"`
-	Volumes           types.List     `tfsdk:"volumes"`
+	CloudId           types.Int64       `tfsdk:"cloud_id"`
+	Config            types.Dynamic     `tfsdk:"config"`
+	ConfigHvm         ConfigHvmValue    `tfsdk:"config_hvm"`
+	ConfigVmware      ConfigVmwareValue `tfsdk:"config_vmware"`
+	ConnectionInfo    types.List        `tfsdk:"connection_info"`
+	Evars             types.Set         `tfsdk:"evars"`
+	GroupId           types.Int64       `tfsdk:"group_id"`
+	Id                types.Int64       `tfsdk:"id"`
+	InstanceContext   types.String      `tfsdk:"instance_context"`
+	InstanceTypeId    types.Int64       `tfsdk:"instance_type_id"`
+	LayoutId          types.Int64       `tfsdk:"layout_id"`
+	LayoutSize        types.Int64       `tfsdk:"layout_size"`
+	Name              types.String      `tfsdk:"name"`
+	NetworkInterfaces types.List        `tfsdk:"network_interfaces"`
+	PlanId            types.Int64       `tfsdk:"plan_id"`
+	Ports             types.Set         `tfsdk:"ports"`
+	Tags              types.Set         `tfsdk:"tags"`
+	TaskSetId         types.Int64       `tfsdk:"task_set_id"`
+	Timeouts          timeouts.Value    `tfsdk:"timeouts"`
+	Volumes           types.List        `tfsdk:"volumes"`
+}
+
+var _ basetypes.ObjectTypable = ConfigHvmType{}
+
+type ConfigHvmType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigHvmType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigHvmType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigHvmType) String() string {
+	return "ConfigHvmType"
+}
+
+func (t ConfigHvmType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigHvmValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigHvmValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	createUserAttribute, ok := attributes["create_user"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_user is missing from object`)
+
+		return nil, diags
+	}
+
+	createUserVal, ok := createUserAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_user expected to be basetypes.BoolValue, was: %T`, createUserAttribute))
+	}
+
+	kvmHostIdAttribute, ok := attributes["kvm_host_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`kvm_host_id is missing from object`)
+
+		return nil, diags
+	}
+
+	kvmHostIdVal, ok := kvmHostIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`kvm_host_id expected to be basetypes.Int64Value, was: %T`, kvmHostIdAttribute))
+	}
+
+	nestedVirtualizationAttribute, ok := attributes["nested_virtualization"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`nested_virtualization is missing from object`)
+
+		return nil, diags
+	}
+
+	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`nested_virtualization expected to be basetypes.StringValue, was: %T`, nestedVirtualizationAttribute))
+	}
+
+	noAgentAttribute, ok := attributes["no_agent"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`no_agent is missing from object`)
+
+		return nil, diags
+	}
+
+	noAgentVal, ok := noAgentAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`no_agent expected to be basetypes.BoolValue, was: %T`, noAgentAttribute))
+	}
+
+	resourcePoolIdAttribute, ok := attributes["resource_pool_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`resource_pool_id is missing from object`)
+
+		return nil, diags
+	}
+
+	resourcePoolIdVal, ok := resourcePoolIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`resource_pool_id expected to be basetypes.StringValue, was: %T`, resourcePoolIdAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigHvmValue{
+		CreateUser:           createUserVal,
+		KvmHostId:            kvmHostIdVal,
+		NestedVirtualization: nestedVirtualizationVal,
+		NoAgent:              noAgentVal,
+		ResourcePoolId:       resourcePoolIdVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigHvmValueNull() ConfigHvmValue {
+	return ConfigHvmValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigHvmValueUnknown() ConfigHvmValue {
+	return ConfigHvmValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigHvmValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigHvmValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigHvmValue Attribute Value",
+				"While creating a ConfigHvmValue value, a missing attribute value was detected. "+
+					"A ConfigHvmValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigHvmValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigHvmValue Attribute Type",
+				"While creating a ConfigHvmValue value, an invalid attribute value was detected. "+
+					"A ConfigHvmValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigHvmValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigHvmValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigHvmValue Attribute Value",
+				"While creating a ConfigHvmValue value, an extra attribute value was detected. "+
+					"A ConfigHvmValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigHvmValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigHvmValueUnknown(), diags
+	}
+
+	createUserAttribute, ok := attributes["create_user"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_user is missing from object`)
+
+		return NewConfigHvmValueUnknown(), diags
+	}
+
+	createUserVal, ok := createUserAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_user expected to be basetypes.BoolValue, was: %T`, createUserAttribute))
+	}
+
+	kvmHostIdAttribute, ok := attributes["kvm_host_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`kvm_host_id is missing from object`)
+
+		return NewConfigHvmValueUnknown(), diags
+	}
+
+	kvmHostIdVal, ok := kvmHostIdAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`kvm_host_id expected to be basetypes.Int64Value, was: %T`, kvmHostIdAttribute))
+	}
+
+	nestedVirtualizationAttribute, ok := attributes["nested_virtualization"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`nested_virtualization is missing from object`)
+
+		return NewConfigHvmValueUnknown(), diags
+	}
+
+	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`nested_virtualization expected to be basetypes.StringValue, was: %T`, nestedVirtualizationAttribute))
+	}
+
+	noAgentAttribute, ok := attributes["no_agent"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`no_agent is missing from object`)
+
+		return NewConfigHvmValueUnknown(), diags
+	}
+
+	noAgentVal, ok := noAgentAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`no_agent expected to be basetypes.BoolValue, was: %T`, noAgentAttribute))
+	}
+
+	resourcePoolIdAttribute, ok := attributes["resource_pool_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`resource_pool_id is missing from object`)
+
+		return NewConfigHvmValueUnknown(), diags
+	}
+
+	resourcePoolIdVal, ok := resourcePoolIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`resource_pool_id expected to be basetypes.StringValue, was: %T`, resourcePoolIdAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigHvmValueUnknown(), diags
+	}
+
+	return ConfigHvmValue{
+		CreateUser:           createUserVal,
+		KvmHostId:            kvmHostIdVal,
+		NestedVirtualization: nestedVirtualizationVal,
+		NoAgent:              noAgentVal,
+		ResourcePoolId:       resourcePoolIdVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigHvmValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigHvmValue {
+	object, diags := NewConfigHvmValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigHvmValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigHvmType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigHvmValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigHvmValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigHvmValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigHvmValueMust(ConfigHvmValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigHvmType) ValueType(ctx context.Context) attr.Value {
+	return ConfigHvmValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigHvmValue{}
+
+type ConfigHvmValue struct {
+	CreateUser           basetypes.BoolValue   `tfsdk:"create_user"`
+	KvmHostId            basetypes.Int64Value  `tfsdk:"kvm_host_id"`
+	NestedVirtualization basetypes.StringValue `tfsdk:"nested_virtualization"`
+	NoAgent              basetypes.BoolValue   `tfsdk:"no_agent"`
+	ResourcePoolId       basetypes.StringValue `tfsdk:"resource_pool_id"`
+	state                attr.ValueState
+}
+
+func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 5)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["create_user"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["kvm_host_id"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["nested_virtualization"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["no_agent"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["resource_pool_id"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 5)
+
+		val, err = v.CreateUser.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["create_user"] = val
+
+		val, err = v.KvmHostId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["kvm_host_id"] = val
+
+		val, err = v.NestedVirtualization.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["nested_virtualization"] = val
+
+		val, err = v.NoAgent.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["no_agent"] = val
+
+		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["resource_pool_id"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigHvmValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigHvmValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigHvmValue) String() string {
+	return "ConfigHvmValue"
+}
+
+func (v ConfigHvmValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"create_user":           basetypes.BoolType{},
+		"kvm_host_id":           basetypes.Int64Type{},
+		"nested_virtualization": basetypes.StringType{},
+		"no_agent":              basetypes.BoolType{},
+		"resource_pool_id":      basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"create_user":           v.CreateUser,
+			"kvm_host_id":           v.KvmHostId,
+			"nested_virtualization": v.NestedVirtualization,
+			"no_agent":              v.NoAgent,
+			"resource_pool_id":      v.ResourcePoolId,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigHvmValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigHvmValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.CreateUser.Equal(other.CreateUser) {
+		return false
+	}
+
+	if !v.KvmHostId.Equal(other.KvmHostId) {
+		return false
+	}
+
+	if !v.NestedVirtualization.Equal(other.NestedVirtualization) {
+		return false
+	}
+
+	if !v.NoAgent.Equal(other.NoAgent) {
+		return false
+	}
+
+	if !v.ResourcePoolId.Equal(other.ResourcePoolId) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigHvmValue) Type(ctx context.Context) attr.Type {
+	return ConfigHvmType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigHvmValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"create_user":           basetypes.BoolType{},
+		"kvm_host_id":           basetypes.Int64Type{},
+		"nested_virtualization": basetypes.StringType{},
+		"no_agent":              basetypes.BoolType{},
+		"resource_pool_id":      basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = ConfigVmwareType{}
+
+type ConfigVmwareType struct {
+	basetypes.ObjectType
+}
+
+func (t ConfigVmwareType) Equal(o attr.Type) bool {
+	other, ok := o.(ConfigVmwareType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ConfigVmwareType) String() string {
+	return "ConfigVmwareType"
+}
+
+func (t ConfigVmwareType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewConfigVmwareValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigVmwareValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	createUserAttribute, ok := attributes["create_user"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_user is missing from object`)
+
+		return nil, diags
+	}
+
+	createUserVal, ok := createUserAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_user expected to be basetypes.BoolValue, was: %T`, createUserAttribute))
+	}
+
+	nestedVirtualizationAttribute, ok := attributes["nested_virtualization"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`nested_virtualization is missing from object`)
+
+		return nil, diags
+	}
+
+	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`nested_virtualization expected to be basetypes.StringValue, was: %T`, nestedVirtualizationAttribute))
+	}
+
+	noAgentAttribute, ok := attributes["no_agent"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`no_agent is missing from object`)
+
+		return nil, diags
+	}
+
+	noAgentVal, ok := noAgentAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`no_agent expected to be basetypes.BoolValue, was: %T`, noAgentAttribute))
+	}
+
+	resourcePoolIdAttribute, ok := attributes["resource_pool_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`resource_pool_id is missing from object`)
+
+		return nil, diags
+	}
+
+	resourcePoolIdVal, ok := resourcePoolIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`resource_pool_id expected to be basetypes.StringValue, was: %T`, resourcePoolIdAttribute))
+	}
+
+	vmwareFolderIdAttribute, ok := attributes["vmware_folder_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`vmware_folder_id is missing from object`)
+
+		return nil, diags
+	}
+
+	vmwareFolderIdVal, ok := vmwareFolderIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`vmware_folder_id expected to be basetypes.StringValue, was: %T`, vmwareFolderIdAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ConfigVmwareValue{
+		CreateUser:           createUserVal,
+		NestedVirtualization: nestedVirtualizationVal,
+		NoAgent:              noAgentVal,
+		ResourcePoolId:       resourcePoolIdVal,
+		VmwareFolderId:       vmwareFolderIdVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigVmwareValueNull() ConfigVmwareValue {
+	return ConfigVmwareValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewConfigVmwareValueUnknown() ConfigVmwareValue {
+	return ConfigVmwareValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewConfigVmwareValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ConfigVmwareValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ConfigVmwareValue Attribute Value",
+				"While creating a ConfigVmwareValue value, a missing attribute value was detected. "+
+					"A ConfigVmwareValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigVmwareValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ConfigVmwareValue Attribute Type",
+				"While creating a ConfigVmwareValue value, an invalid attribute value was detected. "+
+					"A ConfigVmwareValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ConfigVmwareValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ConfigVmwareValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ConfigVmwareValue Attribute Value",
+				"While creating a ConfigVmwareValue value, an extra attribute value was detected. "+
+					"A ConfigVmwareValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ConfigVmwareValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewConfigVmwareValueUnknown(), diags
+	}
+
+	createUserAttribute, ok := attributes["create_user"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`create_user is missing from object`)
+
+		return NewConfigVmwareValueUnknown(), diags
+	}
+
+	createUserVal, ok := createUserAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`create_user expected to be basetypes.BoolValue, was: %T`, createUserAttribute))
+	}
+
+	nestedVirtualizationAttribute, ok := attributes["nested_virtualization"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`nested_virtualization is missing from object`)
+
+		return NewConfigVmwareValueUnknown(), diags
+	}
+
+	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`nested_virtualization expected to be basetypes.StringValue, was: %T`, nestedVirtualizationAttribute))
+	}
+
+	noAgentAttribute, ok := attributes["no_agent"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`no_agent is missing from object`)
+
+		return NewConfigVmwareValueUnknown(), diags
+	}
+
+	noAgentVal, ok := noAgentAttribute.(basetypes.BoolValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`no_agent expected to be basetypes.BoolValue, was: %T`, noAgentAttribute))
+	}
+
+	resourcePoolIdAttribute, ok := attributes["resource_pool_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`resource_pool_id is missing from object`)
+
+		return NewConfigVmwareValueUnknown(), diags
+	}
+
+	resourcePoolIdVal, ok := resourcePoolIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`resource_pool_id expected to be basetypes.StringValue, was: %T`, resourcePoolIdAttribute))
+	}
+
+	vmwareFolderIdAttribute, ok := attributes["vmware_folder_id"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`vmware_folder_id is missing from object`)
+
+		return NewConfigVmwareValueUnknown(), diags
+	}
+
+	vmwareFolderIdVal, ok := vmwareFolderIdAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`vmware_folder_id expected to be basetypes.StringValue, was: %T`, vmwareFolderIdAttribute))
+	}
+
+	if diags.HasError() {
+		return NewConfigVmwareValueUnknown(), diags
+	}
+
+	return ConfigVmwareValue{
+		CreateUser:           createUserVal,
+		NestedVirtualization: nestedVirtualizationVal,
+		NoAgent:              noAgentVal,
+		ResourcePoolId:       resourcePoolIdVal,
+		VmwareFolderId:       vmwareFolderIdVal,
+		state:                attr.ValueStateKnown,
+	}, diags
+}
+
+func NewConfigVmwareValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ConfigVmwareValue {
+	object, diags := NewConfigVmwareValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewConfigVmwareValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ConfigVmwareType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewConfigVmwareValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewConfigVmwareValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewConfigVmwareValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewConfigVmwareValueMust(ConfigVmwareValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ConfigVmwareType) ValueType(ctx context.Context) attr.Value {
+	return ConfigVmwareValue{}
+}
+
+var _ basetypes.ObjectValuable = ConfigVmwareValue{}
+
+type ConfigVmwareValue struct {
+	CreateUser           basetypes.BoolValue   `tfsdk:"create_user"`
+	NestedVirtualization basetypes.StringValue `tfsdk:"nested_virtualization"`
+	NoAgent              basetypes.BoolValue   `tfsdk:"no_agent"`
+	ResourcePoolId       basetypes.StringValue `tfsdk:"resource_pool_id"`
+	VmwareFolderId       basetypes.StringValue `tfsdk:"vmware_folder_id"`
+	state                attr.ValueState
+}
+
+func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 5)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["create_user"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["nested_virtualization"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["no_agent"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["resource_pool_id"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["vmware_folder_id"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 5)
+
+		val, err = v.CreateUser.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["create_user"] = val
+
+		val, err = v.NestedVirtualization.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["nested_virtualization"] = val
+
+		val, err = v.NoAgent.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["no_agent"] = val
+
+		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["resource_pool_id"] = val
+
+		val, err = v.VmwareFolderId.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["vmware_folder_id"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ConfigVmwareValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ConfigVmwareValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ConfigVmwareValue) String() string {
+	return "ConfigVmwareValue"
+}
+
+func (v ConfigVmwareValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"create_user":           basetypes.BoolType{},
+		"nested_virtualization": basetypes.StringType{},
+		"no_agent":              basetypes.BoolType{},
+		"resource_pool_id":      basetypes.StringType{},
+		"vmware_folder_id":      basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"create_user":           v.CreateUser,
+			"nested_virtualization": v.NestedVirtualization,
+			"no_agent":              v.NoAgent,
+			"resource_pool_id":      v.ResourcePoolId,
+			"vmware_folder_id":      v.VmwareFolderId,
+		})
+
+	return objVal, diags
+}
+
+func (v ConfigVmwareValue) Equal(o attr.Value) bool {
+	other, ok := o.(ConfigVmwareValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.CreateUser.Equal(other.CreateUser) {
+		return false
+	}
+
+	if !v.NestedVirtualization.Equal(other.NestedVirtualization) {
+		return false
+	}
+
+	if !v.NoAgent.Equal(other.NoAgent) {
+		return false
+	}
+
+	if !v.ResourcePoolId.Equal(other.ResourcePoolId) {
+		return false
+	}
+
+	if !v.VmwareFolderId.Equal(other.VmwareFolderId) {
+		return false
+	}
+
+	return true
+}
+
+func (v ConfigVmwareValue) Type(ctx context.Context) attr.Type {
+	return ConfigVmwareType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ConfigVmwareValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"create_user":           basetypes.BoolType{},
+		"nested_virtualization": basetypes.StringType{},
+		"no_agent":              basetypes.BoolType{},
+		"resource_pool_id":      basetypes.StringType{},
+		"vmware_folder_id":      basetypes.StringType{},
+	}
 }
 
 var _ basetypes.ObjectTypable = EvarsType{}

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -12,7 +12,10 @@ Instance is a virtual machine, bare metal machine or container deployed and mana
 Morpheus oversees its entire lifecycle, from initial provisioning to scaling, 
 monitoring, and eventual decommissioning.
 
--> Currently HVM, VMware and BMaaS instances are supported. Some general issues<br>
+-> Currently HVM, VMware and BMaaS instances are supported.  We have static `config` schema for the following:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- HVM: `config_hvm`<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- VMware: `config_vmware`<br><br>
+Some general issues<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- With Morpheus versions prior to 8.0.11, make sure the root volume is the first defined.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- The addition and removal of volumes is not supported during updates.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Updates fail when removing optional fields.<br>
@@ -39,9 +42,9 @@ When creating an instance with network bonding and/or LAGs we cannot reconcile t
 with the HCL supplied.  In these cases the `connection_info` section will contain IP address(es).  To access the full
 network configuration use the `hpe_morpheus_instance` `data-source` to read back the created instance.
 
--> The following examples all have the following settings in their `config` blocks:<br>
-&nbsp;&nbsp;&nbsp;&nbsp;- `noAgent` is set to `false`<br>
-&nbsp;&nbsp;&nbsp;&nbsp;- `createUser` is set to `true`<br><br>
+-> Some of the examples below have the following settings in their `config` blocks:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- `no_agent` in static config (equivalent to `noAgent` in dynamic config) is set to `true`<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- `create_user` in static config (equivalent to `createUser` in dynamic config) is set to `false`<br><br>
 These settings can be changed as required.
 
 ## HVM Instance


### PR DESCRIPTION
In this PR we add instance resource static config for HVM and VMware. We've modified instance_create.go to use these new static config and modified instance_read.go to create examples of each as appropriate when importing an existing instance.  We've updated the docs.