### PR TITLE
Instance update and addition of service_plan_options

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -17,9 +17,10 @@ monitoring, and eventual decommissioning.
 &nbsp;&nbsp;&nbsp;&nbsp;- VMware: `config_vmware`<br><br>
 Some general issues<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- With Morpheus versions prior to 8.0.11, make sure the root volume is the first defined.<br>
-&nbsp;&nbsp;&nbsp;&nbsp;- The addition and removal of volumes is not supported during updates.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Updates fail when removing optional fields.<br>
-&nbsp;&nbsp;&nbsp;&nbsp;- Updates fail when removing `evars`.<br><br>
+&nbsp;&nbsp;&nbsp;&nbsp;- Updates fail when removing `evars`.<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- Updates to `service_plan_options` for service plans that allow the setting of options<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  will fail silently.<br><br>
 These will be addressed in a future release.
 
 -> Some general notes:<br><br>
@@ -35,6 +36,11 @@ If the `timeouts` settings are changed in HCL an
 `Update` will be triggered.  If the only change detected is for `timeouts` then the State will be updated with
 the new settings but no `Morpheus` `Update` API calls will be made.  The default timeout for `create`, `delete`
 `read` and `update` is 45 minutes.<br><br>
+**Update** is supported but has some limitations at the moment.  The addition and removal of volumes is supported
+during update. Existing volumes can have their size increased but not decreased.  **Do not** change the order of
+volumes in HCL.  Network interface changes will result in instance recreation.  Updates fail when removing optional
+fields or `evars`. Updates to `service_plan_options` for service plans that support the setting of options will
+fail silently.<br><br>
 We've added a `connection_info` section (read-only) which contains the IP address(es) by which the instance
 can be accessed<br><br>
 The `datastore_auto_selection` attribute is not supported for BMaaS instances.<br><br>
@@ -399,6 +405,104 @@ resource "hpe_morpheus_instance" "example" {
 }
 ```
 
+## VMware VM Instance with Service Plan Options
+
+Some Service Plans have options that must be set at the time of creation of the instance.
+
+```terraform
+data "hpe_morpheus_cloud" "vmware_cloud" {
+  name = "QA VMware"
+}
+
+data "hpe_morpheus_service_plan" "vmware_512mb" {
+  name                = "1 CPU, 1GB Memory"
+  provision_type_code = "vmware"
+}
+
+data "hpe_morpheus_instance_type_layout" "vmware" {
+  name    = "VMware VM"
+  version = "22.04"
+}
+
+resource "hpe_morpheus_instance" "example" {
+  name             = "TestInstance"
+  cloud_id         = data.hpe_morpheus_cloud.vmware_cloud.id
+  layout_id        = data.hpe_morpheus_instance_type_layout.vmware.id
+  instance_type_id = 9
+
+  group_id = 28
+  plan_id  = data.hpe_morpheus_service_plan.vmware_512mb.id
+
+  instance_context = "dev"
+  network_interfaces = [
+    {
+      network_id = 86657
+    }
+  ]
+
+  service_plan_options = {
+    max_cores = 2
+    max_memory = 2048
+  }
+
+  volumes = [
+    {
+      root_volume              = true
+      name                     = "root"
+      size                     = 10
+      storage_type_id          = 1
+      datastore_auto_selection = "auto"
+    },
+    {
+      root_volume              = false
+      name                     = "data"
+      size                     = 10
+      storage_type_id          = 1
+      datastore_auto_selection = "auto"
+    }
+  ]
+
+  tags = [
+    {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
+      name  = "managed_by"
+      value = "terraform"
+    }
+  ]
+
+  config_vmware = {
+    resource_pool_id      = "pool-1"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
+    vmware_folder_id      = "group-v79"
+  }
+
+  timeouts = {
+    create = "1h"
+    delete = "20m"
+    update = "20m"
+    read   = "10m"
+  }
+}
+```
+
+
 ## BMaaS Instance
 
 -> Note that Morpheus version `8.0.13` or later is required for BMaaS instance support.
@@ -541,6 +645,7 @@ The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" ca
 - `ports` (Attributes Set) The ports parameter is for port configuration.
 
 The layout may have default ports, which are defined in node types, that are always configured. This parameter will be for additional custom ports to be opened. (see [below for nested schema](#nestedatt--ports))
+- `service_plan_options` (Attributes) Custom options for selected service plan - the supported options depend on the service plan selected (see [below for nested schema](#nestedatt--service_plan_options))
 - `tags` (Attributes Set) Metadata tags, Array of objects having a name and value. (see [below for nested schema](#nestedatt--tags))
 - `task_set_id` (Number) The Workflow ID to execute.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
@@ -643,6 +748,16 @@ Optional:
 - `name` (String) A name for the port.
 
 
+<a id="nestedatt--service_plan_options"></a>
+### Nested Schema for `service_plan_options`
+
+Optional:
+
+- `cores_per_socket` (Number) The number of cores per socket to use for the instance.  This is only applicable for certain service plans.
+- `max_cores` (Number) The maximum number of cores to use for the instance.  This is only applicable for certain service plans.
+- `max_memory` (Number) The maximum amount of memory (in MB) to use for the instance.  This is only applicable for certain service plans.
+
+
 <a id="nestedatt--tags"></a>
 ### Nested Schema for `tags`
 
@@ -681,6 +796,8 @@ Use /api/provision-types?code=vmware to see the available controllerTypes for vm
 - `root_volume` (Boolean) If set to false then a non-root LV will be created.
 - `size` (Number) Size of the LV to be created in GBs.  Uses default from service plan.
 - `size_id` (Number) Can be used to select pre-existing LV choices from Morpheus.
+- `storage_profile` (String) Storage Profile Code for the volume storage profile assignment. eg. `"kvm-cache-none"` or `"kvm-cache-directsync"`.
+Use `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.
 - `storage_type_id` (Number) Identifier for LV type
 
 Read-Only:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e34cd02e9
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.25.0
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.26.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e3
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e34cd02e9/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.25.0 h1:MjviY2wvyyqrUR5EZ8Hu/dIforBBuD7Eq28xDtEgQI8=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.25.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.26.0 h1:SX+8pEvR2ySR/3WKwYitehBD6Ku38fEijdnFJcXfuwM=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.26.0/go.mod h1:hH79EA7VE9lwShyc9M4jii794SzNC24Guh0BKITV+Lc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=

