### PR TITLE
Fix forms delete issue with subtenants

### DIFF
--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -1673,7 +1673,11 @@ func resourceFormDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	diagsFromUpdate := resourceFormUpdate(ctx, d, meta)
 	if diagsFromUpdate.HasError() {
-		return diagsFromUpdate
+		logStr := fmt.Sprintf("Error during pre-destroy update of form to remove option types and field groups: %s",
+			diagsFromUpdate)
+		log.Printf(logStr)
+
+		return diag.Errorf(logStr)
 	}
 
 	resp, err := client.DeleteForm(convert.StringToInt64(id), req)

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -1673,9 +1673,8 @@ func resourceFormDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	diagsFromUpdate := resourceFormUpdate(ctx, d, meta)
 	if diagsFromUpdate.HasError() {
-		logStr := fmt.Sprintf("Error during pre-destroy update of form to remove option types and field groups: %s",
+		logStr := fmt.Sprintf("Error during pre-destroy update of form to remove option types and field groups: %v",
 			diagsFromUpdate)
-		log.Printf(logStr)
 
 		return diag.Errorf(logStr)
 	}

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -1673,7 +1673,6 @@ func resourceFormDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	diagsFromUpdate := resourceFormUpdate(ctx, d, meta)
 	if diagsFromUpdate.HasError() {
-
 		return diag.Errorf("Error during pre-destroy update of form to remove option types and field groups: %v",
 			diagsFromUpdate)
 	}

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -1665,6 +1665,17 @@ func resourceFormDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 		)
 	}
 
+	// to avoid constraint errors on destroy in some circumstances (for instance when running in a sub-tenant)
+	// we'll first do an update to the form to remove all option blocks and field groups before we
+	// attempt to delete the form
+	d.Set("option_type", []map[string]any{})
+	d.Set("field_group", []map[string]any{})
+
+	diagsFromUpdate := resourceFormUpdate(ctx, d, meta)
+	if diagsFromUpdate.HasError() {
+		return diagsFromUpdate
+	}
+
 	resp, err := client.DeleteForm(convert.StringToInt64(id), req)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -1673,10 +1673,9 @@ func resourceFormDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	diagsFromUpdate := resourceFormUpdate(ctx, d, meta)
 	if diagsFromUpdate.HasError() {
-		logStr := fmt.Sprintf("Error during pre-destroy update of form to remove option types and field groups: %v",
-			diagsFromUpdate)
 
-		return diag.Errorf(logStr)
+		return diag.Errorf("Error during pre-destroy update of form to remove option types and field groups: %v",
+			diagsFromUpdate)
 	}
 
 	resp, err := client.DeleteForm(convert.StringToInt64(id), req)


### PR DESCRIPTION
Forms created in a subtenant could not be deleted due to a constraint error.  In this PR before forms delete we do an update to remove all option blocks and field groups, which fixes the issue.