### PR TITLE
Fix hpe_morpheus_setting_monitoring

### DIFF
--- a/morpheus/sdkv2/resources/setting/setting_monitoring.go
+++ b/morpheus/sdkv2/resources/setting/setting_monitoring.go
@@ -318,15 +318,8 @@ func resourceSettingMonitoringCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
 	}
 
-	var result *morpheus.UpdateMonitoringSettingsResult
-	if v, ok := resp.Result.(*morpheus.UpdateMonitoringSettingsResult); ok {
-		result = v
-	} else {
+	if _, ok := resp.Result.(*morpheus.UpdateMonitoringSettingsResult); !ok {
 		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
-	}
-
-	if result.MonitoringSettings == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("MonitoringSettings"))
 	}
 
 	d.SetId(convert.Int64ToString(1))
@@ -597,15 +590,8 @@ func resourceSettingMonitoringUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
 	}
 
-	var result *morpheus.UpdateMonitoringSettingsResult
-	if v, ok := resp.Result.(*morpheus.UpdateMonitoringSettingsResult); ok {
-		result = v
-	} else {
+	if _, ok := resp.Result.(*morpheus.UpdateMonitoringSettingsResult); !ok {
 		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
-	}
-
-	if result.MonitoringSettings == nil {
-		return diag.FromErr(helpers.NotFoundInResponseError("MonitoringSettings"))
 	}
 
 	d.SetId(convert.Int64ToString(1))

--- a/morpheus/sdkv2/resources/setting/setting_monitoring_resource_example.go
+++ b/morpheus/sdkv2/resources/setting/setting_monitoring_resource_example.go
@@ -50,7 +50,7 @@ func RenderSettingMonitoringConfig(t *testing.T, overrides map[string]string) (s
 		return "", fmt.Errorf("unable to get current file path")
 	}
 	dir := filepath.Dir(filename)
-	templatePath := filepath.Join(dir, "setting_monitoring_resource.tf.tmpl")
+	templatePath := filepath.Join(dir, "setting_monitoring_resource_test.tf.tmpl")
 
 	return testhelpers.RenderExample(
 		t,

--- a/morpheus/sdkv2/resources/setting/setting_monitoring_resource_test.go
+++ b/morpheus/sdkv2/resources/setting/setting_monitoring_resource_test.go
@@ -23,9 +23,6 @@ func TestAccMorpheusSettingMonitoringExampleOk(t *testing.T) {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	t.Skip("Skipping due to missing infrastructure in test environment")
-	// "serviceNow.integration":"Integration not found for id '1'"
-
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())
@@ -62,59 +59,59 @@ func TestAccMorpheusSettingMonitoringExampleOk(t *testing.T) {
 			"120",
 		),
 
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"new_relic_license_key",
-			"ABC123",
-		),
-
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"new_relic_monitoring_enabled",
-			"true",
-		),
-
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"servicenow_close_incident_action",
-			"activity",
-		),
-
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"servicenow_integration_id",
-			"1",
-		),
-
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"servicenow_monitoring_enabled",
-			"true",
-		),
-
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"servicenow_new_incident_action",
-			"create",
-		),
-
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"servicenow_severity_critical_impact",
-			"low",
-		),
-
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"servicenow_severity_info_impact",
-			"high",
-		),
-
-		resource.TestCheckResourceAttr(
-			"hpe_morpheus_setting_monitoring.example",
-			"servicenow_severity_warning_impact",
-			"high",
-		),
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"new_relic_license_key",
+		// 	"ABC123",
+		// ),
+		//
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"new_relic_monitoring_enabled",
+		// 	"true",
+		// ),
+		//
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"servicenow_close_incident_action",
+		// 	"activity",
+		// ),
+		//
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"servicenow_integration_id",
+		// 	"1",
+		// ),
+		//
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"servicenow_monitoring_enabled",
+		// 	"true",
+		// ),
+		//
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"servicenow_new_incident_action",
+		// 	"create",
+		// ),
+		//
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"servicenow_severity_critical_impact",
+		// 	"low",
+		// ),
+		//
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"servicenow_severity_info_impact",
+		// 	"high",
+		// ),
+		//
+		// resource.TestCheckResourceAttr(
+		// 	"hpe_morpheus_setting_monitoring.example",
+		// 	"servicenow_severity_warning_impact",
+		// 	"high",
+		// ),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)

--- a/morpheus/sdkv2/resources/setting/setting_monitoring_resource_test.tf.tmpl
+++ b/morpheus/sdkv2/resources/setting/setting_monitoring_resource_test.tf.tmpl
@@ -1,0 +1,6 @@
+resource "hpe_morpheus_setting_monitoring" "example" {
+  morpheus_auto_create_checks         = {{.MorpheusAutoCreateChecks}}
+  morpheus_availability_time_frame    = {{.MorpheusAvailabilityTimeFrame}}
+  morpheus_availability_precision     = {{.MorpheusAvailabilityPrecision}}
+  morpheus_default_check_interval     = {{.MorpheusDefaultCheckInterval}}
+}


### PR DESCRIPTION

This PR fixes the hpe_morpheus_setting_monitoring resource and
adds a simpler test that doesn't require external services (ServiceNow and NewRelic)