--- a/morpheus/framework/resources/instance/example_vmware_sp_options.tf
+++ b/morpheus/framework/resources/instance/example_vmware_sp_options.tf
@@ -1,0 +1,90 @@
+data "hpe_morpheus_cloud" "vmware_cloud" {
+  name = "QA VMware"
+}
+
+data "hpe_morpheus_service_plan" "vmware_512mb" {
+  name                = "1 CPU, 1GB Memory"
+  provision_type_code = "vmware"
+}
+
+data "hpe_morpheus_instance_type_layout" "vmware" {
+  name    = "VMware VM"
+  version = "22.04"
+}
+
+resource "hpe_morpheus_instance" "example" {
+  name             = "TestInstance"
+  cloud_id         = data.hpe_morpheus_cloud.vmware_cloud.id
+  layout_id        = data.hpe_morpheus_instance_type_layout.vmware.id
+  instance_type_id = 9
+
+  group_id = 28
+  plan_id  = data.hpe_morpheus_service_plan.vmware_512mb.id
+
+  instance_context = "dev"
+  network_interfaces = [
+    {
+      network_id = 86657
+    }
+  ]
+
+  service_plan_options = {
+    max_cores = 2
+    max_memory = 2048
+  }
+
+  volumes = [
+    {
+      root_volume              = true
+      name                     = "root"
+      size                     = 10
+      storage_type_id          = 1
+      datastore_auto_selection = "auto"
+    },
+    {
+      root_volume              = false
+      name                     = "data"
+      size                     = 10
+      storage_type_id          = 1
+      datastore_auto_selection = "auto"
+    }
+  ]
+
+  tags = [
+    {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
+      name  = "managed_by"
+      value = "terraform"
+    }
+  ]
+
+  config_vmware = {
+    resource_pool_id      = "pool-1"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
+    vmware_folder_id      = "group-v79"
+  }
+
+  timeouts = {
+    create = "1h"
+    delete = "20m"
+    update = "20m"
+    read   = "10m"
+  }
+}

--- a/morpheus/framework/resources/instance/example_vmware_sp_options.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_vmware_sp_options.tf.tmpl
@@ -1,0 +1,90 @@
+data "hpe_morpheus_cloud" "vmware_cloud" {
+  name = "QA VMware"
+}
+
+data "hpe_morpheus_service_plan" "vmware_512mb" {
+  name                = "1 CPU, 1GB Memory"
+  provision_type_code = "vmware"
+}
+
+data "hpe_morpheus_instance_type_layout" "vmware" {
+  name    = "VMware VM"
+  version = "22.04"
+}
+
+resource "hpe_morpheus_instance" "example" {
+  name             = "{{.Name}}"
+  cloud_id         = data.hpe_morpheus_cloud.vmware_cloud.id
+  layout_id        = data.hpe_morpheus_instance_type_layout.vmware.id
+  instance_type_id = {{.InstanceType}}
+
+  group_id = 28
+  plan_id  = data.hpe_morpheus_service_plan.vmware_512mb.id
+
+  instance_context = "dev"
+  network_interfaces = [
+    {
+      network_id = 86657
+    }
+  ]
+
+  service_plan_options = {
+    max_cores = 2
+    max_memory = 2048
+  }
+
+  volumes = [
+    {
+      root_volume              = true
+      name                     = "root"
+      size                     = 10
+      storage_type_id          = 1
+      datastore_auto_selection = "auto"
+    },
+    {
+      root_volume              = false
+      name                     = "data"
+      size                     = 10
+      storage_type_id          = 1
+      datastore_auto_selection = "auto"
+    }
+  ]
+
+  tags = [
+    {
+      name  = "terraform"
+      value = "true"
+    },
+    {
+      name  = "acctest"
+      value = "true"
+    },
+    {
+      name  = "hpe_morpheus_instance"
+      value = "true"
+    },
+    {
+      name  = "sweepable"
+      value = "true"
+    },
+    {
+      name  = "managed_by"
+      value = "terraform"
+    }
+  ]
+
+  config_vmware = {
+    resource_pool_id      = "{{.ResourcePool}}"
+    nested_virtualization = "off"
+    no_agent              = true
+    create_user           = false
+    vmware_folder_id      = "group-v79"
+  }
+
+  timeouts = {
+    create = "1h"
+    delete = "20m"
+    update = "20m"
+    read   = "10m"
+  }
+}

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -241,6 +241,25 @@ func (g *Resource) Create(
 	}
 	reqInstance.SetPorts(ports)
 
