### PR TITLE
Allow null else in conditional_workflow task

### DIFF
--- a/docs/resources/morpheus_task.md
+++ b/docs/resources/morpheus_task.md
@@ -39,6 +39,33 @@ resource "hpe_morpheus_task" "example_task" {
 }
 ```
 
+## Conditional Workflow Task with Null Else
+
+```terraform
+resource "hpe_morpheus_task" "example_task" {
+  name           = "Example Conditional Workflow Task"
+  task_type_code = "conditionalWorkflow"
+  config_conditional_workflow = {
+    conditional_script           = <<-EOT
+        if (1 == true) {
+            return true;
+        }
+
+        return false;
+        EOT
+    if_operational_workflow_id   = "4090"
+    if_operational_workflow_name = "Example If Workflow"
+
+    else_operational_workflow_id   = null
+    else_operational_workflow_name = null
+  }
+
+  execute_target      = "local"
+  retryable           = false
+  allow_custom_config = true
+}
+```
+
 ## Generic Config Task
 
 ```terraform

--- a/examples/resources/morpheus_task/example_conditional_workflow_null_else.tf
+++ b/examples/resources/morpheus_task/example_conditional_workflow_null_else.tf
@@ -1,0 +1,22 @@
+resource "hpe_morpheus_task" "example_task" {
+  name           = "Example Conditional Workflow Task"
+  task_type_code = "conditionalWorkflow"
+  config_conditional_workflow = {
+    conditional_script           = <<-EOT
+        if (1 == true) {
+            return true;
+        }
+
+        return false;
+        EOT
+    if_operational_workflow_id   = "4090"
+    if_operational_workflow_name = "Example If Workflow"
+
+    else_operational_workflow_id   = null
+    else_operational_workflow_name = null
+  }
+
+  execute_target      = "local"
+  retryable           = false
+  allow_custom_config = true
+}

--- a/morpheus/framework/resources/task/create.go
+++ b/morpheus/framework/resources/task/create.go
@@ -82,11 +82,17 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		conditionalWorkflow.IfOperationalWorkflowName = plan.ConfigConditionalWorkflow.
 			IfOperationalWorkflowName.ValueStringPointer()
 
-		conditionalWorkflow.ElseOperationalWorkflowId = plan.ConfigConditionalWorkflow.
-			ElseOperationalWorkflowId.ValueInt64Pointer()
+		if !plan.ConfigConditionalWorkflow.ElseOperationalWorkflowId.IsNull() &&
+			!plan.ConfigConditionalWorkflow.ElseOperationalWorkflowId.IsUnknown() {
+			conditionalWorkflow.ElseOperationalWorkflowId = plan.ConfigConditionalWorkflow.
+				ElseOperationalWorkflowId.ValueInt64Pointer()
+		}
 
-		conditionalWorkflow.ElseOperationalWorkflowName = plan.ConfigConditionalWorkflow.
-			ElseOperationalWorkflowName.ValueStringPointer()
+		if !plan.ConfigConditionalWorkflow.ElseOperationalWorkflowName.IsNull() &&
+			!plan.ConfigConditionalWorkflow.ElseOperationalWorkflowName.IsUnknown() {
+			conditionalWorkflow.ElseOperationalWorkflowName = plan.ConfigConditionalWorkflow.
+				ElseOperationalWorkflowName.ValueStringPointer()
+		}
 
 		taskOptions.ConditionalWorkflowTaskConfig = conditionalWorkflow
 

--- a/morpheus/framework/resources/task/example_conditional_workflow_null_else.tf.tmpl
+++ b/morpheus/framework/resources/task/example_conditional_workflow_null_else.tf.tmpl
@@ -1,0 +1,22 @@
+resource "hpe_morpheus_task" "example_task" {
+    name = "{{ .Name }}"
+    task_type_code = "conditionalWorkflow"
+    config_conditional_workflow = {
+        conditional_script = <<-EOT
+        if (1 == true) {
+            return true;
+        }
+
+        return false;
+        EOT
+        if_operational_workflow_id   = "{{.IfOperationalWorkflowId}}"
+        if_operational_workflow_name = "{{.IfOperationalWorkflowName}}"
+
+        else_operational_workflow_id   = null
+        else_operational_workflow_name = null
+    }
+
+    execute_target = "local"
+    retryable = false
+    allow_custom_config = true
+}

--- a/morpheus/framework/resources/task/task_test.go
+++ b/morpheus/framework/resources/task/task_test.go
@@ -1,6 +1,7 @@
 package task_test
 
 //go:generate go run ../../../../cmd/render -out examples/resources/morpheus_task/example_conditional_workflow.tf example_conditional_workflow.tf.tmpl Name "Example Conditional Workflow Task" IfOperationalWorkflowId "4090" IfOperationalWorkflowName "Example If Workflow" ElseOperationalWorkflowId "4091" ElseOperationalWorkflowName "Example Else Workflow"
