### PR TITLE
Expand list of valid types in hpe_morpheus_form

### DIFF
--- a/docs/resources/morpheus_form.md
+++ b/docs/resources/morpheus_form.md
@@ -255,7 +255,7 @@ Optional:
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of rows to display for a text area
-- `type` (String) The type of option type to add to the field group (checkbox, hidden, number, password, radio, select, text, textarea, byteSize, code-editor, fileContent, logoSelector, textArray, typeahead, environment)
+- `type` (String) The type of option type to add to the field group (byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, httpHeader, instances-input, keyValue, layout, logoSelector, networkManager, number, password, plan, ports, radio, resourcePool, secGroup, select, servers-input, text, textArray, textarea, typeahead, virtual-image, vmwFolders)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 
@@ -299,7 +299,7 @@ Optional:
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of lines to show for a code editor or text area option type
-- `type` (String) The type of option type to add to the form (checkbox, hidden, number, password, radio, select, text, textarea, byteSize, code-editor, fileContent, logoSelector, textArray, typeahead, environment)
+- `type` (String) The type of option type to add to the form (byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, httpHeader, instances-input, keyValue, layout, logoSelector, networkManager, number, password, plan, ports, radio, resourcePool, secGroup, select, servers-input, text, textArray, textarea, typeahead, virtual-image, vmwFolders)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -101,13 +101,16 @@ func ResourceForm() *schema.Resource {
 						"type": {
 							Type: schema.TypeString,
 							Description: "The type of option type to add to the form " +
-								"(checkbox, hidden, number, password, radio, select, text, textarea, byteSize, " +
-								"code-editor, fileContent, logoSelector, textArray, typeahead, environment)",
+								"(byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, " +
+								"httpHeader, instances-input, keyValue, layout, logoSelector, networkManager, number, password, plan, " +
+								"ports, radio, resourcePool, secGroup, select, servers-input, text, textArray, textarea, typeahead, " +
+								"virtual-image, vmwFolders)",
 							ValidateFunc: validation.StringInSlice(
 								[]string{
-									"checkbox", "hidden", "number", "password", "radio", "select", "text",
-									"textarea", "byteSize", "code-editor", "fileContent", "logoSelector",
-									"textArray", "typeahead", "environment",
+									"byteSize", "checkbox", "cloud", "code-editor", "diskManager", "environment", "fileContent",
+									"group", "hidden", "httpHeader", "instances-input", "keyValue", "layout", "logoSelector",
+									"networkManager", "number", "password", "plan", "ports", "radio", "resourcePool", "secGroup", "select",
+									"servers-input", "text", "textArray", "textarea", "typeahead", "virtual-image", "vmwFolders",
 								},
 								false,
 							),
@@ -372,13 +375,17 @@ func ResourceForm() *schema.Resource {
 									"type": {
 										Type: schema.TypeString,
 										Description: "The type of option type to add to the field group " +
-											"(checkbox, hidden, number, password, radio, select, text, textarea, byteSize, " +
-											"code-editor, fileContent, logoSelector, textArray, typeahead, environment)",
+											"(byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, " +
+											"httpHeader, instances-input, keyValue, layout, logoSelector, networkManager, number, password, plan, " +
+											"ports, radio, resourcePool, secGroup, select, servers-input, text, textArray, textarea, typeahead, " +
+											"virtual-image, vmwFolders)",
 										ValidateFunc: validation.StringInSlice(
 											[]string{
-												"checkbox", "hidden", "number", "password", "radio", "select", "text",
-												"textarea", "byteSize", "code-editor", "fileContent", "logoSelector",
-												"textArray", "typeahead", "environment",
+												"byteSize", "checkbox", "cloud", "code-editor", "diskManager", "environment", "fileContent",
+												"group", "hidden", "httpHeader", "instances-input", "keyValue", "layout", "logoSelector",
+												"networkManager", "number", "password", "plan", "ports", "radio", "resourcePool", "secGroup",
+												"select", "servers-input", "text", "textArray", "textarea", "typeahead", "virtual-image",
+												"vmwFolders",
 											},
 											false,
 										),


### PR DESCRIPTION
In this PR we expand the list of valid types in hpe_morpheus_form using the current set of valid values as returned by the API.