### PR TITLE
Update instance destroy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ linters:
       rules:
         - name: var-naming
           # Suppress warnings about Id "initialism" - i.e. make Id and ID valid
-          arguments: [ [ "ID", "URL", "API" ] ]
+          arguments: [ [ "ID", "URL", "API", "IDS" ] ]
   exclusions:
     generated: lax
     presets:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e34cd02e9
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.19.0
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.22.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,12 @@ github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e3
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e34cd02e9/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.19.0 h1:ALB2/ALXWYRLugETeuYi4zRy9KWvXjlQtuSrCmUnNYE=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.19.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.20.0 h1:2yuoExxhYMuY2dCWiMydpAd3aJtfIvXB8m0yIEYRiug=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.20.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.21.0 h1:7zM9mD+tJ6x4VLfhCVCLKvUYPQ+lFEWB4mQ4jdA3tgM=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.21.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.22.0 h1:+3H1grRRR7V1Vi0jIl5IdUhSM5knZVT+/XsFRWGJ2jM=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.22.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=

--- a/morpheus/framework/resources/instance/instance_delete.go
+++ b/morpheus/framework/resources/instance/instance_delete.go
@@ -24,6 +24,13 @@ var DeleteErrorStatuses = []string{
 	"restoring",
 }
 
+var StopErrorStatuses = []string{
+	"denied",
+	"cancelled",
+	"failed",
+	"restoring",
+}
+
 // Delete implements resource.Resource.
 func (g *Resource) Delete(
 	ctx context.Context,
@@ -40,6 +47,7 @@ func (g *Resource) Delete(
 	// Get timeout from HCL if set, the default is 45 minutes
 	deleteTimeout, diags := data.Timeouts.Delete(ctx, 45*time.Minute)
 	resp.Diagnostics.Append(diags...)
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -55,16 +63,190 @@ func (g *Resource) Delete(
 		return
 	}
 
-	deleteReq := client.InstancesAPI.DeleteInstance(ctx, id.ValueInt64()).Force("on").
-		RemoveVolumes("on").ReleaseEIPs("on").ReleaseFloatingIps("on")
-	_, hresp, err := deleteReq.Execute()
-	if err != nil || hresp.StatusCode != http.StatusOK {
+	// Get instance
+	ret, hresp, err := client.InstancesAPI.GetInstance(ctx, id.ValueInt64()).Execute()
+	if err != nil {
+		if hresp == nil || hresp.StatusCode != http.StatusNotFound {
+			resp.Diagnostics.AddError(
+				"delete instance resource",
+				fmt.Sprintf("instance %d: GET failed ", id)+errfmt.ErrMsg(err, hresp),
+			)
+		}
+
+		return
+	}
+
+	instance, ok := ret.GetInstanceOk()
+	if !ok || instance == nil {
 		resp.Diagnostics.AddError(
 			"delete instance resource",
-			fmt.Sprintf("instance %d: DELETE failed ", id)+errfmt.ErrMsg(err, hresp),
+			fmt.Sprintf("instance %d: GET returned empty instance", id),
 		)
 
 		return
+	}
+
+	// Get serverId(s).  At the moment we only support a single server per instance, but we'll loop just in case
+	containers, ok := instance.GetContainerDetailsOk()
+	if !ok || containers == nil {
+		resp.Diagnostics.AddError(
+			"delete instance resource",
+			fmt.Sprintf("instance %d: GET returned empty containers", id),
+		)
+
+		return
+	}
+
+	serverIds := make([]int64, 0)
+	for _, container := range containers {
+		server, ok := container.GetServerOk()
+		if !ok || server == nil {
+			resp.Diagnostics.AddError(
+				"delete instance resource",
+				fmt.Sprintf("instance %d: GET returned empty server in container", id),
+			)
+
+			return
+		}
+
+		serverId, ok := server.GetIdOk()
+		if !ok || serverId == nil {
+			resp.Diagnostics.AddError(
+				"delete instance resource",
+				fmt.Sprintf("instance %d: GET returned empty server ID in container", id),
+			)
+
+			return
+		}
+
+		serverIds = append(serverIds, *serverId)
+	}
+
+	// Stop the server(s) if they are not already stopped, otherwise we cannot delete them
+	for _, serverId := range serverIds {
+		stopReq := client.HostsAPI.StopHost(ctx, serverId)
+		_, hresp, err := stopReq.Execute()
+		if err != nil || (hresp.StatusCode != http.StatusOK && hresp.StatusCode != http.StatusConflict) {
+			resp.Diagnostics.AddError(
+				"delete instance resource",
+				fmt.Sprintf("instance %d: failed to stop server %d before delete ", id, serverId)+errfmt.ErrMsg(err, hresp),
+			)
+
+			return
+		}
+
+		waitForStopped := func() (*sdk.GetHost200Response, error) {
+			resp, hresp, err := client.HostsAPI.GetHost(ctx, serverId).Execute()
+			if err != nil {
+				if hresp == nil || hresp.StatusCode != http.StatusNotFound {
+					return nil, backoff.Permanent(err)
+				}
+			}
+
+			server, ok := resp.GetServerOk()
+			if !ok || server == nil {
+				return nil, backoff.Permanent(fmt.Errorf("instance %d: GET server %d returned empty server", id, serverId))
+			}
+
+			status, ok := server.GetStatusOk()
+			if !ok || status == nil {
+				return nil, backoff.Permanent(fmt.Errorf("instance %d: GET server %d returned empty status", id, serverId))
+			}
+
+			return resp, checkStatusDone(
+				*status,
+				[]string{"provisioned", "stopped"},
+				StopErrorStatuses,
+			)
+		}
+
+		if _, err := backoff.Retry(
+			ctx,
+			waitForStopped,
+			backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)),
+			backoff.WithMaxElapsedTime(deleteTimeout),
+		); err != nil {
+			resp.Diagnostics.AddError(
+				"delete instance resource",
+				fmt.Sprintf("instance %d: failed to stop server %d before delete ", id, serverId)+err.Error(),
+			)
+
+			return
+		}
+	}
+
+	// Delete the server(s) associated with the instance.
+	for _, serverId := range serverIds {
+		deleteServerReq := client.HostsAPI.RemoveHost(ctx, serverId).Force("on").
+			RemoveResources("on").RemoveInstances("on")
+		_, hresp, err := deleteServerReq.Execute()
+		if err != nil || hresp.StatusCode != http.StatusOK {
+			resp.Diagnostics.AddError(
+				"delete instance resource",
+				fmt.Sprintf("instance %d: DELETE server %d failed ", id, serverId)+errfmt.ErrMsg(err, hresp),
+			)
+
+			return
+		}
+
+		waitForServerDeleted := func() (*sdk.GetHost200Response, error) {
+			resp, hresp, err := client.HostsAPI.GetHost(ctx, serverId).Execute()
+			if err != nil {
+				if hresp == nil || hresp.StatusCode != http.StatusNotFound {
+					return nil, backoff.Permanent(err)
+				}
+			}
+
+			// 404 status code counts as a successful delete
+			if hresp.StatusCode == http.StatusNotFound {
+				return nil, nil
+			}
+
+			server, ok := resp.GetServerOk()
+			if !ok || server == nil {
+				return nil, backoff.Permanent(fmt.Errorf("instance %d: GET server %d returned empty server", id, serverId))
+			}
+
+			status, ok := server.GetStatusOk()
+			if !ok || status == nil {
+				return nil, backoff.Permanent(fmt.Errorf("instance %d: GET server %d returned empty status", id, serverId))
+			}
+
+			return resp, checkStatusDone(
+				*status,
+				nil,
+				StopErrorStatuses,
+			)
+		}
+
+		if _, err := backoff.Retry(
+			ctx,
+			waitForServerDeleted,
+			backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)),
+			backoff.WithMaxElapsedTime(deleteTimeout),
+		); err != nil {
+			resp.Diagnostics.AddError(
+				"delete instance resource",
+				fmt.Sprintf("instance %d: DELETE server %d failed ", id, serverId)+err.Error(),
+			)
+
+			return
+		}
+	}
+
+	// If we get here, all servers have been deleted successfully.  Now we can delete the instance itself.
+	deleteReq := client.InstancesAPI.DeleteInstance(ctx, id.ValueInt64()).Force("on").
+		RemoveVolumes("on").ReleaseEIPs("on").ReleaseFloatingIps("on")
+	_, hresp, err = deleteReq.Execute()
+	if err != nil {
+		if hresp == nil || (hresp.StatusCode != http.StatusOK && hresp.StatusCode != http.StatusNotFound) {
+			resp.Diagnostics.AddError(
+				"delete instance resource",
+				fmt.Sprintf("instance %d: DELETE failed ", id)+errfmt.ErrMsg(err, hresp),
+			)
+
+			return
+		}
 	}
 
 	waitForDeleted := func() (*sdk.GetInstance200Response, error) {

--- a/morpheus/framework/resources/instance/sweep.go
+++ b/morpheus/framework/resources/instance/sweep.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
 package instance
 
@@ -125,17 +125,80 @@ func (s *instanceSweeper) Sweep(_ string) error {
 
 		log.Printf("[INFO] Sweeping instance: %s (id: %d)", *name, *id)
 
-		// Delete the instance
-		_, hresp, err = s.client.InstancesAPI.DeleteInstance(ctx, *id).Execute()
-		if err != nil || hresp.StatusCode != http.StatusOK {
+		// Get serverId(s).  At the moment we only support a single server per instance, but we'll loop just in case
+		containers, ok := instance.GetContainerDetailsOk()
+		if !ok || containers == nil {
 			errMsg := fmt.Sprintf(
-				"failed to delete instance %s (id: %d): %s",
-				*name, *id, errfmt.ErrMsg(err, hresp),
+				"failed to delete instance %s (id: %d): failed to get container details",
+				*name, *id,
 			)
 			log.Printf("[ERROR] %s", errMsg)
 			sweepErrors = append(sweepErrors, errMsg)
 
 			continue
+		}
+
+		serverIds := make([]int64, 0)
+		for _, container := range containers {
+			server, ok := container.GetServerOk()
+			if !ok || server == nil {
+				errMsg := fmt.Sprintf(
+					"failed to delete instance %s (id: %d): failed to get server details from container",
+					*name, *id,
+				)
+				log.Printf("[ERROR] %s", errMsg)
+				sweepErrors = append(sweepErrors, errMsg)
+
+				continue
+			}
+
+			serverId, ok := server.GetIdOk()
+			if !ok || serverId == nil {
+
+				errMsg := fmt.Sprintf(
+					"failed to delete instance %s (id: %d): failed to get server ID from container",
+					*name, *id,
+				)
+				log.Printf("[ERROR] %s", errMsg)
+				sweepErrors = append(sweepErrors, errMsg)
+
+				continue
+			}
+
+			serverIds = append(serverIds, *serverId)
+		}
+
+		// Stop the server(s) if they are not already stopped, otherwise we cannot delete them
+		for _, serverId := range serverIds {
+			stopReq := s.client.HostsAPI.StopHost(ctx, serverId)
+			_, hresp, err := stopReq.Execute()
+			if err != nil || (hresp.StatusCode != http.StatusOK && hresp.StatusCode != http.StatusConflict) {
+				errMsg := fmt.Sprintf(
+					"failed to delete instance %s (id: %d): %s",
+					*name, *id, errfmt.ErrMsg(err, hresp),
+				)
+				log.Printf("[ERROR] %s", errMsg)
+				sweepErrors = append(sweepErrors, errMsg)
+
+				continue
+			}
+		}
+
+		// Delete the server(s) associated with the instance.
+		for _, serverId := range serverIds {
+			deleteServerReq := s.client.HostsAPI.RemoveHost(ctx, serverId).Force("on").
+				RemoveResources("on").RemoveInstances("on")
+			_, hresp, err := deleteServerReq.Execute()
+			if err != nil || hresp.StatusCode != http.StatusOK {
+				errMsg := fmt.Sprintf(
+					"failed to delete instance %s (id: %d): %s",
+					*name, *id, errfmt.ErrMsg(err, hresp),
+				)
+				log.Printf("[ERROR] %s", errMsg)
+				sweepErrors = append(sweepErrors, errMsg)
+
+				continue
+			}
 		}
 
 		sweptCount++


### PR DESCRIPTION
In this PR we update instance destroy to:
- get a list of instance containers, note that at the moment we only allow one container on creation
- get a list of the associated server ids
- stop those servers
- force delete of the servers

Before trying to delete the instance.  This is to circumvent issues that we see periodically with instance delete failing.

We also update the sweeper to do the above and remove the call to delete the actual instance - it should be deleted automatically by Morpheus.