### PR TITLE
Add forms networkManager type

### DIFF
--- a/docs/resources/morpheus_form.md
+++ b/docs/resources/morpheus_form.md
@@ -133,6 +133,26 @@ resource "hpe_morpheus_form" "example" {
     step                     = 2
   }
 
+  option_type {
+    name                        = "tf network manager example"
+    code                        = "network-manager-input"
+    description                 = "Terraform network manager example"
+    type                        = "networkManager"
+    field_label                 = "network input"
+    field_name                  = "networkInput"
+    default_value               = "test123"
+    placeholder                 = "Select network"
+    help_block                  = "Select a network"
+    required                    = true
+    export_meta                 = true
+    display_value_on_details    = true
+    locked                      = true
+    hidden                      = false
+    exclude_from_search         = true
+    show_network_type_selection = true
+    enable_ip_mode_selection    = true
+  }
+
   field_group {
     name                 = "fg1"
     description          = "testin"
@@ -235,6 +255,7 @@ Optional:
 - `description` (String) A description of the option type to add to the field group
 - `display` (String) The memory or storage value to use (GB or MB)
 - `display_value_on_details` (Boolean) Display the selected value of the option type on the associated resource's details page
+- `enable_ip_mode_selection` (Boolean) Whether to enable IP Mode Selection
 - `exclude_from_search` (Boolean) Whether the option type should be execluded from search or not
 - `export_meta` (Boolean) Whether to export the option type as a tag
 - `field_label` (String) The label of the option type
@@ -252,10 +273,11 @@ Optional:
 - `require_field` (String) The field or code used to determine whether the field is required or not
 - `required` (Boolean) Whether the option type is required or not
 - `show_line_numbers` (Boolean) Whether to show the line numbers for the code editor option type
+- `show_network_type_selection` (Boolean) Whether to show the network type selection
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of rows to display for a text area
-- `type` (String) The type of option type to add to the field group (byteSize, checkbox, code-editor, hidden, number, password, radio, select, text, textArray, textarea, typeahead)
+- `type` (String) The type of option type to add to the field group (byteSize, checkbox, code-editor, hidden, networkManager, number, password, radio, select, text, textarea, textArray, typeahead)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 
@@ -279,6 +301,7 @@ Optional:
 - `description` (String) A description of the option type to add to the form
 - `display` (String) The memory or storage value to use (GB or MB)
 - `display_value_on_details` (Boolean) Display the selected value of the option type on the associated resource's details page
+- `enable_ip_mode_selection` (Boolean) Whether to enable IP Mode Selection
 - `exclude_from_search` (Boolean) Whether the option type should be execluded from search or not
 - `export_meta` (Boolean) Whether to export the option type as a tag
 - `field_label` (String) The label used for the option type
@@ -296,10 +319,11 @@ Optional:
 - `require_field` (String) The field or code used to determine whether the field is required or not
 - `required` (Boolean) Whether the option type is required or not
 - `show_line_numbers` (Boolean) Whether to show the line numbers for the code editor option type
+- `show_network_type_selection` (Boolean) Whether to show the network type selection
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of lines to show for a code editor or text area option type
-- `type` (String) The type of option type to add to the form (byteSize, checkbox, code-editor, hidden, number, password, radio, select, text, textArray, textarea, typeahead)
+- `type` (String) The type of option type to add to the form (byteSize, checkbox, code-editor, hidden, networkManager, number, password, radio, select, text, textarea, textArray, typeahead)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 

--- a/examples/resources/morpheus_form/resource.tf
+++ b/examples/resources/morpheus_form/resource.tf
@@ -117,6 +117,26 @@ resource "hpe_morpheus_form" "example" {
     step                     = 2
   }
 
+  option_type {
+    name                        = "tf network manager example"
+    code                        = "network-manager-input"
+    description                 = "Terraform network manager example"
+    type                        = "networkManager"
+    field_label                 = "network input"
+    field_name                  = "networkInput"
+    default_value               = "test123"
+    placeholder                 = "Select network"
+    help_block                  = "Select a network"
+    required                    = true
+    export_meta                 = true
+    display_value_on_details    = true
+    locked                      = true
+    hidden                      = false
+    exclude_from_search         = true
+    show_network_type_selection = true
+    enable_ip_mode_selection    = true
+  }
+
   field_group {
     name                 = "fg1"
     description          = "testin"

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -20,18 +20,19 @@ import (
 )
 
 const (
-	typeByteSize   = "byteSize"
-	typeCheckbox   = "checkbox"
-	typeCodeEditor = "code-editor"
-	typeHidden     = "hidden"
-	typeNumber     = "number"
-	typePassword   = "password"
-	typeRadio      = "radio"
-	typeSelect     = "select"
-	typeText       = "text"
-	typeTextArea   = "textarea"
-	typeTextArray  = "textArray"
-	typeTypeahead  = "typeahead"
+	typeByteSize       = "byteSize"
+	typeCheckbox       = "checkbox"
+	typeCodeEditor     = "code-editor"
+	typeHidden         = "hidden"
+	typeNetworkManager = "networkManager"
+	typeNumber         = "number"
+	typePassword       = "password"
+	typeRadio          = "radio"
+	typeSelect         = "select"
+	typeText           = "text"
+	typeTextArea       = "textarea"
+	typeTextArray      = "textArray"
+	typeTypeahead      = "typeahead"
 )
 
 // TODO: Add switch case handling for these option types.
@@ -47,7 +48,6 @@ const (
 	typeKeyValue       = "keyValue"
 	typeLayout         = "layout"
 	typeLogoSelector   = "logoSelector"
-	typeNetworkManager = "networkManager"
 	typePlan           = "plan"
 	typePorts          = "ports"
 	typeResourcePool   = "resourcePool"
@@ -198,12 +198,12 @@ func ResourceForm() *schema.Resource {
 						"type": {
 							Type: schema.TypeString,
 							Description: "The type of option type to add to the form " +
-								"(byteSize, checkbox, code-editor, hidden, number, password, radio, select, text, " +
-								"textArray, textarea, typeahead)",
+								"(byteSize, checkbox, code-editor, hidden, networkManager, number, password, radio, select, text, " +
+								"textarea, textArray, typeahead)",
 							ValidateFunc: validation.StringInSlice(
 								[]string{
-									typeByteSize, typeCheckbox, typeCodeEditor, typeHidden, typeNumber, typePassword,
-									typeRadio, typeSelect, typeText, typeTextArray, typeTextArea, typeTypeahead,
+									typeByteSize, typeCheckbox, typeCodeEditor, typeHidden, typeNetworkManager, typeNumber,
+									typePassword, typeRadio, typeSelect, typeText, typeTextArea, typeTextArray, typeTypeahead,
 								},
 								false,
 							),
@@ -343,6 +343,18 @@ func ResourceForm() *schema.Resource {
 							Optional:    true,
 							Computed:    true,
 						},
+						"show_network_type_selection": {
+							Type:        schema.TypeBool,
+							Description: "Whether to show the network type selection",
+							Optional:    true,
+							Computed:    true,
+						},
+						"enable_ip_mode_selection": {
+							Type:        schema.TypeBool,
+							Description: "Whether to enable IP Mode Selection",
+							Optional:    true,
+							Computed:    true,
+						},
 						"allow_multiple_selections": {
 							Type: schema.TypeBool,
 							Description: "Whether to allow multiple items to be selected when using a " +
@@ -468,12 +480,14 @@ func ResourceForm() *schema.Resource {
 									"type": {
 										Type: schema.TypeString,
 										Description: "The type of option type to add to the field group " +
-											"(byteSize, checkbox, code-editor, hidden, number, password, radio, select, text, " +
-											"textArray, textarea, typeahead)",
+											"(byteSize, checkbox, code-editor, hidden, networkManager, number, " +
+											"password, radio, select, text, " +
+											"textarea, textArray, typeahead)",
 										ValidateFunc: validation.StringInSlice(
 											[]string{
-												typeByteSize, typeCheckbox, typeCodeEditor, typeHidden, typeNumber, typePassword,
-												typeRadio, typeSelect, typeText, typeTextArray, typeTextArea, typeTypeahead,
+												typeByteSize, typeCheckbox, typeCodeEditor, typeHidden, typeNetworkManager,
+												typeNumber, typePassword, typeRadio, typeSelect, typeText, typeTextArea,
+												typeTextArray, typeTypeahead,
 											},
 											false,
 										),
@@ -610,6 +624,18 @@ func ResourceForm() *schema.Resource {
 									"sortable": {
 										Type:        schema.TypeBool,
 										Description: "Whether the selected options can be sorted or not",
+										Optional:    true,
+										Computed:    true,
+									},
+									"show_network_type_selection": {
+										Type:        schema.TypeBool,
+										Description: "Whether to show the network type selection",
+										Optional:    true,
+										Computed:    true,
+									},
+									"enable_ip_mode_selection": {
+										Type:        schema.TypeBool,
+										Description: "Whether to enable IP Mode Selection",
 										Optional:    true,
 										Computed:    true,
 									},
@@ -768,6 +794,12 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 					configStep["step"] = optionTypeConfig["step"]
 					row["config"] = configStep
 				}
+			case typeNetworkManager:
+				config := make(map[string]any)
+				config["showNetworkTypeSelection"] = optionTypeConfig["show_network_type_selection"] // boolean
+				config["enableIPModeSelection"] = optionTypeConfig["enable_ip_mode_selection"]       // boolean
+				row["defaultValue"] = optionTypeConfig["default_value"]
+				row["config"] = config
 			case typeRadio:
 				row["defaultValue"] = optionTypeConfig["default_value"]
 				row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
@@ -915,6 +947,12 @@ func resourceFormCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 							configStep["step"] = optionTypeConfig["step"]
 							row["config"] = configStep
 						}
+					case typeNetworkManager:
+						config := make(map[string]any)
+						config["showNetworkTypeSelection"] = optionTypeConfig["show_network_type_selection"] // boolean
+						config["enableIPModeSelection"] = optionTypeConfig["enable_ip_mode_selection"]       // boolean
+						row["defaultValue"] = optionTypeConfig["default_value"]
+						row["config"] = config
 					case typeRadio:
 						row["defaultValue"] = optionTypeConfig["default_value"]
 						row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
@@ -1131,6 +1169,9 @@ func resourceFormRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 				row["step"] = optionType.Config.Step
 				row["min_value"] = optionType.MinVal
 				row["max_value"] = optionType.MaxVal
+			case typeNetworkManager:
+				row["show_network_type_selection"] = optionType.Config.ShowNetworkTypeSelection
+				row["enable_ip_mode_selection"] = optionType.Config.EnableIPModeSelection
 			case typeRadio:
 				row["option_list_id"] = optionType.OptionList.ID
 			case typeSelect:
@@ -1206,6 +1247,9 @@ func resourceFormRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 						optionTypeRow["step"] = optionType.Config.Step
 						optionTypeRow["min_value"] = optionType.MinVal
 						optionTypeRow["max_value"] = optionType.MaxVal
+					case typeNetworkManager:
+						row["show_network_type_selection"] = optionType.Config.ShowNetworkTypeSelection
+						row["enable_ip_mode_selection"] = optionType.Config.EnableIPModeSelection
 					case typeRadio:
 						optionTypeRow["option_list_id"] = optionType.OptionList.ID
 					case typeSelect:
@@ -1332,6 +1376,12 @@ func resourceFormUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 					configStep["step"] = optionTypeConfig["step"]
 					row["config"] = configStep
 				}
+			case typeNetworkManager:
+				config := make(map[string]any)
+				config["showNetworkTypeSelection"] = optionTypeConfig["show_network_type_selection"] // boolean
+				config["enableIPModeSelection"] = optionTypeConfig["enable_ip_mode_selection"]       // boolean
+				row["defaultValue"] = optionTypeConfig["default_value"]
+				row["config"] = config
 			case typeRadio:
 				row["defaultValue"] = optionTypeConfig["default_value"]
 				row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
@@ -1481,6 +1531,12 @@ func resourceFormUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 							configStep["step"] = optionTypeConfig["step"]
 							row["config"] = configStep
 						}
+					case typeNetworkManager:
+						config := make(map[string]any)
+						config["showNetworkTypeSelection"] = optionTypeConfig["show_network_type_selection"] // boolean
+						config["enableIPModeSelection"] = optionTypeConfig["enable_ip_mode_selection"]       // boolean
+						row["defaultValue"] = optionTypeConfig["default_value"]
+						row["config"] = config
 					case typeRadio:
 						row["defaultValue"] = optionTypeConfig["default_value"]
 						row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}

--- a/morpheus/sdkv2/resources/form/form_resource.tf.tmpl
+++ b/morpheus/sdkv2/resources/form/form_resource.tf.tmpl
@@ -117,6 +117,26 @@ resource "hpe_morpheus_form" "example" {
     step                     = {{.OptionType6Step}}
   }
 
+  option_type {
+    name                        = "{{.OptionType7Name}}"
+    code                        = "{{.OptionType7Code}}"
+    description                 = "{{.OptionType7Description}}"
+    type                        = "{{.OptionType7Type}}"
+    field_label                 = "{{.OptionType7FieldLabel}}"
+    field_name                  = "{{.OptionType7FieldName}}"
+    default_value               = "{{.OptionType7DefaultValue}}"
+    placeholder                 = "{{.OptionType7Placeholder}}"
+    help_block                  = "{{.OptionType7HelpBlock}}"
+    required                    = {{.OptionType7Required}}
+    export_meta                 = {{.OptionType7ExportMeta}}
+    display_value_on_details    = {{.OptionType7DisplayValueOnDetails}}
+    locked                      = {{.OptionType7Locked}}
+    hidden                      = {{.OptionType7Hidden}}
+    exclude_from_search         = {{.OptionType7ExcludeFromSearch}}
+    show_network_type_selection = {{.OptionType7ShowNetworkTypeSelection}}
+    enable_ip_mode_selection    = {{.OptionType7EnableIPModeSelection}}
+  }
+
   field_group {
     name                   = "{{.FieldGroup1Name}}"
     description            = "{{.FieldGroup1Description}}"

--- a/morpheus/sdkv2/resources/form/form_resource_example.go
+++ b/morpheus/sdkv2/resources/form/form_resource_example.go
@@ -156,6 +156,23 @@ func RenderFormConfig(t *testing.T, overrides map[string]string) (string, error)
 		"OptionType6Required":                        "true",
 		"OptionType6Step":                            "2",
 		"OptionType6Type":                            "number",
+		"OptionType7Code":                            "network-manager-input",
+		"OptionType7DefaultValue":                    "test123",
+		"OptionType7Description":                     "Terraform network manager example",
+		"OptionType7DisplayValueOnDetails":           "true",
+		"OptionType7EnableIPModeSelection":           "true",
+		"OptionType7ExcludeFromSearch":               "true",
+		"OptionType7ExportMeta":                      "true",
+		"OptionType7FieldLabel":                      "network input",
+		"OptionType7FieldName":                       "networkInput",
+		"OptionType7HelpBlock":                       "Select a network",
+		"OptionType7Hidden":                          "false",
+		"OptionType7Locked":                          "true",
+		"OptionType7Name":                            "tf network manager example",
+		"OptionType7Placeholder":                     "Select network",
+		"OptionType7Required":                        "true",
+		"OptionType7ShowNetworkTypeSelection":        "true",
+		"OptionType7Type":                            "networkManager",
 	}
 
 	// Apply overrides to defaults

--- a/morpheus/sdkv2/resources/form/form_resource_test.go
+++ b/morpheus/sdkv2/resources/form/form_resource_test.go
@@ -32,7 +32,7 @@ func TestAccMorpheusFormExampleOk(t *testing.T) {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	t.Skip("Skipping due to error in resource code")
+	// t.Skip("Skipping due to error in resource code")
 
 	providerConfig := testhelpers.ProviderBlock()
 
@@ -866,6 +866,108 @@ func TestAccMorpheusFormExampleOk(t *testing.T) {
 			"hpe_morpheus_form.example",
 			"option_type6_type",
 			"number",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_code",
+			"network-manager-input",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_default_value",
+			"test123",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_description",
+			"Terraform network manager example",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_display_value_on_details",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_enable_ip_mode_selection",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_exclude_from_search",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_export_meta",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_field_label",
+			"network input",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_field_name",
+			"networkInput",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_help_block",
+			"Select a network",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_hidden",
+			"false",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_locked",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_name",
+			"tf network manager example",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_placeholder",
+			"Select network",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_required",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_show_network_type_selection",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type7_type",
+			"networkManager",
 		),
 	}
 

--- a/morpheus/sdkv2/resources/form/generate_example.sh
+++ b/morpheus/sdkv2/resources/form/generate_example.sh
@@ -140,4 +140,21 @@
   OptionType6Placeholder 'Testing 123' \
   OptionType6Required 'true' \
   OptionType6Step '2' \
-  OptionType6Type 'number'
+  OptionType6Type 'number' \
+  OptionType7Code 'network-manager-input' \
+  OptionType7DefaultValue 'test123' \
+  OptionType7Description 'Terraform network manager example' \
+  OptionType7DisplayValueOnDetails 'true' \
+  OptionType7EnableIPModeSelection 'true' \
+  OptionType7ExcludeFromSearch 'true' \
+  OptionType7ExportMeta 'true' \
+  OptionType7FieldLabel 'network input' \
+  OptionType7FieldName 'networkInput' \
+  OptionType7HelpBlock 'Select a network' \
+  OptionType7Hidden 'false' \
+  OptionType7Locked 'true' \
+  OptionType7Name 'tf network manager example' \
+  OptionType7Placeholder 'Select network' \
+  OptionType7Required 'true' \
+  OptionType7ShowNetworkTypeSelection 'true' \
+  OptionType7Type 'networkManager'


### PR DESCRIPTION
In this PR we add support for option type networkManager to the forms resource.  We've added an example block for docs and tests, and added checks for the example block attributes to the acceptance test.