+	// service_plan_options
+	if !plan.ServicePlanOptions.IsNull() {
+		servicePlanOptions := sdk.NewServicePlanOptionsWithDefaults()
+		memory := *plan.ServicePlanOptions.MaxMemory.ValueInt64Pointer() << 20
+		servicePlanOptions.MaxMemory = &memory
+		servicePlanOptions.MaxCores = plan.ServicePlanOptions.MaxCores.ValueInt64Pointer()
+		servicePlanOptions.CoresPerSocket = plan.ServicePlanOptions.CoresPerSocket.ValueInt64Pointer()
+		servicePlanOptionsMap, err := servicePlanOptions.ToMap()
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"error creating instance",
+				fmt.Sprintf("could not convert service plan options to map: %v", err),
+			)
+
+			return
+		}
+		reqInstance.ServicePlanOptions = servicePlanOptionsMap
+	}
+
 	// tags
 	tags, diags := convert.FromSetType(ctx, plan.Tags, createTagMapper)
 	if diags.HasError() {
@@ -358,9 +377,10 @@ func (g *Resource) Create(
 		return
 	}
 
-	state, diag := getInstanceAsState(ctx, instanceId, client, plan)
-	if diag.HasError() {
-		resp.Diagnostics.Append(diag...)
+	// Read the instance state
+	state, d := getInstanceAsState(ctx, instanceId, client, plan)
+	if d.HasError() {
+		resp.Diagnostics.Append(d...)
 		resp.Diagnostics.AddError(
 			"failed to read instance state",
 			fmt.Sprintf("Instance %d was created but could not be read", instanceId),
@@ -369,6 +389,9 @@ func (g *Resource) Create(
 
 		return
 	}
+
+	// Set ServicePlanOptions in state.
+	state.ServicePlanOptions = plan.ServicePlanOptions
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -61,10 +61,15 @@ func (g *Resource) Read(
 		return
 	}
 
+	// servicePlanOptions is not returned by the API
+	servicePlanOptions := data.ServicePlanOptions
+
 	state, diag := getInstanceAsState(ctx, data.Id.ValueInt64(), client, data)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
 		return
 	}
+
+	state.ServicePlanOptions = servicePlanOptions
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/morpheus/framework/resources/instance/instance_update.go
+++ b/morpheus/framework/resources/instance/instance_update.go
@@ -9,7 +9,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
@@ -68,8 +71,9 @@ func (g *Resource) Update(
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
+	var servicePlanOptions ServicePlanOptionsValue
 	if isAPIUpdateNeeded(plan, state) {
-		makeUpdateAPIcalls(ctx, client, plan, state, updateTimeout, resp)
+		servicePlanOptions = makeUpdateAPIcalls(ctx, client, plan, state, updateTimeout, resp)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -82,6 +86,8 @@ func (g *Resource) Update(
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
 		return
 	}
+
+	newState.ServicePlanOptions = servicePlanOptions
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 	if resp.Diagnostics.HasError() {
@@ -96,7 +102,7 @@ func makeUpdateAPIcalls(
 	plan, state InstanceModel,
 	updateTimeout time.Duration,
 	resp *resource.UpdateResponse,
-) {
+) ServicePlanOptionsValue {
 	updateInstance := client.InstancesAPI.UpdateInstance(ctx, plan.Id.ValueInt64())
 	updateRequest := sdk.NewUpdateInstanceRequest()
 	instanceUpdateRequest := sdk.NewUpdateInstanceRequestInstance()
@@ -131,7 +137,7 @@ func makeUpdateAPIcalls(
 			tflog.Error(ctx, "cannot convert tags")
 			resp.Diagnostics.Append(diags...)
 
-			return
+			return NewServicePlanOptionsValueNull()
 		}
 		instanceUpdateRequest.SetTags(tags)
 	}
@@ -141,113 +147,266 @@ func makeUpdateAPIcalls(
 	if err != nil || httpResp.StatusCode != http.StatusOK {
 		resp.Diagnostics.AddError("error updating instance", errfmt.ErrMsg(err, httpResp))
 
-		return
+		return NewServicePlanOptionsValueNull()
 	}
 
-	resizeInstance := client.InstancesAPI.ResizeInstance(ctx, plan.Id.ValueInt64())
-	resizeRequest := sdk.NewResizeInstanceRequest()
+	// if we need to update volumes, network interfaces or service plan options, then we need to make the
+	// resize API call
+	servicePlanOptions, diags := makeResizeAPICalls(ctx, client, plan, state, updateTimeout)
+	resp.Diagnostics.Append(diags...)
 
-	resizing := !state.PlanId.Equal(plan.PlanId)
+	return servicePlanOptions
+}
 
-	// compare state and plan volumes so we only resize if required
-	// TODO: make this compare each volume rather than just length
-	if len(state.Volumes.Elements()) != len(plan.Volumes.Elements()) {
+// makeResizeAPICalls makes any Resize API calls that are needed.
+func makeResizeAPICalls(
+	ctx context.Context,
+	client *sdk.APIClient,
+	plan, state InstanceModel,
+	updateTimeout time.Duration,
+) (ServicePlanOptionsValue, diag.Diagnostics) {
+	var d diag.Diagnostics
+
+	resizeRequest := createResizeRequest(plan, state)
+
+	d.Append(addVolumesToResizeRequest(ctx, plan, state, resizeRequest)...)
+	if d.HasError() {
+		return state.ServicePlanOptions, d
+	}
+
+	d.Append(addNetworkInterfacesToResizeRequest(ctx, plan, state, resizeRequest)...)
+	if d.HasError() {
+		return state.ServicePlanOptions, d
+	}
+
+	addServicePlanOptionsToResizeRequest(plan, state, resizeRequest)
+
+	if resizeRequest.Volumes != nil || resizeRequest.NetworkInterfaces != nil ||
+		resizeRequest.ServicePlanOptions != nil {
+		d.Append(makeResizeRequestAndWaitForComplete(ctx, client, resizeRequest, updateTimeout)...)
+		if d.HasError() {
+			return state.ServicePlanOptions, d
+		}
+	}
+
+	if resizeRequest.ServicePlanOptions == nil {
+		return state.ServicePlanOptions, d
+	}
+
+	return plan.ServicePlanOptions, d
+}
+
+func createResizeRequest(
+	plan InstanceModel,
+	state InstanceModel,
+) *sdk.ResizeInstanceRequest {
+	resizeRequest := sdk.NewResizeInstanceRequestWithDefaults()
+
+	// plan_id
+	if !plan.PlanId.IsNull() || !plan.PlanId.IsUnknown() {
+		resizeRequest.Instance = sdk.NewResizeInstanceRequestInstance()
+		resizeRequest.Instance.Id = state.Id.ValueInt64Pointer()
+		resizeRequest.Instance.Plan = sdk.NewResizeInstanceRequestInstancePlan()
+		resizeRequest.Instance.Plan.SetId(plan.PlanId.ValueInt64())
+	}
+
+	return resizeRequest
+}
+
+func addVolumesToResizeRequest(
+	ctx context.Context,
+	plan, state InstanceModel,
+	resizeRequest *sdk.ResizeInstanceRequest,
+) diag.Diagnostics {
+	resizing := false
+
+	var pVolumes []VolumesValue
+	pdiags := plan.Volumes.ElementsAs(ctx, &pVolumes, false)
+	if pdiags.HasError() {
+		tflog.Error(ctx, "cannot convert plan volumes")
+
+		return pdiags
+	}
+
+	var sVolumes []VolumesValue
+	sdiags := state.Volumes.ElementsAs(ctx, &sVolumes, false)
+	if sdiags.HasError() {
+		tflog.Error(ctx, "cannot convert state volumes")
+
+		return sdiags
+	}
+
+	// Always resize if the number of volumes in the plan and state are different
+	if len(pVolumes) != len(sVolumes) {
 		resizing = true
+	}
 
-		volumes, diags := convert.FromListType(ctx, plan.Volumes, updateVolumeMapper)
-		if diags.HasError() {
-			tflog.Error(ctx, "cannot convert volumes")
-			resp.Diagnostics.Append(diags...)
+	// Go through the lists of volumes from state and in the plan.  Assume that volumes are in the same order
+	// in both lists.  If the volume in the plan is different from the volume in the state, then we add the volume
+	// from the plan to the list of volumes for the resize request.  If the volume in the plan is the same as the
+	// volume in the state, then we add the volume from the state to the list of volumes for the resize request.
+	var volumes []VolumesValue
+	for i, pVolume := range pVolumes {
+		if i < len(sVolumes) {
+			sVolume := sVolumes[i]
+			volForRequest, different := createVolumeFromPlanAndState(pVolume, sVolume)
+			// Resize if the volume for the request is different from the volume in the state
+			if different {
+				resizing = true
+			}
+			volumes = append(volumes, volForRequest)
+		} else {
+			volumes = append(volumes, pVolume)
+		}
+	}
 
-			return
+	if resizing {
+		volumesForRequest := make([]sdk.ResizeInstanceRequestVolumesInner, len(volumes))
+		for i, v := range volumes {
+			volumesForRequest[i] = updateVolumeMapper(v)
 		}
 
-		resizeRequest.SetDeleteOriginalVolumes(false)
-		resizeRequest.SetVolumes(volumes)
+		resizeRequest.SetVolumes(volumesForRequest)
 	}
 
+	return diag.Diagnostics{}
+}
+
+func createVolumeFromPlanAndState(
+	planVolume, stateVolume VolumesValue,
+) (VolumesValue, bool) {
+	different := false
+	volume := stateVolume
+
+	if !planVolume.Size.IsNull() && !planVolume.Size.IsUnknown() {
+		if !stateVolume.Size.IsNull() && !stateVolume.Size.IsUnknown() &&
+			stateVolume.Size.ValueInt64() != planVolume.Size.ValueInt64() {
+			volume.Size = planVolume.Size
+			different = true
+		}
+	}
+
+	return volume, different
+}
+
+func addNetworkInterfacesToResizeRequest(
+	ctx context.Context,
+	plan, state InstanceModel,
+	resizeRequest *sdk.ResizeInstanceRequest,
+) diag.Diagnostics {
 	// compare state and plan network_interfaces so we only resize if required
 	// TODO: make this compare each network interface rather than just length
 	// TODO: if we're resizing network interfaces, then we need to remove the PlanModifier and RequiresReplace from Schema.
 	// TODO: and add the id of the interface to the Schema
-	if len(state.NetworkInterfaces.Elements()) != len(plan.NetworkInterfaces.Elements()) {
-		resizing = true
+	// TODO: resize doesn't work for network interfaces at present, need to revisit this when the API supports it
+	intfsMatch, ndiags := listsMatch[NetworkInterfacesValue](ctx, plan.NetworkInterfaces, state.NetworkInterfaces)
+	if ndiags.HasError() {
+		tflog.Error(ctx, "cannot compare network interfaces")
 
-		networkInterfaces, diags := convert.FromListType(
+		return ndiags
+	}
+
+	if !intfsMatch {
+		networkInterfaces, idiags := convert.FromListType(
 			ctx,
 			plan.NetworkInterfaces,
 			updateNetworkInterfaceMapper(ctx),
 		)
-		if diags.HasError() {
+		if idiags.HasError() {
 			tflog.Error(ctx, "cannot convert network interfaces")
-			resp.Diagnostics.Append(diags...)
 
-			return
+			return idiags
 		}
 
 		resizeRequest.SetNetworkInterfaces(networkInterfaces)
 	}
 
-	if resizing {
-		// plan_id
-		if !plan.PlanId.IsNull() || !plan.PlanId.IsUnknown() {
-			resizeRequest.Instance = sdk.NewResizeInstanceRequestInstance()
-			resizeRequest.Instance.Plan = sdk.NewResizeInstanceRequestInstancePlan()
-			resizeRequest.Instance.Plan.SetId(plan.PlanId.ValueInt64())
+	return diag.Diagnostics{}
+}
+
+func addServicePlanOptionsToResizeRequest(
+	plan, state InstanceModel,
+	resizeRequest *sdk.ResizeInstanceRequest,
+) {
+	// compare state and plan service_plan_options so we only resize if required
+	if !plan.ServicePlanOptions.Equal(state.ServicePlanOptions) {
+		servicePlanOptions := sdk.NewResizeInstanceRequestServicePlanOptions()
+		if !plan.ServicePlanOptions.MaxCores.IsNull() && !plan.ServicePlanOptions.MaxCores.IsUnknown() {
+			servicePlanOptions.MaxCores = plan.ServicePlanOptions.MaxCores.ValueInt64Pointer()
+		}
+		if !plan.ServicePlanOptions.CoresPerSocket.IsNull() && !plan.ServicePlanOptions.CoresPerSocket.IsUnknown() {
+			servicePlanOptions.CoresPerSocket = plan.ServicePlanOptions.CoresPerSocket.ValueInt64Pointer()
+		}
+		if !plan.ServicePlanOptions.MaxMemory.IsNull() && !plan.ServicePlanOptions.MaxMemory.IsUnknown() {
+			memoryInBytes := *plan.ServicePlanOptions.MaxMemory.ValueInt64Pointer() << 20
+			servicePlanOptions.MaxMemory = &memoryInBytes
 		}
 
-		resizeResp, httpResp, err := resizeInstance.ResizeInstanceRequest(*resizeRequest).Execute()
-		if err != nil || httpResp.StatusCode != http.StatusOK {
-			resp.Diagnostics.AddError("error resizing instance", errfmt.ErrMsg(err, httpResp))
-
-			return
-		}
-
-		tflog.Info(ctx, fmt.Sprintln(resizeResp))
-
-		waitForReady := func() (string, error) {
-			resp, hresp, err := client.InstancesAPI.GetInstance(ctx, plan.Id.ValueInt64()).Execute()
-			if err != nil {
-				if hresp == nil || hresp.StatusCode != http.StatusOK {
-					return "", backoff.Permanent(err)
-				}
-			}
-
-			// Get instance
-			inst, ok := resp.GetInstanceOk()
-			if !ok || inst == nil {
-				return "", backoff.Permanent(fmt.Errorf("instance %d: GET returned empty instance", plan.Id.ValueInt64()))
-			}
-
-			// Get status
-			status, ok := inst.GetStatusOk()
-			if !ok || status == nil {
-				return "", backoff.Permanent(fmt.Errorf("instance %d: GET returned empty status", plan.Id.ValueInt64()))
-			}
-
-			return *status, checkStatusDone(
-				*status,
-				UpdateTargetStatuses,
-				UpdateErrorStatuses,
-			)
-		}
-
-		if status, err := backoff.Retry(
-			ctx,
-			waitForReady,
-			backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)),
-			backoff.WithMaxElapsedTime(updateTimeout),
-		); err != nil {
-			resp.Diagnostics.AddError(
-				"resize instance resource",
-				fmt.Sprintf(
-					"instance %d: resizing failed current status is: %s",
-					plan.Id.ValueInt64(),
-					status,
-				),
-			)
-		}
+		resizeRequest.SetServicePlanOptions(*servicePlanOptions)
 	}
+}
+
+func makeResizeRequestAndWaitForComplete(
+	ctx context.Context,
+	client *sdk.APIClient,
+	resizeRequest *sdk.ResizeInstanceRequest,
+	updateTimeout time.Duration,
+) diag.Diagnostics {
+	var d diag.Diagnostics
+	resizeInstance := client.InstancesAPI.ResizeInstance(ctx, *resizeRequest.Instance.Id)
+	resizeResp, httpResp, err := resizeInstance.ResizeInstanceRequest(*resizeRequest).Execute()
+	if err != nil || httpResp.StatusCode != http.StatusOK {
+		d.AddError("instance resize failed", errfmt.ErrMsg(err, httpResp))
+
+		return d
+	}
+
+	tflog.Info(ctx, fmt.Sprintln(resizeResp))
+
+	waitForReady := func() (string, error) {
+		resp, hresp, err := client.InstancesAPI.GetInstance(ctx, *resizeRequest.Instance.Id).Execute()
+		if err != nil {
+			if hresp == nil || hresp.StatusCode != http.StatusOK {
+				return "", backoff.Permanent(err)
+			}
+		}
+
+		// Get instance
+		inst, ok := resp.GetInstanceOk()
+		if !ok || inst == nil {
+			return "", backoff.Permanent(fmt.Errorf("instance %d: GET returned empty instance", *resizeRequest.Instance.Id))
+		}
+
+		// Get status
+		status, ok := inst.GetStatusOk()
+		if !ok || status == nil {
+			return "", backoff.Permanent(fmt.Errorf("instance %d: GET returned empty status", *resizeRequest.Instance.Id))
+		}
+
+		return *status, checkStatusDone(
+			*status,
+			UpdateTargetStatuses,
+			UpdateErrorStatuses,
+		)
+	}
+
+	if status, err := backoff.Retry(
+		ctx,
+		waitForReady,
+		backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)),
+		backoff.WithMaxElapsedTime(updateTimeout),
+	); err != nil {
+		d.AddError(
+			"resize instance resource",
+			fmt.Sprintf(
+				"instance %d: resizing failed current status is: %s",
+				*resizeRequest.Instance.Id,
+				status,
+			),
+		)
+	}
+
+	return d
 }
 
 // isAPIUpdateNeeded is a function that will compare the plan and state of attributes
@@ -282,8 +441,12 @@ func isAPIUpdateNeeded(plan, state InstanceModel) bool {
 	}
 
 	// network-interfaces
-	// TODO check this carefully when resizing of networks is allowed
 	if !plan.NetworkInterfaces.Equal(state.NetworkInterfaces) {
+		return true
+	}
+
+	// service_plan_options
+	if !plan.ServicePlanOptions.Equal(state.ServicePlanOptions) {
 		return true
 	}
 
@@ -294,4 +457,43 @@ func isAPIUpdateNeeded(plan, state InstanceModel) bool {
 
 	// For safety's sake we will return true by default
 	return true
+}
+
+// listsMatch is a generic that compares lists from plan and state to see if they are the same
+// Returns true if they are, false otherwise
+func listsMatch[S attr.Value](
+	ctx context.Context,
+	planList, stateList basetypes.ListValue,
+) (bool, diag.Diagnostics) {
+	var planVals, stateVals []S
+
+	diags := planList.ElementsAs(ctx, &planVals, false)
+	if diags.HasError() {
+		tflog.Error(ctx, fmt.Sprintf("cannot convert list values to type %T", planVals))
+
+		return false, diags
+	}
+
+	diags = stateList.ElementsAs(ctx, &stateVals, false)
+	if diags.HasError() {
+		tflog.Error(ctx, fmt.Sprintf("cannot convert list values to type %T", stateVals))
+
+		return false, diags
+	}
+
+	// Check length of lists first
+	if len(planVals) != len(stateVals) {
+		return false, nil
+	}
+
+	// Compare each element in the lists to see if they are the same
+	for i, planVal := range planVals {
+		stateVal := stateVals[i]
+
+		if !planVal.Equal(stateVal) {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/morpheus/framework/resources/instance/instance_update.go
+++ b/morpheus/framework/resources/instance/instance_update.go
@@ -469,14 +469,14 @@ func listsMatch[S attr.Value](
 
 	diags := planList.ElementsAs(ctx, &planVals, false)
 	if diags.HasError() {
-		tflog.Error(ctx, fmt.Sprintf("cannot convert list values to type %T", planVals))
+		tflog.Error(ctx, fmt.Sprintf("cannot convert plan list values to type %T", planVals))
 
 		return false, diags
 	}
 
 	diags = stateList.ElementsAs(ctx, &stateVals, false)
 	if diags.HasError() {
-		tflog.Error(ctx, fmt.Sprintf("cannot convert list values to type %T", stateVals))
+		tflog.Error(ctx, fmt.Sprintf("cannot convert state list values to type %T", stateVals))
 
 		return false, diags
 	}

--- a/morpheus/framework/resources/instance/resource_test.go
+++ b/morpheus/framework/resources/instance/resource_test.go
@@ -4,6 +4,7 @@
 //go:generate ../../../../bin/render example_twonetworks.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
 //go:generate ../../../../bin/render example_timeouts.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
 //go:generate ../../../../bin/render example_vmware.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-1"
+//go:generate ../../../../bin/render example_vmware_sp_options.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-1"
 //go:generate ../../../../bin/render example_metal.tf.tmpl Name "TestInstance" CloudName "aCloud" EnvironmentName "anEnvironment" GroupName "aGroup" InstanceTypeLayout "Single ILO Server" Role "aRole" PlanName "G3i"
 
 package instance_test

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -483,6 +483,44 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The ports parameter is for port configuration.\n\nThe layout may have default ports, which are defined in node types, that are always configured. This parameter will be for additional custom ports to be opened.\n",
 				MarkdownDescription: "The ports parameter is for port configuration.\n\nThe layout may have default ports, which are defined in node types, that are always configured. This parameter will be for additional custom ports to be opened.\n",
 			},
+			"service_plan_options": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"cores_per_socket": schema.Int64Attribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "The number of cores per socket to use for the instance.  This is only applicable for certain service plans.",
+						MarkdownDescription: "The number of cores per socket to use for the instance.  This is only applicable for certain service plans.",
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
+						Default: int64default.StaticInt64(1),
+					},
+					"max_cores": schema.Int64Attribute{
+						Optional:            true,
+						Description:         "The maximum number of cores to use for the instance.  This is only applicable for certain service plans.",
+						MarkdownDescription: "The maximum number of cores to use for the instance.  This is only applicable for certain service plans.",
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
+					},
+					"max_memory": schema.Int64Attribute{
+						Optional:            true,
+						Description:         "The maximum amount of memory (in MB) to use for the instance.  This is only applicable for certain service plans.",
+						MarkdownDescription: "The maximum amount of memory (in MB) to use for the instance.  This is only applicable for certain service plans.",
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
+					},
+				},
+				CustomType: ServicePlanOptionsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: ServicePlanOptionsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional:            true,
+				Description:         "Custom options for selected service plan - the supported options depend on the service plan selected",
+				MarkdownDescription: "Custom options for selected service plan - the supported options depend on the service plan selected",
+			},
 			"tags": schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -518,9 +556,6 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "The controller mount point specification for this volume in the format:\n  \"id:busNumber:typeId:unitNumber\"\nFor new storage controllers the id is passed as -1, so an example value would be:\n  \"-1:1:6:0\"\nwhich translates to id: -1 (new), busNumber: 1, storage controller type id: 6 (SCSI VMware Paravirtual), unit number: 0.\nThe current list of storage controllers is returned for instances and servers for determining existing id values.\nUse /api/provision-types?code=vmware to see the available controllerTypes for vmware.\"\n",
 							MarkdownDescription: "The controller mount point specification for this volume in the format:\n  \"id:busNumber:typeId:unitNumber\"\nFor new storage controllers the id is passed as -1, so an example value would be:\n  \"-1:1:6:0\"\nwhich translates to id: -1 (new), busNumber: 1, storage controller type id: 6 (SCSI VMware Paravirtual), unit number: 0.\nThe current list of storage controllers is returned for instances and servers for determining existing id values.\nUse /api/provision-types?code=vmware to see the available controllerTypes for vmware.\"\n",
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
 						},
 						"datastore_auto_selection": schema.StringAttribute{
 							Optional:            true,
@@ -538,17 +573,11 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							Description:         "The ID of the specific datastore.",
 							MarkdownDescription: "The ID of the specific datastore.",
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.UseStateForUnknown(),
-							},
 						},
 						"id": schema.Int64Attribute{
 							Computed:            true,
 							Description:         "The id for the LV configuration being created.",
 							MarkdownDescription: "The id for the LV configuration being created.",
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.UseStateForUnknown(),
-							},
 						},
 						"name": schema.StringAttribute{
 							Optional:            true,
@@ -572,6 +601,11 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 							Description:         "Can be used to select pre-existing LV choices from Morpheus.",
 							MarkdownDescription: "Can be used to select pre-existing LV choices from Morpheus.",
 						},
+						"storage_profile": schema.StringAttribute{
+							Optional:            true,
+							Description:         "Storage Profile Code for the volume storage profile assignment. eg. `\"kvm-cache-none\"` or `\"kvm-cache-directsync\"`.\nUse `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.",
+							MarkdownDescription: "Storage Profile Code for the volume storage profile assignment. eg. `\"kvm-cache-none\"` or `\"kvm-cache-directsync\"`.\nUse `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.",
+						},
 						"storage_type_id": schema.Int64Attribute{
 							Optional:            true,
 							Description:         "Identifier for LV type",
@@ -588,42 +622,33 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Logical Volume configuration to create additional LVs at provision time",
 				MarkdownDescription: "Logical Volume configuration to create additional LVs at provision time",
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.RequiresReplaceIf(func(_ context.Context, req planmodifier.ListRequest, resp *listplanmodifier.RequiresReplaceIfFuncResponse) {
-						if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
-							return
-						}
-						if !req.StateValue.Equal(req.ConfigValue) {
-							resp.RequiresReplace = true
-						}
-					}, "require replace if volume layout has changed", "require replace if volume layout has changed"),
-				},
 			},
 		},
 	}
 }
 
 type InstanceModel struct {
-	CloudId           types.Int64       `tfsdk:"cloud_id"`
-	Config            types.Dynamic     `tfsdk:"config"`
-	ConfigHvm         ConfigHvmValue    `tfsdk:"config_hvm"`
-	ConfigVmware      ConfigVmwareValue `tfsdk:"config_vmware"`
-	ConnectionInfo    types.List        `tfsdk:"connection_info"`
-	Evars             types.Set         `tfsdk:"evars"`
-	GroupId           types.Int64       `tfsdk:"group_id"`
-	Id                types.Int64       `tfsdk:"id"`
-	InstanceContext   types.String      `tfsdk:"instance_context"`
-	InstanceTypeId    types.Int64       `tfsdk:"instance_type_id"`
-	LayoutId          types.Int64       `tfsdk:"layout_id"`
-	LayoutSize        types.Int64       `tfsdk:"layout_size"`
-	Name              types.String      `tfsdk:"name"`
-	NetworkInterfaces types.List        `tfsdk:"network_interfaces"`
-	PlanId            types.Int64       `tfsdk:"plan_id"`
-	Ports             types.Set         `tfsdk:"ports"`
-	Tags              types.Set         `tfsdk:"tags"`
-	TaskSetId         types.Int64       `tfsdk:"task_set_id"`
-	Timeouts          timeouts.Value    `tfsdk:"timeouts"`
-	Volumes           types.List        `tfsdk:"volumes"`
+	CloudId            types.Int64             `tfsdk:"cloud_id"`
+	Config             types.Dynamic           `tfsdk:"config"`
+	ConfigHvm          ConfigHvmValue          `tfsdk:"config_hvm"`
+	ConfigVmware       ConfigVmwareValue       `tfsdk:"config_vmware"`
+	ConnectionInfo     types.List              `tfsdk:"connection_info"`
+	Evars              types.Set               `tfsdk:"evars"`
+	GroupId            types.Int64             `tfsdk:"group_id"`
+	Id                 types.Int64             `tfsdk:"id"`
+	InstanceContext    types.String            `tfsdk:"instance_context"`
+	InstanceTypeId     types.Int64             `tfsdk:"instance_type_id"`
+	LayoutId           types.Int64             `tfsdk:"layout_id"`
+	LayoutSize         types.Int64             `tfsdk:"layout_size"`
+	Name               types.String            `tfsdk:"name"`
+	NetworkInterfaces  types.List              `tfsdk:"network_interfaces"`
+	PlanId             types.Int64             `tfsdk:"plan_id"`
+	Ports              types.Set               `tfsdk:"ports"`
+	ServicePlanOptions ServicePlanOptionsValue `tfsdk:"service_plan_options"`
+	Tags               types.Set               `tfsdk:"tags"`
+	TaskSetId          types.Int64             `tfsdk:"task_set_id"`
+	Timeouts           timeouts.Value          `tfsdk:"timeouts"`
+	Volumes            types.List              `tfsdk:"volumes"`
 }
 
 var _ basetypes.ObjectTypable = ConfigHvmType{}
@@ -4083,6 +4108,448 @@ func (v PortsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	}
 }
 
