### PR TITLE
Basic update support for cluster - HVM and generic config

### DIFF
--- a/morpheus/framework/resources/cluster/cluster_test.go
+++ b/morpheus/framework/resources/cluster/cluster_test.go
@@ -39,6 +39,7 @@ func TestAccMorpheusClusterHVMExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
+	// nolint:goconst
 	dataSourcesConfig := `
 data "hpe_morpheus_cloud" "test" {
 	name = "hvm"
@@ -220,6 +221,7 @@ func TestAccMorpheusClusterGenericExampleOk(t *testing.T) {
 
 	name := acctest.RandomWithPrefix(t.Name())
 
+	// nolint:goconst
 	dataSourcesConfig := `
 data "hpe_morpheus_cloud" "test" {
 	name = "hvm"
@@ -388,6 +390,7 @@ func TestAccMorpheusClusterHVMUpdateOk(t *testing.T) {
 	name := acctest.RandomWithPrefix(t.Name())
 	updatedName := name + "-updated"
 
+	// nolint:goconst
 	dataSourcesConfig := `
 data "hpe_morpheus_cloud" "test" {
 	name = "hvm"
@@ -566,6 +569,7 @@ func TestAccMorpheusClusterGenericUpdateOk(t *testing.T) {
 	name := acctest.RandomWithPrefix(t.Name())
 	updatedName := name + "-updated"
 
+	// nolint:goconst
 	dataSourcesConfig := `
 data "hpe_morpheus_cloud" "test" {
 	name = "hvm"

--- a/morpheus/framework/resources/cluster/cluster_test.go
+++ b/morpheus/framework/resources/cluster/cluster_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
 	"github.com/HPE/terraform-provider-hpe/morpheus"
 	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/cluster"
@@ -368,6 +369,359 @@ data "hpe_morpheus_service_plan" "test" {
 			{
 				Config:             providerConfig + dataSourcesConfig + resourceConfig,
 				ExpectNonEmptyPlan: true,
+				PlanOnly:           true,
+			},
+		},
+	})
+}
+
+func TestAccMorpheusClusterHVMUpdateOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+	updatedName := name + "-updated"
+
+	dataSourcesConfig := `
+data "hpe_morpheus_cloud" "test" {
+	name = "hvm"
+}
+
+data "hpe_morpheus_group" "test" {
+	name = "HVM"
+}
+
+data "hpe_morpheus_key_pair" "test" {
+	name = "hvmserviceuser-keypair"
+}
+
+data "hpe_morpheus_service_plan" "test" {
+	name = "Default Manual"
+	provision_type_code = "manual"
+}
+`
+
+	serverConfig := `
+	server = {
+		service_plan_id = data.hpe_morpheus_service_plan.test.id
+
+		ssh_username = "hvmserviceuser"
+		ssh_key_pair_id = data.hpe_morpheus_key_pair.test.id
+
+		ssh_hosts = [
+			{
+				name = "` + name + `-worker-1"
+				ip   = "10.118.67.20"
+			},
+			{
+				name = "` + name + `-worker-2"
+				ip   = "10.118.67.21"
+			},
+			{
+				name = "` + name + `-worker-3"
+				ip   = "10.118.67.22"
+			}
+		]
+
+		management_net_interface = "eth0"
+
+		visibility = "private"
+
+		tags = [
+			{
+				name  = "source"
+				value = "terraform"
+			},
+			{
+				name  = "environment"
+				value = "test"
+			},
+		]
+	}
+`
+
+	createConfig := providerConfig + dataSourcesConfig + `
+resource "hpe_morpheus_cluster" "test" {
+	name        = "` + name + `"
+	description = "Initial description"
+	cloud_id    = data.hpe_morpheus_cloud.test.id
+	group_id    = data.hpe_morpheus_group.test.id
+	layout_id   = 219
+
+	labels = ["terraform", "test"]
+
+	config_hvm = {
+		create_user       = false
+		dynamic_placement = false
+		cpu_arch          = "x86_64"
+		cpu_model         = "host-model"
+		power_policy      = "balanced"
+	}
+
+` + serverConfig + `
+}
+`
+
+	// Update all updatable fields in a single operation:
+	// top-level: name, description, labels
+	// config_hvm: cpu_arch, cpu_model, dynamic_placement, vcpu_placement_mode, power_policy
+	updateConfig := providerConfig + dataSourcesConfig + `
+resource "hpe_morpheus_cluster" "test" {
+	name        = "` + updatedName + `"
+	description = "Updated description"
+	cloud_id    = data.hpe_morpheus_cloud.test.id
+	group_id    = data.hpe_morpheus_group.test.id
+	layout_id   = 219
+
+	labels = ["terraform-updated", "test-updated"]
+
+	config_hvm = {
+		create_user         = false
+		dynamic_placement   = true
+		cpu_arch            = "x86_64"
+		cpu_model           = "host-passthrough"
+		power_policy        = "performance"
+		vcpu_placement_mode = "auto"
+	}
+
+` + serverConfig + `
+}
+`
+
+	resourceName := "hpe_morpheus_cluster.test"
+
+	createChecks := resource.ComposeAggregateTestCheckFunc(
+		// top-level fields
+		resource.TestCheckResourceAttr(resourceName, "name", name),
+		resource.TestCheckResourceAttr(resourceName, "description", "Initial description"),
+		resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "labels.*", "terraform"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "labels.*", "test"),
+		// config_hvm fields
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.dynamic_placement", "false"),
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.cpu_arch", "x86_64"),
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.cpu_model", "host-model"),
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.power_policy", "balanced"),
+	)
+
+	updateChecks := resource.ComposeAggregateTestCheckFunc(
+		// top-level fields
+		resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+		resource.TestCheckResourceAttr(resourceName, "description", "Updated description"),
+		resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "labels.*", "terraform-updated"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "labels.*", "test-updated"),
+		// config_hvm fields
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.dynamic_placement", "true"),
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.cpu_arch", "x86_64"),
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.cpu_model", "host-passthrough"),
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.power_policy", "performance"),
+		resource.TestCheckResourceAttr(resourceName, "config_hvm.vcpu_placement_mode", "auto"),
+	)
+
+	checkInPlaceUpdate := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction(
+				resourceName,
+				plancheck.ResourceActionUpdate,
+			),
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check:  createChecks,
+			},
+			{
+				Config:           updateConfig,
+				Check:            updateChecks,
+				ConfigPlanChecks: checkInPlaceUpdate,
+			},
+			{
+				Config:             updateConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+		},
+	})
+}
+
+func TestAccMorpheusClusterGenericUpdateOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+	updatedName := name + "-updated"
+
+	dataSourcesConfig := `
+data "hpe_morpheus_cloud" "test" {
+	name = "hvm"
+}
+
+data "hpe_morpheus_group" "test" {
+	name = "HVM"
+}
+
+data "hpe_morpheus_key_pair" "test" {
+	name = "hvmserviceuser-keypair"
+}
+
+data "hpe_morpheus_service_plan" "test" {
+	name = "Default Manual"
+	provision_type_code = "manual"
+}
+`
+
+	serverConfig := `
+	server = {
+		service_plan_id = data.hpe_morpheus_service_plan.test.id
+
+		ssh_username = "hvmserviceuser"
+		ssh_key_pair_id = data.hpe_morpheus_key_pair.test.id
+
+		ssh_hosts = [
+			{
+				name = "` + name + `-worker-1"
+				ip   = "10.118.67.20"
+			},
+			{
+				name = "` + name + `-worker-2"
+				ip   = "10.118.67.21"
+			},
+			{
+				name = "` + name + `-worker-3"
+				ip   = "10.118.67.22"
+			}
+		]
+
+		management_net_interface = "eth0"
+
+		visibility = "private"
+
+		tags = [
+			{
+				name  = "source"
+				value = "terraform"
+			},
+			{
+				name  = "environment"
+				value = "test"
+			},
+		]
+	}
+`
+
+	createConfig := providerConfig + dataSourcesConfig + `
+resource "hpe_morpheus_cluster" "test" {
+	name              = "` + name + `"
+	description       = "Initial description"
+	cloud_id          = data.hpe_morpheus_cloud.test.id
+	group_id          = data.hpe_morpheus_group.test.id
+	layout_id         = 219
+	cluster_type_code = "mvm-cluster"
+
+	labels = ["terraform", "test"]
+
+	config = {
+		cpuArch              = "x86_64"
+		cpuModel             = "host-model"
+		dynamicPlacementMode = "off"
+		powerPolicy          = "balanced"
+	}
+
+` + serverConfig + `
+}
+`
+
+	updateConfig := providerConfig + dataSourcesConfig + `
+resource "hpe_morpheus_cluster" "test" {
+	name              = "` + updatedName + `"
+	description       = "Updated description"
+	cloud_id          = data.hpe_morpheus_cloud.test.id
+	group_id          = data.hpe_morpheus_group.test.id
+	layout_id         = 219
+	cluster_type_code = "mvm-cluster"
+
+	labels = ["terraform-updated", "test-updated"]
+
+	config = {
+		cpuArch              = "x86_64"
+		cpuModel             = "host-passthrough"
+		dynamicPlacementMode = "on"
+		powerPolicy          = "performance"
+		vcpuPlacementMode    = "auto"
+	}
+
+` + serverConfig + `
+}
+`
+
+	resourceName := "hpe_morpheus_cluster.test"
+
+	createChecks := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(resourceName, "name", name),
+		resource.TestCheckResourceAttr(resourceName, "description", "Initial description"),
+		resource.TestCheckResourceAttr(resourceName, "cluster_type_code", "mvm-cluster"),
+		resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "labels.*", "terraform"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "labels.*", "test"),
+		resource.TestCheckResourceAttr(resourceName, "config.cpuArch", "x86_64"),
+		resource.TestCheckResourceAttr(resourceName, "config.cpuModel", "host-model"),
+		resource.TestCheckResourceAttr(resourceName, "config.dynamicPlacementMode", "off"),
+		resource.TestCheckResourceAttr(resourceName, "config.powerPolicy", "balanced"),
+	)
+
+	updateChecks := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+		resource.TestCheckResourceAttr(resourceName, "description", "Updated description"),
+		resource.TestCheckResourceAttr(resourceName, "cluster_type_code", "mvm-cluster"),
+		resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "labels.*", "terraform-updated"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "labels.*", "test-updated"),
+		resource.TestCheckResourceAttr(resourceName, "config.cpuArch", "x86_64"),
+		resource.TestCheckResourceAttr(resourceName, "config.cpuModel", "host-passthrough"),
+		resource.TestCheckResourceAttr(resourceName, "config.dynamicPlacementMode", "on"),
+		resource.TestCheckResourceAttr(resourceName, "config.powerPolicy", "performance"),
+		resource.TestCheckResourceAttr(resourceName, "config.vcpuPlacementMode", "auto"),
+	)
+
+	checkInPlaceUpdate := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction(
+				resourceName,
+				plancheck.ResourceActionUpdate,
+			),
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check:  createChecks,
+			},
+			{
+				Config:           updateConfig,
+				Check:            updateChecks,
+				ConfigPlanChecks: checkInPlaceUpdate,
+			},
+			{
+				Config:             updateConfig,
+				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
 		},

