### PR TITLE
Fix the OS Type Image tests

### DIFF
--- a/docs/resources/morpheus_os_type_image.md
+++ b/docs/resources/morpheus_os_type_image.md
@@ -12,6 +12,8 @@ An OS type image maps a virtual image to an operating system type, optionally sc
 
 ~> All attributes on this resource force recreation when changed. There is no in-place update.
 
+~> When associating a virtual image with an OS type image, Morpheus will not automatically update the osType field of that virtual image with the `os_type_id` set in the os type image. It is therefore recommended you update the virtual image's `os_type_id` field using the provider BEFORE creating an os type image associated with that virtual image.
+
 ## Example Usage
 
 ```terraform

--- a/morpheus/framework/resources/image/example.tf.tmpl
+++ b/morpheus/framework/resources/image/example.tf.tmpl
@@ -7,7 +7,7 @@ resource "hpe_morpheus_image" "example_image" {
     storage_provider_id = {{.StorageProviderId}}
     auto_join_domain = true
     cloud_init = true
-    os_type_id = 75
+    os_type_id = {{.OsTypeId}}
     ssh_username = "alpine"
     min_ram = 1
     min_disk = 20

--- a/morpheus/framework/resources/image/image_example.go
+++ b/morpheus/framework/resources/image/image_example.go
@@ -11,7 +11,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 )
 
-//go:generate ../../../../bin/render example.tf.tmpl Name "Alpine Example Image" StorageProviderId "196"
+//go:generate ../../../../bin/render example.tf.tmpl Name "Alpine Example Image" StorageProviderId "196" OsTypeId "75"
 
 func RenderImageConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()

--- a/morpheus/framework/resources/image/image_example.go
+++ b/morpheus/framework/resources/image/image_example.go
@@ -19,6 +19,7 @@ func RenderImageConfig(t *testing.T, overrides map[string]string) (string, error
 	defaults := map[string]string{
 		"Name":              "Alpine Example Image",
 		"StorageProviderId": "196",
+		"OsTypeId":          "75",
 	}
 
 	for key, value := range overrides {

--- a/morpheus/framework/resources/image/image_test.go
+++ b/morpheus/framework/resources/image/image_test.go
@@ -54,6 +54,7 @@ func TestAccMorpheusImageExampleOk(t *testing.T) {
 	resourceConfig, err := testhelpers.RenderExample(t, "example.tf.tmpl",
 		"Name", name,
 		"StorageProviderId", "196",
+		"OsTypeId", "75",
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/morpheus/framework/resources/ostypeimage/resource_test.go
+++ b/morpheus/framework/resources/ostypeimage/resource_test.go
@@ -4,47 +4,79 @@ package ostypeimage_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/HPE/terraform-provider-hpe/morpheus"
+	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/image"
 	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/ostypeimage"
+	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
-	"github.com/HPE/terraform-provider-hpe/provider"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/systemoverride"
 )
 
 func TestMain(m *testing.M) {
 	code := m.Run()
+	systemoverride.ParseFlags()
 	testhelpers.WriteMergedResults()
 	os.Exit(code)
 }
 
-func newProviderWithError() (tfprotov6.ProviderServer, error) {
-	providerInstance := provider.New("test", morpheus.New())()
-
-	return providerserver.NewProtocol6WithError(providerInstance)()
-}
-
-var testAccProtoV6ProviderFactories = map[string]func() (
-	tfprotov6.ProviderServer, error,
-){
-	"hpe": newProviderWithError,
-}
-
 // Tests that our example file template used for docs is a valid config.
 func TestAccMorpheusOsTypeImageExampleOk(t *testing.T) {
+	t.Parallel()
 	defer testhelpers.RecordResult(t)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	providerConfig := testhelpers.ProviderBlock()
+	testSystem := systemoverride.GetPreferred(t, "zodiac")
+	providerConfig := testhelpers.ProviderBlockForServer(testSystem)
 
-	resourceConfig, err := ostypeimage.RenderOsTypeImageConfig(t, nil)
+	name := acctest.RandomWithPrefix(t.Name())
+	code := strings.ToLower(name)
+
+	imageConfig, err := image.RenderImageConfig(t, map[string]string{
+		"Name":              name,
+		"OsTypeId":          "hpe_morpheus_os_type.test.id",
+		"StorageProviderId": "1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	datasourceConfig := `
+data "hpe_morpheus_provision_type" "test" {
+	name = "KVM"
+}
+
+data "hpe_morpheus_cloud" "test" {
+	name = "hvm"
+}
+`
+	// The virtual images API will NOT update the underlying osType.Id of the virtual image.
+	// So we set up a clean room scenario with the virtual image we wish to create
+	// an OS Type image from, with the virtual image's os_type set correctly to an os type
+	// that we create.
+	dependencyConfig := `
+resource "hpe_morpheus_os_type" "test" {
+  name      = "` + name + `"
+  code      = "` + code + `"
+  platform  = "linux"
+  bit_count = 64
+}
+` + imageConfig
+
+	resourceConfig, err := ostypeimage.RenderOsTypeImageConfig(t, map[string]string{
+		"OsTypeId":        "hpe_morpheus_os_type.test.id",
+		"VirtualImageId":  "hpe_morpheus_image.example_image.id",
+		"CloudId":         "data.hpe_morpheus_cloud.test.id",
+		"ProvisionTypeId": "data.hpe_morpheus_provision_type.test.id",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,45 +86,48 @@ func TestAccMorpheusOsTypeImageExampleOk(t *testing.T) {
 			"hpe_morpheus_os_type_image.example",
 			"id",
 		),
-		resource.TestCheckResourceAttr(
+		resource.TestCheckResourceAttrPair(
 			"hpe_morpheus_os_type_image.example",
 			"os_type_id",
-			"75",
+			"hpe_morpheus_os_type.test",
+			"id",
 		),
-		resource.TestCheckResourceAttr(
+		resource.TestCheckResourceAttrPair(
 			"hpe_morpheus_os_type_image.example",
 			"virtual_image_id",
-			"257",
+			"hpe_morpheus_image.example_image",
+			"id",
 		),
-		resource.TestCheckResourceAttr(
+		resource.TestCheckResourceAttrPair(
 			"hpe_morpheus_os_type_image.example",
 			"cloud_id",
-			"1",
+			"data.hpe_morpheus_cloud.test",
+			"id",
 		),
-		resource.TestCheckResourceAttr(
+		resource.TestCheckResourceAttrPair(
 			"hpe_morpheus_os_type_image.example",
 			"provision_type_id",
-			"22",
+			"data.hpe_morpheus_provision_type.test",
+			"id",
 		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
 		Steps: []resource.TestStep{
 			{
-				Config:             providerConfig + resourceConfig,
+				Config:             providerConfig + datasourceConfig + dependencyConfig + resourceConfig,
 				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"os_type_id"},
-				ResourceName:            "hpe_morpheus_os_type_image.example",
-				Check:                   checkFn,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "hpe_morpheus_os_type_image.example",
+				Check:             checkFn,
 			},
 		},
 	})
@@ -100,17 +135,44 @@ func TestAccMorpheusOsTypeImageExampleOk(t *testing.T) {
 
 // Tests creating with only the required attributes.
 func TestAccMorpheusOsTypeImageRequiredAttrsOk(t *testing.T) {
+	t.Parallel()
 	defer testhelpers.RecordResult(t)
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	providerConfig := testhelpers.ProviderBlock()
+	testSystem := systemoverride.GetPreferred(t, "zodiac")
+	providerConfig := testhelpers.ProviderBlockForServer(testSystem)
+
+	name := acctest.RandomWithPrefix(t.Name())
+	code := strings.ToLower(name)
+
+	imageConfig, err := image.RenderImageConfig(t, map[string]string{
+		"Name":              name,
+		"OsTypeId":          "hpe_morpheus_os_type.test.id",
+		"StorageProviderId": "1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The virtual images API will NOT update the underlying osType.Id of the virtual image.
+	// So we set up a clean room scenario with the virtual image we wish to create
+	// an OS Type image from, with the virtual image's os_type set correctly to an os type
+	// that we create.
+	dependencyConfig := `
+resource "hpe_morpheus_os_type" "test" {
+  name      = "` + name + `"
+  code      = "` + code + `"
+  platform  = "linux"
+  bit_count = 64
+}
+` + imageConfig
 
 	resourceConfig := `
 resource "hpe_morpheus_os_type_image" "required_only" {
-  os_type_id       = 75
-  virtual_image_id = 257
+  os_type_id       = resource.hpe_morpheus_os_type.test.id
+  virtual_image_id = resource.hpe_morpheus_image.example_image.id
 }
 `
 
@@ -119,35 +181,36 @@ resource "hpe_morpheus_os_type_image" "required_only" {
 			"hpe_morpheus_os_type_image.required_only",
 			"id",
 		),
-		resource.TestCheckResourceAttr(
+		resource.TestCheckResourceAttrPair(
 			"hpe_morpheus_os_type_image.required_only",
 			"os_type_id",
-			"75",
+			"hpe_morpheus_os_type.test",
+			"id",
 		),
-		resource.TestCheckResourceAttr(
+		resource.TestCheckResourceAttrPair(
 			"hpe_morpheus_os_type_image.required_only",
 			"virtual_image_id",
-			"257",
+			"hpe_morpheus_image.example_image",
+			"id",
 		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
 		Steps: []resource.TestStep{
 			{
-				Config:             providerConfig + resourceConfig,
+				Config:             providerConfig + dependencyConfig + resourceConfig,
 				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"os_type_id"},
-				ResourceName:            "hpe_morpheus_os_type_image.required_only",
-				Check:                   checkFn,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "hpe_morpheus_os_type_image.required_only",
+				Check:             checkFn,
 			},
 		},
 	})

--- a/templates/resources/morpheus_os_type_image.md.tmpl
+++ b/templates/resources/morpheus_os_type_image.md.tmpl
@@ -12,6 +12,8 @@ An OS type image maps a virtual image to an operating system type, optionally sc
 
 ~> All attributes on this resource force recreation when changed. There is no in-place update.
 
+~> When associating a virtual image with an OS type image, Morpheus will not automatically update the osType field of that virtual image with the `os_type_id` set in the os type image. It is therefore recommended you update the virtual image's `os_type_id` field using the provider BEFORE creating an os type image associated with that virtual image.
+
 ## Example Usage
 
 {{ tffile "examples/resources/morpheus_os_type_image/example.tf" }}


### PR DESCRIPTION
Fixes `TestAccMorpheusOsTypeImageRequiredAttrsOk` which was previously failing.

We now also set both `TestAccMorpheusOsTypeImageExampleOk` and `TestAccMorpheusOsTypeImageRequiredAttrsOk` to point to zodiac.

We set up a clean set of dependencies for the tests to guarantee they work as expected.

The virtual images API will not automatically update the OS Type of a virtual image if an os type image is created using that virtual image, so we create a new image specifically for testing, associating its os_type with the os type that our os_type image is to be used for.

We also add a note to documentation to explain that creating an os type image will not automatically update the associated virtual images's os_type_id.