### PR TITLE
Fix failing task acceptance tests

### DIFF
--- a/docs/resources/morpheus_task.md
+++ b/docs/resources/morpheus_task.md
@@ -26,11 +26,11 @@ resource "hpe_morpheus_task" "example_task" {
 
         return false;
         EOT
-    if_operational_workflow_id   = 90
-    if_operational_workflow_name = "Test 1"
+    if_operational_workflow_id   = "4090"
+    if_operational_workflow_name = "Example If Workflow"
 
-    else_operational_workflow_id   = 91
-    else_operational_workflow_name = "Test 2"
+    else_operational_workflow_id   = "4091"
+    else_operational_workflow_name = "Example Else Workflow"
   }
 
   execute_target      = "local"
@@ -47,8 +47,8 @@ resource "hpe_morpheus_task" "example_task" {
   task_type_code = "nestedWorkflow"
 
   config = {
-    operationalWorkflowId   = "90"
-    operationalWorkflowName = "Test 1"
+    operationalWorkflowId   = "4090"
+    operationalWorkflowName = "Example Workflow"
   }
 
   execute_target = "local"

--- a/examples/resources/morpheus_task/example_conditional_workflow.tf
+++ b/examples/resources/morpheus_task/example_conditional_workflow.tf
@@ -9,11 +9,11 @@ resource "hpe_morpheus_task" "example_task" {
 
         return false;
         EOT
-    if_operational_workflow_id   = 90
-    if_operational_workflow_name = "Test 1"
+    if_operational_workflow_id   = "4090"
+    if_operational_workflow_name = "Example If Workflow"
 
-    else_operational_workflow_id   = 91
-    else_operational_workflow_name = "Test 2"
+    else_operational_workflow_id   = "4091"
+    else_operational_workflow_name = "Example Else Workflow"
   }
 
   execute_target      = "local"

--- a/examples/resources/morpheus_task/example_generic_config.tf
+++ b/examples/resources/morpheus_task/example_generic_config.tf
@@ -3,8 +3,8 @@ resource "hpe_morpheus_task" "example_task" {
   task_type_code = "nestedWorkflow"
 
   config = {
-    operationalWorkflowId   = "90"
-    operationalWorkflowName = "Test 1"
+    operationalWorkflowId   = "4090"
+    operationalWorkflowName = "Example Workflow"
   }
 
   execute_target = "local"

--- a/morpheus/framework/resources/task/example_conditional_workflow.tf.tmpl
+++ b/morpheus/framework/resources/task/example_conditional_workflow.tf.tmpl
@@ -9,11 +9,11 @@ resource "hpe_morpheus_task" "example_task" {
 
         return false;
         EOT
-        if_operational_workflow_id   = 90
-        if_operational_workflow_name = "Test 1"
+        if_operational_workflow_id   = "{{.IfOperationalWorkflowId}}"
+        if_operational_workflow_name = "{{.IfOperationalWorkflowName}}"
 
-        else_operational_workflow_id   = 91
-        else_operational_workflow_name = "Test 2"
+        else_operational_workflow_id   = "{{.ElseOperationalWorkflowId}}"
+        else_operational_workflow_name = "{{.ElseOperationalWorkflowName}}"
     }
 
     execute_target = "local"

--- a/morpheus/framework/resources/task/example_generic_config.tf.tmpl
+++ b/morpheus/framework/resources/task/example_generic_config.tf.tmpl
@@ -3,8 +3,8 @@ resource "hpe_morpheus_task" "example_task" {
     task_type_code = "nestedWorkflow"
 
     config = {
-        operationalWorkflowId = "90"
-        operationalWorkflowName = "Test 1"
+        operationalWorkflowId = "{{.OperationalWorkflowId}}"
+        operationalWorkflowName = "{{.OperationalWorkflowName}}"
     }
 
     execute_target = "local"

--- a/morpheus/framework/resources/task/task_test.go
+++ b/morpheus/framework/resources/task/task_test.go
@@ -1,7 +1,7 @@
 package task_test
 
-//go:generate go run ../../../../cmd/render -out examples/resources/morpheus_task/example_conditional_workflow.tf example_conditional_workflow.tf.tmpl Name "Example Conditional Workflow Task"
-//go:generate go run ../../../../cmd/render -out examples/resources/morpheus_task/example_generic_config.tf example_generic_config.tf.tmpl Name "Example Generic Task"
+//go:generate go run ../../../../cmd/render -out examples/resources/morpheus_task/example_conditional_workflow.tf example_conditional_workflow.tf.tmpl Name "Example Conditional Workflow Task" IfOperationalWorkflowId "4090" IfOperationalWorkflowName "Example If Workflow" ElseOperationalWorkflowId "4091" ElseOperationalWorkflowName "Example Else Workflow"
+//go:generate go run ../../../../cmd/render -out examples/resources/morpheus_task/example_generic_config.tf example_generic_config.tf.tmpl Name "Example Generic Task" OperationalWorkflowId "4090" OperationalWorkflowName "Example Workflow"
 
 import (
 	"os"
@@ -48,8 +48,16 @@ func TestAccMorpheusTaskExampleConditionalOk(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())
+	ifOperationalWorkflowId := "140"
+	elseOperationalWorkflowId := "102"
+	ifOperationalWorkflowName := "A Failure"
+	elseOperationalWorkflowName := "A Test"
 	resourceConfig, err := testhelpers.RenderExample(t, "example_conditional_workflow.tf.tmpl",
 		"Name", name,
+		"IfOperationalWorkflowId", ifOperationalWorkflowId,
+		"ElseOperationalWorkflowId", elseOperationalWorkflowId,
+		"IfOperationalWorkflowName", ifOperationalWorkflowName,
+		"ElseOperationalWorkflowName", elseOperationalWorkflowName,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -69,12 +77,12 @@ func TestAccMorpheusTaskExampleConditionalOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config_conditional_workflow.if_operational_workflow_id",
-			"90",
+			ifOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config_conditional_workflow.else_operational_workflow_id",
-			"91",
+			elseOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
@@ -122,8 +130,16 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())
+	ifOperationalWorkflowId := "140"
+	elseOperationalWorkflowId := "102"
+	ifOperationalWorkflowName := "A Failure"
+	elseOperationalWorkflowName := "A Test"
 	resourceConfig, err := testhelpers.RenderExample(t, "example_conditional_workflow.tf.tmpl",
 		"Name", name,
+		"IfOperationalWorkflowId", ifOperationalWorkflowId,
+		"ElseOperationalWorkflowId", elseOperationalWorkflowId,
+		"IfOperationalWorkflowName", ifOperationalWorkflowName,
+		"ElseOperationalWorkflowName", elseOperationalWorkflowName,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -143,12 +159,12 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config_conditional_workflow.if_operational_workflow_id",
-			"90",
+			ifOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config_conditional_workflow.else_operational_workflow_id",
-			"91",
+			elseOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
@@ -195,11 +211,11 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 						name = "` + name + `2"
 						task_type_code = "conditionalWorkflow"
 						config_conditional_workflow = {
-							if_operational_workflow_id   = 90
-							if_operational_workflow_name = "Test 1"
+							if_operational_workflow_id   = ` + ifOperationalWorkflowId + `
+							if_operational_workflow_name = "` + ifOperationalWorkflowName + `"
 
-							else_operational_workflow_id   = 91
-							else_operational_workflow_name = "Test 2"
+							else_operational_workflow_id   = ` + elseOperationalWorkflowId + `
+							else_operational_workflow_name = "` + elseOperationalWorkflowName + `"
 						}
 
 						execute_target = "local"
@@ -215,6 +231,11 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 					resource "hpe_morpheus_task" "example_task" {
 						name = "` + name + `2"
 						task_type_code = "nestedWorkflow"
+
+						config = {
+							operationalWorkflowId   = "` + ifOperationalWorkflowId + `"
+							operationalWorkflowName = "` + ifOperationalWorkflowName + `"
+						}
 
 						execute_target = "local"
 						retryable = false
@@ -236,8 +257,12 @@ func TestAccMorpheusTaskExampleGenericNestedOk(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())
+	operationalWorkflowId := "102"
+	operationalWorkflowName := "A Test"
 	resourceConfig, err := testhelpers.RenderExample(t, "example_generic_config.tf.tmpl",
 		"Name", name,
+		"OperationalWorkflowId", operationalWorkflowId,
+		"OperationalWorkflowName", operationalWorkflowName,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -257,12 +282,12 @@ func TestAccMorpheusTaskExampleGenericNestedOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config.operationalWorkflowId",
-			"90",
+			operationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config.operationalWorkflowName",
-			"Test 1",
+			operationalWorkflowName,
 		),
 	}
 

--- a/morpheus/framework/resources/task/task_test.go
+++ b/morpheus/framework/resources/task/task_test.go
@@ -18,6 +18,13 @@ import (
 	"github.com/HPE/terraform-provider-hpe/provider"
 )
 
+const (
+	testWorkflowName              = "A Test"
+	testFailureWorkflowName       = "A Failure"
+	testIfOperationalWorkflowId   = "140"
+	testElseOperationalWorkflowId = "102"
+)
+
 func TestMain(m *testing.M) {
 	code := m.Run()
 	testhelpers.WriteMergedResults()
@@ -48,16 +55,12 @@ func TestAccMorpheusTaskExampleConditionalOk(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())
-	ifOperationalWorkflowId := "140"
-	elseOperationalWorkflowId := "102"
-	ifOperationalWorkflowName := "A Failure"
-	elseOperationalWorkflowName := "A Test"
 	resourceConfig, err := testhelpers.RenderExample(t, "example_conditional_workflow.tf.tmpl",
 		"Name", name,
-		"IfOperationalWorkflowId", ifOperationalWorkflowId,
-		"ElseOperationalWorkflowId", elseOperationalWorkflowId,
-		"IfOperationalWorkflowName", ifOperationalWorkflowName,
-		"ElseOperationalWorkflowName", elseOperationalWorkflowName,
+		"IfOperationalWorkflowId", testIfOperationalWorkflowId,
+		"ElseOperationalWorkflowId", testElseOperationalWorkflowId,
+		"IfOperationalWorkflowName", testFailureWorkflowName,
+		"ElseOperationalWorkflowName", testWorkflowName,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -77,12 +80,12 @@ func TestAccMorpheusTaskExampleConditionalOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config_conditional_workflow.if_operational_workflow_id",
-			ifOperationalWorkflowId,
+			testIfOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config_conditional_workflow.else_operational_workflow_id",
-			elseOperationalWorkflowId,
+			testElseOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
@@ -130,16 +133,12 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())
-	ifOperationalWorkflowId := "140"
-	elseOperationalWorkflowId := "102"
-	ifOperationalWorkflowName := "A Failure"
-	elseOperationalWorkflowName := "A Test"
 	resourceConfig, err := testhelpers.RenderExample(t, "example_conditional_workflow.tf.tmpl",
 		"Name", name,
-		"IfOperationalWorkflowId", ifOperationalWorkflowId,
-		"ElseOperationalWorkflowId", elseOperationalWorkflowId,
-		"IfOperationalWorkflowName", ifOperationalWorkflowName,
-		"ElseOperationalWorkflowName", elseOperationalWorkflowName,
+		"IfOperationalWorkflowId", testIfOperationalWorkflowId,
+		"ElseOperationalWorkflowId", testElseOperationalWorkflowId,
+		"IfOperationalWorkflowName", testFailureWorkflowName,
+		"ElseOperationalWorkflowName", testWorkflowName,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -159,12 +158,12 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config_conditional_workflow.if_operational_workflow_id",
-			ifOperationalWorkflowId,
+			testIfOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config_conditional_workflow.else_operational_workflow_id",
-			elseOperationalWorkflowId,
+			testElseOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
@@ -211,11 +210,11 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 						name = "` + name + `2"
 						task_type_code = "conditionalWorkflow"
 						config_conditional_workflow = {
-							if_operational_workflow_id   = ` + ifOperationalWorkflowId + `
-							if_operational_workflow_name = "` + ifOperationalWorkflowName + `"
+							if_operational_workflow_id   = ` + testIfOperationalWorkflowId + `
+							if_operational_workflow_name = "` + testFailureWorkflowName + `"
 
-							else_operational_workflow_id   = ` + elseOperationalWorkflowId + `
-							else_operational_workflow_name = "` + elseOperationalWorkflowName + `"
+							else_operational_workflow_id   = ` + testElseOperationalWorkflowId + `
+							else_operational_workflow_name = "` + testWorkflowName + `"
 						}
 
 						execute_target = "local"
@@ -233,8 +232,8 @@ func TestAccMorpheusTaskConditionalWorkflowUpdate(t *testing.T) {
 						task_type_code = "nestedWorkflow"
 
 						config = {
-							operationalWorkflowId   = "` + ifOperationalWorkflowId + `"
-							operationalWorkflowName = "` + ifOperationalWorkflowName + `"
+							operationalWorkflowId   = "` + testIfOperationalWorkflowId + `"
+							operationalWorkflowName = "` + testFailureWorkflowName + `"
 						}
 
 						execute_target = "local"
@@ -257,12 +256,10 @@ func TestAccMorpheusTaskExampleGenericNestedOk(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())
-	operationalWorkflowId := "102"
-	operationalWorkflowName := "A Test"
 	resourceConfig, err := testhelpers.RenderExample(t, "example_generic_config.tf.tmpl",
 		"Name", name,
-		"OperationalWorkflowId", operationalWorkflowId,
-		"OperationalWorkflowName", operationalWorkflowName,
+		"OperationalWorkflowId", testElseOperationalWorkflowId,
+		"OperationalWorkflowName", testWorkflowName,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -282,12 +279,12 @@ func TestAccMorpheusTaskExampleGenericNestedOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config.operationalWorkflowId",
-			operationalWorkflowId,
+			testElseOperationalWorkflowId,
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_task.example_task",
 			"config.operationalWorkflowName",
-			operationalWorkflowName,
+			testWorkflowName,
 		),
 	}
 


### PR DESCRIPTION
The referenced tasks were missing.  Also there was a missing config block in one of the acceptance tests.  The task HCL templates have been updated and the docs regenerated.