### PR TITLE
Adding sweepers for the rest of the framework resources

### DIFF
--- a/morpheus/framework/resources/group/sweep/sweep.go
+++ b/morpheus/framework/resources/group/sweep/sweep.go
@@ -1,0 +1,61 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	testsweep "github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/sweep"
+)
+
+func init() {
+	testsweep.RegisterTypedAPISweeper(
+		"hpe_morpheus_group",
+		// List all group resources.
+		func(ctx context.Context, client *sdk.APIClient) (
+			[]sdk.ListGroups200ResponseAllOfGroupsInner,
+			*http.Response,
+			error,
+		) {
+			resp, hresp, err := client.GroupsAPI.ListGroups(ctx).Execute()
+			if resp == nil {
+				return nil, hresp, err
+			}
+
+			return resp.GetGroups(), hresp, err
+		},
+		// Is this a test group?
+		func(item sdk.ListGroups200ResponseAllOfGroupsInner) bool {
+			name, ok := item.GetNameOk()
+			if !ok || name == nil {
+				return false
+			}
+
+			return strings.HasPrefix(*name, testsweep.TestResourcePrefix)
+		},
+		// Delete the test group.
+		func(
+			ctx context.Context,
+			client *sdk.APIClient,
+			item sdk.ListGroups200ResponseAllOfGroupsInner,
+		) (*http.Response, error) {
+			id, ok := item.GetIdOk()
+			if !ok || id == nil {
+				return nil, fmt.Errorf("could not get ID")
+			}
+
+			_, hresp, err := client.GroupsAPI.RemoveGroups(ctx, *id).Execute()
+
+			return hresp, err
+		},
+		testsweep.WithIgnoreListStatuses[sdk.ListGroups200ResponseAllOfGroupsInner](
+			http.StatusNotFound,
+			http.StatusForbidden,
+		),
+	)
+}

--- a/morpheus/framework/resources/group/sweep_import.go
+++ b/morpheus/framework/resources/group/sweep_import.go
@@ -1,0 +1,7 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+//go:build sweep
+
+package group
+
+import _ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/group/sweep"

--- a/morpheus/framework/resources/image/sweep/sweep.go
+++ b/morpheus/framework/resources/image/sweep/sweep.go
@@ -1,0 +1,61 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	testsweep "github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/sweep"
+)
+
+func init() {
+	testsweep.RegisterTypedAPISweeper(
+		"hpe_morpheus_image",
+		// List all image resources.
+		func(ctx context.Context, client *sdk.APIClient) (
+			[]sdk.ListVirtualImages200ResponseAllOfVirtualImagesInner,
+			*http.Response,
+			error,
+		) {
+			resp, hresp, err := client.LibraryAPI.ListVirtualImages(ctx).Execute()
+			if resp == nil {
+				return nil, hresp, err
+			}
+
+			return resp.GetVirtualImages(), hresp, err
+		},
+		// Is this a test image?
+		func(item sdk.ListVirtualImages200ResponseAllOfVirtualImagesInner) bool {
+			name, ok := item.GetNameOk()
+			if !ok || name == nil {
+				return false
+			}
+
+			return strings.HasPrefix(*name, testsweep.TestResourcePrefix)
+		},
+		// Delete the test image.
+		func(
+			ctx context.Context,
+			client *sdk.APIClient,
+			item sdk.ListVirtualImages200ResponseAllOfVirtualImagesInner,
+		) (*http.Response, error) {
+			id, ok := item.GetIdOk()
+			if !ok || id == nil {
+				return nil, fmt.Errorf("could not get ID")
+			}
+
+			_, hresp, err := client.LibraryAPI.RemoveVirtualImage(ctx, *id).Execute()
+
+			return hresp, err
+		},
+		testsweep.WithIgnoreListStatuses[sdk.ListVirtualImages200ResponseAllOfVirtualImagesInner](
+			http.StatusNotFound,
+			http.StatusForbidden,
+		),
+	)
+}

--- a/morpheus/framework/resources/image/sweep_import.go
+++ b/morpheus/framework/resources/image/sweep_import.go
@@ -1,0 +1,7 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+//go:build sweep
+
+package image
+
+import _ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/image/sweep"

