### PR TITLE
Remove unimplemented form types from the list of valid options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ In this release (v1.2.0) we have added the following resource functionality:
 - hpe_morpheus_instance addition and removal of volumes is now supported in Update
 - hpe_morpheus_instance supports service_plan_options for use with Service Plans that accept options
 - hpe_morpheus_cloud no longer requires group_id to be set
-- hpe_morpheus_form supports more valid type values, see the docs
 - hpe_morpheus_group supports a list of cloud-ids to associate the group with
 
 ## New known issues

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,6 @@ In this release (v1.2.0) we have added the following resource functionality:
 - hpe_morpheus_instance addition and removal of volumes is now supported in Update
 - hpe_morpheus_instance supports service_plan_options for use with Service Plans that accept options
 - hpe_morpheus_cloud no longer requires group_id to be set
-- hpe_morpheus_form supports more valid type values, see the docs
 - hpe_morpheus_group supports a list of cloud-ids to associate the group with
 
 ### New known issues

--- a/docs/resources/morpheus_form.md
+++ b/docs/resources/morpheus_form.md
@@ -255,7 +255,7 @@ Optional:
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of rows to display for a text area
-- `type` (String) The type of option type to add to the field group (byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, httpHeader, instances-input, keyValue, layout, logoSelector, networkManager, number, password, plan, ports, radio, resourcePool, secGroup, select, servers-input, text, textArray, textarea, typeahead, virtual-image, vmwFolders)
+- `type` (String) The type of option type to add to the field group (byteSize, checkbox, code-editor, hidden, number, password, radio, select, text, textArray, textarea, typeahead)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 
@@ -299,7 +299,7 @@ Optional:
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of lines to show for a code editor or text area option type
-- `type` (String) The type of option type to add to the form (byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, httpHeader, instances-input, keyValue, layout, logoSelector, networkManager, number, password, plan, ports, radio, resourcePool, secGroup, select, servers-input, text, textArray, textarea, typeahead, virtual-image, vmwFolders)
+- `type` (String) The type of option type to add to the form (byteSize, checkbox, code-editor, hidden, number, password, radio, select, text, textArray, textarea, typeahead)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -35,6 +35,28 @@ const (
 	valueTrue  = "true"
 )
 
+// TODO: Add switch case handling for these option types.
+const (
+	typeCloud          = "cloud"
+	typeDiskManager    = "diskManager"
+	typeEnvironment    = "environment"
+	typeFileContent    = "fileContent"
+	typeGroup          = "group"
+	typeHTTPHeader     = "httpHeader"
+	typeInstancesInput = "instances-input"
+	typeKeyValue       = "keyValue"
+	typeLayout         = "layout"
+	typeLogoSelector   = "logoSelector"
+	typeNetworkManager = "networkManager"
+	typePlan           = "plan"
+	typePorts          = "ports"
+	typeResourcePool   = "resourcePool"
+	typeSecGroup       = "secGroup"
+	typeServersInput   = "servers-input"
+	typeVirtualImage   = "virtual-image"
+	typeVMWFolders     = "vmwFolders"
+)
+
 func ResourceForm() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Provides a Morpheus form resource",
@@ -101,16 +123,12 @@ func ResourceForm() *schema.Resource {
 						"type": {
 							Type: schema.TypeString,
 							Description: "The type of option type to add to the form " +
-								"(byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, " +
-								"httpHeader, instances-input, keyValue, layout, logoSelector, networkManager, number, password, plan, " +
-								"ports, radio, resourcePool, secGroup, select, servers-input, text, textArray, textarea, typeahead, " +
-								"virtual-image, vmwFolders)",
+								"(byteSize, checkbox, code-editor, hidden, number, password, radio, select, text, " +
+								"textArray, textarea, typeahead)",
 							ValidateFunc: validation.StringInSlice(
 								[]string{
-									"byteSize", "checkbox", "cloud", "code-editor", "diskManager", "environment", "fileContent",
-									"group", "hidden", "httpHeader", "instances-input", "keyValue", "layout", "logoSelector",
-									"networkManager", "number", "password", "plan", "ports", "radio", "resourcePool", "secGroup", "select",
-									"servers-input", "text", "textArray", "textarea", "typeahead", "virtual-image", "vmwFolders",
+									typeByteSize, typeCheckbox, typeCodeEditor, typeHidden, typeNumber, typePassword,
+									typeRadio, typeSelect, typeText, typeTextArray, typeTextArea, typeTypeahead,
 								},
 								false,
 							),
@@ -375,17 +393,12 @@ func ResourceForm() *schema.Resource {
 									"type": {
 										Type: schema.TypeString,
 										Description: "The type of option type to add to the field group " +
-											"(byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, " +
-											"httpHeader, instances-input, keyValue, layout, logoSelector, networkManager, number, password, plan, " +
-											"ports, radio, resourcePool, secGroup, select, servers-input, text, textArray, textarea, typeahead, " +
-											"virtual-image, vmwFolders)",
+											"(byteSize, checkbox, code-editor, hidden, number, password, radio, select, text, " +
+											"textArray, textarea, typeahead)",
 										ValidateFunc: validation.StringInSlice(
 											[]string{
-												"byteSize", "checkbox", "cloud", "code-editor", "diskManager", "environment", "fileContent",
-												"group", "hidden", "httpHeader", "instances-input", "keyValue", "layout", "logoSelector",
-												"networkManager", "number", "password", "plan", "ports", "radio", "resourcePool", "secGroup",
-												"select", "servers-input", "text", "textArray", "textarea", "typeahead", "virtual-image",
-												"vmwFolders",
+												typeByteSize, typeCheckbox, typeCodeEditor, typeHidden, typeNumber, typePassword,
+												typeRadio, typeSelect, typeText, typeTextArray, typeTextArea, typeTypeahead,
 											},
 											false,
 										),

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -36,7 +36,8 @@ const (
 )
 
 // TODO: Add switch case handling for these option types.
-const ( //nolint:unused
+//nolint: unused
+const (
 	typeCloud          = "cloud"
 	typeDiskManager    = "diskManager"
 	typeEnvironment    = "environment"

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -36,7 +36,7 @@ const (
 )
 
 // TODO: Add switch case handling for these option types.
-//nolint: unused
+// nolint: unused
 const (
 	typeCloud          = "cloud"
 	typeDiskManager    = "diskManager"

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -36,7 +36,7 @@ const (
 )
 
 // TODO: Add switch case handling for these option types.
-const (
+const ( //nolint:unused
 	typeCloud          = "cloud"
 	typeDiskManager    = "diskManager"
 	typeEnvironment    = "environment"

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -77,7 +77,6 @@ In this release (v1.2.0) we have added the following resource functionality:
 - hpe_morpheus_instance addition and removal of volumes is now supported in Update
 - hpe_morpheus_instance supports service_plan_options for use with Service Plans that accept options
 - hpe_morpheus_cloud no longer requires group_id to be set
-- hpe_morpheus_form supports more valid type values, see the docs
 - hpe_morpheus_group supports a list of cloud-ids to associate the group with
 
 ### New known issues


### PR DESCRIPTION
We sort the implemented types alphabetically, create constants for the unimplemented types and put them in a TODO list