### PR TITLE
fix TestAccClusterHKSVsphereExampleOk

### DIFF
--- a/morpheus/sdkv2/resources/cluster/cluster_hks_vsphere_test.go
+++ b/morpheus/sdkv2/resources/cluster/cluster_hks_vsphere_test.go
@@ -13,9 +13,11 @@ import (
 	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
 	"github.com/HPE/terraform-provider-hpe/morpheus/sdkv2/resources/cluster"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/systemoverride"
 )
 
 func TestMain(m *testing.M) {
+	systemoverride.ParseFlags()
 	code := m.Run()
 
 	testhelpers.WriteMergedResults()
@@ -32,7 +34,8 @@ func TestAccClusterHKSVsphereExampleOk(t *testing.T) {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	providerConfig := testhelpers.ProviderBlock()
+	testSystem := systemoverride.GetPreferred(t, "feature")
+	providerConfig := testhelpers.ProviderBlockForServer(testSystem)
 
 	name := acctest.RandomWithPrefix(t.Name())
 


### PR DESCRIPTION
We now explicitly point it to the `feature` system.