--- a/morpheus/framework/resources/ostypeimage/sweep/sweep.go
+++ b/morpheus/framework/resources/ostypeimage/sweep/sweep.go
@@ -1,0 +1,93 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	testsweep "github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/sweep"
+)
+
+type osTypeImageSweepItem struct {
+	id               int64
+	virtualImageName string
+}
+
+func init() {
+	testsweep.RegisterTypedAPISweeper(
+		"hpe_morpheus_os_type_image",
+		// List all os type image resources.
+		func(ctx context.Context, client *sdk.APIClient) (
+			[]osTypeImageSweepItem,
+			*http.Response,
+			error,
+		) {
+			resp, hresp, err := client.LibraryAPI.ListOsTypes(ctx).Execute()
+			if resp == nil {
+				return nil, hresp, err
+			}
+
+			items := make([]osTypeImageSweepItem, 0)
+			for _, osType := range resp.GetOsTypes() {
+				osTypeID, ok := osType.GetIdOk()
+				if !ok || osTypeID == nil {
+					continue
+				}
+
+				osTypeResp, osTypeHresp, osTypeErr := client.LibraryAPI.GetOsType(ctx, *osTypeID).Execute()
+				if osTypeErr != nil || osTypeHresp == nil || osTypeHresp.StatusCode != http.StatusOK {
+					if osTypeHresp != nil && (osTypeHresp.StatusCode == http.StatusNotFound ||
+						osTypeHresp.StatusCode == http.StatusForbidden) {
+						continue
+					}
+
+					return nil, osTypeHresp, osTypeErr
+				}
+
+				osTypeDetail := osTypeResp.GetOsType()
+
+				for _, image := range osTypeDetail.GetImages() {
+					id, ok := image.GetIdOk()
+					if !ok || id == nil {
+						continue
+					}
+
+					name, ok := image.GetVirtualImageNameOk()
+					if !ok || name == nil {
+						continue
+					}
+
+					items = append(items, osTypeImageSweepItem{
+						id:               *id,
+						virtualImageName: *name,
+					})
+				}
+			}
+
+			return items, hresp, nil
+		},
+		// Is this a test os type image?
+		func(item osTypeImageSweepItem) bool {
+			return strings.HasPrefix(item.virtualImageName, testsweep.TestResourcePrefix)
+		},
+		// Delete the test os type image.
+		func(
+			ctx context.Context,
+			client *sdk.APIClient,
+			item osTypeImageSweepItem,
+		) (*http.Response, error) {
+			if item.id == 0 {
+				return nil, fmt.Errorf("could not get ID")
+			}
+
+			_, hresp, err := client.LibraryAPI.DeleteOsTypeImage(ctx, item.id).Execute()
+
+			return hresp, err
+		},
+	)
+}

--- a/morpheus/framework/resources/ostypeimage/sweep_import.go
+++ b/morpheus/framework/resources/ostypeimage/sweep_import.go
@@ -1,0 +1,7 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+//go:build sweep
+
+package ostypeimage
+
+import _ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/ostypeimage/sweep"

--- a/morpheus/framework/resources/role/sweep/sweep.go
+++ b/morpheus/framework/resources/role/sweep/sweep.go
@@ -1,0 +1,61 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	testsweep "github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/sweep"
+)
+
+func init() {
+	testsweep.RegisterTypedAPISweeper(
+		"hpe_morpheus_role",
+		// List all role resources.
+		func(ctx context.Context, client *sdk.APIClient) (
+			[]sdk.ListRoles200ResponseAllOfRolesInner,
+			*http.Response,
+			error,
+		) {
+			resp, hresp, err := client.RolesAPI.ListRoles(ctx).Execute()
+			if resp == nil {
+				return nil, hresp, err
+			}
+
+			return resp.GetRoles(), hresp, err
+		},
+		// Is this a test role?
+		func(item sdk.ListRoles200ResponseAllOfRolesInner) bool {
+			name, ok := item.GetNameOk()
+			if !ok || name == nil {
+				return false
+			}
+
+			return strings.HasPrefix(*name, testsweep.TestResourcePrefix)
+		},
+		// Delete the test role.
+		func(
+			ctx context.Context,
+			client *sdk.APIClient,
+			item sdk.ListRoles200ResponseAllOfRolesInner,
+		) (*http.Response, error) {
+			id, ok := item.GetIdOk()
+			if !ok || id == nil {
+				return nil, fmt.Errorf("could not get ID")
+			}
+
+			_, hresp, err := client.RolesAPI.DeleteRole(ctx, *id).Execute()
+
+			return hresp, err
+		},
+		testsweep.WithIgnoreListStatuses[sdk.ListRoles200ResponseAllOfRolesInner](
+			http.StatusNotFound,
+			http.StatusForbidden,
+		),
+	)
+}

--- a/morpheus/framework/resources/role/sweep_import.go
+++ b/morpheus/framework/resources/role/sweep_import.go
@@ -1,0 +1,7 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+//go:build sweep
+
+package role
+
+import _ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/role/sweep"

