### PR TITLE
Fix the version check to use only the first three parts of the Morpheus

### DIFF
--- a/morpheus/framework/resources/instance/resource.go
+++ b/morpheus/framework/resources/instance/resource.go
@@ -116,7 +116,18 @@ func (g *Resource) ModifyPlan(
 		return
 	}
 
-	version, err := semver.NewVersion(*apiVersion)
+	versionParts := strings.Split(*apiVersion, ".")
+	if len(versionParts) < 3 {
+		resp.Diagnostics.AddError(
+			"Unable to Parse Appliance Version",
+			"Not enough components - expect at least major.minor.patch, got %s"+
+				*apiVersion,
+		)
+	}
+
+	trimmedVersion := strings.Join(versionParts[:3], ".")
+
+	version, err := semver.NewVersion(trimmedVersion)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Parse Appliance Version",


### PR DESCRIPTION

Currently the healthcheck endpoint is returning 9.0.0.dev.460.
A semantic version check is failing because of the extra .dev.460 part.
