### PR TITLE
Updating documentation to include tfmigrator

### DIFF
--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -129,6 +129,7 @@ The following table lists the resources that have identical schema between the M
 | morpheus_typeahead_option_type            | hpe_morpheus_option_type_typeahead            |
 | morpheus_user_group                       | hpe_morpheus_user_group                       |
 | morpheus_vro_integration                  | hpe_morpheus_integration_vro                  |
+| morpheus_vro_task                         | hpe_morpheus_vro_task                         |
 | morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_hks_vsphere              |
 | morpheus_wiki_page                        | hpe_morpheus_wiki_page                        |
 | morpheus_workflow_catalog_item            | hpe_morpheus_catalog_item_workflow            |
@@ -181,7 +182,6 @@ in the HPE provider and several Morpheus provider resources map to a single HPE 
 | morpheus_group | hpe_morpheus_group |
 | morpheus_service_plan | hpe_morpheus_service_plan |
 | morpheus_user | hpe_morpheus_user |
-| morpheus_vro_task | hpe_morpheus_task |
 
 For these resources terraform can be used to generate the HPE resource definition.  Examples of this process for `hpe_morpheus_instance`
 are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for

--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -9,8 +9,8 @@ To migrate resources from the Morpheus Terraform provider to the HPE Terraform p
 import the existing Morpheus resources created with the Morpheus provider into the HPE provider. HashiCorp documentation
 on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
 
--> We plan to develop tooling to assist with this migration in the future; however, the process is currently manual.
-In the meantime, we intend to publish guides on our blog, as well as other materials, to demonstrate the migration
+-> [tfmigrator](./tfmigrator_migration.md) has been developed in order to assist with migration. By following the documented process, this tooling should assist in porting `morpheus` resources to their corresponding `hpe` resources - including handling for modules and variables.
+Manual guides will continue available on our blog, as well as other materials to demonstrate the migration
 process using real-world use cases.<br><br>
 The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk) requires provider support for the `List` RPC.  The HPE provider does not currently
 support `List`, this is something that we are considering for a future release.<br><br>

--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -10,7 +10,7 @@ import the existing Morpheus resources created with the Morpheus provider into t
 on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
 
 -> [tfmigrator](./tfmigrator_migration.md) has been developed in order to assist with migration. By following the documented process, this tooling should assist in porting `morpheus` resources to their corresponding `hpe` resources - including handling for modules and variables.
-Manual guides will continue available on our blog, as well as other materials to demonstrate the migration
+Manual guides will continue to be available on our blog, as well as other materials to demonstrate the migration
 process using real-world use cases.<br><br>
 The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk) requires provider support for the `List` RPC.  The HPE provider does not currently
 support `List`, this is something that we are considering for a future release.<br><br>

--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -129,7 +129,7 @@ The following table lists the resources that have identical schema between the M
 | morpheus_typeahead_option_type            | hpe_morpheus_option_type_typeahead            |
 | morpheus_user_group                       | hpe_morpheus_user_group                       |
 | morpheus_vro_integration                  | hpe_morpheus_integration_vro                  |
-| morpheus_vro_task                         | hpe_morpheus_vro_task                         |
+| morpheus_vro_task                         | hpe_morpheus_task_vro                         |
 | morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_hks_vsphere              |
 | morpheus_wiki_page                        | hpe_morpheus_wiki_page                        |
 | morpheus_workflow_catalog_item            | hpe_morpheus_catalog_item_workflow            |

--- a/docs/guides/morpheus_to_hpe_migration.md
+++ b/docs/guides/morpheus_to_hpe_migration.md
@@ -86,7 +86,7 @@ The following table lists the resources that have identical schema between the M
 | morpheus_instance_type                    | hpe_morpheus_instance_type                    |
 | morpheus_ipv4_ip_pool                     | hpe_morpheus_ip_pool_ipv4                     |
 | morpheus_javascript_task                  | hpe_morpheus_task_javascript                  |
-| morpheus_key_pairs                        | hpe_morpheus_key_pair                         |
+| morpheus_key_pair                         | hpe_morpheus_key_pair                         |
 | morpheus_kubernetes_app_blueprint         | hpe_morpheus_app_blueprint_kubernetes         |
 | morpheus_kubernetes_spec_template         | hpe_morpheus_spec_template_kubernetes         |
 | morpheus_library_script_task              | hpe_morpheus_task_library_script              |
@@ -178,6 +178,10 @@ in the HPE provider and several Morpheus provider resources map to a single HPE 
 | morpheus_workflow_policy | hpe_morpheus_policy |
 | morpheus_tenant_role | hpe_morpheus_role |
 | morpheus_user_role | hpe_morpheus_role |
+| morpheus_group | hpe_morpheus_group |
+| morpheus_service_plan | hpe_morpheus_service_plan |
+| morpheus_user | hpe_morpheus_user |
+| morpheus_vro_task | hpe_morpheus_task |
 
 For these resources terraform can be used to generate the HPE resource definition.  Examples of this process for `hpe_morpheus_instance`
 are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -78,6 +78,19 @@ provider "hpe" {
     password = var.morpheus_password
   }
 }
