### PR TITLE
Fix load_balancer permissions

### DIFF
--- a/docs/resources/morpheus_load_balancer.md
+++ b/docs/resources/morpheus_load_balancer.md
@@ -34,6 +34,10 @@ resource "hpe_morpheus_load_balancer" "haproxy" {
     plan_id = 8
     pool    = "pool-574"
   }
+
+  permissions = {
+    all = true
+  }
 }
 ```
 
@@ -63,6 +67,10 @@ resource "hpe_morpheus_load_balancer" "haproxy_generic" {
     pool = {
       id = "pool-574"
     }
+  }
+
+  permissions = {
+    groups = [data.hpe_morpheus_group.example.id]
   }
 }
 ```
@@ -106,7 +114,7 @@ Required:
 Optional:
 
 - `all` (Boolean) Pass true to allow access to all groups
-- `groups` (Set of Number) Array of group IDs that are allowed access
+- `groups` (List of Number) Array of group IDs that are allowed access
 
 
 <a id="nestedatt--tenants"></a>

--- a/examples/resources/morpheus_load_balancer/example_haproxy.tf
+++ b/examples/resources/morpheus_load_balancer/example_haproxy.tf
@@ -17,4 +17,8 @@ resource "hpe_morpheus_load_balancer" "haproxy" {
     plan_id = 8
     pool    = "pool-574"
   }
+
+  permissions = {
+    all = true
+  }
 }

--- a/examples/resources/morpheus_load_balancer/example_haproxy_generic.tf
+++ b/examples/resources/morpheus_load_balancer/example_haproxy_generic.tf
@@ -22,4 +22,8 @@ resource "hpe_morpheus_load_balancer" "haproxy_generic" {
       id = "pool-574"
     }
   }
+
+  permissions = {
+    groups = [data.hpe_morpheus_group.example.id]
+  }
 }

--- a/morpheus/framework/resources/loadbalancer/create.go
+++ b/morpheus/framework/resources/loadbalancer/create.go
@@ -242,6 +242,7 @@ func setCreatePermissions(
 	}
 
 	if !plan.Permissions.Groups.IsNull() && !plan.Permissions.Groups.IsUnknown() {
+		perms.SetAll(false)
 		var groupIDs []int64
 		if diags := plan.Permissions.Groups.ElementsAs(ctx, &groupIDs, false); diags.HasError() {
 			return fmt.Errorf("failed to parse permission groups: %s", diags.Errors())

--- a/morpheus/framework/resources/loadbalancer/example_haproxy.tf.tmpl
+++ b/morpheus/framework/resources/loadbalancer/example_haproxy.tf.tmpl
@@ -17,4 +17,8 @@ resource "hpe_morpheus_load_balancer" "haproxy" {
     plan_id = {{.PlanId}}
     pool    = "{{.Pool}}"
   }
+
+  permissions = {
+    all = true
+  }
 }

--- a/morpheus/framework/resources/loadbalancer/example_haproxy_generic.tf.tmpl
+++ b/morpheus/framework/resources/loadbalancer/example_haproxy_generic.tf.tmpl
@@ -22,4 +22,8 @@ resource "hpe_morpheus_load_balancer" "haproxy_generic" {
       id = "{{.Pool}}"
     }
   }
+
+  permissions = {
+    groups = [ data.hpe_morpheus_group.example.id ]
+  }
 }

--- a/morpheus/framework/resources/loadbalancer/read.go
+++ b/morpheus/framework/resources/loadbalancer/read.go
@@ -104,6 +104,13 @@ func getLoadBalancerAsState(
 			return state, fmt.Errorf("failed to convert resource permissions: %w", err)
 		}
 
+		// The API does not return per-group (site) assignments in the GET response,
+		// so preserve groups from plan/state. After import they will be null.
+		if !plan.Permissions.IsNull() && !plan.Permissions.IsUnknown() &&
+			!plan.Permissions.Groups.IsNull() && !plan.Permissions.Groups.IsUnknown() {
+			perms.Groups = plan.Permissions.Groups
+		}
+
 		state.Permissions = perms
 	} else {
 		state.Permissions = NewPermissionsValueNull()
@@ -129,16 +136,16 @@ func convertResourcePermissions(
 		}
 	}
 