--- a/morpheus/framework/resources/cluster/schema_gen.go
+++ b/morpheus/framework/resources/cluster/schema_gen.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/dynamicplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
@@ -58,9 +57,6 @@ func ClusterResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				Description:         "Generic Cluster Configuration",
 				MarkdownDescription: "Generic Cluster Configuration",
-				PlanModifiers: []planmodifier.Dynamic{
-					dynamicplanmodifier.RequiresReplace(),
-				},
 				Validators: []validator.Dynamic{
 					dynamicvalidator.ConflictsWith(path.Expressions{path.MatchRoot("config_hvm")}...),
 				},
@@ -120,9 +116,6 @@ func ClusterResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				Description:         "Configuration for HVM cluster servers",
 				MarkdownDescription: "Configuration for HVM cluster servers",
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,

--- a/morpheus/framework/resources/cluster/update.go
+++ b/morpheus/framework/resources/cluster/update.go
@@ -4,8 +4,16 @@ package cluster
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus/utils/errfmt"
+	"github.com/HPE/terraform-provider-hpe/utils/convert"
 )
 
 const (
@@ -17,5 +25,137 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	resp.Diagnostics.AddError(updateOperation, "Cluster update not implemented yet")
+	var plan, state ClusterModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get timeout from HCL if set, the default is 45 minutes
+	updateTimeout, diags := plan.Timeouts.Update(ctx, 45*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
+	id := state.Id.ValueInt64()
+
+	updateClusterReq := sdk.NewUpdateClusterRequest()
+	cluster := sdk.NewUpdateClusterRequestCluster()
+
+	// name
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		cluster.SetName(plan.Name.ValueString())
+	}
+
+	// description
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+		cluster.SetDescription(plan.Description.ValueString())
+	}
+
+	// labels
+	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
+		labels, err := convert.SetToStrSlice(plan.Labels)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				updateOperation,
+				"cluster "+plan.Name.ValueString()+": failed to parse label: "+err.Error(),
+			)
+
+			return
+		}
+
+		cluster.SetLabels(labels)
+	}
+
+	switch {
+	case !plan.Config.IsNull() && !plan.Config.IsUnknown():
+		configValue := plan.Config.UnderlyingValue()
+		configAny, err := convert.ValueToAny(ctx, configValue)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				updateOperation,
+				"cluster: failed to convert config: "+
+					err.Error(),
+			)
+
+			return
+		}
+
+		configDataMap, ok := configAny.(map[string]any)
+		if !ok {
+			resp.Diagnostics.AddError(
+				"error updating cluster",
+				"could not parse config value",
+			)
+
+			return
+		}
+
+		cluster.SetConfig(sdk.UpdateClusterRequestClusterConfig{
+			AdditionalProperties: configDataMap,
+		})
+	// HVM config updatable fields
+	case !plan.ConfigHvm.IsNull() && !plan.ConfigHvm.IsUnknown():
+		config := sdk.NewUpdateClusterRequestClusterConfig()
+
+		config.AdditionalProperties = make(map[string]any)
+
+		if !plan.ConfigHvm.CpuArch.IsNull() && !plan.ConfigHvm.CpuArch.IsUnknown() {
+			config.AdditionalProperties["cpuArch"] = plan.ConfigHvm.CpuArch.ValueString()
+		}
+
+		if !plan.ConfigHvm.CpuModel.IsNull() && !plan.ConfigHvm.CpuModel.IsUnknown() {
+			config.AdditionalProperties["cpuModel"] = plan.ConfigHvm.CpuModel.ValueString()
+		}
+
+		if !plan.ConfigHvm.DynamicPlacement.IsNull() && !plan.ConfigHvm.DynamicPlacement.IsUnknown() {
+			config.SetDynamicPlacementMode(
+				*convert.BoolTypeToStringPointerOnOff(plan.ConfigHvm.DynamicPlacement),
+			)
+		}
+
+		if !plan.ConfigHvm.VcpuPlacementMode.IsNull() && !plan.ConfigHvm.VcpuPlacementMode.IsUnknown() {
+			config.AdditionalProperties["vcpuPlacementMode"] = plan.ConfigHvm.VcpuPlacementMode.ValueString()
+		}
+
+		if !plan.ConfigHvm.PowerPolicy.IsNull() && !plan.ConfigHvm.PowerPolicy.IsUnknown() {
+			config.AdditionalProperties["powerPolicy"] = plan.ConfigHvm.PowerPolicy.ValueString()
+		}
+
+		cluster.SetConfig(*config)
+
+	}
+
+	updateClusterReq.SetCluster(*cluster)
+
+	client, err := r.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("creating client failed", err.Error())
+
+		return
+	}
+
+	_, hresp, err := client.ClustersAPI.UpdateCluster(ctx, id).
+		UpdateClusterRequest(*updateClusterReq).Execute()
+	if err != nil || hresp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError(
+			updateOperation,
+			fmt.Sprintf("cluster %d PUT failed: ", id)+errfmt.ErrMsg(err, hresp),
+		)
+
+		return
+	}
+
+	updatedState, diag := getClusterAsState(ctx, id, client, plan)
+	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
 }

--- a/morpheus/framework/resources/cluster/update.go
+++ b/morpheus/framework/resources/cluster/update.go
@@ -141,12 +141,12 @@ func (r *Resource) Update(
 		return
 	}
 
-	_, hresp, err := client.ClustersAPI.UpdateCluster(ctx, id).
+	_, httpResp, err := client.ClustersAPI.UpdateCluster(ctx, id).
 		UpdateClusterRequest(*updateClusterReq).Execute()
-	if err != nil || hresp.StatusCode != http.StatusOK {
+	if err != nil || httpResp.StatusCode != http.StatusOK {
 		resp.Diagnostics.AddError(
 			updateOperation,
-			fmt.Sprintf("cluster %d PUT failed: ", id)+errfmt.ErrMsg(err, hresp),
+			fmt.Sprintf("cluster %d PUT failed: ", id)+errfmt.ErrMsg(err, httpResp),
 		)
 
 		return


### PR DESCRIPTION
Implements basic update support for cluster (`config_hvm` and `config` supported).

Adds acceptance test for cluster update (HVM).

Adds acceptance test for cluster update (Generic config - HVM).

Updates schema_gen.go to remove require replace from `config` and `config_hvm`.
