### PR TITLE
fix TestAccMorpheusOptionListRestExampleOk

### DIFF
--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource_test.go
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource_test.go
@@ -108,7 +108,7 @@ func TestAccMorpheusOptionListRestExampleOk(t *testing.T) {
 			{
 				Config:             providerConfig + resourceConfig,
 				Check:              checkFn,
-				ExpectNonEmptyPlan: true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})


### PR DESCRIPTION
The create step erroneously expected a non-empty refresh plan.
