### PR TITLE
Fix instance acceptance test

### DIFF
--- a/morpheus/framework/resources/instance/resource_test.go
+++ b/morpheus/framework/resources/instance/resource_test.go
@@ -79,7 +79,7 @@ func TestAccMorpheusInstanceExampleOk(t *testing.T) {
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_instance.example",
-			"config.resourcePoolId",
+			"config_hvm.resource_pool_id",
 			resourcePool,
 		),
 	}


### PR DESCRIPTION
It was checking for an attribute that was no longer present.