### PR TITLE
Point instance acceptance tests at zodiac

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -62,7 +62,7 @@ These settings can be changed as required.
 
 ```terraform
 data "hpe_morpheus_cloud" "vme_cloud" {
-  name = "HPE Alletra VME"
+  name = "MyCloud"
 }
 
 data "hpe_morpheus_service_plan" "vme_512mb" {
@@ -72,9 +72,9 @@ data "hpe_morpheus_service_plan" "vme_512mb" {
 
 resource "hpe_morpheus_instance" "example" {
   name             = "TestInstance"
-  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
-  layout_id        = 5385                                 # Single KVM VM
-  instance_type_id = 9                  # (HVM) mvm-cluster
+  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id 
+  layout_id        = 644 # Single KVM VM
+  instance_type_id = 9 # (HVM) mvm-cluster
 
   group_id = 1
   plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
@@ -82,7 +82,7 @@ resource "hpe_morpheus_instance" "example" {
   instance_context = "dev"
   network_interfaces = [
     {
-      network_id = 103481
+      network_id = 755
     }
   ]
 
@@ -92,14 +92,14 @@ resource "hpe_morpheus_instance" "example" {
       name            = "root"
       size            = 10
       storage_type_id = 1
-      datastore_id    = 38658
+      datastore_id    = 555
     },
     {
       root_volume     = false
       name            = "data"
       size            = 10
       storage_type_id = 1
-      datastore_id    = 38658
+      datastore_id    = 555
     }
   ]
 
@@ -127,7 +127,7 @@ resource "hpe_morpheus_instance" "example" {
   ]
 
   config_hvm = {
-    resource_pool_id      = "pool-62299"
+    resource_pool_id      = "pool-700"
     nested_virtualization = "off"
     no_agent              = true
     create_user           = false

--- a/morpheus/framework/resources/instance/example.tf
+++ b/morpheus/framework/resources/instance/example.tf
@@ -1,5 +1,5 @@
 data "hpe_morpheus_cloud" "vme_cloud" {
-  name = "HPE Alletra VME"
+  name = "MyCloud"
 }
 
 data "hpe_morpheus_service_plan" "vme_512mb" {
@@ -9,9 +9,9 @@ data "hpe_morpheus_service_plan" "vme_512mb" {
 
 resource "hpe_morpheus_instance" "example" {
   name             = "TestInstance"
-  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
-  layout_id        = 5385                                 # Single KVM VM
-  instance_type_id = 9                  # (HVM) mvm-cluster
+  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id 
+  layout_id        = 644 # Single KVM VM
+  instance_type_id = 9 # (HVM) mvm-cluster
 
   group_id = 1
   plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
@@ -19,7 +19,7 @@ resource "hpe_morpheus_instance" "example" {
   instance_context = "dev"
   network_interfaces = [
     {
-      network_id = 103481
+      network_id = 755
     }
   ]
 
@@ -29,14 +29,14 @@ resource "hpe_morpheus_instance" "example" {
       name            = "root"
       size            = 10
       storage_type_id = 1
-      datastore_id    = 38658
+      datastore_id    = 555
     },
     {
       root_volume     = false
       name            = "data"
       size            = 10
       storage_type_id = 1
-      datastore_id    = 38658
+      datastore_id    = 555
     }
   ]
 
@@ -64,7 +64,7 @@ resource "hpe_morpheus_instance" "example" {
   ]
 
   config_hvm = {
-    resource_pool_id      = "pool-62299"
+    resource_pool_id      = "pool-700"
     nested_virtualization = "off"
     no_agent              = true
     create_user           = false

--- a/morpheus/framework/resources/instance/example.tf.tmpl
+++ b/morpheus/framework/resources/instance/example.tf.tmpl
@@ -1,5 +1,5 @@
 data "hpe_morpheus_cloud" "vme_cloud" {
-  name = "HPE Alletra VME"
+  name = "{{.CloudName}}"
 }
 
 data "hpe_morpheus_service_plan" "vme_512mb" {
@@ -9,17 +9,17 @@ data "hpe_morpheus_service_plan" "vme_512mb" {
 
 resource "hpe_morpheus_instance" "example" {
   name             = "{{.Name}}"
-  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id # HPE Alletra VME
-  layout_id        = 5385                                 # Single KVM VM
-  instance_type_id = {{.InstanceType}}                  # (HVM) mvm-cluster
+  cloud_id         = data.hpe_morpheus_cloud.vme_cloud.id 
+  layout_id        = {{.LayoutId}} # Single KVM VM
+  instance_type_id = {{.InstanceType}} # (HVM) mvm-cluster
 
   group_id = 1
   plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
 
-  instance_context = "dev"
+  instance_context = "{{.InstanceContext}}"
   network_interfaces = [
     {
-      network_id = 103481
+      network_id = {{.NetworkId}}
     }
   ]
 
@@ -29,18 +29,18 @@ resource "hpe_morpheus_instance" "example" {
       name            = "root"
       size            = 10
       storage_type_id = 1
-      datastore_id    = 38658
+      datastore_id    = {{.DatastoreId}}
     },
     {
       root_volume     = false
       name            = "data"
       size            = 10
       storage_type_id = 1
-      datastore_id    = 38658
+      datastore_id    = {{.DatastoreId}}
     }
   ]
 
-  tags = [
+  tags = [{{if .MultipleTags}}
     {
       name  = "terraform"
       value = "true"
@@ -56,7 +56,7 @@ resource "hpe_morpheus_instance" "example" {
     {
       name  = "sweepable"
       value = "true"
-    },
+    },{{end}}
     {
       name  = "managed_by"
       value = "terraform"

--- a/morpheus/framework/resources/instance/instance_example.go
+++ b/morpheus/framework/resources/instance/instance_example.go
@@ -1,0 +1,59 @@
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+
+package instance
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+)
+
+//go:generate ../../../../bin/render example.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-700" CloudName "MyCloud" NetworkId "755" LayoutId "644" DatastoreId "555" InstanceContext "dev" MultipleTags "true"
+//go:generate ../../../../bin/render example_twonetworks.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
+//go:generate ../../../../bin/render example_timeouts.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
+//go:generate ../../../../bin/render example_vmware.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-1"
+//go:generate ../../../../bin/render example_vmware_sp_options.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-1"
+//go:generate ../../../../bin/render example_metal.tf.tmpl Name "TestInstance" CloudName "aCloud" EnvironmentName "anEnvironment" GroupName "aGroup" InstanceTypeLayout "Single ILO Server" Role "aRole" PlanName "G3i"
+//go:generate ../../../../bin/render example_aws.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-12284"
+
+func RenderInstanceConfig(t *testing.T, overrides map[string]string) (string, error) {
+	t.Helper()
+
+	defaults := map[string]string{
+		"Name":            "TestInstance",
+		"InstanceType":    "34",
+		"ResourcePool":    "pool-1",
+		"CloudName":       "hvm",
+		"LayoutId":        "77",
+		"NetworkId":       "1",
+		"DatastoreId":     "1",
+		"InstanceContext": "dev",
+		"MultipleTags":    "",
+	}
+
+	for key, value := range overrides {
+		defaults[key] = value
+	}
+
+	var args []string
+	for key, value := range defaults {
+		args = append(args, key, value)
+	}
+
+	// Get the directory where this source file is located
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to get current file path")
+	}
+	dir := filepath.Dir(filename)
+	templatePath := filepath.Join(dir, "example.tf.tmpl")
+
+	return testhelpers.RenderExample(
+		t,
+		templatePath,
+		args...,
+	)
+}

--- a/morpheus/framework/resources/instance/resource_test.go
+++ b/morpheus/framework/resources/instance/resource_test.go
@@ -1,28 +1,18 @@
 // (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 
-//go:generate ../../../../bin/render example.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
-//go:generate ../../../../bin/render example_twonetworks.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
-//go:generate ../../../../bin/render example_timeouts.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-62299"
-//go:generate ../../../../bin/render example_vmware.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-1"
-//go:generate ../../../../bin/render example_vmware_sp_options.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-1"
-//go:generate ../../../../bin/render example_metal.tf.tmpl Name "TestInstance" CloudName "aCloud" EnvironmentName "anEnvironment" GroupName "aGroup" InstanceTypeLayout "Single ILO Server" Role "aRole" PlanName "G3i"
-//go:generate ../../../../bin/render example_aws.tf.tmpl Name "TestInstance" InstanceType "9" ResourcePool "pool-12284"
-
 package instance_test
 
 import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/HPE/terraform-provider-hpe/morpheus"
+	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/instance"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/systemoverride"
-	"github.com/HPE/terraform-provider-hpe/provider"
 )
 
 func TestMain(m *testing.M) {
@@ -30,18 +20,6 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	testhelpers.WriteMergedResults()
 	os.Exit(code)
-}
-
-func newProviderWithError() (tfprotov6.ProviderServer, error) {
-	providerInstance := provider.New("test", morpheus.New())()
-
-	return providerserver.NewProtocol6WithError(providerInstance)()
-}
-
-var testAccProtoV6ProviderFactories = map[string]func() (
-	tfprotov6.ProviderServer, error,
-){
-	"hpe": newProviderWithError,
 }
 
 // Tests that our example file template used for docs is a valid config
@@ -54,18 +32,18 @@ func TestAccMorpheusInstanceExampleOk(t *testing.T) {
 
 	t.Parallel()
 
-	testSystem := systemoverride.GetPreferred(t, "feature")
+	testSystem := systemoverride.GetPreferred(t, "zodiac")
 	providerConfig := testhelpers.ProviderBlockForServer(testSystem)
 
 	name := acctest.RandomWithPrefix(t.Name())
-	instanceTypeID := "9"
-	resourcePool := "pool-62299"
+	instanceTypeID := "34"
+	resourcePool := "pool-1"
 
-	resourceConfig, err := testhelpers.RenderExample(t, "example.tf.tmpl",
-		"Name", name,
-		"InstanceType", instanceTypeID,
-		"ResourcePool", resourcePool,
-	)
+	resourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name":         name,
+		"InstanceType": instanceTypeID,
+		"ResourcePool": resourcePool,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +69,7 @@ func TestAccMorpheusInstanceExampleOk(t *testing.T) {
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), nil),
 		Steps: []resource.TestStep{
 			{
 				Config:             providerConfig + resourceConfig,
@@ -112,66 +90,31 @@ func TestAccMorpheusInstanceUpdateName(t *testing.T) {
 
 	t.Parallel()
 
-	testSystem := systemoverride.GetPreferred(t, "feature")
+	testSystem := systemoverride.GetPreferred(t, "zodiac")
 	providerConfig := testhelpers.ProviderBlockForServer(testSystem)
+
 	name := acctest.RandomWithPrefix(t.Name())
 	updatedName := name + "-updated"
 
+	resourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name": name,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updatedResourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name": updatedName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), nil),
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-					data "hpe_morpheus_cloud" "vme_cloud" {
-						name = "HPE Alletra VME"
-					}
-
-					data "hpe_morpheus_service_plan" "vme_512mb" {
-						name                = "1 CPU, 1GB Memory"
-						provision_type_code = "kvm"
-					}
-
-					resource "hpe_morpheus_instance" "example" {
-						name               = "` + name + `"
-						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
-						layout_id          = 5385
-						instance_type_id   = 9
-
-						group_id           = 1
-						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
-
-						instance_context   = "dev"
-						network_interfaces = [
-							{
-								network_id = 103481
-							}
-						]
-
-						volumes = [
-							{
-								root_volume     = true
-								name            = "root"
-								size            = 10
-								storage_type_id = 1
-								datastore_id    = 38658
-							}
-						]
-
-						tags = [
-							{
-								name  = "managed_by"
-								value = "terraform"
-							}
-						]
-
-						config = {
-							resourcePoolId       = "pool-62299"
-							poolProviderType     = "mvm"
-							nestedVirtualization = "off"
-							noAgent              = true
-							createUser           = false
-						}
-					}`,
+				Config: providerConfig + resourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_instance.example",
@@ -181,57 +124,7 @@ func TestAccMorpheusInstanceUpdateName(t *testing.T) {
 				),
 			},
 			{
-				Config: providerConfig + `
-					data "hpe_morpheus_cloud" "vme_cloud" {
-						name = "HPE Alletra VME"
-					}
-
-					data "hpe_morpheus_service_plan" "vme_512mb" {
-						name                = "1 CPU, 1GB Memory"
-						provision_type_code = "kvm"
-					}
-
-					resource "hpe_morpheus_instance" "example" {
-						name               = "` + updatedName + `"
-						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
-						layout_id          = 5385
-						instance_type_id   = 9
-
-						group_id           = 1
-						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
-
-						instance_context   = "dev"
-						network_interfaces = [
-							{
-								network_id = 103481
-							}
-						]
-
-						volumes = [
-							{
-								root_volume     = true
-								name            = "root"
-								size            = 10
-								storage_type_id = 1
-								datastore_id    = 38658
-							}
-						]
-
-						tags = [
-							{
-								name  = "managed_by"
-								value = "terraform"
-							}
-						]
-
-						config = {
-							resourcePoolId       = "pool-62299"
-							poolProviderType     = "mvm"
-							nestedVirtualization = "off"
-							noAgent              = true
-							createUser           = false
-						}
-					}`,
+				Config: providerConfig + updatedResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_instance.example",
@@ -253,65 +146,32 @@ func TestAccMorpheusInstanceUpdateInstanceContext(t *testing.T) {
 
 	t.Parallel()
 
-	testSystem := systemoverride.GetPreferred(t, "feature")
+	testSystem := systemoverride.GetPreferred(t, "zodiac")
 	providerConfig := testhelpers.ProviderBlockForServer(testSystem)
+
 	name := acctest.RandomWithPrefix(t.Name())
 
+	resourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name":            name,
+		"InstanceContext": "dev",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updatedResourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name":            name,
+		"InstanceContext": "production",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), nil),
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-					data "hpe_morpheus_cloud" "vme_cloud" {
-						name = "HPE Alletra VME"
-					}
-
-					data "hpe_morpheus_service_plan" "vme_512mb" {
-						name                = "1 CPU, 1GB Memory"
-						provision_type_code = "kvm"
-					}
-
-					resource "hpe_morpheus_instance" "example" {
-						name               = "` + name + `"
-						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
-						layout_id          = 5385
-						instance_type_id   = 9
-
-						group_id           = 1
-						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
-
-						instance_context   = "dev"
-						network_interfaces = [
-							{
-								network_id = 103481
-							}
-						]
-
-						volumes = [
-							{
-								root_volume     = true
-								name            = "root"
-								size            = 10
-								storage_type_id = 1
-								datastore_id    = 38658
-							}
-						]
-
-						tags = [
-							{
-								name  = "managed_by"
-								value = "terraform"
-							}
-						]
-
-						config = {
-							resourcePoolId       = "pool-62299"
-							poolProviderType     = "mvm"
-							nestedVirtualization = "off"
-							noAgent              = true
-							createUser           = false
-						}
-					}`,
+				Config: providerConfig + resourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_instance.example",
@@ -321,57 +181,7 @@ func TestAccMorpheusInstanceUpdateInstanceContext(t *testing.T) {
 				),
 			},
 			{
-				Config: providerConfig + `
-					data "hpe_morpheus_cloud" "vme_cloud" {
-						name = "HPE Alletra VME"
-					}
-
-					data "hpe_morpheus_service_plan" "vme_512mb" {
-						name                = "1 CPU, 1GB Memory"
-						provision_type_code = "kvm"
-					}
-
-					resource "hpe_morpheus_instance" "example" {
-						name               = "` + name + `"
-						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
-						layout_id          = 5385
-						instance_type_id   = 9
-
-						group_id           = 1
-						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
-
-						instance_context   = "production"
-						network_interfaces = [
-							{
-								network_id = 103481
-							}
-						]
-
-						volumes = [
-							{
-								root_volume     = true
-								name            = "root"
-								size            = 10
-								storage_type_id = 1
-								datastore_id    = 38658
-							}
-						]
-
-						tags = [
-							{
-								name  = "managed_by"
-								value = "terraform"
-							}
-						]
-
-						config = {
-							resourcePoolId       = "pool-62299"
-							poolProviderType     = "mvm"
-							nestedVirtualization = "off"
-							noAgent              = true
-							createUser           = false
-						}
-					}`,
+				Config: providerConfig + updatedResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_instance.example",
@@ -393,65 +203,31 @@ func TestAccMorpheusInstanceUpdateTags(t *testing.T) {
 
 	t.Parallel()
 
-	testSystem := systemoverride.GetPreferred(t, "feature")
+	testSystem := systemoverride.GetPreferred(t, "zodiac")
 	providerConfig := testhelpers.ProviderBlockForServer(testSystem)
+
 	name := acctest.RandomWithPrefix(t.Name())
 
+	resourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name": name,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updatedResourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name":         name,
+		"MultipleTags": "true",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), nil),
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-					data "hpe_morpheus_cloud" "vme_cloud" {
-						name = "HPE Alletra VME"
-					}
-
-					data "hpe_morpheus_service_plan" "vme_512mb" {
-						name                = "1 CPU, 1GB Memory"
-						provision_type_code = "kvm"
-					}
-
-					resource "hpe_morpheus_instance" "example" {
-						name               = "` + name + `"
-						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
-						layout_id          = 5385
-						instance_type_id   = 9
-
-						group_id           = 1
-						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
-
-						instance_context   = "dev"
-						network_interfaces = [
-							{
-								network_id = 103481
-							}
-						]
-
-						volumes = [
-							{
-								root_volume     = true
-								name            = "root"
-								size            = 10
-								storage_type_id = 1
-								datastore_id    = 38658
-							}
-						]
-
-						tags = [
-							{
-								name  = "managed_by"
-								value = "terraform"
-							}
-						]
-
-						config = {
-							resourcePoolId       = "pool-62299"
-							poolProviderType     = "mvm"
-							nestedVirtualization = "off"
-							noAgent              = true
-							createUser           = false
-						}
-					}`,
+				Config: providerConfig + resourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_instance.example",
@@ -461,66 +237,12 @@ func TestAccMorpheusInstanceUpdateTags(t *testing.T) {
 				),
 			},
 			{
-				Config: providerConfig + `
-					data "hpe_morpheus_cloud" "vme_cloud" {
-						name = "HPE Alletra VME"
-					}
-
-					data "hpe_morpheus_service_plan" "vme_512mb" {
-						name                = "1 CPU, 1GB Memory"
-						provision_type_code = "kvm"
-					}
-
-					resource "hpe_morpheus_instance" "example" {
-						name               = "` + name + `"
-						cloud_id           = data.hpe_morpheus_cloud.vme_cloud.id
-						layout_id          = 5385
-						instance_type_id   = 9
-
-						group_id           = 1
-						plan_id            = data.hpe_morpheus_service_plan.vme_512mb.id
-
-						instance_context   = "dev"
-						network_interfaces = [
-							{
-								network_id = 103481
-							}
-						]
-
-						volumes = [
-							{
-								root_volume     = true
-								name            = "root"
-								size            = 10
-								storage_type_id = 1
-								datastore_id    = 38658
-							}
-						]
-
-						tags = [
-							{
-								name  = "managed_by"
-								value = "terraform"
-							},
-							{
-								name  = "environment"
-								value = "test"
-							}
-						]
-
-						config = {
-							resourcePoolId       = "pool-62299"
-							poolProviderType     = "mvm"
-							nestedVirtualization = "off"
-							noAgent              = true
-							createUser           = false
-						}
-					}`,
+				Config: providerConfig + updatedResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_instance.example",
 						"tags.#",
-						"2",
+						"5",
 					),
 				),
 			},


### PR DESCRIPTION

The tests that are being performed are checking small changes to the instance.
Those tests are indifferent to the underlying instance type so they can
safely be pointed at Zodiac.
