### PR TITLE
fix TestAccMorpheusOptionListApiExampleOk

### DIFF
--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_api_resource_test.go
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_api_resource_test.go
@@ -76,13 +76,6 @@ func TestAccMorpheusOptionListApiExampleOk(t *testing.T) {
 				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
 			},
-			// Plan after apply
-			{
-				Config:             providerConfig + resourceConfig,
-				ExpectNonEmptyPlan: false,
-				Check:              checkFn,
-				PlanOnly:           true,
-			},
 		},
 	})
 }

--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_api_resource_test.go
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_api_resource_test.go
@@ -73,8 +73,15 @@ func TestAccMorpheusOptionListApiExampleOk(t *testing.T) {
 			// Apply - Note: translation_script formatting causes persistent drift
 			{
 				Config:             providerConfig + resourceConfig,
-				ExpectNonEmptyPlan: true,
+				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
+			},
+			// Plan after apply
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+				PlanOnly:           true,
 			},
 		},
 	})


### PR DESCRIPTION
The test's create step erroneously expected a non-empty plan. For this step, `ExpectNonEmptyPlan` means to check the refresh plan.
Add a separate plan-only step to validate plan-after-apply is empty.