-	var groupIDsSet attr.Value
+	var groupIDsList attr.Value
 	if len(groupIDValues) > 0 {
-		s, d := types.SetValue(types.Int64Type, groupIDValues)
+		l, d := types.ListValue(types.Int64Type, groupIDValues)
 		if d.HasError() {
-			return PermissionsValue{}, fmt.Errorf("failed to build groups set: %s", d.Errors())
+			return PermissionsValue{}, fmt.Errorf("failed to build groups list: %s", d.Errors())
 		}
 
-		groupIDsSet = s
+		groupIDsList = l
 	} else {
-		groupIDsSet = types.SetNull(types.Int64Type)
+		groupIDsList = types.ListNull(types.Int64Type)
 	}
 
 	perms, d := NewPermissionsValue(
@@ -148,7 +155,7 @@ func convertResourcePermissions(
 				resourcePermission.All != nil &&
 					*resourcePermission.All,
 			),
-			"groups": groupIDsSet,
+			"groups": groupIDsList,
 		},
 	)
 	if d.HasError() {

--- a/morpheus/framework/resources/loadbalancer/resource_test.go
+++ b/morpheus/framework/resources/loadbalancer/resource_test.go
@@ -4,6 +4,7 @@ package loadbalancer_test
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -114,7 +115,43 @@ func TestAccMorpheusLoadBalancerHAProxyGenericExampleOk(t *testing.T) {
 					"cloud_id",
 					"network_server_id",
 					"type_code",
+					"permissions.groups",
 				},
+			},
+		},
+	})
+}
+
+// Test validation: permissions.all conflicts with permissions.groups
+func TestAccMorpheusLoadBalancerValidationPermissionsConflict(t *testing.T) {
+	t.Parallel()
+	defer testhelpers.RecordResult(t)
+
+	testSystem := systemoverride.GetPreferred(t, "feature")
+	providerConfig := testhelpers.ProviderBlockForServer(testSystem)
+	name := acctest.RandomWithPrefix(t.Name())
+	name = name[0:16] + name[len(name)-16:]
+
+	resourceConfig := `
+resource "hpe_morpheus_load_balancer" "test" {
+  name = "` + name + `"
+
+  config = {}
+
+  permissions = {
+    all    = true
+    groups = [1, 2]
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile(`(?i)attribute "permissions.groups" cannot be specified when`),
 			},
 		},
 	})

--- a/morpheus/framework/resources/loadbalancer/schema_gen.go
+++ b/morpheus/framework/resources/loadbalancer/schema_gen.go
@@ -5,6 +5,9 @@ package loadbalancer
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -19,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -113,8 +115,13 @@ func LoadBalancerResourceSchema(ctx context.Context) schema.Schema {
 						Computed:            true,
 						Description:         "Pass true to allow access to all groups",
 						MarkdownDescription: "Pass true to allow access to all groups",
+						Validators: []validator.Bool{
+							boolvalidator.ConflictsWith(path.Expressions{
+								path.MatchRelative().AtParent().AtName("groups"),
+							}...),
+						},
 					},
-					"groups": schema.SetAttribute{
+					"groups": schema.ListAttribute{
 						ElementType:         types.Int64Type,
 						Optional:            true,
 						Computed:            true,
@@ -424,14 +431,12 @@ func (t ConfigHaproxyType) ValueFromTerraform(ctx context.Context, in tftypes.Va
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -470,7 +475,6 @@ func (v ConfigHaproxyValue) ToTerraformValue(ctx context.Context) (tftypes.Value
 		vals := make(map[string]tftypes.Value, 2)
 
 		val, err = v.PlanId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -478,7 +482,6 @@ func (v ConfigHaproxyValue) ToTerraformValue(ctx context.Context) (tftypes.Value
 		vals["plan_id"] = val
 
 		val, err = v.Pool.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -639,12 +642,12 @@ func (t PermissionsType) ValueFromObject(ctx context.Context, in basetypes.Objec
 		return nil, diags
 	}
 
-	groupsVal, ok := groupsAttribute.(basetypes.SetValue)
+	groupsVal, ok := groupsAttribute.(basetypes.ListValue)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`groups expected to be basetypes.SetValue, was: %T`, groupsAttribute))
+			fmt.Sprintf(`groups expected to be basetypes.ListValue, was: %T`, groupsAttribute))
 	}
 
 	if diags.HasError() {
@@ -749,12 +752,12 @@ func NewPermissionsValue(attributeTypes map[string]attr.Type, attributes map[str
 		return NewPermissionsValueUnknown(), diags
 	}
 
-	groupsVal, ok := groupsAttribute.(basetypes.SetValue)
+	groupsVal, ok := groupsAttribute.(basetypes.ListValue)
 
 	if !ok {
 		diags.AddError(
 			"Attribute Wrong Type",
-			fmt.Sprintf(`groups expected to be basetypes.SetValue, was: %T`, groupsAttribute))
+			fmt.Sprintf(`groups expected to be basetypes.ListValue, was: %T`, groupsAttribute))
 	}
 
 	if diags.HasError() {
@@ -811,14 +814,12 @@ func (t PermissionsType) ValueFromTerraform(ctx context.Context, in tftypes.Valu
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -837,7 +838,7 @@ var _ basetypes.ObjectValuable = PermissionsValue{}
 
 type PermissionsValue struct {
 	All    basetypes.BoolValue `tfsdk:"all"`
-	Groups basetypes.SetValue  `tfsdk:"groups"`
+	Groups basetypes.ListValue `tfsdk:"groups"`
 	state  attr.ValueState
 }
 
@@ -848,7 +849,7 @@ func (v PermissionsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 	var err error
 
 	attrTypes["all"] = basetypes.BoolType{}.TerraformType(ctx)
-	attrTypes["groups"] = basetypes.SetType{
+	attrTypes["groups"] = basetypes.ListType{
 		ElemType: types.Int64Type,
 	}.TerraformType(ctx)
 
@@ -859,7 +860,6 @@ func (v PermissionsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals := make(map[string]tftypes.Value, 2)
 
 		val, err = v.All.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -867,7 +867,6 @@ func (v PermissionsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["all"] = val
 
 		val, err = v.Groups.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -903,22 +902,22 @@ func (v PermissionsValue) String() string {
 func (v PermissionsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	var groupsVal basetypes.SetValue
+	var groupsVal basetypes.ListValue
 	switch {
 	case v.Groups.IsUnknown():
-		groupsVal = types.SetUnknown(types.Int64Type)
+		groupsVal = types.ListUnknown(types.Int64Type)
 	case v.Groups.IsNull():
-		groupsVal = types.SetNull(types.Int64Type)
+		groupsVal = types.ListNull(types.Int64Type)
 	default:
 		var d diag.Diagnostics
-		groupsVal, d = types.SetValue(types.Int64Type, v.Groups.Elements())
+		groupsVal, d = types.ListValue(types.Int64Type, v.Groups.Elements())
 		diags.Append(d...)
 	}
 
 	if diags.HasError() {
 		return types.ObjectUnknown(map[string]attr.Type{
 			"all": basetypes.BoolType{},
-			"groups": basetypes.SetType{
+			"groups": basetypes.ListType{
 				ElemType: types.Int64Type,
 			},
 		}), diags
@@ -926,7 +925,7 @@ func (v PermissionsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectVa
 
 	attributeTypes := map[string]attr.Type{
 		"all": basetypes.BoolType{},
-		"groups": basetypes.SetType{
+		"groups": basetypes.ListType{
 			ElemType: types.Int64Type,
 		},
 	}
@@ -986,7 +985,7 @@ func (v PermissionsValue) Type(ctx context.Context) attr.Type {
 func (v PermissionsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 	return map[string]attr.Type{
 		"all": basetypes.BoolType{},
-		"groups": basetypes.SetType{
+		"groups": basetypes.ListType{
 			ElemType: types.Int64Type,
 		},
 	}
@@ -1225,14 +1224,12 @@ func (t TenantsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -1271,7 +1268,6 @@ func (v TenantsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals := make(map[string]tftypes.Value, 2)
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1279,7 +1275,6 @@ func (v TenantsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["id"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}

--- a/morpheus/framework/resources/loadbalancer/update.go
+++ b/morpheus/framework/resources/loadbalancer/update.go
@@ -184,6 +184,8 @@ func setUpdatePermissions(
 
 	if !plan.Permissions.All.IsNull() && !plan.Permissions.All.IsUnknown() {
 		perms.SetAll(plan.Permissions.All.ValueBool())
+	} else if !plan.Permissions.Groups.IsNull() && !plan.Permissions.Groups.IsUnknown() {
+		perms.SetAll(false)
 	}
 
 	if !plan.Permissions.Groups.IsNull() && !plan.Permissions.Groups.IsUnknown() {


### PR DESCRIPTION

This PR:

- Adds a conflict constraint between permissions.all and permissions.groups
- Uses state to set the group permissions as an empty list is returned.
- Adds permissions examples to the ha_proxy and generic example templates.