+var _ basetypes.ObjectTypable = ServicePlanOptionsType{}
+
+type ServicePlanOptionsType struct {
+	basetypes.ObjectType
+}
+
+func (t ServicePlanOptionsType) Equal(o attr.Type) bool {
+	other, ok := o.(ServicePlanOptionsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ServicePlanOptionsType) String() string {
+	return "ServicePlanOptionsType"
+}
+
+func (t ServicePlanOptionsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsUnknown() {
+		return NewServicePlanOptionsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewServicePlanOptionsValueNull(), nil
+	}
+
+	attributes := in.Attributes()
+
+	coresPerSocketAttribute, ok := attributes["cores_per_socket"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cores_per_socket is missing from object`)
+
+		return nil, diags
+	}
+
+	coresPerSocketVal, ok := coresPerSocketAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cores_per_socket expected to be basetypes.Int64Value, was: %T`, coresPerSocketAttribute))
+	}
+
+	maxCoresAttribute, ok := attributes["max_cores"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_cores is missing from object`)
+
+		return nil, diags
+	}
+
+	maxCoresVal, ok := maxCoresAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_cores expected to be basetypes.Int64Value, was: %T`, maxCoresAttribute))
+	}
+
+	maxMemoryAttribute, ok := attributes["max_memory"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_memory is missing from object`)
+
+		return nil, diags
+	}
+
+	maxMemoryVal, ok := maxMemoryAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_memory expected to be basetypes.Int64Value, was: %T`, maxMemoryAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return ServicePlanOptionsValue{
+		CoresPerSocket: coresPerSocketVal,
+		MaxCores:       maxCoresVal,
+		MaxMemory:      maxMemoryVal,
+		state:          attr.ValueStateKnown,
+	}, diags
+}
+
+func NewServicePlanOptionsValueNull() ServicePlanOptionsValue {
+	return ServicePlanOptionsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewServicePlanOptionsValueUnknown() ServicePlanOptionsValue {
+	return ServicePlanOptionsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewServicePlanOptionsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (ServicePlanOptionsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing ServicePlanOptionsValue Attribute Value",
+				"While creating a ServicePlanOptionsValue value, a missing attribute value was detected. "+
+					"A ServicePlanOptionsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ServicePlanOptionsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid ServicePlanOptionsValue Attribute Type",
+				"While creating a ServicePlanOptionsValue value, an invalid attribute value was detected. "+
+					"A ServicePlanOptionsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("ServicePlanOptionsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("ServicePlanOptionsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra ServicePlanOptionsValue Attribute Value",
+				"While creating a ServicePlanOptionsValue value, an extra attribute value was detected. "+
+					"A ServicePlanOptionsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra ServicePlanOptionsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewServicePlanOptionsValueUnknown(), diags
+	}
+
+	coresPerSocketAttribute, ok := attributes["cores_per_socket"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`cores_per_socket is missing from object`)
+
+		return NewServicePlanOptionsValueUnknown(), diags
+	}
+
+	coresPerSocketVal, ok := coresPerSocketAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`cores_per_socket expected to be basetypes.Int64Value, was: %T`, coresPerSocketAttribute))
+	}
+
+	maxCoresAttribute, ok := attributes["max_cores"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_cores is missing from object`)
+
+		return NewServicePlanOptionsValueUnknown(), diags
+	}
+
+	maxCoresVal, ok := maxCoresAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_cores expected to be basetypes.Int64Value, was: %T`, maxCoresAttribute))
+	}
+
+	maxMemoryAttribute, ok := attributes["max_memory"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`max_memory is missing from object`)
+
+		return NewServicePlanOptionsValueUnknown(), diags
+	}
+
+	maxMemoryVal, ok := maxMemoryAttribute.(basetypes.Int64Value)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`max_memory expected to be basetypes.Int64Value, was: %T`, maxMemoryAttribute))
+	}
+
+	if diags.HasError() {
+		return NewServicePlanOptionsValueUnknown(), diags
+	}
+
+	return ServicePlanOptionsValue{
+		CoresPerSocket: coresPerSocketVal,
+		MaxCores:       maxCoresVal,
+		MaxMemory:      maxMemoryVal,
+		state:          attr.ValueStateKnown,
+	}, diags
+}
+
+func NewServicePlanOptionsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) ServicePlanOptionsValue {
+	object, diags := NewServicePlanOptionsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewServicePlanOptionsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t ServicePlanOptionsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewServicePlanOptionsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewServicePlanOptionsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewServicePlanOptionsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewServicePlanOptionsValueMust(ServicePlanOptionsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t ServicePlanOptionsType) ValueType(ctx context.Context) attr.Value {
+	return ServicePlanOptionsValue{}
+}
+
+var _ basetypes.ObjectValuable = ServicePlanOptionsValue{}
+
+type ServicePlanOptionsValue struct {
+	CoresPerSocket basetypes.Int64Value `tfsdk:"cores_per_socket"`
+	MaxCores       basetypes.Int64Value `tfsdk:"max_cores"`
+	MaxMemory      basetypes.Int64Value `tfsdk:"max_memory"`
+	state          attr.ValueState
+}
+
+func (v ServicePlanOptionsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["cores_per_socket"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["max_cores"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["max_memory"] = basetypes.Int64Type{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.CoresPerSocket.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["cores_per_socket"] = val
+
+		val, err = v.MaxCores.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_cores"] = val
+
+		val, err = v.MaxMemory.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["max_memory"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v ServicePlanOptionsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v ServicePlanOptionsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v ServicePlanOptionsValue) String() string {
+	return "ServicePlanOptionsValue"
+}
+
+func (v ServicePlanOptionsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"cores_per_socket": basetypes.Int64Type{},
+		"max_cores":        basetypes.Int64Type{},
+		"max_memory":       basetypes.Int64Type{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"cores_per_socket": v.CoresPerSocket,
+			"max_cores":        v.MaxCores,
+			"max_memory":       v.MaxMemory,
+		})
+
+	return objVal, diags
+}
+
+func (v ServicePlanOptionsValue) Equal(o attr.Value) bool {
+	other, ok := o.(ServicePlanOptionsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.CoresPerSocket.Equal(other.CoresPerSocket) {
+		return false
+	}
+
+	if !v.MaxCores.Equal(other.MaxCores) {
+		return false
+	}
+
+	if !v.MaxMemory.Equal(other.MaxMemory) {
+		return false
+	}
+
+	return true
+}
+
+func (v ServicePlanOptionsValue) Type(ctx context.Context) attr.Type {
+	return ServicePlanOptionsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v ServicePlanOptionsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"cores_per_socket": basetypes.Int64Type{},
+		"max_cores":        basetypes.Int64Type{},
+		"max_memory":       basetypes.Int64Type{},
+	}
+}
+
 var _ basetypes.ObjectTypable = TagsType{}
 
 type TagsType struct {
@@ -4647,6 +5114,24 @@ func (t VolumesType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 			fmt.Sprintf(`size_id expected to be basetypes.Int64Value, was: %T`, sizeIdAttribute))
 	}
 
+	storageProfileAttribute, ok := attributes["storage_profile"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`storage_profile is missing from object`)
+
+		return nil, diags
+	}
+
+	storageProfileVal, ok := storageProfileAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`storage_profile expected to be basetypes.StringValue, was: %T`, storageProfileAttribute))
+	}
+
 	storageTypeIdAttribute, ok := attributes["storage_type_id"]
 
 	if !ok {
@@ -4678,6 +5163,7 @@ func (t VolumesType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 		RootVolume:             rootVolumeVal,
 		Size:                   sizeVal,
 		SizeId:                 sizeIdVal,
+		StorageProfile:         storageProfileVal,
 		StorageTypeId:          storageTypeIdVal,
 		state:                  attr.ValueStateKnown,
 	}, diags
@@ -4890,6 +5376,24 @@ func NewVolumesValue(attributeTypes map[string]attr.Type, attributes map[string]
 			fmt.Sprintf(`size_id expected to be basetypes.Int64Value, was: %T`, sizeIdAttribute))
 	}
 
