### PR TITLE
Adding visibility field across task resources

### DIFF
--- a/docs/resources/morpheus_task_ansible_playbook.md
+++ b/docs/resources/morpheus_task_ansible_playbook.md
@@ -51,6 +51,7 @@ resource "hpe_morpheus_task_ansible_playbook" "example" {
 - `retryable` (Boolean) Whether to retry the task if there is a failure
 - `skip_tags` (String) The tags to skip during execution of the ansible playbook
 - `tags` (String) The tags to specify during execution of the ansible playbook
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_email.md
+++ b/docs/resources/morpheus_task_email.md
@@ -93,6 +93,7 @@ resource "hpe_morpheus_task_email" "tfexample_email_git" {
 - `skip_wrapped_email_template` (Boolean) Whether to ignore the Morpheus-styled email template
 - `source` (String) Choose local to draft or paste the email directly into the Task. Choose Repository or URL to bring in a template from a Git repository or another outside source (local, repository, url)
 - `version_ref` (String) The git reference of the repository to pull (main, master, etc.)
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_groovy_script.md
+++ b/docs/resources/morpheus_task_groovy_script.md
@@ -85,6 +85,7 @@ resource "hpe_morpheus_task_groovy_script" "tfexample_groovy_git" {
 - `script_content` (String) The content of the groovy script. Used when the local source type is specified
 - `script_path` (String) The path of the groovy script, either the url or the path in the repository
 - `version_ref` (String) The git reference of the repository to pull (main, master, etc.)
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_javascript.md
+++ b/docs/resources/morpheus_task_javascript.md
@@ -42,6 +42,7 @@ EOF
 - `retry_delay_seconds` (Number) The number of seconds to wait between retry attempts
 - `retryable` (Boolean) Whether to retry the task if there is a failure
 - `script_content` (String) The content of the javascript script
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_nested_workflow.md
+++ b/docs/resources/morpheus_task_nested_workflow.md
@@ -37,6 +37,7 @@ resource "hpe_morpheus_task_nested_workflow" "example" {
 - `retry_count` (Number) The number of times to retry the task if there is a failure
 - `retry_delay_seconds` (Number) The number of seconds to wait between retry attempts
 - `retryable` (Boolean) Whether to retry the task if there is a failure
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_powershell_script.md
+++ b/docs/resources/morpheus_task_powershell_script.md
@@ -94,6 +94,7 @@ resource "hpe_morpheus_task_powershell_script" "tfexample_powershell_git" {
 - `script_content` (String) The content of the powershell script. Used when the local source type is specified
 - `script_path` (String) The path of the powershell script, either the url or the path in the repository
 - `version_ref` (String) The git reference of the repository to pull (main, master, etc.)
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_python_script.md
+++ b/docs/resources/morpheus_task_python_script.md
@@ -98,6 +98,7 @@ resource "hpe_morpheus_task_python_script" "tfexample_python_git" {
 - `script_content` (String) The content of the python script. Used when the local source type is specified
 - `script_path` (String) The path of the python script, either the url or the path in the repository
 - `version_ref` (String) The git reference of the repository to pull (main, master, etc.)
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_restart.md
+++ b/docs/resources/morpheus_task_restart.md
@@ -37,6 +37,7 @@ resource "hpe_morpheus_task_restart" "tfexample_restart" {
 - `retry_count` (Number) The number of times to retry the task if there is a failure
 - `retry_delay_seconds` (Number) The number of seconds to wait between retry attempts
 - `retryable` (Boolean) Whether to retry the task if there is a failure
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_ruby_script.md
+++ b/docs/resources/morpheus_task_ruby_script.md
@@ -85,6 +85,7 @@ resource "hpe_morpheus_task_ruby_script" "tfexample_ruby_git" {
 - `script_content` (String) The content of the ruby script. Used when the local source type is specified
 - `script_path` (String) The path of the ruby script, either the url or the path in the repository
 - `version_ref` (String) The git reference of the repository to pull (main, master, etc.)
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/docs/resources/morpheus_task_vro.md
+++ b/docs/resources/morpheus_task_vro.md
@@ -57,6 +57,7 @@ EOF
 - `retry_count` (Number) The number of times to retry the task if there is a failure
 - `retry_delay_seconds` (Number) The number of seconds to wait between retry attempts
 - `retryable` (Boolean) Whether to retry the task if there is a failure
+- `visibility` (String) The visibility of the task (private or public)
 
 ### Read-Only
 

--- a/morpheus/sdkv2/resources/task/resource_task_ansible_playbook.go
+++ b/morpheus/sdkv2/resources/task/resource_task_ansible_playbook.go
@@ -242,9 +242,6 @@ func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceDa
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
 
 	var retryCount int
 	if retryCountValue, ok := d.Get("retry_count").(int); ok {
@@ -269,6 +266,7 @@ func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceDa
 				"taskType":          taskType,
 				"taskOptions":       taskOptions,
 				"executeTarget":     executeTarget,
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -494,9 +492,6 @@ func resourceTaskAnsiblePlaybookUpdate(ctx context.Context, d *schema.ResourceDa
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
 
 	var executeTarget string
 	if executeTargetValue, ok := d.Get("execute_target").(string); ok {
@@ -528,6 +523,7 @@ func resourceTaskAnsiblePlaybookUpdate(ctx context.Context, d *schema.ResourceDa
 				"taskType":          taskType,
 				"taskOptions":       taskOptions,
 				"executeTarget":     executeTarget,
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,

--- a/morpheus/sdkv2/resources/task/resource_task_ansible_playbook.go
+++ b/morpheus/sdkv2/resources/task/resource_task_ansible_playbook.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func ResourceTaskAnsiblePlaybook() *schema.Resource {
@@ -106,6 +107,13 @@ func ResourceTaskAnsiblePlaybook() *schema.Resource {
 				Description: "Custom configuration data to pass during the execution of the ansible playbook",
 				Optional:    true,
 				Default:     false,
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -226,6 +234,16 @@ func resourceTaskAnsiblePlaybookCreate(ctx context.Context, d *schema.ResourceDa
 		allowCustomConfig = allowCustomConfigValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	var retryCount int
@@ -359,6 +377,7 @@ func resourceTaskAnsiblePlaybookRead(ctx context.Context, d *schema.ResourceData
 	d.Set("retry_count", ansiblePlaybookTask.RetryCount)
 	d.Set("retry_delay_seconds", ansiblePlaybookTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", ansiblePlaybookTask.AllowCustomConfig)
+	d.Set("visibility", ansiblePlaybookTask.Visibility)
 
 	return diags
 }
@@ -467,6 +486,16 @@ func resourceTaskAnsiblePlaybookUpdate(ctx context.Context, d *schema.ResourceDa
 		allowCustomConfig = allowCustomConfigValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	var executeTarget string

--- a/morpheus/sdkv2/resources/task/resource_task_email.go
+++ b/morpheus/sdkv2/resources/task/resource_task_email.go
@@ -300,6 +300,13 @@ func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta a
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -316,6 +323,7 @@ func resourceTaskEmailCreate(ctx context.Context, d *schema.ResourceData, meta a
 				},
 				"file":              contentConfig,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -602,9 +610,6 @@ func resourceTaskEmailUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		"emailSubject":      subject,
 		"emailSkipTemplate": skipWrappedEmailTemplate,
 	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
 
 	req := &morpheus.Request{
 		Body: map[string]any{
@@ -618,6 +623,7 @@ func resourceTaskEmailUpdate(ctx context.Context, d *schema.ResourceData, meta a
 				"taskOptions":       taskOptions,
 				"file":              contentConfig,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,

--- a/morpheus/sdkv2/resources/task/resource_task_email.go
+++ b/morpheus/sdkv2/resources/task/resource_task_email.go
@@ -605,12 +605,6 @@ func resourceTaskEmailUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	taskOptions := map[string]any{
-		"emailAddress":      emailAddress,
-		"emailSubject":      subject,
-		"emailSkipTemplate": skipWrappedEmailTemplate,
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -620,7 +614,11 @@ func resourceTaskEmailUpdate(ctx context.Context, d *schema.ResourceData, meta a
 				"taskType": map[string]any{
 					"code": "email",
 				},
-				"taskOptions":       taskOptions,
+				"taskOptions": map[string]any{
+					"emailAddress":      emailAddress,
+					"emailSubject":      subject,
+					"emailSkipTemplate": skipWrappedEmailTemplate,
+				},
 				"file":              contentConfig,
 				"executeTarget":     "local",
 				"visibility":        visibility,

--- a/morpheus/sdkv2/resources/task/resource_task_email.go
+++ b/morpheus/sdkv2/resources/task/resource_task_email.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func ResourceTaskEmail() *schema.Resource {
@@ -132,6 +133,13 @@ func ResourceTaskEmail() *schema.Resource {
 				Description: "Custom configuration data to pass during the execution of the email task",
 				Optional:    true,
 				Default:     false,
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -429,6 +437,7 @@ func resourceTaskEmailRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set("retry_count", emailTask.RetryCount)
 	d.Set("retry_delay_seconds", emailTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", emailTask.AllowCustomConfig)
+	d.Set("visibility", emailTask.Visibility)
 
 	return diags
 }
@@ -581,6 +590,22 @@ func resourceTaskEmailUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	taskOptions := map[string]any{
+		"emailAddress":      emailAddress,
+		"emailSubject":      subject,
+		"emailSkipTemplate": skipWrappedEmailTemplate,
+	}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -590,11 +615,7 @@ func resourceTaskEmailUpdate(ctx context.Context, d *schema.ResourceData, meta a
 				"taskType": map[string]any{
 					"code": "email",
 				},
-				"taskOptions": map[string]any{
-					"emailAddress":      emailAddress,
-					"emailSubject":      subject,
-					"emailSkipTemplate": skipWrappedEmailTemplate,
-				},
+				"taskOptions":       taskOptions,
 				"file":              contentConfig,
 				"executeTarget":     "local",
 				"retryable":         retryable,

--- a/morpheus/sdkv2/resources/task/resource_task_groovy_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_groovy_script.go
@@ -201,8 +201,6 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 	taskType := make(map[string]any)
 	taskType["code"] = "groovyTask"
 
-	taskOptions := make(map[string]any)
-
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
 		if labelSet, ok := attr.(*schema.Set); ok {
@@ -275,7 +273,6 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 				"labels":            labelsPayload,
 				"file":              sourceOptions,
 				"taskType":          taskType,
-				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     "local",
 				"visibility":        visibility,
@@ -459,8 +456,6 @@ func resourceTaskGroovyScriptUpdate(ctx context.Context, d *schema.ResourceData,
 	taskType := make(map[string]any)
 	taskType["code"] = "groovyTask"
 
-	taskOptions := make(map[string]any)
-
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
 		if labelSet, ok := attr.(*schema.Set); ok {
@@ -533,7 +528,6 @@ func resourceTaskGroovyScriptUpdate(ctx context.Context, d *schema.ResourceData,
 				"labels":            labelsPayload,
 				"file":              sourceOptions,
 				"taskType":          taskType,
-				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     "local",
 				"visibility":        visibility,

--- a/morpheus/sdkv2/resources/task/resource_task_groovy_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_groovy_script.go
@@ -238,9 +238,6 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
 
 	var retryable bool
 	if retryableValue, ok := d.Get("retryable").(bool); ok {
@@ -498,9 +495,6 @@ func resourceTaskGroovyScriptUpdate(ctx context.Context, d *schema.ResourceData,
 		visibility = visibilityValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
-	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
 	}
 
 	var retryable bool

--- a/morpheus/sdkv2/resources/task/resource_task_groovy_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_groovy_script.go
@@ -94,6 +94,13 @@ func ResourceTaskGroovyScript() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
+			},
 			"retryable": {
 				Type:        schema.TypeBool,
 				Description: "Whether to retry the task if there is a failure",
@@ -194,6 +201,8 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 	taskType := make(map[string]any)
 	taskType["code"] = "groovyTask"
 
+	taskOptions := make(map[string]any)
+
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
 		if labelSet, ok := attr.(*schema.Set); ok {
@@ -221,6 +230,16 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 		resultType = resultTypeValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("result_type", d.Get("result_type")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	var retryable bool
@@ -259,8 +278,10 @@ func resourceTaskGroovyScriptCreate(ctx context.Context, d *schema.ResourceData,
 				"labels":            labelsPayload,
 				"file":              sourceOptions,
 				"taskType":          taskType,
+				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -368,6 +389,7 @@ func resourceTaskGroovyScriptRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("retry_count", groovyScriptTask.RetryCount)
 	d.Set("retry_delay_seconds", groovyScriptTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", groovyScriptTask.AllowCustomConfig)
+	d.Set("visibility", groovyScriptTask.Visibility)
 
 	return diags
 }
@@ -440,6 +462,8 @@ func resourceTaskGroovyScriptUpdate(ctx context.Context, d *schema.ResourceData,
 	taskType := make(map[string]any)
 	taskType["code"] = "groovyTask"
 
+	taskOptions := make(map[string]any)
+
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
 		if labelSet, ok := attr.(*schema.Set); ok {
@@ -467,6 +491,16 @@ func resourceTaskGroovyScriptUpdate(ctx context.Context, d *schema.ResourceData,
 		resultType = resultTypeValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("result_type", d.Get("result_type")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	var retryable bool
@@ -505,8 +539,10 @@ func resourceTaskGroovyScriptUpdate(ctx context.Context, d *schema.ResourceData,
 				"labels":            labelsPayload,
 				"file":              sourceOptions,
 				"taskType":          taskType,
+				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,

--- a/morpheus/sdkv2/resources/task/resource_task_javascript.go
+++ b/morpheus/sdkv2/resources/task/resource_task_javascript.go
@@ -87,6 +87,13 @@ func ResourceTaskJavaScript() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -180,6 +187,17 @@ func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, m
 		retryDelaySeconds = retryDelaySecondsValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("retry_delay_seconds", d.Get("retry_delay_seconds")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	req := &morpheus.Request{
@@ -295,6 +313,7 @@ func resourceTaskJavaScriptRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("retry_count", javascriptTask.RetryCount)
 	d.Set("retry_delay_seconds", javascriptTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", javascriptTask.AllowCustomConfig)
+	d.Set("visibility", javascriptTask.Visibility)
 
 	return diags
 }
@@ -384,6 +403,17 @@ func resourceTaskJavaScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 		retryDelaySeconds = retryDelaySecondsValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("retry_delay_seconds", d.Get("retry_delay_seconds")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	req := &morpheus.Request{

--- a/morpheus/sdkv2/resources/task/resource_task_javascript.go
+++ b/morpheus/sdkv2/resources/task/resource_task_javascript.go
@@ -196,10 +196,6 @@ func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -210,6 +206,7 @@ func resourceTaskJavaScriptCreate(ctx context.Context, d *schema.ResourceData, m
 				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -412,10 +409,6 @@ func resourceTaskJavaScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -426,6 +419,7 @@ func resourceTaskJavaScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,

--- a/morpheus/sdkv2/resources/task/resource_task_library_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_library_script.go
@@ -140,9 +140,6 @@ func resourceTaskLibraryScriptCreate(ctx context.Context, d *schema.ResourceData
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
 
 	var scriptTemplateId string
 	if scriptTemplateIdValue, ok := d.Get("script_template_id").(string); ok {
@@ -376,9 +373,6 @@ func resourceTaskLibraryScriptUpdate(ctx context.Context, d *schema.ResourceData
 		visibility = visibilityValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
-	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
 	}
 
 	var scriptTemplateId string

--- a/morpheus/sdkv2/resources/task/resource_task_library_template.go
+++ b/morpheus/sdkv2/resources/task/resource_task_library_template.go
@@ -140,9 +140,6 @@ func resourceTaskLibraryTemplateCreate(ctx context.Context, d *schema.ResourceDa
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
 
 	var fileTemplateId string
 	if fileTemplateIdValue, ok := d.Get("file_template_id").(string); ok {
@@ -376,9 +373,6 @@ func resourceTaskLibraryTemplateUpdate(ctx context.Context, d *schema.ResourceDa
 		visibility = visibilityValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
-	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
 	}
 
 	var fileTemplateId string

--- a/morpheus/sdkv2/resources/task/resource_task_nested_workflow.go
+++ b/morpheus/sdkv2/resources/task/resource_task_nested_workflow.go
@@ -192,10 +192,6 @@ func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -205,6 +201,7 @@ func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceDat
 				"taskType":          taskType,
 				"taskOptions":       taskOptions,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -408,10 +405,6 @@ func resourceTaskNestedWorkflowUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -421,6 +414,7 @@ func resourceTaskNestedWorkflowUpdate(ctx context.Context, d *schema.ResourceDat
 				"taskType":          taskType,
 				"taskOptions":       taskOptions,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,

--- a/morpheus/sdkv2/resources/task/resource_task_nested_workflow.go
+++ b/morpheus/sdkv2/resources/task/resource_task_nested_workflow.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func ResourceTaskNestedWorkflow() *schema.Resource {
@@ -80,6 +81,13 @@ func ResourceTaskNestedWorkflow() *schema.Resource {
 				Description: "Custom configuration data to pass during the execution of the shell script",
 				Optional:    true,
 				Computed:    true,
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -175,6 +183,17 @@ func resourceTaskNestedWorkflowCreate(ctx context.Context, d *schema.ResourceDat
 		retryDelaySeconds = retryDelaySecondsValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("retry_delay_seconds", d.Get("retry_delay_seconds")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	req := &morpheus.Request{
@@ -289,6 +308,7 @@ func resourceTaskNestedWorkflowRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("retry_count", nestedWorkflowTask.RetryCount)
 	d.Set("retry_delay_seconds", nestedWorkflowTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", nestedWorkflowTask.AllowCustomConfig)
+	d.Set("visibility", nestedWorkflowTask.Visibility)
 
 	return diags
 }
@@ -379,6 +399,17 @@ func resourceTaskNestedWorkflowUpdate(ctx context.Context, d *schema.ResourceDat
 		retryDelaySeconds = retryDelaySecondsValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("retry_delay_seconds", d.Get("retry_delay_seconds")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	req := &morpheus.Request{

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -109,6 +109,13 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 				Default:      "local",
 				Optional:     true,
 			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
+			},
 			"remote_target_host": {
 				Type:        schema.TypeString,
 				Description: "The hostname or ip address of the remote target",
@@ -293,6 +300,16 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 		taskOptions["password"] = remoteTargetPassword
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
+	}
+
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
 		if labelSet, ok := attr.(*schema.Set); ok {
@@ -368,6 +385,7 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     executeTarget,
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -486,6 +504,7 @@ func resourceTaskPowerShellScriptRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("retry_count", powerShellScriptTask.RetryCount)
 	d.Set("retry_delay_seconds", powerShellScriptTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", powerShellScriptTask.AllowCustomConfig)
+	d.Set("visibility", powerShellScriptTask.Visibility)
 
 	return diags
 }
@@ -592,6 +611,13 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 			taskOptions["password"] = remoteTargetPassword
 		}
 	}
+	if d.HasChange("visibility") {
+		if visibility, ok := d.Get("visibility").(string); ok {
+			taskOptions["visibility"] = visibility
+		} else {
+			return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+		}
+	}
 
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
@@ -627,6 +653,13 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 		executeTarget = executeTargetValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("execute_target", d.Get("execute_target")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
 	var retryable bool
@@ -668,6 +701,7 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     executeTarget,
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -306,9 +306,6 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
 
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
@@ -611,14 +608,6 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 			taskOptions["password"] = remoteTargetPassword
 		}
 	}
-	if d.HasChange("visibility") {
-		if visibility, ok := d.Get("visibility").(string); ok {
-			taskOptions["visibility"] = visibility
-		} else {
-			return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
-		}
-	}
-
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
 		if labelSet, ok := attr.(*schema.Set); ok {

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -593,6 +593,7 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 			taskOptions["host"] = remoteTargetHost
 		}
 	}
+
 	if d.HasChange("remote_target_port") {
 		if remoteTargetPort, ok := d.Get("remote_target_port").(string); ok {
 			taskOptions["port"] = remoteTargetPort

--- a/morpheus/sdkv2/resources/task/resource_task_python_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_python_script.go
@@ -135,6 +135,13 @@ func ResourceTaskPythonScript() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -294,6 +301,17 @@ func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -409,6 +427,7 @@ func resourceTaskPythonScriptRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("retry_count", pythonScriptTask.RetryCount)
 	d.Set("retry_delay_seconds", pythonScriptTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", pythonScriptTask.AllowCustomConfig)
+	d.Set("visibility", pythonScriptTask.Visibility)
 
 	return diags
 }
@@ -441,6 +460,10 @@ func resourceTaskPythonScriptUpdate(ctx context.Context, d *schema.ResourceData,
 	taskOptions["pythonAdditionalPackages"] = d.Get("additional_packages")
 	taskOptions["pythonArgs"] = d.Get("command_arguments")
 	taskOptions["pythonBinary"] = d.Get("python_binary")
+
+	if visibilityValue, ok := d.Get("visibility").(string); ok && visibilityValue != "" {
+		taskOptions["visibility"] = visibilityValue
+	}
 
 	taskType := make(map[string]any)
 	taskType["code"] = "jythonTask"

--- a/morpheus/sdkv2/resources/task/resource_task_python_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_python_script.go
@@ -308,10 +308,6 @@ func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -323,6 +319,7 @@ func resourceTaskPythonScriptCreate(ctx context.Context, d *schema.ResourceData,
 				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -461,8 +458,11 @@ func resourceTaskPythonScriptUpdate(ctx context.Context, d *schema.ResourceData,
 	taskOptions["pythonArgs"] = d.Get("command_arguments")
 	taskOptions["pythonBinary"] = d.Get("python_binary")
 
-	if visibilityValue, ok := d.Get("visibility").(string); ok && visibilityValue != "" {
-		taskOptions["visibility"] = visibilityValue
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
 	taskType := make(map[string]any)
@@ -486,6 +486,7 @@ func resourceTaskPythonScriptUpdate(ctx context.Context, d *schema.ResourceData,
 				"taskOptions":       taskOptions,
 				"resultType":        d.Get("result_type"),
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         d.Get("retryable"),
 				"retryCount":        d.Get("retry_count"),
 				"retryDelaySeconds": d.Get("retry_delay_seconds"),

--- a/morpheus/sdkv2/resources/task/resource_task_restart.go
+++ b/morpheus/sdkv2/resources/task/resource_task_restart.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func ResourceTaskRestart() *schema.Resource {
@@ -68,6 +69,13 @@ func ResourceTaskRestart() *schema.Resource {
 				Description: "Custom configuration data to pass during the execution of the restart task",
 				Optional:    true,
 				Computed:    true,
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -147,6 +155,18 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	taskOptions := map[string]any{}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -159,6 +179,7 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
 				"allowCustomConfig": allowCustomConfig,
+				"taskOptions":       taskOptions,
 			},
 		},
 	}
@@ -256,6 +277,7 @@ func resourceTaskRestartRead(ctx context.Context, d *schema.ResourceData, meta a
 	d.Set("retry_count", restartTask.RetryCount)
 	d.Set("retry_delay_seconds", restartTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", restartTask.AllowCustomConfig)
+	d.Set("visibility", restartTask.Visibility)
 
 	return diags
 }
@@ -330,6 +352,18 @@ func resourceTaskRestartUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	taskOptions := map[string]any{}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -342,6 +376,7 @@ func resourceTaskRestartUpdate(ctx context.Context, d *schema.ResourceData, meta
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
 				"allowCustomConfig": allowCustomConfig,
+				"taskOptions":       taskOptions,
 			},
 		},
 	}

--- a/morpheus/sdkv2/resources/task/resource_task_restart.go
+++ b/morpheus/sdkv2/resources/task/resource_task_restart.go
@@ -162,11 +162,6 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	taskOptions := map[string]any{}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -175,11 +170,11 @@ func resourceTaskRestartCreate(ctx context.Context, d *schema.ResourceData, meta
 				"labels":            labelsPayload,
 				"taskType":          taskType,
 				"executeTarget":     "resource",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
 				"allowCustomConfig": allowCustomConfig,
-				"taskOptions":       taskOptions,
 			},
 		},
 	}
@@ -359,11 +354,6 @@ func resourceTaskRestartUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	taskOptions := map[string]any{}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -372,11 +362,11 @@ func resourceTaskRestartUpdate(ctx context.Context, d *schema.ResourceData, meta
 				"labels":            labelsPayload,
 				"taskType":          taskType,
 				"executeTarget":     "resource",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
 				"allowCustomConfig": allowCustomConfig,
-				"taskOptions":       taskOptions,
 			},
 		},
 	}

--- a/morpheus/sdkv2/resources/task/resource_task_ruby_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_ruby_script.go
@@ -258,11 +258,6 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	taskOptions := map[string]any{}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -273,11 +268,11 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 				"taskType":          taskType,
 				"resultType":        resultType,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
 				"allowCustomConfig": allowCustomConfig,
-				"taskOptions":       taskOptions,
 			},
 		},
 	}
@@ -518,11 +513,6 @@ func resourceTaskRubyScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	taskOptions := map[string]any{}
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -533,11 +523,11 @@ func resourceTaskRubyScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 				"taskType":          taskType,
 				"resultType":        resultType,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
 				"allowCustomConfig": allowCustomConfig,
-				"taskOptions":       taskOptions,
 			},
 		},
 	}

--- a/morpheus/sdkv2/resources/task/resource_task_ruby_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_ruby_script.go
@@ -111,6 +111,13 @@ func ResourceTaskRubyScript() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -244,6 +251,18 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	taskOptions := map[string]any{}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -258,6 +277,7 @@ func resourceTaskRubyScriptCreate(ctx context.Context, d *schema.ResourceData, m
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
 				"allowCustomConfig": allowCustomConfig,
+				"taskOptions":       taskOptions,
 			},
 		},
 	}
@@ -361,6 +381,7 @@ func resourceTaskRubyScriptRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("retry_count", rubyScriptTask.RetryCount)
 	d.Set("retry_delay_seconds", rubyScriptTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", rubyScriptTask.AllowCustomConfig)
+	d.Set("visibility", rubyScriptTask.Visibility)
 
 	return diags
 }
@@ -490,6 +511,18 @@ func resourceTaskRubyScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	taskOptions := map[string]any{}
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -504,6 +537,7 @@ func resourceTaskRubyScriptUpdate(ctx context.Context, d *schema.ResourceData, m
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
 				"allowCustomConfig": allowCustomConfig,
+				"taskOptions":       taskOptions,
 			},
 		},
 	}

--- a/morpheus/sdkv2/resources/task/resource_task_shell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_shell_script.go
@@ -295,13 +295,6 @@ func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, 
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("local_repository_ref", d.Get("local_repository_ref")))
 	}
-	if visibility, ok := d.Get("visibility").(string); ok {
-		if visibility != "" {
-			taskOptions["visibility"] = visibility
-		}
-	} else {
-		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
-	}
 
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
@@ -630,14 +623,6 @@ func resourceTaskShellScriptUpdate(ctx context.Context, d *schema.ResourceData, 
 			return diag.FromErr(helpers.TypeAssertFailError("local_repository_ref", d.Get("local_repository_ref")))
 		}
 	}
-	if d.HasChange("visibility") {
-		if visibility, ok := d.Get("visibility").(string); ok {
-			taskOptions["visibility"] = visibility
-		} else {
-			return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
-		}
-	}
-
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {
 		if labelSet, ok := attr.(*schema.Set); ok {

--- a/morpheus/sdkv2/resources/task/resource_task_vro.go
+++ b/morpheus/sdkv2/resources/task/resource_task_vro.go
@@ -96,15 +96,13 @@ func ResourceTaskVRO() *schema.Resource {
 				Description: "Custom configuration data to pass during the execution of the vRO workflow task",
 				Optional:    true,
 				Default:     false,
-			},
-			"visibility": {
+			}, "visibility": {
 				Type:         schema.TypeString,
 				Description:  "The visibility of the task (private or public)",
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Computed:     true,
-			},
-		},
+			}},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -229,10 +227,6 @@ func resourceTaskVROCreate(ctx context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -243,6 +237,7 @@ func resourceTaskVROCreate(ctx context.Context, d *schema.ResourceData, meta any
 				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     executeTarget,
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -472,10 +467,6 @@ func resourceTaskVROUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -486,6 +477,7 @@ func resourceTaskVROUpdate(ctx context.Context, d *schema.ResourceData, meta any
 				"taskOptions":       taskOptions,
 				"resultType":        resultType,
 				"executeTarget":     executeTarget,
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,

--- a/morpheus/sdkv2/resources/task/resource_task_vro.go
+++ b/morpheus/sdkv2/resources/task/resource_task_vro.go
@@ -96,13 +96,15 @@ func ResourceTaskVRO() *schema.Resource {
 				Description: "Custom configuration data to pass during the execution of the vRO workflow task",
 				Optional:    true,
 				Default:     false,
-			}, "visibility": {
+			},
+			"visibility": {
 				Type:         schema.TypeString,
 				Description:  "The visibility of the task (private or public)",
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Computed:     true,
-			}},
+			},
+		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/morpheus/sdkv2/resources/task/resource_task_vro.go
+++ b/morpheus/sdkv2/resources/task/resource_task_vro.go
@@ -97,6 +97,13 @@ func ResourceTaskVRO() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Description:  "The visibility of the task (private or public)",
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Optional:     true,
+				Computed:     true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -213,6 +220,17 @@ func resourceTaskVROCreate(ctx context.Context, d *schema.ResourceData, meta any
 		allowCustomConfig = allowCustomConfigValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	req := &morpheus.Request{
@@ -332,6 +350,7 @@ func resourceTaskVRORead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("retry_count", workflowTask.RetryCount)
 	d.Set("retry_delay_seconds", workflowTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", workflowTask.AllowCustomConfig)
+	d.Set("visibility", workflowTask.Visibility)
 
 	return diags
 }
@@ -444,6 +463,17 @@ func resourceTaskVROUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		allowCustomConfig = allowCustomConfigValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	req := &morpheus.Request{

--- a/morpheus/sdkv2/resources/task/resource_task_write_attributes.go
+++ b/morpheus/sdkv2/resources/task/resource_task_write_attributes.go
@@ -173,6 +173,17 @@ func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
 	}
 
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -286,6 +297,7 @@ func resourceTaskWriteAttributesRead(ctx context.Context, d *schema.ResourceData
 	d.Set("retry_count", writeAttributesTask.RetryCount)
 	d.Set("retry_delay_seconds", writeAttributesTask.RetryDelaySeconds)
 	d.Set("allow_custom_config", writeAttributesTask.AllowCustomConfig)
+	d.Set("visibility", writeAttributesTask.Visibility)
 
 	return diags
 }
@@ -368,6 +380,17 @@ func resourceTaskWriteAttributesUpdate(ctx context.Context, d *schema.ResourceDa
 		allowCustomConfig = allowCustomConfigValue
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("allow_custom_config", d.Get("allow_custom_config")))
+	}
+
+	var visibility string
+	if visibilityValue, ok := d.Get("visibility").(string); ok {
+		visibility = visibilityValue
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
+	}
+
+	if visibility != "" {
+		taskOptions["visibility"] = visibility
 	}
 
 	req := &morpheus.Request{

--- a/morpheus/sdkv2/resources/task/resource_task_write_attributes.go
+++ b/morpheus/sdkv2/resources/task/resource_task_write_attributes.go
@@ -180,10 +180,6 @@ func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -193,6 +189,7 @@ func resourceTaskWriteAttributesCreate(ctx context.Context, d *schema.ResourceDa
 				"taskType":          taskType,
 				"taskOptions":       taskOptions,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,
@@ -389,10 +386,6 @@ func resourceTaskWriteAttributesUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(helpers.TypeAssertFailError("visibility", d.Get("visibility")))
 	}
 
-	if visibility != "" {
-		taskOptions["visibility"] = visibility
-	}
-
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"task": map[string]any{
@@ -402,6 +395,7 @@ func resourceTaskWriteAttributesUpdate(ctx context.Context, d *schema.ResourceDa
 				"taskType":          taskType,
 				"taskOptions":       taskOptions,
 				"executeTarget":     "local",
+				"visibility":        visibility,
 				"retryable":         retryable,
 				"retryCount":        retryCount,
 				"retryDelaySeconds": retryDelaySeconds,


### PR DESCRIPTION
Adding the visibility field across the following task resources:
- hpe_morpheus_task_powershell_script
- hpe_morpheus_task_groovy_script
- hpe_morpheus_task_ansible_playbook
- hpe_morpheus_task_email
- hpe_morpheus_task_javascript
- hpe_morpheus_task_nested_workflow
- hpe_morpheus_task_python_script
- hpe_morpheus_task_restart
- hpe_morpheus_task_ruby_script
- hpe_morpheus_task_vro