### PR TITLE
Add support for forms group option type

### DIFF
--- a/docs/resources/morpheus_form.md
+++ b/docs/resources/morpheus_form.md
@@ -172,6 +172,25 @@ resource "hpe_morpheus_form" "example" {
     filter_from_resource     = true
   }
 
+  option_type {
+    name                     = "tf group example"
+    code                     = "group-input"
+    description              = "Terraform group example"
+    type                     = "group"
+    field_label              = "group input"
+    field_name               = "groupInput"
+    default_value            = "test123"
+    placeholder              = "Select group"
+    help_block               = "Select a group"
+    required                 = true
+    export_meta              = true
+    display_value_on_details = true
+    locked                   = true
+    hidden                   = false
+    exclude_from_search      = true
+    allow_read_only          = true
+  }
+
   field_group {
     name                 = "fg1"
     description          = "testin"
@@ -264,6 +283,7 @@ Optional:
 - `allow_duplicates` (Boolean) Whether duplicate selections are allowed
 - `allow_multiple_selections` (Boolean) Whether to allow multiple items to be selected when using a select list or type ahead option type
 - `allow_password_peek` (Boolean) Whether the value of the password option type can be revealed by the user to ensure they correctly entered the password
+- `allow_read_only` (Boolean) Whether to allow read only instances of this type
 - `code` (String) The code of the option type to add to the field group
 - `code_language` (String) The coding language used for highlighting code syntax
 - `custom_data` (String) Custom JSON data payload to pass (Must be a JSON string)
@@ -297,7 +317,7 @@ Optional:
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of rows to display for a text area or code editor option type
-- `type` (String) The type of option type to add to the field group (byteSize, checkbox, cloud, code-editor, hidden, networkManager, number, password, radio, select, text, textarea, textArray, typeahead)
+- `type` (String) The type of option type to add to the field group (byteSize, checkbox, cloud, code-editor, group, hidden, networkManager, number, password, radio, select, text, textarea, textArray, typeahead)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 
@@ -311,6 +331,7 @@ Optional:
 - `allow_duplicates` (Boolean) Whether duplicate selections are allowed
 - `allow_multiple_selections` (Boolean) Whether to allow multiple items to be selected when using a select list or type ahead option type
 - `allow_password_peek` (Boolean) Whether the value of the password option type can be revealed by the user to ensure they correctly entered the password
+- `allow_read_only` (Boolean) Whether to allow read only instances of this type
 - `code` (String) The code of the option type to add to the form
 - `code_language` (String) The coding language used for highlighting code syntax
 - `custom_data` (String) Custom JSON data payload to pass (Must be a JSON string)
@@ -344,7 +365,7 @@ Optional:
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of rows to display for a text area or code editor option type
-- `type` (String) The type of option type to add to the form (byteSize, checkbox, cloud, code-editor, hidden, networkManager, number, password, radio, select, text, textarea, textArray, typeahead)
+- `type` (String) The type of option type to add to the form (byteSize, checkbox, cloud, code-editor, group, hidden, networkManager, number, password, radio, select, text, textarea, textArray, typeahead)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 

--- a/examples/resources/morpheus_form/resource.tf
+++ b/examples/resources/morpheus_form/resource.tf
@@ -156,6 +156,25 @@ resource "hpe_morpheus_form" "example" {
     filter_from_resource     = true
   }
 
+  option_type {
+    name                     = "tf group example"
+    code                     = "group-input"
+    description              = "Terraform group example"
+    type                     = "group"
+    field_label              = "group input"
+    field_name               = "groupInput"
+    default_value            = "test123"
+    placeholder              = "Select group"
+    help_block               = "Select a group"
+    required                 = true
+    export_meta              = true
+    display_value_on_details = true
+    locked                   = true
+    hidden                   = false
+    exclude_from_search      = true
+    allow_read_only          = true
+  }
+
   field_group {
     name                 = "fg1"
     description          = "testin"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HPE/terraform-provider-hpe
 go 1.25.0
 
 require (
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260401134317-b9efcca4e808
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260403112922-614f1a291e3f
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.32.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e3
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260127104537-7d5e34cd02e9/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260401134317-b9efcca4e808 h1:Z/B2N6kF+7pREDnVNOJBecjK0+coMblx1XEsqutSrms=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260401134317-b9efcca4e808/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260403112922-614f1a291e3f h1:7aNd2R17gXSBzK9vSfyO1AwTVAMoogDAfd4rHebTLWU=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260403112922-614f1a291e3f/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.32.0 h1:KI1hIaClDMWEMIBznioKav9YzcW9EeBChd2SjX7LbmA=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.32.0/go.mod h1:b6E29JKzlWyMCIEjwUz/KstqXIBna2qdcTwvSJQF5bI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -25,6 +25,7 @@ const (
 	typeCheckbox       = "checkbox"
 	typeCloud          = "cloud"
 	typeCodeEditor     = "code-editor"
+	typeGroup          = "group"
 	typeHidden         = "hidden"
 	typeNetworkManager = "networkManager"
 	typeNumber         = "number"
@@ -43,7 +44,6 @@ const (
 	typeDiskManager    = "diskManager"
 	typeEnvironment    = "environment"
 	typeFileContent    = "fileContent"
-	typeGroup          = "group"
 	typeHTTPHeader     = "httpHeader"
 	typeInstancesInput = "instances-input"
 	typeKeyValue       = "keyValue"
@@ -154,6 +154,11 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		config := make(map[string]any)
 		config["filterResource"] = optionTypeConfig["filter_from_resource"]
 		row["config"] = config
+	case typeGroup:
+		row["defaultValue"] = optionTypeConfig["default_value"]
+		config := make(map[string]any)
+		config["allowReadonly"] = optionTypeConfig["allow_read_only"]
+		row["config"] = config
 	case typeNumber:
 		var defaultValue string
 		if v, ok := optionTypeConfig["default_value"].(string); ok {
@@ -251,6 +256,8 @@ func applyReadOptionTypeByType(row map[string]any, optionType morpheus.Option, l
 	case typeCodeEditor:
 		row["show_line_numbers"] = optionType.Config.ShowLineNumbers
 		row["code_language"] = optionType.Config.Lang
+	case typeGroup:
+		row["allow_read_only"] = optionType.Config.AllowReadonly
 	case typeNumber:
 		row["step"] = optionType.Config.Step
 		row["min_value"] = optionType.MinVal
@@ -398,11 +405,11 @@ func optionTypeSchema(parent string) *schema.Schema {
 				"type": {
 					Type: schema.TypeString,
 					Description: fmt.Sprintf("The type of option type to add to the %s ", parent) +
-						"(byteSize, checkbox, cloud, code-editor, hidden, networkManager, number, password, radio, " +
+						"(byteSize, checkbox, cloud, code-editor, group, hidden, networkManager, number, password, radio, " +
 						"select, text, textarea, textArray, typeahead)",
 					ValidateFunc: validation.StringInSlice(
 						[]string{
-							typeByteSize, typeCheckbox, typeCloud, typeCodeEditor, typeHidden, typeNetworkManager, typeNumber,
+							typeByteSize, typeCheckbox, typeCloud, typeCodeEditor, typeGroup, typeHidden, typeNetworkManager, typeNumber,
 							typePassword, typeRadio, typeSelect, typeText, typeTextArea, typeTextArray, typeTypeahead,
 						},
 						false,
@@ -560,6 +567,12 @@ func optionTypeSchema(parent string) *schema.Schema {
 				"filter_from_resource": {
 					Type:        schema.TypeBool,
 					Description: "Whether to filter out resources that are not associated with this option",
+					Optional:    true,
+					Computed:    true,
+				},
+				"allow_read_only": {
+					Type:        schema.TypeBool,
+					Description: "Whether to allow read only instances of this type",
 					Optional:    true,
 					Computed:    true,
 				},

--- a/morpheus/sdkv2/resources/form/form_resource.tf.tmpl
+++ b/morpheus/sdkv2/resources/form/form_resource.tf.tmpl
@@ -156,6 +156,25 @@ resource "hpe_morpheus_form" "example" {
     filter_from_resource     = {{.OptionType8FilterFromResource}}
   }
 
+  option_type {
+    name                     = "{{.OptionType10Name}}"
+    code                     = "{{.OptionType10Code}}"
+    description              = "{{.OptionType10Description}}"
+    type                     = "{{.OptionType10Type}}"
+    field_label              = "{{.OptionType10FieldLabel}}"
+    field_name               = "{{.OptionType10FieldName}}"
+    default_value            = "{{.OptionType10DefaultValue}}"
+    placeholder              = "{{.OptionType10Placeholder}}"
+    help_block               = "{{.OptionType10HelpBlock}}"
+    required                 = {{.OptionType10Required}}
+    export_meta              = {{.OptionType10ExportMeta}}
+    display_value_on_details = {{.OptionType10DisplayValueOnDetails}}
+    locked                   = {{.OptionType10Locked}}
+    hidden                   = {{.OptionType10Hidden}}
+    exclude_from_search      = {{.OptionType10ExcludeFromSearch}}
+    allow_read_only          = {{.OptionType10AllowReadOnly}}
+  }
+
   field_group {
     name                   = "{{.FieldGroup1Name}}"
     description            = "{{.FieldGroup1Description}}"

--- a/morpheus/sdkv2/resources/form/form_resource_example.go
+++ b/morpheus/sdkv2/resources/form/form_resource_example.go
@@ -189,6 +189,22 @@ func RenderFormConfig(t *testing.T, overrides map[string]string) (string, error)
 		"OptionType8Placeholder":                     "Select cloud",
 		"OptionType8Required":                        "true",
 		"OptionType8Type":                            "cloud",
+		"OptionType10AllowReadOnly":                  "true",
+		"OptionType10Code":                           "group-input",
+		"OptionType10DefaultValue":                   "test123",
+		"OptionType10Description":                    "Terraform group example",
+		"OptionType10DisplayValueOnDetails":          "true",
+		"OptionType10ExcludeFromSearch":              "true",
+		"OptionType10ExportMeta":                     "true",
+		"OptionType10FieldLabel":                     "group input",
+		"OptionType10FieldName":                      "groupInput",
+		"OptionType10HelpBlock":                      "Select a group",
+		"OptionType10Hidden":                         "false",
+		"OptionType10Locked":                         "true",
+		"OptionType10Name":                           "tf group example",
+		"OptionType10Placeholder":                    "Select group",
+		"OptionType10Required":                       "true",
+		"OptionType10Type":                           "group",
 	}
 
 	// Apply overrides to defaults

--- a/morpheus/sdkv2/resources/form/form_resource_test.go
+++ b/morpheus/sdkv2/resources/form/form_resource_test.go
@@ -1065,6 +1065,102 @@ func TestAccMorpheusFormExampleOk(t *testing.T) {
 			"option_type8_type",
 			"cloud",
 		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_allow_read_only",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_code",
+			"group-input",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_default_value",
+			"test123",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_description",
+			"Terraform group example",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_display_value_on_details",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_exclude_from_search",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_export_meta",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_field_label",
+			"group input",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_field_name",
+			"groupInput",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_help_block",
+			"Select a group",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_hidden",
+			"false",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_locked",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_name",
+			"tf group example",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_placeholder",
+			"Select group",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_required",
+			"true",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_form.example",
+			"option_type10_type",
+			"group",
+		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)

--- a/morpheus/sdkv2/resources/form/generate_example.sh
+++ b/morpheus/sdkv2/resources/form/generate_example.sh
@@ -173,4 +173,20 @@
   OptionType8Name 'tf cloud example' \
   OptionType8Placeholder 'Select cloud' \
   OptionType8Required 'true' \
-  OptionType8Type 'cloud'
+  OptionType8Type 'cloud' \
+  OptionType10AllowReadOnly 'true' \
+  OptionType10Code 'group-input' \
+  OptionType10DefaultValue 'test123' \
+  OptionType10Description 'Terraform group example' \
+  OptionType10DisplayValueOnDetails 'true' \
+  OptionType10ExcludeFromSearch 'true' \
+  OptionType10ExportMeta 'true' \
+  OptionType10FieldLabel 'group input' \
+  OptionType10FieldName 'groupInput' \
+  OptionType10HelpBlock 'Select a group' \
+  OptionType10Hidden 'false' \
+  OptionType10Locked 'true' \
+  OptionType10Name 'tf group example' \
+  OptionType10Placeholder 'Select group' \
+  OptionType10Required 'true' \
+  OptionType10Type 'group'


### PR DESCRIPTION
In this PR we add support for the group forms option type.  We've updated docs and acceptance tests. We've also updated the version of the legacy SDK.