### PR TITLE
Updating option list id to send the correct format

### DIFF
--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -770,10 +770,10 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 				}
 			case typeRadio:
 				row["defaultValue"] = optionTypeConfig["default_value"]
-				row["optionList"] = optionTypeConfig["option_list_id"]
+				row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 			case typeSelect:
 				row["defaultValue"] = optionTypeConfig["default_value"]
-				row["optionList"] = optionTypeConfig["option_list_id"]
+				row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 				config := make(map[string]any)
 				config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 				config["sortable"] = optionTypeConfig["sortable"]
@@ -800,7 +800,7 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 				config["allowDuplicates"] = optionTypeConfig["allow_duplicates"]
 				config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 				config["customData"] = optionTypeConfig["custom_data"]
-				row["optionList"] = optionTypeConfig["option_list_id"]
+				row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 				row["config"] = config
 			case typeHidden:
 				row["defaultValue"] = optionTypeConfig["default_value"]
@@ -917,10 +917,10 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 						}
 					case typeRadio:
 						row["defaultValue"] = optionTypeConfig["default_value"]
-						row["optionList"] = optionTypeConfig["option_list_id"]
+						row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 					case typeSelect:
 						row["defaultValue"] = optionTypeConfig["default_value"]
-						row["optionList"] = optionTypeConfig["option_list_id"]
+						row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 						config := make(map[string]any)
 						config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 						config["sortable"] = optionTypeConfig["sortable"]
@@ -947,7 +947,7 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 						config["allowDuplicates"] = optionTypeConfig["allow_duplicates"]
 						config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 						config["customData"] = optionTypeConfig["custom_data"]
-						row["optionList"] = optionTypeConfig["option_list_id"]
+						row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 						row["config"] = config
 					case typeHidden:
 						row["defaultValue"] = optionTypeConfig["default_value"]
@@ -1334,10 +1334,10 @@ func resourceFormUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 				}
 			case typeRadio:
 				row["defaultValue"] = optionTypeConfig["default_value"]
-				row["optionList"] = optionTypeConfig["option_list_id"]
+				row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 			case typeSelect:
 				row["defaultValue"] = optionTypeConfig["default_value"]
-				row["optionList"] = optionTypeConfig["option_list_id"]
+				row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 				config := make(map[string]any)
 				config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 				config["sortable"] = optionTypeConfig["sortable"]
@@ -1364,7 +1364,7 @@ func resourceFormUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 				config["allowDuplicates"] = optionTypeConfig["allow_duplicates"]
 				config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 				config["customData"] = optionTypeConfig["custom_data"]
-				row["optionList"] = optionTypeConfig["option_list_id"]
+				row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 				row["config"] = config
 			case typeHidden:
 				row["defaultValue"] = optionTypeConfig["default_value"]
@@ -1483,10 +1483,10 @@ func resourceFormUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 						}
 					case typeRadio:
 						row["defaultValue"] = optionTypeConfig["default_value"]
-						row["optionList"] = optionTypeConfig["option_list_id"]
+						row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 					case typeSelect:
 						row["defaultValue"] = optionTypeConfig["default_value"]
-						row["optionList"] = optionTypeConfig["option_list_id"]
+						row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 						config := make(map[string]any)
 						config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 						config["sortable"] = optionTypeConfig["sortable"]
@@ -1513,7 +1513,7 @@ func resourceFormUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 						config["allowDuplicates"] = optionTypeConfig["allow_duplicates"]
 						config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 						config["customData"] = optionTypeConfig["custom_data"]
-						row["optionList"] = optionTypeConfig["option_list_id"]
+						row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 						row["config"] = config
 					case typeHidden:
 						row["defaultValue"] = optionTypeConfig["default_value"]


### PR DESCRIPTION
Previous option list ids would be sent as such:
```json
Request:
{
    "optionTypeForm": {
        "options": [
            {
                "optionList": 1,
            }
        ]
    }
}

Return:
{
    "success": true,
    "msg": "Form Saved",
    "optionTypeForm": {
        "options": [
            {
                "optionList": {
                    "id": 1,
                    "name": "API Clouds"
                },
            },
        ]
    }
}
```

They have been changed to be more consistent with what is expected by the API (noting that both work on the current version of Morpheus).
```json
Request
{
    "optionTypeForm": {
        "options": [
            {
                "optionList": {
                    "id": 1
                },
            },
        ]
    }
}

Response
{
    "success": true,
    "msg": "Form Saved",
    "optionTypeForm": {
        "options": [
            {
                "optionList": {
                    "id": 1,
                    "name": "API Clouds"
                },
            }
        ],
    }
}
```