### PR TITLE
Fix sdkv2 task visibility schema - remove Computed

### DIFF
--- a/morpheus/sdkv2/resources/task/resource_task_ansible_playbook.go
+++ b/morpheus/sdkv2/resources/task/resource_task_ansible_playbook.go
@@ -114,7 +114,6 @@ func ResourceTaskAnsiblePlaybook() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_email.go
+++ b/morpheus/sdkv2/resources/task/resource_task_email.go
@@ -140,7 +140,6 @@ func ResourceTaskEmail() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_groovy_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_groovy_script.go
@@ -100,7 +100,6 @@ func ResourceTaskGroovyScript() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 			"retryable": {
 				Type:        schema.TypeBool,

--- a/morpheus/sdkv2/resources/task/resource_task_javascript.go
+++ b/morpheus/sdkv2/resources/task/resource_task_javascript.go
@@ -93,7 +93,6 @@ func ResourceTaskJavaScript() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_library_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_library_script.go
@@ -103,7 +103,6 @@ func ResourceTaskLibraryScript() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_library_template.go
+++ b/morpheus/sdkv2/resources/task/resource_task_library_template.go
@@ -103,7 +103,6 @@ func ResourceTaskLibraryTemplate() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_nested_workflow.go
+++ b/morpheus/sdkv2/resources/task/resource_task_nested_workflow.go
@@ -88,7 +88,6 @@ func ResourceTaskNestedWorkflow() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -115,7 +115,6 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 			"remote_target_host": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/task/resource_task_python_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_python_script.go
@@ -141,7 +141,6 @@ func ResourceTaskPythonScript() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_restart.go
+++ b/morpheus/sdkv2/resources/task/resource_task_restart.go
@@ -76,7 +76,6 @@ func ResourceTaskRestart() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_ruby_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_ruby_script.go
@@ -117,7 +117,6 @@ func ResourceTaskRubyScript() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_shell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_shell_script.go
@@ -130,7 +130,6 @@ func ResourceTaskShellScript() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 			"remote_target_host": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/task/resource_task_vro.go
+++ b/morpheus/sdkv2/resources/task/resource_task_vro.go
@@ -103,7 +103,6 @@ func ResourceTaskVRO() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/morpheus/sdkv2/resources/task/resource_task_write_attributes.go
+++ b/morpheus/sdkv2/resources/task/resource_task_write_attributes.go
@@ -92,7 +92,6 @@ func ResourceTaskWriteAttributes() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
 				Optional:     true,
 				Default:      "private",
-				Computed:     true,
 			},
 		},
 		Importer: &schema.ResourceImporter{


### PR DESCRIPTION
sdkv2 appears to expect attributes with a default value to be just Optional - not Computed and Optional.

#1064 introduced this bug into all our tests that use task...


before:

```
        Internal validation of the provider failed! This is always a bug
        with the provider itself, and not a user issue. Please report
        this bug:

        resource hpe_morpheus_task_ruby_script: visibility: Default must be nil if
        computed
        resource hpe_morpheus_task_groovy_script: visibility: Default must be nil if
        computed
        resource hpe_morpheus_task_javascript: visibility: Default must be nil if
        computed
        resource hpe_morpheus_task_library_script: visibility: Default must be nil if
        computed
        resource hpe_morpheus_task_powershell_script: visibility: Default must be nil
        if computed
        resource hpe_morpheus_task_write_attributes: visibility: Default must be nil
        if computed
        resource hpe_morpheus_task_restart: visibility: Default must be nil if
        computed
        resource hpe_morpheus_task_vro: visibility: Default must be nil if computed
        resource hpe_morpheus_task_nested_workflow: visibility: Default must be nil
        if computed
        resource hpe_morpheus_task_library_template: visibility: Default must be nil
        if computed
        resource hpe_morpheus_task_python_script: visibility: Default must be nil if
        computed
        resource hpe_morpheus_task_shell_script: visibility: Default must be nil if
        computed
        resource hpe_morpheus_task_email: visibility: Default must be nil if computed
        resource hpe_morpheus_task_ansible_playbook: visibility: Default must be nil
```

after:

```
PASS
ok      github.com/HPE/terraform-provider-hpe/morpheus/sdkv2/resources/task     8.909s
```
