### PR TITLE
Implementing tag option type and fixing default_value

### DIFF
--- a/docs/resources/morpheus_form.md
+++ b/docs/resources/morpheus_form.md
@@ -776,6 +776,38 @@ resource "hpe_morpheus_form" "example" {
 }
 ```
 
+### Tag
+
+```terraform
+resource "hpe_morpheus_form" "example" {
+  name        = "demo"
+  code        = "demo"
+  description = "demo"
+  labels      = ["terraform", "demo"]
+
+  option_type {
+    name                     = "tf tag example"
+    code                     = "tag-input"
+    description              = "Terraform tag example"
+    type                     = "tag"
+    field_label              = "Tags"
+    field_name               = "tags"
+    default_value            = ""
+    help_block               = "Configure tags"
+    group_field_type         = "value"
+    group_id                 = 1
+    cloud_field_type         = "value"
+    cloud_id                 = 1
+    required                 = true
+    export_meta              = true
+    display_value_on_details = true
+    locked                   = true
+    hidden                   = false
+    exclude_from_search      = true
+  }
+}
+```
+
 ### Ports
 
 ```terraform

--- a/docs/resources/morpheus_form.md
+++ b/docs/resources/morpheus_form.md
@@ -792,7 +792,7 @@ resource "hpe_morpheus_form" "example" {
     type                     = "tag"
     field_label              = "Tags"
     field_name               = "tags"
-    default_value            = ""
+    default_value            = jsonencode([{ name = "Sample Name", value = "Sample Value" }])
     help_block               = "Configure tags"
     group_field_type         = "value"
     group_id                 = 1

--- a/examples/resources/morpheus_form/resource_tag.tf
+++ b/examples/resources/morpheus_form/resource_tag.tf
@@ -11,7 +11,7 @@ resource "hpe_morpheus_form" "example" {
     type                     = "tag"
     field_label              = "Tags"
     field_name               = "tags"
-    default_value            = ""
+    default_value            = jsonencode([{ name = "Sample Name", value = "Sample Value" }])
     help_block               = "Configure tags"
     group_field_type         = "value"
     group_id                 = 1

--- a/examples/resources/morpheus_form/resource_tag.tf
+++ b/examples/resources/morpheus_form/resource_tag.tf
@@ -1,0 +1,27 @@
+resource "hpe_morpheus_form" "example" {
+  name        = "demo"
+  code        = "demo"
+  description = "demo"
+  labels      = ["terraform", "demo"]
+
+  option_type {
+    name                     = "tf tag example"
+    code                     = "tag-input"
+    description              = "Terraform tag example"
+    type                     = "tag"
+    field_label              = "Tags"
+    field_name               = "tags"
+    default_value            = ""
+    help_block               = "Configure tags"
+    group_field_type         = "value"
+    group_id                 = 1
+    cloud_field_type         = "value"
+    cloud_id                 = 1
+    required                 = true
+    export_meta              = true
+    display_value_on_details = true
+    locked                   = true
+    hidden                   = false
+    exclude_from_search      = true
+  }
+}

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -45,6 +45,7 @@ const (
 	typeSecGroup       = "secGroup"
 	typeSelect         = "select"
 	typeServersInput   = "servers-input"
+	typeTag            = "tag"
 	typeText           = "text"
 	typeTextArea       = "textarea"
 	typeTextArray      = "textArray"
@@ -200,6 +201,16 @@ func validateOptionTypeConfig(optionType cty.Value, path string, index int) erro
 			return err
 		}
 	case typeSecGroup:
+		if err := validateLayoutFieldTypePair(optionType, path, index,
+			"cloud_field_type", "cloud_field", "cloud_id"); err != nil {
+			return err
+		}
+	case typeTag:
+		if err := validateLayoutFieldTypePair(optionType, path, index,
+			"group_field_type", "group_field", "group_id"); err != nil {
+			return err
+		}
+
 		if err := validateLayoutFieldTypePair(optionType, path, index,
 			"cloud_field_type", "cloud_field", "cloud_id"); err != nil {
 			return err
@@ -371,8 +382,8 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		config["cloudId"] = optionTypeConfig["cloud_id"]
 		row["config"] = config
 	case typePlan:
-		row["defaultValue"] = optionTypeConfig["default_value"]
 		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		config["showPricing"] = optionTypeConfig["show_pricing"]
 		config["groupFieldType"] = optionTypeConfig["group_field_type"]
 		config["groupField"] = optionTypeConfig["group_field"]
@@ -387,10 +398,11 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		config["poolField"] = optionTypeConfig["pool_field"]
 		config["poolId"] = optionTypeConfig["pool_id"]
 		config["diskField"] = optionTypeConfig["disk_field"]
+		row["defaultValue"] = optionTypeConfig["default_value"]
 		row["config"] = config
 	case typeDiskManager:
-		row["defaultValue"] = optionTypeConfig["default_value"]
 		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		config["groupFieldType"] = optionTypeConfig["group_field_type"]
 		config["groupField"] = optionTypeConfig["group_field"]
 		config["groupId"] = optionTypeConfig["group_id"]
@@ -412,6 +424,7 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		config["enableDiskTypeSelection"] = optionTypeConfig["enable_disk_type_selection"]
 		config["enableStorageTypeSelection"] = optionTypeConfig["enable_storage_type_selection"]
 		config["enableDatastoreSelection"] = optionTypeConfig["enable_datastore_selection"]
+		row["defaultValue"] = optionTypeConfig["default_value"]
 		row["config"] = config
 	case typeGroup:
 		row["defaultValue"] = optionTypeConfig["default_value"]
@@ -419,11 +432,12 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		config["allowReadonly"] = optionTypeConfig["allow_read_only"]
 		row["config"] = config
 	case typeKeyValue:
-		row["defaultValue"] = optionTypeConfig["default_value"]
 		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		config["asObject"] = optionTypeConfig["convert_to_object"]
 		config["keyPlaceholder"] = optionTypeConfig["key_placeholder"]
 		config["valuePlaceholder"] = optionTypeConfig["value_placeholder"]
+		row["defaultValue"] = optionTypeConfig["default_value"]
 		row["config"] = config
 	case typeServersInput:
 		row["defaultValue"] = optionTypeConfig["default_value"]
@@ -449,19 +463,32 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		config["layoutId"] = optionTypeConfig["layout_id"]
 		row["config"] = config
 	case typeSecGroup:
-		row["defaultValue"] = optionTypeConfig["default_value"]
 		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		config["cloudFieldType"] = optionTypeConfig["cloud_field_type"]
 		config["cloudField"] = optionTypeConfig["cloud_field"]
 		config["cloudId"] = optionTypeConfig["cloud_id"]
 		config["resourcePoolField"] = optionTypeConfig["pool_field"]
+		row["defaultValue"] = optionTypeConfig["default_value"]
+		row["config"] = config
+	case typeTag:
+		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
+		config["groupFieldType"] = optionTypeConfig["group_field_type"]
+		config["groupField"] = optionTypeConfig["group_field"]
+		config["groupId"] = optionTypeConfig["group_id"]
+		config["cloudFieldType"] = optionTypeConfig["cloud_field_type"]
+		config["cloudField"] = optionTypeConfig["cloud_field"]
+		config["cloudId"] = optionTypeConfig["cloud_id"]
+		row["defaultValue"] = optionTypeConfig["default_value"]
 		row["config"] = config
 	case typePorts:
-		row["defaultValue"] = optionTypeConfig["default_value"]
 		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		config["groupField"] = optionTypeConfig["group_field"]
 		config["cloudField"] = optionTypeConfig["cloud_field"]
 		config["layoutField"] = optionTypeConfig["layout_field"]
+		row["defaultValue"] = optionTypeConfig["default_value"]
 		row["config"] = config
 	case typeNumber:
 		var defaultValue string
@@ -496,6 +523,7 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		}
 	case typeNetworkManager:
 		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		config["groupFieldType"] = optionTypeConfig["group_field_type"]
 		config["groupField"] = optionTypeConfig["group_field"]
 		config["groupId"] = optionTypeConfig["group_id"]
@@ -519,6 +547,7 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 		row["defaultValue"] = optionTypeConfig["default_value"]
 		row["optionList"] = map[string]any{"id": optionTypeConfig["option_list_id"]}
 		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
 		config["sortable"] = optionTypeConfig["sortable"]
 		row["config"] = config
@@ -540,6 +569,7 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 	case typeTypeahead:
 		row["defaultValue"] = optionTypeConfig["default_value"]
 		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		config["sortable"] = optionTypeConfig["sortable"]
 		config["allowDuplicates"] = optionTypeConfig["allow_duplicates"]
 		config["multiSelect"] = optionTypeConfig["allow_multiple_selections"]
@@ -553,7 +583,10 @@ func applyOptionTypeConfigByType(row map[string]any, optionTypeConfig map[string
 	case typeHTTPHeader:
 		row["defaultValue"] = optionTypeConfig["default_value"]
 	case typeLogoSelector:
+		config := make(map[string]any)
+		config["defaultValue"] = optionTypeConfig["default_value"]
 		row["defaultValue"] = optionTypeConfig["default_value"]
+		row["config"] = config
 	case typeText:
 		row["defaultValue"] = optionTypeConfig["default_value"]
 	case typeVirtualImage:
@@ -680,10 +713,19 @@ func applyReadOptionTypeByType(row map[string]any, optionType morpheus.Option, l
 		row["layout_field"] = optionType.Config.LayoutField
 		row["layout_id"] = optionType.Config.LayoutId
 	case typeSecGroup:
+		row["default_value"] = optionType.Config.DefaultValue
 		row["cloud_field_type"] = optionType.Config.CloudFieldType
 		row["cloud_field"] = optionType.Config.CloudField
 		row["cloud_id"] = optionType.Config.CloudId
 		row["pool_field"] = optionType.Config.ResourcePoolField
+	case typeTag:
+		row["default_value"] = optionType.Config.DefaultValue
+		row["group_field_type"] = optionType.Config.GroupFieldType
+		row["group_field"] = optionType.Config.GroupField
+		row["group_id"] = optionType.Config.GroupId
+		row["cloud_field_type"] = optionType.Config.CloudFieldType
+		row["cloud_field"] = optionType.Config.CloudField
+		row["cloud_id"] = optionType.Config.CloudId
 	case typePorts:
 		row["default_value"] = optionType.Config.DefaultValue
 		row["group_field"] = optionType.Config.GroupField
@@ -694,6 +736,7 @@ func applyReadOptionTypeByType(row map[string]any, optionType morpheus.Option, l
 		row["min_value"] = optionType.MinVal
 		row["max_value"] = optionType.MaxVal
 	case typeNetworkManager:
+		row["default_value"] = optionType.Config.DefaultValue
 		row["group_field_type"] = optionType.Config.GroupFieldType
 		row["group_field"] = optionType.Config.GroupField
 		row["group_id"] = optionType.Config.GroupId
@@ -723,6 +766,7 @@ func applyReadOptionTypeByType(row map[string]any, optionType morpheus.Option, l
 	case typeTextArray:
 		row["delimiter"] = optionType.Config.Separator
 	case typeTypeahead:
+		row["default_value"] = optionType.Config.DefaultValue
 		row["sortable"] = optionType.Config.Sortable
 		row["allow_duplicates"] = optionType.Config.AllowDuplicates
 		row["custom_data"] = optionType.Config.CustomData
@@ -743,7 +787,7 @@ func applyReadOptionTypeByType(row map[string]any, optionType morpheus.Option, l
 		row["plan_field"] = optionType.Config.PlanField
 		row["plan_id"] = optionType.Config.PlanId
 	case typeLogoSelector:
-		// Logo selector default value is stored in the top-level field
+		row["default_value"] = optionType.Config.DefaultValue
 	}
 }
 
@@ -876,6 +920,7 @@ func optionTypeSchema(parent string) *schema.Schema {
 							typeEnvironment, typeFileContent, typeGroup, typeHTTPHeader, typeInstancesInput, typeHidden,
 							typeKeyValue, typeLayout, typeLogoSelector,
 							typeNetworkManager, typeNumber, typePassword, typePlan, typePorts, typeRadio, typeResourcePool, typeSecGroup,
+							typeTag,
 							typeSelect,
 							typeServersInput, typeText, typeTextArea,
 							typeTextArray, typeTypeahead, typeVirtualImage, typeVMWFolders,
@@ -1592,7 +1637,13 @@ func resourceFormRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 			row["type"] = optionType.Type
 			row["field_label"] = optionType.FieldLabel
 			row["field_name"] = optionType.FieldName
-			row["default_value"] = optionType.DefaultValue
+			defaultValue := optionType.DefaultValue
+			if configDefault, ok := row["default_value"]; ok {
+				if configDefaultValue, ok := configDefault.(string); ok && configDefaultValue != "" {
+					defaultValue = configDefaultValue
+				}
+			}
+			row["default_value"] = defaultValue
 			row["placeholder"] = optionType.PlaceHolder
 			row["help_block"] = optionType.HelpBlock
 			row["required"] = optionType.Required
@@ -1633,7 +1684,13 @@ func resourceFormRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 					optionTypeRow["type"] = optionType.Type
 					optionTypeRow["field_label"] = optionType.FieldLabel
 					optionTypeRow["field_name"] = optionType.FieldName
-					optionTypeRow["default_value"] = optionType.DefaultValue
+					defaultValue := optionType.DefaultValue
+					if configDefault, ok := optionTypeRow["default_value"]; ok {
+						if configDefaultValue, ok := configDefault.(string); ok && configDefaultValue != "" {
+							defaultValue = configDefaultValue
+						}
+					}
+					optionTypeRow["default_value"] = defaultValue
 					optionTypeRow["placeholder"] = optionType.PlaceHolder
 					optionTypeRow["help_block"] = optionType.HelpBlock
 					optionTypeRow["required"] = optionType.Required

--- a/morpheus/sdkv2/resources/form/form_resource_example.go
+++ b/morpheus/sdkv2/resources/form/form_resource_example.go
@@ -1384,7 +1384,7 @@ func RenderTagConfig(t *testing.T, overrides map[string]string) (string, error) 
 		"Labels":                          "[\"terraform\", \"demo\"]",
 		"Name":                            "demo",
 		"OptionTypeCode":                  "tag-input",
-		"OptionTypeDefaultValue":          "",
+		"OptionTypeDefaultValue":          `jsonencode([{ name = "Sample Name", value = "Sample Value" }])`,
 		"OptionTypeDescription":           "Terraform tag example",
 		"OptionTypeDisplayValueOnDetails": "true",
 		"OptionTypeExcludeFromSearch":     "true",

--- a/morpheus/sdkv2/resources/form/form_resource_example.go
+++ b/morpheus/sdkv2/resources/form/form_resource_example.go
@@ -1375,6 +1375,53 @@ func RenderSecGroupConfig(t *testing.T, overrides map[string]string) (string, er
 	return testhelpers.RenderExample(t, templatePath, args...)
 }
 
+func RenderTagConfig(t *testing.T, overrides map[string]string) (string, error) {
+	t.Helper()
+
+	defaults := map[string]string{
+		"Code":                            "demo",
+		"Description":                     "demo",
+		"Labels":                          "[\"terraform\", \"demo\"]",
+		"Name":                            "demo",
+		"OptionTypeCode":                  "tag-input",
+		"OptionTypeDefaultValue":          "",
+		"OptionTypeDescription":           "Terraform tag example",
+		"OptionTypeDisplayValueOnDetails": "true",
+		"OptionTypeExcludeFromSearch":     "true",
+		"OptionTypeExportMeta":            "true",
+		"OptionTypeFieldLabel":            "Tags",
+		"OptionTypeFieldName":             "tags",
+		"OptionTypeHelpBlock":             "Configure tags",
+		"OptionTypeHidden":                "false",
+		"OptionTypeLocked":                "true",
+		"OptionTypeName":                  "tf tag example",
+		"OptionTypeRequired":              "true",
+		"OptionTypeType":                  "tag",
+		"OptionTypeGroupFieldType":        "value",
+		"OptionTypeGroupId":               "1",
+		"OptionTypeCloudFieldType":        "value",
+		"OptionTypeCloudId":               "1",
+	}
+
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to get current file path")
+	}
+	dir := filepath.Dir(filename)
+	templatePath := filepath.Join(dir, "form_tag.tf.tmpl")
+
+	return testhelpers.RenderExample(t, templatePath, args...)
+}
+
 func RenderInstancesInputConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 

--- a/morpheus/sdkv2/resources/form/form_tag.tf.tmpl
+++ b/morpheus/sdkv2/resources/form/form_tag.tf.tmpl
@@ -1,0 +1,27 @@
+resource "hpe_morpheus_form" "example" {
+  name        = "{{.Name}}"
+  code        = "{{.Code}}"
+  description = "{{.Description}}"
+  labels      = {{.Labels}}
+
+  option_type {
+    name                     = "{{.OptionTypeName}}"
+    code                     = "{{.OptionTypeCode}}"
+    description              = "{{.OptionTypeDescription}}"
+    type                     = "{{.OptionTypeType}}"
+    field_label              = "{{.OptionTypeFieldLabel}}"
+    field_name               = "{{.OptionTypeFieldName}}"
+    default_value            = "{{.OptionTypeDefaultValue}}"
+    help_block               = "{{.OptionTypeHelpBlock}}"
+    group_field_type         = "{{.OptionTypeGroupFieldType}}"
+    group_id                 = {{.OptionTypeGroupId}}
+    cloud_field_type         = "{{.OptionTypeCloudFieldType}}"
+    cloud_id                 = {{.OptionTypeCloudId}}
+    required                 = {{.OptionTypeRequired}}
+    export_meta              = {{.OptionTypeExportMeta}}
+    display_value_on_details = {{.OptionTypeDisplayValueOnDetails}}
+    locked                   = {{.OptionTypeLocked}}
+    hidden                   = {{.OptionTypeHidden}}
+    exclude_from_search      = {{.OptionTypeExcludeFromSearch}}
+  }
+}

--- a/morpheus/sdkv2/resources/form/form_tag.tf.tmpl
+++ b/morpheus/sdkv2/resources/form/form_tag.tf.tmpl
@@ -11,7 +11,7 @@ resource "hpe_morpheus_form" "example" {
     type                     = "{{.OptionTypeType}}"
     field_label              = "{{.OptionTypeFieldLabel}}"
     field_name               = "{{.OptionTypeFieldName}}"
-    default_value            = "{{.OptionTypeDefaultValue}}"
+    default_value            = {{.OptionTypeDefaultValue}}
     help_block               = "{{.OptionTypeHelpBlock}}"
     group_field_type         = "{{.OptionTypeGroupFieldType}}"
     group_id                 = {{.OptionTypeGroupId}}

--- a/morpheus/sdkv2/resources/form/generate_example.sh
+++ b/morpheus/sdkv2/resources/form/generate_example.sh
@@ -579,6 +579,32 @@ $RENDER \
   OptionTypePoolField 'resourcePool'
 
 $RENDER \
+  -out examples/resources/morpheus_form/resource_tag.tf \
+  form_tag.tf.tmpl \
+  Name 'demo' \
+  Code 'demo' \
+  Description 'demo' \
+  Labels '["terraform", "demo"]' \
+  OptionTypeName 'tf tag example' \
+  OptionTypeCode 'tag-input' \
+  OptionTypeDescription 'Terraform tag example' \
+  OptionTypeType 'tag' \
+  OptionTypeFieldLabel 'Tags' \
+  OptionTypeFieldName 'tags' \
+  OptionTypeDefaultValue '' \
+  OptionTypeHelpBlock 'Configure tags' \
+  OptionTypeRequired 'true' \
+  OptionTypeExportMeta 'true' \
+  OptionTypeDisplayValueOnDetails 'true' \
+  OptionTypeLocked 'true' \
+  OptionTypeHidden 'false' \
+  OptionTypeExcludeFromSearch 'true' \
+  OptionTypeGroupFieldType 'value' \
+  OptionTypeGroupId '1' \
+  OptionTypeCloudFieldType 'value' \
+  OptionTypeCloudId '1'
+
+$RENDER \
   -out examples/resources/morpheus_form/resource_instances_input.tf \
   form_instances_input.tf.tmpl \
   Name 'demo' \

--- a/morpheus/sdkv2/resources/form/generate_example.sh
+++ b/morpheus/sdkv2/resources/form/generate_example.sh
@@ -591,7 +591,7 @@ $RENDER \
   OptionTypeType 'tag' \
   OptionTypeFieldLabel 'Tags' \
   OptionTypeFieldName 'tags' \
-  OptionTypeDefaultValue '' \
+  OptionTypeDefaultValue 'jsonencode([{ name = "Sample Name", value = "Sample Value" }])' \
   OptionTypeHelpBlock 'Configure tags' \
   OptionTypeRequired 'true' \
   OptionTypeExportMeta 'true' \

--- a/morpheus/sdkv2/resources/form/tag_test.go
+++ b/morpheus/sdkv2/resources/form/tag_test.go
@@ -1,0 +1,96 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package form_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus"
+	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
+	"github.com/HPE/terraform-provider-hpe/morpheus/sdkv2/resources/form"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+)
+
+func TestAccMorpheusFormTagOk(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	defer testhelpers.RecordResult(t)
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+	code := toCode(name)
+	optTypeCode := code + "-ot"
+	optTypeName := name + " option type"
+
+	resourceConfig, err := form.RenderTagConfig(t, map[string]string{
+		"Name":           name,
+		"Code":           code,
+		"OptionTypeCode": optTypeCode,
+		"OptionTypeName": optTypeName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "code", code),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "description", "demo"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.type", "tag"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.code", optTypeCode),
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_form.example",
+						"option_type.0.description",
+						"Terraform tag example",
+					),
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_form.example",
+						"option_type.0.display_value_on_details",
+						"true",
+					),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.exclude_from_search", "true"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.export_meta", "true"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.field_label", "Tags"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.field_name", "tags"),
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_form.example",
+						"option_type.0.help_block",
+						"Configure tags",
+					),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.hidden", "false"),
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_form.example",
+						"option_type.0.group_field_type",
+						"value",
+					),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.group_id", "1"),
+					resource.TestCheckResourceAttr(
+						"hpe_morpheus_form.example",
+						"option_type.0.cloud_field_type",
+						"value",
+					),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.cloud_id", "1"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.locked", "true"),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.name", optTypeName),
+					resource.TestCheckResourceAttr("hpe_morpheus_form.example", "option_type.0.required", "true"),
+				),
+			},
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+		},
+	})
+}

--- a/templates/resources/morpheus_form.md.tmpl
+++ b/templates/resources/morpheus_form.md.tmpl
@@ -105,6 +105,10 @@ and all inputs or option types must be defined in the form.
 
 {{tffile "examples/resources/morpheus_form/resource_sec_group.tf"}}
 
+### Tag
+
+{{tffile "examples/resources/morpheus_form/resource_tag.tf"}}
+
 ### Ports
 
 {{tffile "examples/resources/morpheus_form/resource_ports.tf"}}


### PR DESCRIPTION
Some form options types use `optionType` and others use `config.optionType` (and some use both). This PR sets the relevant fields according to each optionType and also implements the tag option type.