### PR TITLE
Register hpe_morpheus_os_type_image resource

### DIFF
--- a/morpheus/resources.go
+++ b/morpheus/resources.go
@@ -39,6 +39,7 @@ func (s SubProvider) GetResources(
 		instance.NewResource,
 		policy.NewResource,
 		cluster.NewResource,
+		ostypeimage.NewResource,
 	}
 
 	return resources


### PR DESCRIPTION
We forgot to register this in `resources.go` which is causing `make docs` to fail.