+	storageProfileAttribute, ok := attributes["storage_profile"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`storage_profile is missing from object`)
+
+		return NewVolumesValueUnknown(), diags
+	}
+
+	storageProfileVal, ok := storageProfileAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`storage_profile expected to be basetypes.StringValue, was: %T`, storageProfileAttribute))
+	}
+
 	storageTypeIdAttribute, ok := attributes["storage_type_id"]
 
 	if !ok {
@@ -4921,6 +5425,7 @@ func NewVolumesValue(attributeTypes map[string]attr.Type, attributes map[string]
 		RootVolume:             rootVolumeVal,
 		Size:                   sizeVal,
 		SizeId:                 sizeIdVal,
+		StorageProfile:         storageProfileVal,
 		StorageTypeId:          storageTypeIdVal,
 		state:                  attr.ValueStateKnown,
 	}, diags
@@ -5002,12 +5507,13 @@ type VolumesValue struct {
 	RootVolume             basetypes.BoolValue   `tfsdk:"root_volume"`
 	Size                   basetypes.Int64Value  `tfsdk:"size"`
 	SizeId                 basetypes.Int64Value  `tfsdk:"size_id"`
+	StorageProfile         basetypes.StringValue `tfsdk:"storage_profile"`
 	StorageTypeId          basetypes.Int64Value  `tfsdk:"storage_type_id"`
 	state                  attr.ValueState
 }
 
 func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 9)
