### PR TITLE
Fix os_type code read bug

### DIFF
--- a/morpheus/framework/resources/ostype/resource_create.go
+++ b/morpheus/framework/resources/ostype/resource_create.go
@@ -98,7 +98,7 @@ func (r *Resource) Create(
 
 	createdID := createResp.GetId()
 
-	state, diag := getOsTypeAsState(ctx, createdID, client, plan)
+	state, diag := getOsTypeAsState(ctx, createdID, client)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
 		return
 	}

--- a/morpheus/framework/resources/ostype/resource_read.go
+++ b/morpheus/framework/resources/ostype/resource_read.go
@@ -34,7 +34,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	state, diag := getOsTypeAsState(ctx, data.Id.ValueInt64(), client, data)
+	state, diag := getOsTypeAsState(ctx, data.Id.ValueInt64(), client)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
 		return
 	}
@@ -46,7 +46,6 @@ func getOsTypeAsState(
 	ctx context.Context,
 	id int64,
 	client *sdk.APIClient,
-	prior OsTypeModel,
 ) (OsTypeModel, diag.Diagnostics) {
 	var state OsTypeModel
 	var diags diag.Diagnostics
@@ -90,9 +89,6 @@ func getOsTypeAsState(
 	} else {
 		state.Owner = types.StringNull()
 	}
-
-	// code is not returned in the GET response; preserve from prior state
-	state.Code = prior.Code
 
 	return state, diags
 }

--- a/morpheus/framework/resources/ostype/resource_update.go
+++ b/morpheus/framework/resources/ostype/resource_update.go
@@ -113,7 +113,7 @@ func (r *Resource) Update(
 		return
 	}
 
-	state, diag := getOsTypeAsState(ctx, id, client, plan)
+	state, diag := getOsTypeAsState(ctx, id, client)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
We were seeing a failure on import step of `TestAccMorpheusOsTypeExampleOk`.


```
=== RUN   TestAccMorpheusOsTypeExampleOk
=== PAUSE TestAccMorpheusOsTypeExampleOk
=== CONT  TestAccMorpheusOsTypeExampleOk
    resource_test.go:101: Step 2/2 error running import: ImportStateVerify attributes not equivalent.
 Difference is shown below. The - symbol indicates attributes missing after import.

          map[string]string{
        -       "code": "os.type-2177636368963882626",
          }
--- FAIL: TestAccMorpheusOsTypeExampleOk (3.12s)
FAIL
FAIL    github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/ostype       4.521s
FAIL
```

Code was using plan in read erroneously.

It should not use plan.

It should be read from the response like everything else as it is present when you GET an OS type.
