### PR TITLE
Remove acceptance tests from GitHub Actions run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,8 +15,5 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.12.2
       - run: go version
-      - run: make test
+      - run: make testgha

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,4 +16,4 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go version
-      - run: make testgha
+      - run: make unit-tests

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,11 @@ test:
 	env TF_ACC=1 \
 	go test -short -v -cover -count 1 -timeout 10m ./...
 
-# For use in GitHub Actions
-testgha:
-	cd utils && \
-	go test -v -count 1 -timeout 10m ./...
+unit-tests:
+	# exclude the framework and sdkv2 packages and the
+	# terraform-provider-hpe/morpheus package (but NOT its subpackages)
+	pkgs=$$(go list ./... | grep -Ev 'sdkv2/(resources|datasources)|framework/(resources|datasources)|terraform-provider-hpe/morpheus$$'); \
+	go test -v -count=1 -short -skip "TestAcc*" $$pkgs
 
 testacc:
 	cd morpheus/framework && \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ test:
 	env TF_ACC=1 \
 	go test -short -v -cover -count 1 -timeout 10m ./...
 
+# For use in GitHub Actions
+testgha:
+	cd utils && \
+	go test -v -count 1 -timeout 10m ./...
+
 testacc:
 	cd morpheus/framework && \
 	env TF_ACC=1 \


### PR DESCRIPTION
The time to run tests in GitHub actions was getting out of hand.
This was because we compiled all tests in GitHub actions, even though we skipped the Acceptance Tests.
Using the `cover` tool also takes a significant amount of time.

Adds a new directive to the Makefile: `unit-tests`.
This will compile and run only relevant unit tests.

If we need to cover other packages, we can update `unit-tests` in the Makefile.

This should speed up test runs significantly.
