### PR TITLE
Add forms option type virtual-image

### DIFF
--- a/docs/resources/morpheus_form.md
+++ b/docs/resources/morpheus_form.md
@@ -13,6 +13,36 @@ and all inputs or option types must be defined in the form.
 
 ## Example Usage
 
+### Virtual Image
+
+```terraform
+resource "hpe_morpheus_form" "example" {
+  name        = "demo"
+  code        = "demo"
+  description = "demo"
+  labels      = ["terraform", "demo"]
+
+  option_type {
+    name                           = "tf virtual-image example"
+    code                           = "virtual-image"
+    description                    = "Terraform virtual-image example"
+    type                           = "virtual-image"
+    field_label                    = "Virtual Image"
+    field_name                     = "virtual-image"
+    default_value                  = ""
+    help_block                     = "Select a virtual image"
+    virtual_image_cloud_field_type = "id"
+    virtual_image_cloud_id         = 1
+    required                       = true
+    export_meta                    = true
+    display_value_on_details       = true
+    locked                         = true
+    hidden                         = false
+    exclude_from_search            = true
+  }
+}
+```
+
 ### VmwFolders
 
 ```terraform
@@ -849,8 +879,11 @@ Optional:
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of rows to display for a text area or code editor option type
-- `type` (String) The type of option type to add to the field group (byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, httpHeader, instances-input, layout, networkManager, number, password, plan, ports, radio, resourcePool, secGroup, select, servers-input, text, textarea, textArray, typeahead, vmwFolders)
+- `type` (String) The type of option type to add to the field group (byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, httpHeader, instances-input, layout, networkManager, number, password, plan, ports, radio, resourcePool, secGroup, select, servers-input, text, textarea, textArray, typeahead, virtual-image, vmwFolders)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
+- `virtual_image_cloud` (String) The cloud code used to determine the cloud for a virtual-image option type
+- `virtual_image_cloud_field_type` (String) How the cloud is specified for a virtual-image option type (cloud or id)
+- `virtual_image_cloud_id` (String) The cloud ID used to determine the cloud for a virtual-image option type
 - `virtual_image_field_type` (String) How the virtual image is specified for a diskManager option type (field or value)
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 
@@ -924,8 +957,11 @@ Optional:
 - `sortable` (Boolean) Whether the selected options can be sorted or not
 - `step` (Number) The incrementation number used for the number option type (i.e. - 5s, 10s, 100s, etc.)
 - `text_rows` (Number) The number of rows to display for a text area or code editor option type
-- `type` (String) The type of option type to add to the form (byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, httpHeader, instances-input, layout, networkManager, number, password, plan, ports, radio, resourcePool, secGroup, select, servers-input, text, textarea, textArray, typeahead, vmwFolders)
+- `type` (String) The type of option type to add to the form (byteSize, checkbox, cloud, code-editor, diskManager, environment, fileContent, group, hidden, httpHeader, instances-input, layout, networkManager, number, password, plan, ports, radio, resourcePool, secGroup, select, servers-input, text, textarea, textArray, typeahead, virtual-image, vmwFolders)
 - `verify_pattern` (String) The regex pattern used to validate the entered text
+- `virtual_image_cloud` (String) The cloud code used to determine the cloud for a virtual-image option type
+- `virtual_image_cloud_field_type` (String) How the cloud is specified for a virtual-image option type (cloud or id)
+- `virtual_image_cloud_id` (String) The cloud ID used to determine the cloud for a virtual-image option type
 - `virtual_image_field_type` (String) How the virtual image is specified for a diskManager option type (field or value)
 - `visibility_field` (String) The field or code used to trigger the visibility of the field
 

--- a/examples/resources/morpheus_form/resource_virtual_image.tf
+++ b/examples/resources/morpheus_form/resource_virtual_image.tf
@@ -1,0 +1,25 @@
+resource "hpe_morpheus_form" "example" {
+  name        = "demo"
+  code        = "demo"
+  description = "demo"
+  labels      = ["terraform", "demo"]
+
+  option_type {
+    name                           = "tf virtual-image example"
+    code                           = "virtual-image"
+    description                    = "Terraform virtual-image example"
+    type                           = "virtual-image"
+    field_label                    = "Virtual Image"
+    field_name                     = "virtual-image"
+    default_value                  = ""
+    help_block                     = "Select a virtual image"
+    virtual_image_cloud_field_type = "id"
+    virtual_image_cloud_id         = 1
+    required                       = true
+    export_meta                    = true
+    display_value_on_details       = true
+    locked                         = true
+    hidden                         = false
+    exclude_from_search            = true
+  }
+}

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -47,6 +47,7 @@ const (
 	typeTextArea       = "textarea"
 	typeTextArray      = "textArray"
 	typeTypeahead      = "typeahead"
+	typeVirtualImage   = "virtual-image"
 	typeVMWFolders     = "vmwFolders"
 )
 
@@ -55,7 +56,6 @@ const (
 const (
 	typeKeyValue     = "keyValue"
 	typeLogoSelector = "logoSelector"
-	typeVirtualImage = "virtual-image"
 )
 
 func validateOptionTypeConfig(optionType cty.Value, path string, index int) error {
@@ -215,6 +215,13 @@ func validateOptionTypeConfig(optionType cty.Value, path string, index int) erro
 			return err
 		}
 
+	case typeVirtualImage:
+		if err := validateLayoutFieldTypePair(optionType, path, index,
+			"virtual_image_cloud_field_type", "virtual_image_cloud",
+			"virtual_image_cloud_id"); err != nil {
+			return err
+		}
+
 	case typeVMWFolders:
 		if err := validateLayoutFieldTypePair(optionType, path, index,
 			"group_field_type", "group_field", "group_id"); err != nil {
@@ -237,6 +244,7 @@ func validateOptionTypeConfig(optionType cty.Value, path string, index int) erro
 
 // validateLayoutFieldTypePair enforces that only the appropriate sub-field is set
 // based on the value of fieldTypeAttr ("field" → use fieldAttr, "value" → use valueAttr).
+// except for virtual-image ("cloud" → use fieldAttr, "id" → use valueAttr).
 func validateLayoutFieldTypePair(optionType cty.Value, path string, index int,
 	fieldTypeAttr, fieldAttr, valueAttr string,
 ) error {
@@ -245,18 +253,26 @@ func validateLayoutFieldTypePair(optionType cty.Value, path string, index int,
 		return nil
 	}
 
+	field := "field"
+	value := "value"
+	// virtual-image is a special case where the fieldType can be "cloud" or "id" instead of "field" or "value"
+	if fieldTypeAttr == "virtual_image_cloud_field_type" {
+		field = "cloud"
+		value = "id"
+	}
+
 	switch fieldType.AsString() {
-	case "field":
+	case field:
 		valueField := optionType.GetAttr(valueAttr)
 		if valueField.IsKnown() && !valueField.IsNull() && valueField.AsString() != "" {
-			return fmt.Errorf("%s cannot be set when %s is 'field' at %s[%d]; use %s instead",
-				valueAttr, fieldTypeAttr, path, index, fieldAttr)
+			return fmt.Errorf("%s cannot be set when %s is '%s' at %s[%d]; use %s instead",
+				valueAttr, fieldTypeAttr, field, path, index, fieldAttr)
 		}
-	case "value":
+	case value:
 		fieldField := optionType.GetAttr(fieldAttr)
 		if fieldField.IsKnown() && !fieldField.IsNull() && fieldField.AsString() != "" {
-			return fmt.Errorf("%s cannot be set when %s is 'value' at %s[%d]; use %s instead",
-				fieldAttr, fieldTypeAttr, path, index, valueAttr)
+			return fmt.Errorf("%s cannot be set when %s is '%s' at %s[%d]; use %s instead",
+				fieldAttr, fieldTypeAttr, value, path, index, valueAttr)
 		}
 	}
 
@@ -536,6 +552,13 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		row["defaultValue"] = optionTypeConfig["default_value"]
 	case typeText:
 		row["defaultValue"] = optionTypeConfig["default_value"]
+	case typeVirtualImage:
+		row["defaultValue"] = optionTypeConfig["default_value"]
+		config := make(map[string]any)
+		config["cloudFieldType"] = optionTypeConfig["virtual_image_cloud_field_type"]
+		config["cloudField"] = optionTypeConfig["virtual_image_cloud"]
+		config["cloudId"] = optionTypeConfig["virtual_image_cloud_id"]
+		row["config"] = config
 	case typeVMWFolders:
 		row["defaultValue"] = optionTypeConfig["default_value"]
 		config := make(map[string]any)
@@ -697,6 +720,10 @@ func applyReadOptionTypeByType(row map[string]any, optionType morpheus.Option, l
 		row["custom_data"] = optionType.Config.CustomData
 		row["allow_multiple_selections"] = optionType.Config.MultiSelect
 		row["option_list_id"] = optionType.OptionList.ID
+	case typeVirtualImage:
+		row["virtual_image_cloud_field_type"] = optionType.Config.CloudFieldType
+		row["virtual_image_cloud"] = optionType.Config.CloudField
+		row["virtual_image_cloud_id"] = optionType.Config.CloudId
 	case typeVMWFolders:
 		row["group_field_type"] = optionType.Config.GroupFieldType
 		row["group_field"] = optionType.Config.GroupField
@@ -833,7 +860,7 @@ func optionTypeSchema(parent string) *schema.Schema {
 						" httpHeader, instances-input," +
 						" layout, networkManager," +
 						" number, password, plan, ports, radio, resourcePool, secGroup, select," +
-						" servers-input, text, textarea, textArray, typeahead, vmwFolders)",
+						" servers-input, text, textarea, textArray, typeahead, virtual-image, vmwFolders)",
 					ValidateFunc: validation.StringInSlice(
 						[]string{
 							typeByteSize, typeCheckbox, typeCloud, typeCodeEditor, typeDiskManager,
@@ -841,7 +868,7 @@ func optionTypeSchema(parent string) *schema.Schema {
 							typeNetworkManager, typeNumber, typePassword, typePlan, typePorts, typeRadio, typeResourcePool, typeSecGroup,
 							typeSelect,
 							typeServersInput, typeText, typeTextArea,
-							typeTextArray, typeTypeahead, typeVMWFolders,
+							typeTextArray, typeTypeahead, typeVirtualImage, typeVMWFolders,
 						},
 						false,
 					),
@@ -1042,6 +1069,25 @@ func optionTypeSchema(parent string) *schema.Schema {
 				"cloud_type": {
 					Type:        schema.TypeString,
 					Description: "The id of the cloud type to set for a cloud option type",
+					Optional:    true,
+					Computed:    true,
+				},
+				"virtual_image_cloud_field_type": {
+					Type:         schema.TypeString,
+					Description:  "How the cloud is specified for a virtual-image option type (cloud or id)",
+					ValidateFunc: validation.StringInSlice([]string{"cloud", "id"}, false),
+					Optional:     true,
+					Computed:     true,
+				},
+				"virtual_image_cloud": {
+					Type:        schema.TypeString,
+					Description: "The cloud code used to determine the cloud for a virtual-image option type",
+					Optional:    true,
+					Computed:    true,
+				},
+				"virtual_image_cloud_id": {
+					Type:        schema.TypeString,
+					Description: "The cloud ID used to determine the cloud for a virtual-image option type",
 					Optional:    true,
 					Computed:    true,
 				},

--- a/morpheus/sdkv2/resources/form/form_resource_example.go
+++ b/morpheus/sdkv2/resources/form/form_resource_example.go
@@ -318,6 +318,51 @@ func RenderFormConfig(t *testing.T, overrides map[string]string) (string, error)
 	)
 }
 
+func RenderVirtualImageConfig(t *testing.T, overrides map[string]string) (string, error) {
+	t.Helper()
+
+	defaults := map[string]string{
+		"Code":                            "demo",
+		"Description":                     "demo",
+		"Labels":                          "[\"terraform\", \"demo\"]",
+		"Name":                            "demo",
+		"OptionTypeCode":                  "virtual-image",
+		"OptionTypeDefaultValue":          "",
+		"OptionTypeDescription":           "Terraform virtual-image example",
+		"OptionTypeDisplayValueOnDetails": "true",
+		"OptionTypeExcludeFromSearch":     "true",
+		"OptionTypeExportMeta":            "true",
+		"OptionTypeFieldLabel":            "Virtual Image",
+		"OptionTypeFieldName":             "virtual-image",
+		"OptionTypeHelpBlock":             "Select a virtual image",
+		"OptionTypeHidden":                "false",
+		"OptionTypeLocked":                "true",
+		"OptionTypeName":                  "tf virtual-image example",
+		"OptionTypeRequired":              "true",
+		"OptionTypeType":                  "virtual-image",
+		"OptionTypeCloudFieldType":        "id",
+		"OptionTypeCloudId":               "1",
+	}
+
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to get current file path")
+	}
+	dir := filepath.Dir(filename)
+	templatePath := filepath.Join(dir, "form_virtual_image.tf.tmpl")
+
+	return testhelpers.RenderExample(t, templatePath, args...)
+}
+
 func RenderVmwFoldersConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 

--- a/morpheus/sdkv2/resources/form/form_virtual_image.tf.tmpl
+++ b/morpheus/sdkv2/resources/form/form_virtual_image.tf.tmpl
@@ -1,0 +1,25 @@
+resource "hpe_morpheus_form" "example" {
+  name        = "{{.Name}}"
+  code        = "{{.Code}}"
+  description = "{{.Description}}"
+  labels      = {{.Labels}}
+
+  option_type {
+    name                           = "{{.OptionTypeName}}"
+    code                           = "{{.OptionTypeCode}}"
+    description                    = "{{.OptionTypeDescription}}"
+    type                           = "{{.OptionTypeType}}"
+    field_label                    = "{{.OptionTypeFieldLabel}}"
+    field_name                     = "{{.OptionTypeFieldName}}"
+    default_value                  = "{{.OptionTypeDefaultValue}}"
+    help_block                     = "{{.OptionTypeHelpBlock}}"
+    virtual_image_cloud_field_type = "{{.OptionTypeCloudFieldType}}"
+    virtual_image_cloud_id         = {{.OptionTypeCloudId}}
+    required                       = {{.OptionTypeRequired}}
+    export_meta                    = {{.OptionTypeExportMeta}}
+    display_value_on_details       = {{.OptionTypeDisplayValueOnDetails}}
+    locked                         = {{.OptionTypeLocked}}
+    hidden                         = {{.OptionTypeHidden}}
+    exclude_from_search            = {{.OptionTypeExcludeFromSearch}}
+  }
+}

--- a/morpheus/sdkv2/resources/form/generate_example.sh
+++ b/morpheus/sdkv2/resources/form/generate_example.sh
@@ -4,6 +4,30 @@
 RENDER=../../../../bin/render
 
 $RENDER \
+  -out examples/resources/morpheus_form/resource_virtual_image.tf \
+  form_virtual_image.tf.tmpl \
+  Name 'demo' \
+  Code 'demo' \
+  Description 'demo' \
+  Labels '["terraform", "demo"]' \
+  OptionTypeName 'tf virtual-image example' \
+  OptionTypeCode 'virtual-image' \
+  OptionTypeDescription 'Terraform virtual-image example' \
+  OptionTypeType 'virtual-image' \
+  OptionTypeFieldLabel 'Virtual Image' \
+  OptionTypeFieldName 'virtual-image' \
+  OptionTypeDefaultValue '' \
+  OptionTypeHelpBlock 'Select a virtual image' \
+  OptionTypeCloudFieldType 'id' \
+  OptionTypeCloudId '1' \
+  OptionTypeRequired 'true' \
+  OptionTypeExportMeta 'true' \
+  OptionTypeDisplayValueOnDetails 'true' \
+  OptionTypeLocked 'true' \
+  OptionTypeHidden 'false' \
+  OptionTypeExcludeFromSearch 'true'
+
+$RENDER \
   -out examples/resources/morpheus_form/resource_vmw_folders.tf \
   form_vmw_folders.tf.tmpl \
   Name 'demo' \

--- a/morpheus/sdkv2/resources/form/virtual_image_test.go
+++ b/morpheus/sdkv2/resources/form/virtual_image_test.go
@@ -1,0 +1,87 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package form_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus"
+	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
+	"github.com/HPE/terraform-provider-hpe/morpheus/sdkv2/resources/form"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+)
+
+func TestAccMorpheusFormVirtualImageOk(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	defer testhelpers.RecordResult(t)
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+	code := toCode(name)
+	optTypeCode := code + "-ot"
+	optTypeName := name + " option type"
+
+	resourceConfig, err := form.RenderVirtualImageConfig(t, map[string]string{
+		"Name":           name,
+		"Code":           code,
+		"OptionTypeCode": optTypeCode,
+		"OptionTypeName": optTypeName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "code", code),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "description", "demo"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.type", "virtual-image"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.code", optTypeCode),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example",
+						"option_type.0.virtual_image_cloud_field_type", "id"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.virtual_image_cloud_id", "1"),
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_form.example",
+						"option_type.0.description",
+						"Terraform virtual-image example",
+					),
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_form.example",
+						"option_type.0.display_value_on_details",
+						"true",
+					),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.exclude_from_search", "true"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.export_meta", "true"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.field_label", "Virtual Image"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.field_name", "virtual-image"),
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_form.example",
+						"option_type.0.help_block",
+						"Select a virtual image",
+					),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.hidden", "false"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.locked", "true"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.name", optTypeName),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.required", "true"),
+				),
+			},
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+		},
+	})
+}

--- a/templates/resources/morpheus_form.md.tmpl
+++ b/templates/resources/morpheus_form.md.tmpl
@@ -13,6 +13,10 @@ and all inputs or option types must be defined in the form.
 
 ## Example Usage
 
+### Virtual Image
+
+{{tffile "examples/resources/morpheus_form/resource_virtual_image.tf"}}
+
 ### VmwFolders
 
 {{tffile "examples/resources/morpheus_form/resource_vmw_folders.tf"}}


### PR DESCRIPTION
We've added three new attributes to the Schema:
- virtual_image_cloud_field_type
- virtual_image_cloud
- virtual_image_cloud_id

Since for virtual-image the Cloud field can have a value of 'cloud' or 'id'.  We've updated validateLayoutFieldTypePair to handle these new values along with 'field' and 'value'.