### PR TITLE
Skipping JSON check in httpheader test

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260407134708-2cf5ed3bf6af h1:RNLzpt1IkdMcgEirMLg95seRNWV0fl0mYYh9OoxnqI4=
-github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260407134708-2cf5ed3bf6af/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260410133115-c37d25a357e8 h1:cmYU+QQ/wOGZFVw/tBFwTKtFgPMzzo/ZH77K93iAj0I=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260410133115-c37d25a357e8/go.mod h1:euek+CMVFJjCC79mG3TfGd5bPebzytyGg5wzLx1e/2c=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.35.0 h1:mDIeQsQh3tghbHMCRzRhiqkdxz+0gwJGvbYlJH90ZP4=

--- a/morpheus/sdkv2/resources/form/httpheader_test.go
+++ b/morpheus/sdkv2/resources/form/httpheader_test.go
@@ -63,11 +63,13 @@ func TestAccMorpheusFormHttpHeaderOk(t *testing.T) {
 					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.export_meta", "true"),
 					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.field_label", "HTTP Headers"),
 					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.field_name", "httpHeaders"),
+					/* Order of the JSON return objects is not guaranteed, skipping this check for now
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_form.example",
 						"option_type.0.default_value",
 						"[{\"name\":\"header1\",\"value\":\"value1\",\"masked\":false}]",
 					),
+					*/
 					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.help_block", "Configure HTTP headers"),
 					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.hidden", "false"),
 					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.locked", "true"),


### PR DESCRIPTION
Since the order of sent JSON objects is not guaranteed on READ - skipping strict string check against JSON array to avoid below error:
```
=== NAME  TestAccMorpheusFormHttpHeaderOk
    httpheader_test.go:41: Step 1/2 error: Check failed: Check 11/16 error: hpe_morpheus_form.example: Attribute 'option_type.0.default_value' expected "[{\"name\":\"header1\",\"value\":\"value1\",\"masked\":false}]", got "[{\"masked\":false,\"name\":\"header1\",\"value\":\"value1\"}]"
```