+	attrTypes := make(map[string]tftypes.Type, 10)
 
 	var val tftypes.Value
 	var err error
@@ -5020,13 +5526,14 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 	attrTypes["root_volume"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["size"] = basetypes.Int64Type{}.TerraformType(ctx)
 	attrTypes["size_id"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["storage_profile"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["storage_type_id"] = basetypes.Int64Type{}.TerraformType(ctx)
 
 	objectType := tftypes.Object{AttributeTypes: attrTypes}
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 9)
+		vals := make(map[string]tftypes.Value, 10)
 
 		val, err = v.ControllerMountPoint.ToTerraformValue(ctx)
 
@@ -5092,6 +5599,14 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 
 		vals["size_id"] = val
 
+		val, err = v.StorageProfile.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["storage_profile"] = val
+
 		val, err = v.StorageTypeId.ToTerraformValue(ctx)
 
 		if err != nil {
@@ -5138,6 +5653,7 @@ func (v VolumesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 		"root_volume":              basetypes.BoolType{},
 		"size":                     basetypes.Int64Type{},
 		"size_id":                  basetypes.Int64Type{},
+		"storage_profile":          basetypes.StringType{},
 		"storage_type_id":          basetypes.Int64Type{},
 	}
 
@@ -5160,6 +5676,7 @@ func (v VolumesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 			"root_volume":              v.RootVolume,
 			"size":                     v.Size,
 			"size_id":                  v.SizeId,
+			"storage_profile":          v.StorageProfile,
 			"storage_type_id":          v.StorageTypeId,
 		})
 
@@ -5213,6 +5730,10 @@ func (v VolumesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.StorageProfile.Equal(other.StorageProfile) {
+		return false
+	}
+
 	if !v.StorageTypeId.Equal(other.StorageTypeId) {
 		return false
 	}
@@ -5238,6 +5759,7 @@ func (v VolumesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		"root_volume":              basetypes.BoolType{},
 		"size":                     basetypes.Int64Type{},
 		"size_id":                  basetypes.Int64Type{},
+		"storage_profile":          basetypes.StringType{},
 		"storage_type_id":          basetypes.Int64Type{},
 	}
 }

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -17,9 +17,10 @@ monitoring, and eventual decommissioning.
 &nbsp;&nbsp;&nbsp;&nbsp;- VMware: `config_vmware`<br><br>
 Some general issues<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- With Morpheus versions prior to 8.0.11, make sure the root volume is the first defined.<br>
-&nbsp;&nbsp;&nbsp;&nbsp;- The addition and removal of volumes is not supported during updates.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Updates fail when removing optional fields.<br>
-&nbsp;&nbsp;&nbsp;&nbsp;- Updates fail when removing `evars`.<br><br>
+&nbsp;&nbsp;&nbsp;&nbsp;- Updates fail when removing `evars`.<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- Updates to `service_plan_options` for service plans that allow the setting of options<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  will fail silently.<br><br>
 These will be addressed in a future release.
 
 -> Some general notes:<br><br>
@@ -35,6 +36,11 @@ If the `timeouts` settings are changed in HCL an
 `Update` will be triggered.  If the only change detected is for `timeouts` then the State will be updated with
 the new settings but no `Morpheus` `Update` API calls will be made.  The default timeout for `create`, `delete`
 `read` and `update` is 45 minutes.<br><br>
+**Update** is supported but has some limitations at the moment.  The addition and removal of volumes is supported
+during update. Existing volumes can have their size increased but not decreased.  **Do not** change the order of
+volumes in HCL.  Network interface changes will result in instance recreation.  Updates fail when removing optional
+fields or `evars`. Updates to `service_plan_options` for service plans that support the setting of options will
+fail silently.<br><br>
 We've added a `connection_info` section (read-only) which contains the IP address(es) by which the instance
 can be accessed<br><br>
 The `datastore_auto_selection` attribute is not supported for BMaaS instances.<br><br>
@@ -72,6 +78,13 @@ will be made.  The default timeout for `create`, `delete`, `read` and `update` i
 ## VMware VM Instance
 
 {{ tffile "morpheus/framework/resources/instance/example_vmware.tf" }}
+
+## VMware VM Instance with Service Plan Options
+
+Some Service Plans have options that must be set at the time of creation of the instance.
+
+{{ tffile "morpheus/framework/resources/instance/example_vmware_sp_options.tf" }}
+
 
 ## BMaaS Instance
 


### PR DESCRIPTION
In this PR we make some changes to instance update:
- we add support for the resize endpoint
- the resize endpoint will be called if there are changes to volumes, network interfaces or service_plan_options
- only volume updates work at present

We also add support for service_plan_options which is required for certain service plans.