### PR TITLE
Add more valid strings for instance nested_virtualization

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -124,7 +124,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "pool-62299"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
   }
@@ -218,7 +218,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "pool-62299"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = false
     create_user           = true
   }
@@ -301,7 +301,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "pool-62299"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = false
     create_user           = true
   }
@@ -390,7 +390,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_vmware = {
     resource_pool_id      = "pool-1"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
     vmware_folder_id      = "group-v79"
@@ -487,7 +487,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_vmware = {
     resource_pool_id      = "pool-1"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
     vmware_folder_id      = "group-v79"
@@ -707,7 +707,8 @@ Optional:
 
 - `create_user` (Boolean) Whether to create a user when provisioning the instance.  The default is 'false'
 - `kvm_host_id` (Number) The id of the KVM host to use for provisioning.
-- `nested_virtualization` (Boolean) Enable nested virtualization on the instance. Can be 'true' or 'false'.  The default is 'false'
+- `nested_virtualization` (String) Enable nested virtualization on the instance. Can be a number of valid string values:
+   "on", "off", "0", "1", "true", "false", "yes", "no", "".  The default is "off".
 - `no_agent` (Boolean) Whether to skip installing the Morpheus agent on the instance.  The default is 'true'
 
 
@@ -722,7 +723,8 @@ Required:
 Optional:
 
 - `create_user` (Boolean) Whether to create a user when provisioning the instance.  The default is 'false'
-- `nested_virtualization` (Boolean) Enable nested virtualization on the instance. Can be 'true' or 'false'.  The default is 'false'
+- `nested_virtualization` (String) Enable nested virtualization on the instance. Can be a number of valid string values:
+   "on", "off", "0", "1", "true", "false", "yes", "no", "".  The default is "off".
 - `no_agent` (Boolean) Whether to skip installing the Morpheus agent on the instance.  The default is 'true'
 
 

--- a/morpheus/framework/resources/instance/example.tf
+++ b/morpheus/framework/resources/instance/example.tf
@@ -65,7 +65,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "pool-62299"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
   }

--- a/morpheus/framework/resources/instance/example.tf.tmpl
+++ b/morpheus/framework/resources/instance/example.tf.tmpl
@@ -65,7 +65,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "{{.ResourcePool}}"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
   }

--- a/morpheus/framework/resources/instance/example_timeouts.tf
+++ b/morpheus/framework/resources/instance/example_timeouts.tf
@@ -65,7 +65,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "pool-62299"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = false
     create_user           = true
   }

--- a/morpheus/framework/resources/instance/example_timeouts.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_timeouts.tf.tmpl
@@ -65,7 +65,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "{{.ResourcePool}}"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = false
     create_user           = true
   }

--- a/morpheus/framework/resources/instance/example_twonetworks.tf
+++ b/morpheus/framework/resources/instance/example_twonetworks.tf
@@ -79,7 +79,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "pool-62299"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = false
     create_user           = true
   }

--- a/morpheus/framework/resources/instance/example_twonetworks.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_twonetworks.tf.tmpl
@@ -79,7 +79,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_hvm = {
     resource_pool_id      = "{{.ResourcePool}}"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = false
     create_user           = true
   }

