### PR TITLE
Add summary to cluster documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -145,12 +145,14 @@ provider "hpe" {
 ## Release Notes
 
 ->The following resources use `WriteOnly` attributes:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cluster<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_image<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_user<br><br>
 `WriteOnly` attributes are supported by Terraform versions 1.11 and later.
 
 ->The following resources use a `Dynamic` attribute for `config`:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cloud<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cluster<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_datastore<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_instance<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network<br>

--- a/docs/resources/morpheus_cluster.md
+++ b/docs/resources/morpheus_cluster.md
@@ -10,7 +10,8 @@ description: |-
 
 The `hpe_morpheus_cluster` resource is used to provision and manage various cluster types in HPE Morpheus.
 
-Currently, only HVM clusters are officially supported via the `config_hvm` attribute.
+-> Currently HVM clusters are supported.  We have static `config` schemas for the following:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- HVM: `config_hvm`<br>
 
 ## HVM Cluster
 

--- a/docs/resources/morpheus_cluster.md
+++ b/docs/resources/morpheus_cluster.md
@@ -8,6 +8,10 @@ description: |-
 
 
 
+The `hpe_morpheus_cluster` resource is used to provision and manage various cluster types in HPE Morpheus.
+
+Currently, only HVM clusters are officially supported via the `config_hvm` attribute.
+
 ## HVM Cluster
 
 The `hvm_config` static config block can be used to provision a HVM cluster:

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -65,12 +65,14 @@ be toggled off by setting `insecure` to `true` in the provider block.
 ## Release Notes
 
 ->The following resources use `WriteOnly` attributes:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cluster<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_image<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_user<br><br>
 `WriteOnly` attributes are supported by Terraform versions 1.11 and later.
 
 ->The following resources use a `Dynamic` attribute for `config`:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cloud<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cluster<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_datastore<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_instance<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network<br>

--- a/templates/resources/morpheus_cluster.md.tmpl
+++ b/templates/resources/morpheus_cluster.md.tmpl
@@ -10,7 +10,8 @@ description: |-
 
 The `hpe_morpheus_cluster` resource is used to provision and manage various cluster types in HPE Morpheus.
 
-Currently, only HVM clusters are officially supported via the `config_hvm` attribute.
+-> Currently HVM clusters are supported.  We have static `config` schemas for the following:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- HVM: `config_hvm`<br>
 
 ## HVM Cluster
 

--- a/templates/resources/morpheus_cluster.md.tmpl
+++ b/templates/resources/morpheus_cluster.md.tmpl
@@ -8,6 +8,10 @@ description: |-
 
 {{ .Description | trimspace }}
 
+The `hpe_morpheus_cluster` resource is used to provision and manage various cluster types in HPE Morpheus.
+
+Currently, only HVM clusters are officially supported via the `config_hvm` attribute.
+
 ## HVM Cluster
 
 The `hvm_config` static config block can be used to provision a HVM cluster:


### PR DESCRIPTION
Adds summary to the cluster documentation and adds relevant cluster info to `index.md.tmpl`.