### PR TITLE
Fix bug in instance datasource name listing

### DIFF
--- a/morpheus/framework/datasources/instance/instance.go
+++ b/morpheus/framework/datasources/instance/instance.go
@@ -1,3 +1,5 @@
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+
 package instance
 
 import (
@@ -79,8 +81,7 @@ func (d *DataSource) Read(
 
 	if !data.Name.IsNull() {
 		name := data.Name.ValueString()
-		instanceListReq := client.InstancesAPI.ListInstances(ctx)
-		instanceListReq.Name(name)
+		instanceListReq := client.InstancesAPI.ListInstances(ctx).Name(name)
 
 		instanceListResp, httpResp, err := instanceListReq.Execute()
 		if instanceListResp == nil || err != nil || httpResp.StatusCode != http.StatusOK {


### PR DESCRIPTION
The name wasn't being set on the query to execute.