+
+variable "morpheus_url" {
+  type = string
+}
+
+variable "morpheus_username" {
+  type = string
+}
+
+variable "morpheus_password" {
+  type      = string
+  sensitive = true
+}
 ```
 
 This setup is expected to exist before migration.
@@ -114,7 +127,7 @@ tfmigrator generate \
 
 - `--provider-config` should point to wherever your HPE provider is configured for the migration context (for example, `./provider.tf` or `./main.tf`). Alternatively - create a temporary file for this step (i.e. `.provider/provider.tf`) that follows the below format:
 
-```hclå
+```hcl
 terraform {
   required_providers {
     morpheus = {

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -1,0 +1,344 @@
+---
+page_title: "tfmigrator: Morpheus to HPE"
+subcategory: "Migration"
+---
+
+
+## What This Guide Covers
+
+This document is a step-by-step guide for migrating Terraform configuration from Morpheus provider resources to HPE provider resources using `tfmigrator`.
+
+- Preserve your variables, modules, expressions, and overall configuration structure.
+- Update resource types and schemas to HPE provider resources.
+- Run migration into a separate output directory so you can review before apply.
+
+---
+
+## Command Summary
+
+`tfmigrator` migration flow is typically:
+
+1. `generate` - extract resources from state, build `generated.tf` + `import.tf`
+2. `merge` - merge generated resources into original config while preserving user intent
+3. `terraform init / plan / apply --refresh-only / apply` - validate and apply in migrated output
+
+Optional:
+
+1. `clean` - run if you generated raw Terraform config externally and need cleanup rules - or after running `generate --no-cleanup`
+
+---
+
+## Required Inputs
+
+Before starting, ensure you have:
+
+1. Terraform state JSON, typically from:
+
+```bash
+terraform show -json > state.json
+```
+
+2. Your HPE provider setup in Terraform configuration (root and modules as needed).
+
+3. Your original Terraform configuration directory.
+
+Ensure provider setup is already in your Terraform files before running migration.
+
+---
+
+## Basic Provider Setup (Do This First)
+
+Set up `required_providers` and provider blocks in your Terraform code before using `tfmigrator`. Update the `required_providers` block in root and modules as needed.
+
+```hcl
+terraform {
+  required_providers {
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = "0.13.1"
+    }
+    hpe = {
+      source  = "HPE/hpe"
+      version = "= 1.2.0"
+    }
+  }
+}
+
+
+provider "morpheus" {
+  url      = var.morpheus_url
+  username = var.morpheus_username
+  password = var.morpheus_password
+}
+
+provider "hpe" {
+  morpheus {
+    url      = var.morpheus_url
+    username = var.morpheus_username
+    password = var.morpheus_password
+  }
+}
+```
+
+This setup is expected to exist before migration.
+
+
+---
+
+## Step 1: Generate Migration Artifacts
+
+### Basic command
+
+```bash
+tfmigrator generate \
+  --state state.json \
+  --provider-config ./provider.tf
+```
+
+### Generate flags
+
+- `--state, -s` Path to Terraform state JSON from `terraform show -json > state.json` (required)
+- `--output-dir, -o` Output directory for generated files (default `./generated`)
+- `--provider-config` Path to a Terraform provider context file containing `terraform` and provider blocks (and optional `variable` / `locals` blocks)
+- `--provider-var-file` Optional var-file(s) for provider context, repeatable (default none)
+- `--provider-var` Optional variable(s) passed to Terraform plan in `key=value` format, repeatable (default none)
+- `--no-cleanup` Skip automatic cleanup pass (default `false`)
+- `--dry-run` Preview output without writing files (default `false`)
+
+### Generate output
+
+- `generated/generated.tf`
+  - Combined output for same-schema and different-schema resources
+- `generated/import.tf`
+  - Import blocks for migrated resources
+
+- `--provider-config` should point to wherever your HPE provider is configured for the migration context (for example, `./provider.tf` or `./main.tf`). Alternatively - create a temporary file for this step (i.e. `.provider/provider.tf`) that follows the below format:
+
+```hcl
+terraform {
+  required_providers {
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = "0.13.1"
+    }
+    hpe = {
+      source  = "HPE/hpe"
+      version = "= 1.2.0"
+    }
+  }
+}
+
+
+provider "morpheus" {
+  url      = "YOURURLHERE"
+  username = "YOURUSERNAMEHERE"
+  password = "YOURPASSWORDHERE"
+}
+
+provider "hpe" {
+  morpheus {
+    url      = "YOURURLHERE"
+    username = "YOURUSERNAMEHERE"
+    password = "YOURPASSWORDHERE"
+  }
+}
+```
+-> If variables are used in the `--provider-config` - the respective `variable` blocks are expected to be provided in that file. The values themselves can then be passed in via `--provider-var-file` or `--provider-var`.
+
+- Cleanup is run automatically at the end of `generate` unless you pass `--no-cleanup`.
+
+---
+
+## Optional Step 1.5: Run `clean` Manually
+
+Use this when:
+
+- You ran `generate --no-cleanup`
+- You want to inspect cleanup changes separately
+- You are cleaning a generated file from another workflow
+
+Recommended in-place cleanup:
+
+```bash
+tfmigrator clean \
+  --input ./generated/generated.tf \
+  --in-place
+```
+
+If you prefer a separate output file:
+
+```bash
+tfmigrator clean \
+  --input ./generated/generated.tf \
+  --output ./generated/cleaned.tf
+```
+
+If you write to `cleaned.tf`, use that file as the `--generated` input in Step 2.
+
+---
+
+## Step 2: Merge Into Original Config
+
+### Recommended command
+
+```bash
+tfmigrator merge \
+  --original . \  # Will find .tf files recursively from this directory
+```
+
+### Merge flags
+
+- `--generated, -g` Path to generated Terraform file (default `./generated/generated.tf`)
+- `--original, -o` Original Terraform configuration file(s) and/or directories, repeatable
+- `--output-dir, -d` Output directory for merged configuration (default `./migrated`)
+- `--imports-file` Explicit imports file path (auto-discovered from generated file location when omitted)
+- `--var-file` Var-file(s) to copy into output directory, repeatable (default none)
+- `--dry-run` Preview changes only (default `false`)
+- `--no-color` Disable ANSI color in diff display (default `false`)
+- `--verbose, -v` More detailed logs (default `false`)
+
+### What merge does
+
+- Same-schema resources are renamed while keeping existing expressions/variables where possible.
+- Different-schema resources are merged from generated output.
+- Result is written to your `--output-dir` so you can review before applying.
+
+---
+
+## Dry-Run Workflow (Recommended)
+
+Run both phases in dry-run mode first:
+
+```bash
+tfmigrator generate \
+  --state state.json \
+  --provider-config ./provider.tf \
+  --dry-run
+
+# After an actual generation
+tfmigrator merge \
+  --original . \
+  --dry-run
+```
+
+What to review in merge dry-run output:
+
+1. `Merge Results` counts
+2. `Merge Transformations` lines
+3. Unified diff section (`Proposed Changes`)
+
+
+---
+
+## Dry-Run Output Example
+
+Example excerpt from a successful `merge --dry-run` run:
+
+```text
+Merging configurations...
+
+=== Merge Results ===
+
+Resources added: 0
+Resources merged: 2
+Modules updated: 0
+
+Dry run completed - no files were modified
+
+=== Merge Transformations ===
+~ Updated same-schema module resource morpheus_python_script_task.task -> hpe_morpheus_task_python_script (preserved original attributes)
+~ Updated module resource morpheus_max_cores_policy.user_policy -> hpe_morpheus_policy (affects all instances)
+
+=== Proposed Changes (Unified Diff) ===
+--- user-policy/main.tf
++++ user-policy/main.tf
+@@
+- resource "morpheus_max_cores_policy" "user_policy" {
++ resource "hpe_morpheus_policy" "user_policy" {
+    description = "Max cores policy for user ${var.user_name}"
+    enabled     = var.enabled
+-   user_id     = var.user_id
++   associated_resource_id   = var.user_id
++   associated_resource_type = "User"
+  }
+```
+
+- In terminal output, removed lines are red and added lines are green.
+
+---
+
+## Apply Workflow
+
+After dry-run looks correct:
+
+1. Run merge without `--dry-run`
+2. Move to migrated directory
+3. Run standard Terraform validation/apply flow
+
+```bash
+tfmigrator merge \
+  --original . \
+  --generated ./generated/generated.tf \
+  --output-dir ./migrated
+
+cd ./migrated
+terraform init
+terraform plan
+# Check that everything is just imports
+terraform apply --refresh-only
+terraform apply
+```
+
+---
+
+## Common Patterns
+
+### Using provider var files during generate
+
+```bash
+tfmigrator generate \
+  --state state.json \
+  --provider-config ./provider.tf \
+  --provider-var-file terraform.tfvars \
+  --provider-var-file secrets.auto.tfvars \
+  --output-dir ./generated
+```
+
+Note this currently requires the used `variable` blocks to be in the provider.tf file.
+
+### Copying var files into migrated output during merge
+
+```bash
+tfmigrator merge \
+  --original . \
+  --generated ./generated/generated.tf \
+  --var-file terraform.tfvars \
+  --var-file env/dev.tfvars \
+  --output-dir ./migrated
+```
+
+### Explicit imports file (if auto-discovery is not desired)
+
+```bash
+tfmigrator merge \
+  --original . \
+  --generated ./generated/generated.tf \
+  --imports-file ./generated/import.tf \
+  --output-dir ./migrated
+```
+
+---
+
+## Troubleshooting
+
+For common `generate`, `merge`, and resource-specific migration issues, see [tfmigrator Troubleshooting](./tfmigrator_troubleshooting.md).
+
+---
+
+## What tfmigrator Preserves
+
+- Variable references (`var.*`)
+- Expressions and interpolation
+- Core block structure where possible
+- Modules
+- Comments in the configuration (excluding inline comments from resources with different schema)

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -55,7 +55,7 @@ terraform {
   required_providers {
     morpheus = {
       source  = "gomorpheus/morpheus"
-      version = "0.13.1"
+      version = "0.14.1"
     }
     hpe = {
       source  = "HPE/hpe"
@@ -114,12 +114,12 @@ tfmigrator generate \
 
 - `--provider-config` should point to wherever your HPE provider is configured for the migration context (for example, `./provider.tf` or `./main.tf`). Alternatively - create a temporary file for this step (i.e. `.provider/provider.tf`) that follows the below format:
 
-```hcl
+```hclå
 terraform {
   required_providers {
     morpheus = {
       source  = "gomorpheus/morpheus"
-      version = "0.13.1"
+      version = "0.14.1"
     }
     hpe = {
       source  = "HPE/hpe"

--- a/docs/guides/tfmigrator_troubleshooting.md
+++ b/docs/guides/tfmigrator_troubleshooting.md
@@ -1,0 +1,175 @@
+---
+page_title: "tfmigrator: Troubleshooting"
+subcategory: "Migration"
+---
+
+# tfmigrator Troubleshooting
+
+This guide covers common issues that can appear during `tfmigrator generate`, `tfmigrator merge`, and follow-up Terraform validation and apply steps.
+
+---
+
+## Generate Issues
+
+### Provider context errors during generate
+
+Confirm `--provider-config` points to a real `.tf` file that includes your HPE provider configuration. This provider context is used when `tfmigrator` runs Terraform planning to generate configuration.
+
+If your provider config uses variables, ensure the corresponding `variable` blocks are present in that file and pass values with `--provider-var-file` and/or `--provider-var`.
+```
+terraform {
+  required_providers {
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = "0.13.1"
+    }
+    hpe = {
+      source  = "HPE/hpe"
+      version = "= 1.2.0"
+    }
+  }
+}
+
+
+provider "morpheus" {
+  url      = var.morpheus_url
+  username = var.morpheus_username
+  password = var.morpheus_password
+}
+
+provider "hpe" {
+  morpheus {
+    url      = var.morpheus_url
+    username = var.morpheus_username
+    password = var.morpheus_password
+  }
+}
+
+variable "morpheus_url" {
+  type = string
+}
+
+variable "morpheus_username" {
+  type = string
+}
+
+variable "morpheus_password" {
+  type      = string
+  sensitive = true
+}
+```
+
+### Unauthorized or invalid token errors
+
+A failed generate can return errors similar to:
+
+```text
+# group 41596 GET failed: 401 (Unauthorized):
+# {"error":"invalid_token","error_description":"Invalid access token:\n# BADTOKEN"}
+```
+
+Fix:
+
+- Review the credentials or token used by the provider configuration.
+- Confirm the URL, username, password, or token in `--provider-config` are valid for the Morpheus environment you are targeting.
+- If credentials are supplied via variables, confirm the correct values are being passed through `--provider-var-file` or `--provider-var`.
+
+### Validation errors before cleanup
+
+During `generate`, Terraform validation errors may appear in terminal output before cleanup runs. These are often expected for raw generated configuration and can usually be ignored until the cleanup pass has completed.
+
+If you used `--no-cleanup`, run cleanup separately before reviewing the generated file:
+
+```bash
+tfmigrator clean \
+  --input ./generated/generated.tf \
+  --in-place
+```
+
+### Generated file not found
+
+If `merge` reports that the generated file cannot be found, confirm the path passed to `--generated` and ensure `generate` completed successfully first.
+
+---
+
+## Merge Issues
+
+### Wrong provider source in modules
+
+If Terraform reports an error such as:
+
+```text
+Error: Failed to query available provider packages
+
+Could not retrieve the list of available versions for provider hashicorp/hpe:
+provider registry registry.terraform.io does not have a provider named
+registry.terraform.io/hashicorp/hpe
+```
+
+Fix:
+
+Ensure `required_providers` is set correctly in the root module and in any child modules that declare providers:
+
+```hcl
+terraform {
+  required_providers {
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = "0.13.1"
+    }
+    hpe = {
+      source  = "HPE/hpe"
+      version = "= 1.2.0"
+    }
+  }
+}
+```
+
+---
+
+## hpe_morpheus_instance Issues
+
+### nested_virtualization validation errors
+
+Generated or merged configuration for `hpe_morpheus_instance` can fail with errors such as:
+
+```text
+Attribute config_vmware.nested_virtualization value must be one of: ["on" "off"], got: "0"
+```
+
+Fix:
+- Ensure the HPE provider is at version `1.2.0` or later.
+- Alternatively, set `nested_virtualization` values to `"on"` or `"off"` in the migrated configuration.
+
+
+This issue is most commonly seen in generated or merged VMware instance configuration.
+
+### Tag casing or metadata validation errors
+
+In some environments, tag validation can fail with errors similar to:
+
+```json
+{"errors":{"metadata":"tag:
+'APPLICATION' must have a valid property","APPLICATION":"must have a valid property"}}
+```
+
+Fix:
+
+Review the generated or merged `tags` block and update tag names to match the exact casing and properties expected by the target environment.
+
+Example adjustment:
+
+```hcl
+tags = [
+  {
+    name  = "APPLICATION"
+    value = "ubuntu"
+  },
+  {
+    name  = "name"
+    value = "ubuntutf"
+  },
+]
+```
+
+If the original configuration used title-cased or additional tag names, do not assume those values will remain valid after migration. Reconcile the final tag set against what Morpheus accepts for that environment.

--- a/docs/guides/tfmigrator_troubleshooting.md
+++ b/docs/guides/tfmigrator_troubleshooting.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     morpheus = {
       source  = "gomorpheus/morpheus"
-      version = "0.13.1"
+      version = "0.14.1"
     }
     hpe = {
       source  = "HPE/hpe"
@@ -115,7 +115,7 @@ terraform {
   required_providers {
     morpheus = {
       source  = "gomorpheus/morpheus"
-      version = "0.13.1"
+      version = "0.14.1"
     }
     hpe = {
       source  = "HPE/hpe"

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -129,6 +129,7 @@ The following table lists the resources that have identical schema between the M
 | morpheus_typeahead_option_type            | hpe_morpheus_option_type_typeahead            |
 | morpheus_user_group                       | hpe_morpheus_user_group                       |
 | morpheus_vro_integration                  | hpe_morpheus_integration_vro                  |
+| morpheus_vro_task                         | hpe_morpheus_vro_task                         |
 | morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_hks_vsphere              |
 | morpheus_wiki_page                        | hpe_morpheus_wiki_page                        |
 | morpheus_workflow_catalog_item            | hpe_morpheus_catalog_item_workflow            |
@@ -181,7 +182,6 @@ in the HPE provider and several Morpheus provider resources map to a single HPE 
 | morpheus_group | hpe_morpheus_group |
 | morpheus_service_plan | hpe_morpheus_service_plan |
 | morpheus_user | hpe_morpheus_user |
-| morpheus_vro_task | hpe_morpheus_task |
 
 For these resources terraform can be used to generate the HPE resource definition.  Examples of this process for `hpe_morpheus_instance`
 are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -9,8 +9,8 @@ To migrate resources from the Morpheus Terraform provider to the HPE Terraform p
 import the existing Morpheus resources created with the Morpheus provider into the HPE provider. HashiCorp documentation
 on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
 
--> We plan to develop tooling to assist with this migration in the future; however, the process is currently manual.
-In the meantime, we intend to publish guides on our blog, as well as other materials, to demonstrate the migration
+-> [tfmigrator](./tfmigrator_migration.md) has been developed in order to assist with migration. By following the documented process, this tooling should assist in porting `morpheus` resources to their corresponding `hpe` resources - including handling for modules and variables.
+Manual guides will continue available on our blog, as well as other materials to demonstrate the migration
 process using real-world use cases.<br><br>
 The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk) requires provider support for the `List` RPC.  The HPE provider does not currently
 support `List`, this is something that we are considering for a future release.<br><br>

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -10,7 +10,7 @@ import the existing Morpheus resources created with the Morpheus provider into t
 on import can be found [here](https://developer.hashicorp.com/terraform/language/import).
 
 -> [tfmigrator](./tfmigrator_migration.md) has been developed in order to assist with migration. By following the documented process, this tooling should assist in porting `morpheus` resources to their corresponding `hpe` resources - including handling for modules and variables.
-Manual guides will continue available on our blog, as well as other materials to demonstrate the migration
+Manual guides will continue to be available on our blog, as well as other materials to demonstrate the migration
 process using real-world use cases.<br><br>
 The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk) requires provider support for the `List` RPC.  The HPE provider does not currently
 support `List`, this is something that we are considering for a future release.<br><br>

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -129,7 +129,7 @@ The following table lists the resources that have identical schema between the M
 | morpheus_typeahead_option_type            | hpe_morpheus_option_type_typeahead            |
 | morpheus_user_group                       | hpe_morpheus_user_group                       |
 | morpheus_vro_integration                  | hpe_morpheus_integration_vro                  |
-| morpheus_vro_task                         | hpe_morpheus_vro_task                         |
+| morpheus_vro_task                         | hpe_morpheus_task_vro                         |
 | morpheus_vsphere_mks_cluster              | hpe_morpheus_cluster_hks_vsphere              |
 | morpheus_wiki_page                        | hpe_morpheus_wiki_page                        |
 | morpheus_workflow_catalog_item            | hpe_morpheus_catalog_item_workflow            |

--- a/templates/guides/morpheus_to_hpe_migration.md
+++ b/templates/guides/morpheus_to_hpe_migration.md
@@ -86,7 +86,7 @@ The following table lists the resources that have identical schema between the M
 | morpheus_instance_type                    | hpe_morpheus_instance_type                    |
 | morpheus_ipv4_ip_pool                     | hpe_morpheus_ip_pool_ipv4                     |
 | morpheus_javascript_task                  | hpe_morpheus_task_javascript                  |
-| morpheus_key_pairs                        | hpe_morpheus_key_pair                         |
+| morpheus_key_pair                         | hpe_morpheus_key_pair                         |
 | morpheus_kubernetes_app_blueprint         | hpe_morpheus_app_blueprint_kubernetes         |
 | morpheus_kubernetes_spec_template         | hpe_morpheus_spec_template_kubernetes         |
 | morpheus_library_script_task              | hpe_morpheus_task_library_script              |
@@ -178,6 +178,10 @@ in the HPE provider and several Morpheus provider resources map to a single HPE 
 | morpheus_workflow_policy | hpe_morpheus_policy |
 | morpheus_tenant_role | hpe_morpheus_role |
 | morpheus_user_role | hpe_morpheus_role |
+| morpheus_group | hpe_morpheus_group |
+| morpheus_service_plan | hpe_morpheus_service_plan |
+| morpheus_user | hpe_morpheus_user |
+| morpheus_vro_task | hpe_morpheus_task |
 
 For these resources terraform can be used to generate the HPE resource definition.  Examples of this process for `hpe_morpheus_instance`
 are documented [here](./morpheus_instance_to_hpe_instance.md).  The configuration can be generated resource by resource or for

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -78,6 +78,19 @@ provider "hpe" {
     password = var.morpheus_password
   }
 }
+
+variable "morpheus_url" {
+  type = string
+}
+
+variable "morpheus_username" {
+  type = string
+}
+
+variable "morpheus_password" {
+  type      = string
+  sensitive = true
+}
 ```
 
 This setup is expected to exist before migration.
@@ -114,7 +127,7 @@ tfmigrator generate \
 
 - `--provider-config` should point to wherever your HPE provider is configured for the migration context (for example, `./provider.tf` or `./main.tf`). Alternatively - create a temporary file for this step (i.e. `.provider/provider.tf`) that follows the below format:
 
-```hclå
+```hcl
 terraform {
   required_providers {
     morpheus = {

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -1,0 +1,344 @@
+---
+page_title: "tfmigrator: Morpheus to HPE"
+subcategory: "Migration"
+---
+
+
+## What This Guide Covers
+
+This document is a step-by-step guide for migrating Terraform configuration from Morpheus provider resources to HPE provider resources using `tfmigrator`.
+
+- Preserve your variables, modules, expressions, and overall configuration structure.
+- Update resource types and schemas to HPE provider resources.
+- Run migration into a separate output directory so you can review before apply.
+
+---
+
+## Command Summary
+
+`tfmigrator` migration flow is typically:
+
+1. `generate` - extract resources from state, build `generated.tf` + `import.tf`
+2. `merge` - merge generated resources into original config while preserving user intent
+3. `terraform init / plan / apply --refresh-only / apply` - validate and apply in migrated output
+
+Optional:
+
+1. `clean` - run if you generated raw Terraform config externally and need cleanup rules - or after running `generate --no-cleanup`
+
+---
+
+## Required Inputs
+
+Before starting, ensure you have:
+
+1. Terraform state JSON, typically from:
+
+```bash
+terraform show -json > state.json
+```
+
+2. Your HPE provider setup in Terraform configuration (root and modules as needed).
+
+3. Your original Terraform configuration directory.
+
+Ensure provider setup is already in your Terraform files before running migration.
+
+---
+
+## Basic Provider Setup (Do This First)
+
+Set up `required_providers` and provider blocks in your Terraform code before using `tfmigrator`. Update the `required_providers` block in root and modules as needed.
+
+```hcl
+terraform {
+  required_providers {
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = "0.13.1"
+    }
+    hpe = {
+      source  = "HPE/hpe"
+      version = "= 1.2.0"
+    }
+  }
+}
+
+
+provider "morpheus" {
+  url      = var.morpheus_url
+  username = var.morpheus_username
+  password = var.morpheus_password
+}
+
+provider "hpe" {
+  morpheus {
+    url      = var.morpheus_url
+    username = var.morpheus_username
+    password = var.morpheus_password
+  }
+}
+```
+
+This setup is expected to exist before migration.
+
+
+---
+
+## Step 1: Generate Migration Artifacts
+
+### Basic command
+
+```bash
+tfmigrator generate \
+  --state state.json \
+  --provider-config ./provider.tf
+```
+
+### Generate flags
+
+- `--state, -s` Path to Terraform state JSON from `terraform show -json > state.json` (required)
+- `--output-dir, -o` Output directory for generated files (default `./generated`)
+- `--provider-config` Path to a Terraform provider context file containing `terraform` and provider blocks (and optional `variable` / `locals` blocks)
+- `--provider-var-file` Optional var-file(s) for provider context, repeatable (default none)
+- `--provider-var` Optional variable(s) passed to Terraform plan in `key=value` format, repeatable (default none)
+- `--no-cleanup` Skip automatic cleanup pass (default `false`)
+- `--dry-run` Preview output without writing files (default `false`)
+
+### Generate output
+
+- `generated/generated.tf`
+  - Combined output for same-schema and different-schema resources
+- `generated/import.tf`
+  - Import blocks for migrated resources
+
+- `--provider-config` should point to wherever your HPE provider is configured for the migration context (for example, `./provider.tf` or `./main.tf`). Alternatively - create a temporary file for this step (i.e. `.provider/provider.tf`) that follows the below format:
+
+```hcl
+terraform {
+  required_providers {
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = "0.13.1"
+    }
+    hpe = {
+      source  = "HPE/hpe"
+      version = "= 1.2.0"
+    }
+  }
+}
+
+
+provider "morpheus" {
+  url      = "YOURURLHERE"
+  username = "YOURUSERNAMEHERE"
+  password = "YOURPASSWORDHERE"
+}
+
+provider "hpe" {
+  morpheus {
+    url      = "YOURURLHERE"
+    username = "YOURUSERNAMEHERE"
+    password = "YOURPASSWORDHERE"
+  }
+}
+```
+-> If variables are used in the `--provider-config` - the respective `variable` blocks are expected to be provided in that file. The values themselves can then be passed in via `--provider-var-file` or `--provider-var`.
+
+- Cleanup is run automatically at the end of `generate` unless you pass `--no-cleanup`.
+
+---
+
+## Optional Step 1.5: Run `clean` Manually
+
+Use this when:
+
+- You ran `generate --no-cleanup`
+- You want to inspect cleanup changes separately
+- You are cleaning a generated file from another workflow
+
+Recommended in-place cleanup:
+
+```bash
+tfmigrator clean \
+  --input ./generated/generated.tf \
+  --in-place
+```
+
+If you prefer a separate output file:
+
+```bash
+tfmigrator clean \
+  --input ./generated/generated.tf \
+  --output ./generated/cleaned.tf
+```
+
+If you write to `cleaned.tf`, use that file as the `--generated` input in Step 2.
+
+---
+
+## Step 2: Merge Into Original Config
+
+### Recommended command
+
+```bash
+tfmigrator merge \
+  --original . \  # Will find .tf files recursively from this directory
+```
+
+### Merge flags
+
+- `--generated, -g` Path to generated Terraform file (default `./generated/generated.tf`)
+- `--original, -o` Original Terraform configuration file(s) and/or directories, repeatable
+- `--output-dir, -d` Output directory for merged configuration (default `./migrated`)
+- `--imports-file` Explicit imports file path (auto-discovered from generated file location when omitted)
+- `--var-file` Var-file(s) to copy into output directory, repeatable (default none)
+- `--dry-run` Preview changes only (default `false`)
+- `--no-color` Disable ANSI color in diff display (default `false`)
+- `--verbose, -v` More detailed logs (default `false`)
+
+### What merge does
+
+- Same-schema resources are renamed while keeping existing expressions/variables where possible.
+- Different-schema resources are merged from generated output.
+- Result is written to your `--output-dir` so you can review before applying.
+
+---
+
+## Dry-Run Workflow (Recommended)
+
+Run both phases in dry-run mode first:
+
+```bash
+tfmigrator generate \
+  --state state.json \
+  --provider-config ./provider.tf \
+  --dry-run
+
+# After an actual generation
+tfmigrator merge \
+  --original . \
+  --dry-run
+```
+
+What to review in merge dry-run output:
+
+1. `Merge Results` counts
+2. `Merge Transformations` lines
+3. Unified diff section (`Proposed Changes`)
+
+
+---
+
+## Dry-Run Output Example
+
+Example excerpt from a successful `merge --dry-run` run:
+
+```text
+Merging configurations...
+
+=== Merge Results ===
+
+Resources added: 0
+Resources merged: 2
+Modules updated: 0
+
+Dry run completed - no files were modified
+
+=== Merge Transformations ===
+~ Updated same-schema module resource morpheus_python_script_task.task -> hpe_morpheus_task_python_script (preserved original attributes)
+~ Updated module resource morpheus_max_cores_policy.user_policy -> hpe_morpheus_policy (affects all instances)
+
+=== Proposed Changes (Unified Diff) ===
+--- user-policy/main.tf
++++ user-policy/main.tf
+@@
+- resource "morpheus_max_cores_policy" "user_policy" {
++ resource "hpe_morpheus_policy" "user_policy" {
+    description = "Max cores policy for user ${var.user_name}"
+    enabled     = var.enabled
+-   user_id     = var.user_id
++   associated_resource_id   = var.user_id
++   associated_resource_type = "User"
+  }
+```
+
+- In terminal output, removed lines are red and added lines are green.
+
+---
+
+## Apply Workflow
+
+After dry-run looks correct:
+
+1. Run merge without `--dry-run`
+2. Move to migrated directory
+3. Run standard Terraform validation/apply flow
+
+```bash
+tfmigrator merge \
+  --original . \
+  --generated ./generated/generated.tf \
+  --output-dir ./migrated
+
+cd ./migrated
+terraform init
+terraform plan
+# Check that everything is just imports
+terraform apply --refresh-only
+terraform apply
+```
+
+---
+
+## Common Patterns
+
+### Using provider var files during generate
+
+```bash
+tfmigrator generate \
+  --state state.json \
+  --provider-config ./provider.tf \
+  --provider-var-file terraform.tfvars \
+  --provider-var-file secrets.auto.tfvars \
+  --output-dir ./generated
+```
+
+Note this currently requires the used `variable` blocks to be in the provider.tf file.
+
+### Copying var files into migrated output during merge
+
+```bash
+tfmigrator merge \
+  --original . \
+  --generated ./generated/generated.tf \
+  --var-file terraform.tfvars \
+  --var-file env/dev.tfvars \
+  --output-dir ./migrated
+```
+
+### Explicit imports file (if auto-discovery is not desired)
+
+```bash
+tfmigrator merge \
+  --original . \
+  --generated ./generated/generated.tf \
+  --imports-file ./generated/import.tf \
+  --output-dir ./migrated
+```
+
+---
+
+## Troubleshooting
+
+For common `generate`, `merge`, and resource-specific migration issues, see [tfmigrator Troubleshooting](./tfmigrator_troubleshooting.md).
+
+---
+
+## What tfmigrator Preserves
+
+- Variable references (`var.*`)
+- Expressions and interpolation
+- Core block structure where possible
+- Modules
+- Comments in the configuration (excluding inline comments from resources with different schema)

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -55,7 +55,7 @@ terraform {
   required_providers {
     morpheus = {
       source  = "gomorpheus/morpheus"
-      version = "0.13.1"
+      version = "0.14.1"
     }
     hpe = {
       source  = "HPE/hpe"
@@ -114,12 +114,12 @@ tfmigrator generate \
 
 - `--provider-config` should point to wherever your HPE provider is configured for the migration context (for example, `./provider.tf` or `./main.tf`). Alternatively - create a temporary file for this step (i.e. `.provider/provider.tf`) that follows the below format:
 
-```hcl
+```hclå
 terraform {
   required_providers {
     morpheus = {
       source  = "gomorpheus/morpheus"
-      version = "0.13.1"
+      version = "0.14.1"
     }
     hpe = {
       source  = "HPE/hpe"

--- a/templates/guides/tfmigrator_troubleshooting.md
+++ b/templates/guides/tfmigrator_troubleshooting.md
@@ -1,0 +1,175 @@
+---
+page_title: "tfmigrator: Troubleshooting"
+subcategory: "Migration"
+---
+
+# tfmigrator Troubleshooting
+
+This guide covers common issues that can appear during `tfmigrator generate`, `tfmigrator merge`, and follow-up Terraform validation and apply steps.
+
+---
+
+## Generate Issues
+
+### Provider context errors during generate
+
+Confirm `--provider-config` points to a real `.tf` file that includes your HPE provider configuration. This provider context is used when `tfmigrator` runs Terraform planning to generate configuration.
+
+If your provider config uses variables, ensure the corresponding `variable` blocks are present in that file and pass values with `--provider-var-file` and/or `--provider-var`.
+```
+terraform {
+  required_providers {
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = "0.13.1"
+    }
+    hpe = {
+      source  = "HPE/hpe"
+      version = "= 1.2.0"
+    }
+  }
+}
+
+
+provider "morpheus" {
+  url      = var.morpheus_url
+  username = var.morpheus_username
+  password = var.morpheus_password
+}
+
+provider "hpe" {
+  morpheus {
+    url      = var.morpheus_url
+    username = var.morpheus_username
+    password = var.morpheus_password
+  }
+}
+
+variable "morpheus_url" {
+  type = string
+}
+
+variable "morpheus_username" {
+  type = string
+}
+
+variable "morpheus_password" {
+  type      = string
+  sensitive = true
+}
+```
+
+### Unauthorized or invalid token errors
+
+A failed generate can return errors similar to:
+
+```text
+# group 41596 GET failed: 401 (Unauthorized):
+# {"error":"invalid_token","error_description":"Invalid access token:\n# BADTOKEN"}
+```
+
+Fix:
+
+- Review the credentials or token used by the provider configuration.
+- Confirm the URL, username, password, or token in `--provider-config` are valid for the Morpheus environment you are targeting.
+- If credentials are supplied via variables, confirm the correct values are being passed through `--provider-var-file` or `--provider-var`.
+
+### Validation errors before cleanup
+
+During `generate`, Terraform validation errors may appear in terminal output before cleanup runs. These are often expected for raw generated configuration and can usually be ignored until the cleanup pass has completed.
+
+If you used `--no-cleanup`, run cleanup separately before reviewing the generated file:
+
+```bash
+tfmigrator clean \
+  --input ./generated/generated.tf \
+  --in-place
+```
+
+### Generated file not found
+
+If `merge` reports that the generated file cannot be found, confirm the path passed to `--generated` and ensure `generate` completed successfully first.
+
+---
+
+## Merge Issues
+
+### Wrong provider source in modules
+
+If Terraform reports an error such as:
+
+```text
+Error: Failed to query available provider packages
+
+Could not retrieve the list of available versions for provider hashicorp/hpe:
+provider registry registry.terraform.io does not have a provider named
+registry.terraform.io/hashicorp/hpe
+```
+
+Fix:
+
+Ensure `required_providers` is set correctly in the root module and in any child modules that declare providers:
+
+```hcl
+terraform {
+  required_providers {
+    morpheus = {
+      source  = "gomorpheus/morpheus"
+      version = "0.13.1"
+    }
+    hpe = {
+      source  = "HPE/hpe"
+      version = "= 1.2.0"
+    }
+  }
+}
+```
+
+---
+
+## hpe_morpheus_instance Issues
+
+### nested_virtualization validation errors
+
+Generated or merged configuration for `hpe_morpheus_instance` can fail with errors such as:
+
+```text
+Attribute config_vmware.nested_virtualization value must be one of: ["on" "off"], got: "0"
+```
+
+Fix:
+- Ensure the HPE provider is at version `1.2.0` or later.
+- Alternatively, set `nested_virtualization` values to `"on"` or `"off"` in the migrated configuration.
+
+
+This issue is most commonly seen in generated or merged VMware instance configuration.
+
+### Tag casing or metadata validation errors
+
+In some environments, tag validation can fail with errors similar to:
+
+```json
+{"errors":{"metadata":"tag:
+'APPLICATION' must have a valid property","APPLICATION":"must have a valid property"}}
+```
+
+Fix:
+
+Review the generated or merged `tags` block and update tag names to match the exact casing and properties expected by the target environment.
+
+Example adjustment:
+
+```hcl
+tags = [
+  {
+    name  = "APPLICATION"
+    value = "ubuntu"
+  },
+  {
+    name  = "name"
+    value = "ubuntutf"
+  },
+]
+```
+
+If the original configuration used title-cased or additional tag names, do not assume those values will remain valid after migration. Reconcile the final tag set against what Morpheus accepts for that environment.

--- a/templates/guides/tfmigrator_troubleshooting.md
+++ b/templates/guides/tfmigrator_troubleshooting.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     morpheus = {
       source  = "gomorpheus/morpheus"
-      version = "0.13.1"
+      version = "0.14.1"
     }
     hpe = {
       source  = "HPE/hpe"
@@ -115,7 +115,7 @@ terraform {
   required_providers {
     morpheus = {
       source  = "gomorpheus/morpheus"
-      version = "0.13.1"
+      version = "0.14.1"
     }
     hpe = {
       source  = "HPE/hpe"


### PR DESCRIPTION
Updating documentation to include tfmigrator along with the manual
migration guides so that users have both options available and documented
for performing migrations.
- Added tfmigrator link to original documentation along with omitted resources in list
- Added tfmigrator documentation and troubleshooting