--- a/morpheus/framework/resources/instance/example_vmware.tf
+++ b/morpheus/framework/resources/instance/example_vmware.tf
@@ -70,7 +70,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_vmware = {
     resource_pool_id      = "pool-1"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
     vmware_folder_id      = "group-v79"

--- a/morpheus/framework/resources/instance/example_vmware.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_vmware.tf.tmpl
@@ -70,7 +70,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_vmware = {
     resource_pool_id      = "{{.ResourcePool}}"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
     vmware_folder_id      = "group-v79"

--- a/morpheus/framework/resources/instance/example_vmware_sp_options.tf
+++ b/morpheus/framework/resources/instance/example_vmware_sp_options.tf
@@ -75,7 +75,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_vmware = {
     resource_pool_id      = "pool-1"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
     vmware_folder_id      = "group-v79"

--- a/morpheus/framework/resources/instance/example_vmware_sp_options.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_vmware_sp_options.tf.tmpl
@@ -75,7 +75,7 @@ resource "hpe_morpheus_instance" "example" {
 
   config_vmware = {
     resource_pool_id      = "{{.ResourcePool}}"
-    nested_virtualization = false
+    nested_virtualization = "off"
     no_agent              = true
     create_user           = false
     vmware_folder_id      = "group-v79"

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -85,8 +85,7 @@ func (g *Resource) Create(
 		// The provisionTypeCode default is "mvm" which is the code for the HVM provisioning type.
 		configHvm := sdk.NewHVMInstanceConfigurationWithDefaults()
 		configHvm.SetCreateUser(plan.ConfigHvm.CreateUser.ValueBool())
-		configHvm.SetNestedVirtualization(
-			convert.BoolToStringOnOff(plan.ConfigHvm.NestedVirtualization.ValueBool()).ValueString())
+		configHvm.SetNestedVirtualization(plan.ConfigHvm.NestedVirtualization.ValueString())
 		configHvm.SetNoAgent(plan.ConfigHvm.NoAgent.ValueBool())
 		configHvm.SetResourcePoolId(plan.ConfigHvm.ResourcePoolId.ValueString())
 		if !plan.ConfigHvm.KvmHostId.IsNull() {
@@ -100,8 +99,7 @@ func (g *Resource) Create(
 	// VMware config
 	case !plan.ConfigVmware.IsNull() && !plan.ConfigVmware.IsUnknown():
 		configVMware := sdk.NewVMWareInstanceConfiguration1WithDefaults()
-		configVMware.SetNestedVirtualization(
-			convert.BoolToStringOnOff(plan.ConfigHvm.NestedVirtualization.ValueBool()).ValueString())
+		configVMware.SetNestedVirtualization(plan.ConfigHvm.NestedVirtualization.ValueString())
 		configVMware.SetCreateUser(plan.ConfigVmware.CreateUser.ValueBool())
 		configVMware.SetNoAgent(plan.ConfigVmware.NoAgent.ValueBool())
 		configVMware.SetResourcePoolId(plan.ConfigVmware.ResourcePoolId.ValueString())

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -320,7 +320,7 @@ func getInstanceVMwareConfig(
 
 	configVmware.CreateUser = convert.BoolToType(createUser)
 	configVmware.NoAgent = convert.BoolToType(noAgent)
-	configVmware.NestedVirtualization = convert.StringToBool(ctx, *nestedVirtualization)
+	configVmware.NestedVirtualization = convert.StrToType(nestedVirtualization)
 	configVmware.ResourcePoolId = convert.StrToType(resourcePoolId)
 	configVmware.VmwareFolderId = convert.StrToType(folderId)
 	configVmware.state = attr.ValueStateKnown
@@ -365,7 +365,7 @@ func getInstanceHVMConfig(
 
 	configHvm.CreateUser = convert.BoolToType(createUser)
 	configHvm.NoAgent = convert.BoolToType(noAgent)
-	configHvm.NestedVirtualization = convert.StringToBool(ctx, *nestedVirtualization)
+	configHvm.NestedVirtualization = convert.StrToType(nestedVirtualization)
 	configHvm.ResourcePoolId = convert.StrToType(resourcePoolId)
 	configHvm.KvmHostId = convert.Int64ToType(kvmHostId)
 	configHvm.state = attr.ValueStateKnown

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -67,12 +67,15 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 						Description:         "The id of the KVM host to use for provisioning.",
 						MarkdownDescription: "The id of the KVM host to use for provisioning.",
 					},
-					"nested_virtualization": schema.BoolAttribute{
+					"nested_virtualization": schema.StringAttribute{
 						Optional:            true,
 						Computed:            true,
-						Description:         "Enable nested virtualization on the instance. Can be 'true' or 'false'.  The default is 'false'",
-						MarkdownDescription: "Enable nested virtualization on the instance. Can be 'true' or 'false'.  The default is 'false'",
-						Default:             booldefault.StaticBool(false),
+						Description:         "Enable nested virtualization on the instance. Can be a number of valid string values:\n   \"on\", \"off\", \"0\", \"1\", \"true\", \"false\", \"yes\", \"no\", \"\".  The default is \"off\".\n",
+						MarkdownDescription: "Enable nested virtualization on the instance. Can be a number of valid string values:\n   \"on\", \"off\", \"0\", \"1\", \"true\", \"false\", \"yes\", \"no\", \"\".  The default is \"off\".\n",
+						Validators: []validator.String{
+							stringvalidator.OneOf("on", "off", "0", "1", "true", "false", "yes", "no", ""),
+						},
+						Default: stringdefault.StaticString("off"),
 					},
 					"no_agent": schema.BoolAttribute{
 						Optional:            true,
@@ -108,12 +111,15 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 						MarkdownDescription: "Whether to create a user when provisioning the instance.  The default is 'false'",
 						Default:             booldefault.StaticBool(false),
 					},
-					"nested_virtualization": schema.BoolAttribute{
+					"nested_virtualization": schema.StringAttribute{
 						Optional:            true,
 						Computed:            true,
-						Description:         "Enable nested virtualization on the instance. Can be 'true' or 'false'.  The default is 'false'",
-						MarkdownDescription: "Enable nested virtualization on the instance. Can be 'true' or 'false'.  The default is 'false'",
-						Default:             booldefault.StaticBool(false),
+						Description:         "Enable nested virtualization on the instance. Can be a number of valid string values:\n   \"on\", \"off\", \"0\", \"1\", \"true\", \"false\", \"yes\", \"no\", \"\".  The default is \"off\".\n",
+						MarkdownDescription: "Enable nested virtualization on the instance. Can be a number of valid string values:\n   \"on\", \"off\", \"0\", \"1\", \"true\", \"false\", \"yes\", \"no\", \"\".  The default is \"off\".\n",
+						Validators: []validator.String{
+							stringvalidator.OneOf("on", "off", "0", "1", "true", "false", "yes", "no", ""),
+						},
+						Default: stringdefault.StaticString("off"),
 					},
 					"no_agent": schema.BoolAttribute{
 						Optional:            true,
@@ -724,12 +730,12 @@ func (t ConfigHvmType) ValueFromObject(ctx context.Context, in basetypes.ObjectV
 		return nil, diags
 	}
 
-	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.BoolValue)
+	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.StringValue)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`nested_virtualization expected to be basetypes.BoolValue, was: %T`, nestedVirtualizationAttribute))
+			fmt.Sprintf(`nested_virtualization expected to be basetypes.StringValue, was: %T`, nestedVirtualizationAttribute))
 	}
 
 	noAgentAttribute, ok := attributes["no_agent"]
@@ -891,12 +897,12 @@ func NewConfigHvmValue(attributeTypes map[string]attr.Type, attributes map[strin
 		return NewConfigHvmValueUnknown(), diags
 	}
 
-	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.BoolValue)
+	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.StringValue)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`nested_virtualization expected to be basetypes.BoolValue, was: %T`, nestedVirtualizationAttribute))
+			fmt.Sprintf(`nested_virtualization expected to be basetypes.StringValue, was: %T`, nestedVirtualizationAttribute))
 	}
 
 	noAgentAttribute, ok := attributes["no_agent"]
@@ -1019,7 +1025,7 @@ var _ basetypes.ObjectValuable = ConfigHvmValue{}
 type ConfigHvmValue struct {
 	CreateUser           basetypes.BoolValue   `tfsdk:"create_user"`
 	KvmHostId            basetypes.Int64Value  `tfsdk:"kvm_host_id"`
-	NestedVirtualization basetypes.BoolValue   `tfsdk:"nested_virtualization"`
+	NestedVirtualization basetypes.StringValue `tfsdk:"nested_virtualization"`
 	NoAgent              basetypes.BoolValue   `tfsdk:"no_agent"`
 	ResourcePoolId       basetypes.StringValue `tfsdk:"resource_pool_id"`
 	state                attr.ValueState
@@ -1033,7 +1039,7 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 
 	attrTypes["create_user"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["kvm_host_id"] = basetypes.Int64Type{}.TerraformType(ctx)
-	attrTypes["nested_virtualization"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["nested_virtualization"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["no_agent"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["resource_pool_id"] = basetypes.StringType{}.TerraformType(ctx)
 
@@ -1115,7 +1121,7 @@ func (v ConfigHvmValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValu
 	attributeTypes := map[string]attr.Type{
 		"create_user":           basetypes.BoolType{},
 		"kvm_host_id":           basetypes.Int64Type{},
-		"nested_virtualization": basetypes.BoolType{},
+		"nested_virtualization": basetypes.StringType{},
 		"no_agent":              basetypes.BoolType{},
 		"resource_pool_id":      basetypes.StringType{},
 	}
@@ -1191,7 +1197,7 @@ func (v ConfigHvmValue) AttributeTypes(ctx context.Context) map[string]attr.Type
 	return map[string]attr.Type{
 		"create_user":           basetypes.BoolType{},
 		"kvm_host_id":           basetypes.Int64Type{},
-		"nested_virtualization": basetypes.BoolType{},
+		"nested_virtualization": basetypes.StringType{},
 		"no_agent":              basetypes.BoolType{},
 		"resource_pool_id":      basetypes.StringType{},
 	}
@@ -1258,12 +1264,12 @@ func (t ConfigVmwareType) ValueFromObject(ctx context.Context, in basetypes.Obje
 		return nil, diags
 	}
 
-	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.BoolValue)
+	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.StringValue)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`nested_virtualization expected to be basetypes.BoolValue, was: %T`, nestedVirtualizationAttribute))
+			fmt.Sprintf(`nested_virtualization expected to be basetypes.StringValue, was: %T`, nestedVirtualizationAttribute))
 	}
 
 	noAgentAttribute, ok := attributes["no_agent"]
@@ -1425,12 +1431,12 @@ func NewConfigVmwareValue(attributeTypes map[string]attr.Type, attributes map[st
 		return NewConfigVmwareValueUnknown(), diags
 	}
 
-	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.BoolValue)
+	nestedVirtualizationVal, ok := nestedVirtualizationAttribute.(basetypes.StringValue)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`nested_virtualization expected to be basetypes.BoolValue, was: %T`, nestedVirtualizationAttribute))
+			fmt.Sprintf(`nested_virtualization expected to be basetypes.StringValue, was: %T`, nestedVirtualizationAttribute))
 	}
 
 	noAgentAttribute, ok := attributes["no_agent"]
