### PR TITLE
Make group_id optional for the cloud resource

### DIFF
--- a/docs/resources/morpheus_cloud.md
+++ b/docs/resources/morpheus_cloud.md
@@ -11,9 +11,12 @@ description: |-
 Clouds are integrations or connections to public, private, hybrid clouds, or bare metal servers. Clouds can belong to many groups and contain many hosts.
 HPE Morpheus Enterprise supports most Public Clouds and Private Clouds.
 
--> A `config_hvm` or `config` block is required. They can be empty.
+-> A `config_hvm`, `config_vmware` or `config` block is required. They can be empty.
 
 -> `cloud_type_code` must be set if using a generic `config` block.
+
+-> Currently, a change to the `group_id` attribute will not be applied on update.<br/>
+   We recommend managing group membership using a `group` resource.
 
 ## Example Usage (HVM)
 
@@ -91,7 +94,6 @@ resource "hpe_morpheus_cloud" "example" {
 
 ### Required
 
-- `group_id` (Number) Specifies which Server group this cloud should be assigned to
 - `name` (String) A unique name scoped to your account for the cloud
 - `tenant_id` (Number) Specifies which Tenant this cloud should be assigned to
 
@@ -109,6 +111,7 @@ resource "hpe_morpheus_cloud" "example" {
 - `data_center_name` (String) A custom name used to reference the datacenter for the cloud.
 - `enabled` (Boolean) Can be used to disable the cloud
 - `external_id` (String) The external id of the cloud
+- `group_id` (Number) Specifies which Server group this cloud should be assigned to
 - `guidance_mode` (String) Whether to enable guidance recommendations on the cloud (manual, off)
 - `import_existing_vms` (String) Whether to import existing virtual machines (off, basic, full)
 - `keyboard_layout` (String) The keyboard layout to use for the console

--- a/morpheus/framework/resources/cloud/cloud_create.go
+++ b/morpheus/framework/resources/cloud/cloud_create.go
@@ -34,7 +34,6 @@ func (r *Resource) Create(
 	}
 
 	name := plan.Name.ValueString()
-	groupID := plan.GroupId.ValueInt64()
 	tenantID := plan.TenantId.ValueInt64()
 
 	var config CloudModel
@@ -45,7 +44,10 @@ func (r *Resource) Create(
 
 	addCloud := sdk.NewAddCloudsRequestZoneWithDefaults()
 	addCloud.SetName(name)
-	addCloud.SetGroupId(groupID)
+
+	if !plan.GroupId.IsNull() && !plan.GroupId.IsUnknown() {
+		addCloud.SetGroupId(plan.GroupId.ValueInt64())
+	}
 
 	addCloudConfig := addCloud.GetConfig()
 

--- a/morpheus/framework/resources/cloud/cloud_read.go
+++ b/morpheus/framework/resources/cloud/cloud_read.go
@@ -55,19 +55,19 @@ func getCloudAsState(
 		return state, diags
 	}
 
-	if len(cloud.Groups) == 0 {
-		diags.AddError(
-			readOperation,
-			fmt.Sprintf("cloud %d no associated groups", id),
-		)
-
-		return state, diags
-	}
-
 	importing := plan.Name.IsNull()
 	cloudType := *cloud.ZoneType.Code
 
-	state.GroupId = convert.Int64ToType(cloud.Groups[0].Id)
+	if !plan.GroupId.IsNull() && !plan.GroupId.IsUnknown() {
+		state.GroupId = plan.GroupId
+	} else {
+		// On import, use the first API value
+		state.GroupId = types.Int64Null()
+		if len(cloud.Groups) > 0 {
+			state.GroupId = convert.Int64ToType(cloud.Groups[0].Id)
+		}
+	}
+
 	state.AgentInstallMode = convert.StrToType(cloud.AgentMode)
 	state.AutoRecoverPowerState = convert.BoolToType(cloud.AutoRecoverPowerState)
 	if cloud.GetCode() != "standard" { // workaround an API bug

--- a/morpheus/framework/resources/cloud/cloud_test.go
+++ b/morpheus/framework/resources/cloud/cloud_test.go
@@ -1232,25 +1232,14 @@ func TestAccMorpheusCloudValidationRequiredAttrs(t *testing.T) {
 				Config: `
 					resource "hpe_morpheus_cloud" "example" {
 						name      = "cloud9"
-						group_id  = 1
 					}`,
 				ExpectError: regexp.MustCompile(`The argument "tenant_id" is required`),
-			},
-			{
-				// checks plan fails when GroupId is removed
-				Config: `
-					resource "hpe_morpheus_cloud" "example" {
-						name      = "cloud9"
-						tenant_id  = 1
-					}`,
-				ExpectError: regexp.MustCompile(`The argument "group_id" is required`),
 			},
 			{
 				// checks plan fails when Name is removed
 				Config: `
 					resource "hpe_morpheus_cloud" "example" {
 						tenant_id  = 1
-				    group_id = 1
 					}`,
 				ExpectError: regexp.MustCompile(`The argument "name" is required`),
 			},

--- a/morpheus/framework/resources/cloud/cloud_update.go
+++ b/morpheus/framework/resources/cloud/cloud_update.go
@@ -45,6 +45,11 @@ func (r *Resource) Update(
 	updateCloud.AdditionalProperties = make(map[string]any)
 	updateCloud.SetName(name)
 
+	// This won't do anything with the current API.
+	if !plan.GroupId.IsNull() && !plan.GroupId.IsUnknown() {
+		updateCloud.SetGroupId(plan.GroupId.ValueInt64())
+	}
+
 	if !plan.AutoRecoverPowerState.IsNull() && !plan.AutoRecoverPowerState.IsUnknown() {
 		updateCloud.SetAutoRecoverPowerState(plan.AutoRecoverPowerState.ValueBool())
 	}

--- a/morpheus/framework/resources/cloud/schema_gen.go
+++ b/morpheus/framework/resources/cloud/schema_gen.go
@@ -234,7 +234,7 @@ func CloudResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "The external id of the cloud",
 			},
 			"group_id": schema.Int64Attribute{
-				Required:            true,
+				Optional:            true,
 				Description:         "Specifies which Server group this cloud should be assigned to",
 				MarkdownDescription: "Specifies which Server group this cloud should be assigned to",
 			},

--- a/templates/resources/morpheus_cloud.md.tmpl
+++ b/templates/resources/morpheus_cloud.md.tmpl
@@ -11,9 +11,12 @@ description: |-
 Clouds are integrations or connections to public, private, hybrid clouds, or bare metal servers. Clouds can belong to many groups and contain many hosts.
 HPE Morpheus Enterprise supports most Public Clouds and Private Clouds.
 
--> A `config_hvm` or `config` block is required. They can be empty.
+-> A `config_hvm`, `config_vmware` or `config` block is required. They can be empty.
 
 -> `cloud_type_code` must be set if using a generic `config` block.
+
+-> Currently, a change to the `group_id` attribute will not be applied on update.<br/>
+   We recommend managing group membership using a `group` resource.
 
 ## Example Usage (HVM)
 


### PR DESCRIPTION

The Morpheus UI and CLI force you to supply the group_id. This is not
necessary. Making it optional allows for the management of group membership
directly using the group resource.