+//go:generate go run ../../../../cmd/render -out examples/resources/morpheus_task/example_conditional_workflow_null_else.tf example_conditional_workflow_null_else.tf.tmpl Name "Example Conditional Workflow Task" IfOperationalWorkflowId "4090" IfOperationalWorkflowName "Example If Workflow"
 //go:generate go run ../../../../cmd/render -out examples/resources/morpheus_task/example_generic_config.tf example_generic_config.tf.tmpl Name "Example Generic Task" OperationalWorkflowId "4090" OperationalWorkflowName "Example Workflow"
 
 import (
@@ -304,6 +305,172 @@ func TestAccMorpheusTaskExampleGenericNestedOk(t *testing.T) {
 				ImportStateVerify: true,
 				ResourceName:      "hpe_morpheus_task.example_task",
 				Check:             checkFn,
+			},
+		},
+	})
+}
+
+func TestAccMorpheusTaskExampleConditionalNullElseOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	name := acctest.RandomWithPrefix(t.Name())
+	resourceConfig, err := testhelpers.RenderExample(t, "example_conditional_workflow_null_else.tf.tmpl",
+		"Name", name,
+		"IfOperationalWorkflowId", testIfOperationalWorkflowId,
+		"IfOperationalWorkflowName", testFailureWorkflowName,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"name",
+			name,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"task_type_code",
+			"conditionalWorkflow",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"config_conditional_workflow.if_operational_workflow_id",
+			testIfOperationalWorkflowId,
+		),
+		// Else id should be null in state
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"config_conditional_workflow.else_operational_workflow_id",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"allow_custom_config",
+			"true",
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              checkFn,
+				PlanOnly:           false,
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "hpe_morpheus_task.example_task",
+				ImportStateVerifyIgnore: []string{
+					"config_conditional_workflow.conditional_script",
+				},
+				Check: checkFn,
+			},
+		},
+	})
+}
+
+func TestAccMorpheusTaskExampleConditionalNullElseUpdateOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	name := acctest.RandomWithPrefix(t.Name())
+	resourceConfig, err := testhelpers.RenderExample(t, "example_conditional_workflow_null_else.tf.tmpl",
+		"Name", name,
+		"IfOperationalWorkflowId", testIfOperationalWorkflowId,
+		"IfOperationalWorkflowName", testFailureWorkflowName,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nullElseChecks := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"name",
+			name,
+		),
+		resource.TestCheckNoResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"config_conditional_workflow.else_operational_workflow_id",
+		),
+	)
+
+	nonNullElseChecks := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"name",
+			name,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"config_conditional_workflow.if_operational_workflow_id",
+			testIfOperationalWorkflowId,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_task.example_task",
+			"config_conditional_workflow.else_operational_workflow_id",
+			testElseOperationalWorkflowId,
+		),
+	)
+
+	checkInPlaceUpdate := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction(
+				"hpe_morpheus_task.example_task",
+				plancheck.ResourceActionUpdate,
+			),
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				Check:              nullElseChecks,
+			},
+			// update to add a non-null else workflow
+			{
+				ConfigPlanChecks: checkInPlaceUpdate,
+				Check:            nonNullElseChecks,
+				Config: providerConfig + `
+					resource "hpe_morpheus_task" "example_task" {
+						name = "` + name + `"
+						task_type_code = "conditionalWorkflow"
+						config_conditional_workflow = {
+							if_operational_workflow_id   = ` + testIfOperationalWorkflowId + `
+							if_operational_workflow_name = "` + testFailureWorkflowName + `"
+
+							else_operational_workflow_id   = ` + testElseOperationalWorkflowId + `
+							else_operational_workflow_name = "` + testWorkflowName + `"
+						}
+
+						execute_target = "local"
+						retryable = false
+						allow_custom_config = true
+					}`,
 			},
 		},
 	})

--- a/morpheus/framework/resources/task/update.go
+++ b/morpheus/framework/resources/task/update.go
@@ -92,10 +92,16 @@ func (r *Resource) Update(
 			IfOperationalWorkflowId.ValueInt64Pointer()
 		conditionalWorkflow.IfOperationalWorkflowName = plan.ConfigConditionalWorkflow.
 			IfOperationalWorkflowName.ValueStringPointer()
-		conditionalWorkflow.ElseOperationalWorkflowId = plan.ConfigConditionalWorkflow.
-			ElseOperationalWorkflowId.ValueInt64Pointer()
-		conditionalWorkflow.ElseOperationalWorkflowName = plan.ConfigConditionalWorkflow.
-			ElseOperationalWorkflowName.ValueStringPointer()
+		if !plan.ConfigConditionalWorkflow.ElseOperationalWorkflowName.IsNull() &&
+			!plan.ConfigConditionalWorkflow.ElseOperationalWorkflowName.IsUnknown() {
+			conditionalWorkflow.ElseOperationalWorkflowId = plan.ConfigConditionalWorkflow.
+				ElseOperationalWorkflowId.ValueInt64Pointer()
+		}
+		if !plan.ConfigConditionalWorkflow.ElseOperationalWorkflowName.IsNull() &&
+			!plan.ConfigConditionalWorkflow.ElseOperationalWorkflowName.IsUnknown() {
+			conditionalWorkflow.ElseOperationalWorkflowName = plan.ConfigConditionalWorkflow.
+				ElseOperationalWorkflowName.ValueStringPointer()
+		}
 
 		taskOptions.ConditionalWorkflowTaskConfig3 = conditionalWorkflow
 	}

--- a/templates/resources/morpheus_task.md.tmpl
+++ b/templates/resources/morpheus_task.md.tmpl
@@ -16,6 +16,10 @@ other types may be used through the generic config.
 
 {{tffile "examples/resources/morpheus_task/example_conditional_workflow.tf"}}
 
+## Conditional Workflow Task with Null Else
+
+{{tffile "examples/resources/morpheus_task/example_conditional_workflow_null_else.tf"}}
+
 ## Generic Config Task
 
 {{tffile "examples/resources/morpheus_task/example_generic_config.tf"}}


### PR DESCRIPTION
We didn't support null else in conditional_workflows.  Thanks to Chris Taylor for uncovering the error and proposing a fix.  We've updated the docs and added acceptance tests.