### PR TITLE
Resolving validation error with hpe_morpheus_form

### DIFF
--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -1130,9 +1130,9 @@ func resourceFormRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 					case typeCheckbox:
 						// convert string text to boolean
 						if optionType.DefaultValue == "true" {
-							row["default_checked"] = true
+							optionTypeRow["default_checked"] = true
 						} else {
-							row["default_checked"] = false
+							optionTypeRow["default_checked"] = false
 						}
 					case typeCodeEditor:
 						optionTypeRow["show_line_numbers"] = optionType.Config.ShowLineNumbers

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -30,9 +30,6 @@ const (
 	typeTextArea   = "textarea"
 	typeTextArray  = "textArray"
 	typeTypeahead  = "typeahead"
-
-	valueFalse = "false"
-	valueTrue  = "true"
 )
 
 func ResourceForm() *schema.Resource {
@@ -658,7 +655,7 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 				} else {
 					return diag.FromErr(helpers.TypeAssertFailError("default_value", optionTypeConfig["default_value"]))
 				}
-				if defaultValue != valueTrue && defaultValue != valueFalse {
+				if defaultValue != "" {
 					return diag.Errorf(
 						"The default_value attribute cannot be set when the type attribute is set to checkbox, "+
 							"use the default_checked attribute instead for the %v checkbox resource",
@@ -818,7 +815,7 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 						} else {
 							return diag.FromErr(helpers.TypeAssertFailError("default_value", optionTypeConfig["default_value"]))
 						}
-						if defaultValue != valueTrue && defaultValue != valueFalse {
+						if defaultValue != "" {
 							return diag.Errorf(
 								"The default_value attribute cannot be set when the type attribute is set to checkbox, "+
 									"use the default_checked attribute instead for the %v checkbox resource",
@@ -1248,12 +1245,11 @@ func resourceFormUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 				} else {
 					return diag.FromErr(helpers.TypeAssertFailError("default_value", optionTypeConfig["default_value"]))
 				}
-				if defaultValue != valueTrue && defaultValue != valueFalse {
+				if defaultValue != "" {
 					return diag.Errorf(
 						"The default_value attribute cannot be set when the type attribute is set to checkbox, "+
-							"use the default_checked attribute instead for the %v checkbox resource: %v",
+							"use the default_checked attribute instead for the %v checkbox resource",
 						optionTypeConfig["name"],
-						defaultValue,
 					)
 				}
 				row["defaultValue"] = optionTypeConfig["default_checked"]
@@ -1409,7 +1405,7 @@ func resourceFormUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 						} else {
 							return diag.FromErr(helpers.TypeAssertFailError("default_value", optionTypeConfig["default_value"]))
 						}
-						if defaultValue != valueTrue && defaultValue != valueFalse {
+						if defaultValue != "" {
 							return diag.Errorf(
 								"The default_value attribute cannot be set when the type attribute is set to checkbox, "+
 									"use the default_checked attribute instead for the %v checkbox resource",


### PR DESCRIPTION
There was a bad comparison checking for a non-empty default_value for checkboxes which caused any checkbox without a default_value to fail validation. (Even though it should not have a default_value but a checked_value)

This commit amends the validation to check for a non-empty string before triggering a validation error.

Also fixing incorrect variable (row -> optionTypeRow) on Read that was causing a failure to detect state drift.