@@ -1570,7 +1576,7 @@ var _ basetypes.ObjectValuable = ConfigVmwareValue{}
 
 type ConfigVmwareValue struct {
 	CreateUser           basetypes.BoolValue   `tfsdk:"create_user"`
-	NestedVirtualization basetypes.BoolValue   `tfsdk:"nested_virtualization"`
+	NestedVirtualization basetypes.StringValue `tfsdk:"nested_virtualization"`
 	NoAgent              basetypes.BoolValue   `tfsdk:"no_agent"`
 	ResourcePoolId       basetypes.StringValue `tfsdk:"resource_pool_id"`
 	VmwareFolderId       basetypes.StringValue `tfsdk:"vmware_folder_id"`
@@ -1584,7 +1590,7 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 	var err error
 
 	attrTypes["create_user"] = basetypes.BoolType{}.TerraformType(ctx)
-	attrTypes["nested_virtualization"] = basetypes.BoolType{}.TerraformType(ctx)
+	attrTypes["nested_virtualization"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["no_agent"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["resource_pool_id"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["vmware_folder_id"] = basetypes.StringType{}.TerraformType(ctx)
@@ -1666,7 +1672,7 @@ func (v ConfigVmwareValue) ToObjectValue(ctx context.Context) (basetypes.ObjectV
 
 	attributeTypes := map[string]attr.Type{
 		"create_user":           basetypes.BoolType{},
-		"nested_virtualization": basetypes.BoolType{},
+		"nested_virtualization": basetypes.StringType{},
 		"no_agent":              basetypes.BoolType{},
 		"resource_pool_id":      basetypes.StringType{},
 		"vmware_folder_id":      basetypes.StringType{},
@@ -1742,7 +1748,7 @@ func (v ConfigVmwareValue) Type(ctx context.Context) attr.Type {
 func (v ConfigVmwareValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
 		"create_user":           basetypes.BoolType{},
-		"nested_virtualization": basetypes.BoolType{},
+		"nested_virtualization": basetypes.StringType{},
 		"no_agent":              basetypes.BoolType{},
 		"resource_pool_id":      basetypes.StringType{},
 		"vmware_folder_id":      basetypes.StringType{},


### PR DESCRIPTION
In this PR we revert instance nested_virtualization to being a string and we've added more valid values for it.