--- a/morpheus/framework/resources/serviceplan/sweep/sweep.go
+++ b/morpheus/framework/resources/serviceplan/sweep/sweep.go
@@ -1,0 +1,61 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	testsweep "github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/sweep"
+)
+
+func init() {
+	testsweep.RegisterTypedAPISweeper(
+		"hpe_morpheus_service_plan",
+		// List all service plan resources.
+		func(ctx context.Context, client *sdk.APIClient) (
+			[]sdk.ListServicePlans200ResponseAllOfServicePlansInner,
+			*http.Response,
+			error,
+		) {
+			resp, hresp, err := client.ServicePlansAPI.ListServicePlans(ctx).Execute()
+			if resp == nil {
+				return nil, hresp, err
+			}
+
+			return resp.GetServicePlans(), hresp, err
+		},
+		// Is this a test service plan?
+		func(item sdk.ListServicePlans200ResponseAllOfServicePlansInner) bool {
+			name, ok := item.GetNameOk()
+			if !ok || name == nil {
+				return false
+			}
+
+			return strings.HasPrefix(*name, testsweep.TestResourcePrefix)
+		},
+		// Delete the test service plan.
+		func(
+			ctx context.Context,
+			client *sdk.APIClient,
+			item sdk.ListServicePlans200ResponseAllOfServicePlansInner,
+		) (*http.Response, error) {
+			id, ok := item.GetIdOk()
+			if !ok || id == nil {
+				return nil, fmt.Errorf("could not get ID")
+			}
+
+			_, hresp, err := client.ServicePlansAPI.RemoveServicePlans(ctx, *id).Execute()
+
+			return hresp, err
+		},
+		testsweep.WithIgnoreListStatuses[sdk.ListServicePlans200ResponseAllOfServicePlansInner](
+			http.StatusNotFound,
+			http.StatusForbidden,
+		),
+	)
+}

--- a/morpheus/framework/resources/serviceplan/sweep_import.go
+++ b/morpheus/framework/resources/serviceplan/sweep_import.go
@@ -1,0 +1,7 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+//go:build sweep
+
+package serviceplan
+
+import _ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/serviceplan/sweep"

--- a/morpheus/framework/resources/task/sweep/sweep.go
+++ b/morpheus/framework/resources/task/sweep/sweep.go
@@ -1,0 +1,85 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package sweep
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+
+	testsweep "github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/sweep"
+)
+
+func init() {
+	testsweep.RegisterTypedAPISweeper(
+		"hpe_morpheus_task",
+		// List all task resources.
+		func(ctx context.Context, client *sdk.APIClient) (
+			[]sdk.ListTasks200ResponseAllOfTasksInner,
+			*http.Response,
+			error,
+		) {
+			resp, hresp, err := client.AutomationAPI.ListTasks(ctx).Execute()
+			if resp == nil {
+				return nil, hresp, err
+			}
+
+			return resp.GetTasks(), hresp, err
+		},
+		// Is this a test task?
+		func(item sdk.ListTasks200ResponseAllOfTasksInner) bool {
+			name, _, ok := getTaskNameAndID(item)
+			if !ok {
+				return false
+			}
+
+			return strings.HasPrefix(name, testsweep.TestResourcePrefix)
+		},
+		// Delete the test task.
+		func(
+			ctx context.Context,
+			client *sdk.APIClient,
+			item sdk.ListTasks200ResponseAllOfTasksInner,
+		) (*http.Response, error) {
+			_, id, ok := getTaskNameAndID(item)
+			if !ok {
+				return nil, fmt.Errorf("could not get ID")
+			}
+
+			_, hresp, err := client.AutomationAPI.RemoveTasks(ctx, id).Execute()
+
+			return hresp, err
+		},
+		testsweep.WithIgnoreListStatuses[sdk.ListTasks200ResponseAllOfTasksInner](
+			http.StatusNotFound,
+			http.StatusForbidden,
+		),
+	)
+}
+
+func getTaskNameAndID(item sdk.ListTasks200ResponseAllOfTasksInner) (string, int64, bool) {
+	// Task list responses are polymorphic; parse common top-level fields.
+	payload, err := json.Marshal(item)
+	if err != nil {
+		return "", 0, false
+	}
+
+	var parsed struct {
+		ID   *int64  `json:"id"`
+		Name *string `json:"name"`
+	}
+
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return "", 0, false
+	}
+
+	if parsed.ID == nil || parsed.Name == nil {
+		return "", 0, false
+	}
+
+	return *parsed.Name, *parsed.ID, true
+}

--- a/morpheus/framework/resources/task/sweep_import.go
+++ b/morpheus/framework/resources/task/sweep_import.go
@@ -1,0 +1,7 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+//go:build sweep
+
+package task
+
+import _ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/task/sweep"


### PR DESCRIPTION
Sweepers have been added for each of the remaining framework resources. Including:
- hpe_morpheus_group
- hpe_morpheus_image
- hpe_morpheus_ostype_image
- hpe_morpheus_role
- hpe_morpheus_service_plan
- hpe_morpheus_task