### PR TITLE
Add consts for TF_VAR_testacc* env vars

### DIFF
--- a/morpheus/testhelpers/client.go
+++ b/morpheus/testhelpers/client.go
@@ -17,10 +17,10 @@ func newClient(ctx context.Context, t *testing.T) *sdk.APIClient {
 
 	return clientfactory.NewAPIClient(
 		ctx,
-		os.Getenv("TF_VAR_testacc_morpheus_url"),
-		os.Getenv("TF_VAR_testacc_morpheus_username"),
-		os.Getenv("TF_VAR_testacc_morpheus_password"),
-		os.Getenv("TF_VAR_testacc_morpheus_tenant_subdomain"),
-		os.Getenv("TF_VAR_testacc_morpheus_access_token"),
+		os.Getenv(EnvTFVarTestAccMorpheusUrl),
+		os.Getenv(EnvTFVarTestAccMorpheusUsername),
+		os.Getenv(EnvTFVarTestAccMorpheusPassword),
+		os.Getenv(EnvTFVarTestAccMorpheusTenantSubdomain),
+		os.Getenv(EnvTFVarTestAccMorpheusAccessToken),
 		clientfactory.WithInsecureTLS())
 }

--- a/morpheus/testhelpers/consts.go
+++ b/morpheus/testhelpers/consts.go
@@ -1,5 +1,6 @@
 package testhelpers
 
+// nolint:gosec
 const (
 	EnvTFVarTestAccMorpheusUrl             = "TF_VAR_testacc_morpheus_url"
 	EnvTFVarTestAccMorpheusUsername        = "TF_VAR_testacc_morpheus_username"

--- a/morpheus/testhelpers/consts.go
+++ b/morpheus/testhelpers/consts.go
@@ -1,0 +1,10 @@
+package testhelpers
+
+const (
+	EnvTFVarTestAccMorpheusUrl             = "TF_VAR_testacc_morpheus_url"
+	EnvTFVarTestAccMorpheusUsername        = "TF_VAR_testacc_morpheus_username"
+	EnvTFVarTestAccMorpheusPassword        = "TF_VAR_testacc_morpheus_password"
+	EnvTFVarTestAccMorpheusTenantSubdomain = "TF_VAR_testacc_morpheus_tenant_subdomain"
+	EnvTFVarTestAccMorpheusAccessToken     = "TF_VAR_testacc_morpheus_access_token"
+	EnvTFVarTestAccMorpheusInsecure        = "TF_VAR_testacc_morpheus_insecure"
+)

--- a/morpheus/testhelpers/sweep/sweep.go
+++ b/morpheus/testhelpers/sweep/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 	"github.com/HPE/terraform-provider-hpe/morpheus/utils/clientfactory"
 	"github.com/HPE/terraform-provider-hpe/morpheus/utils/errfmt"
 )
@@ -163,31 +164,33 @@ func WithIgnoreListStatuses[T any](statuses ...int) TypedSweepOption[T] {
 func newSweepClient(ctx context.Context) (*sdk.APIClient, error) {
 	var username, password string
 
-	url, ok := os.LookupEnv("TF_VAR_testacc_morpheus_url")
+	url, ok := os.LookupEnv(testhelpers.EnvTFVarTestAccMorpheusUrl)
 	if !ok {
-		return nil, errors.New("TF_VAR_testacc_morpheus_url not set")
+		return nil, fmt.Errorf("%s not set", testhelpers.EnvTFVarTestAccMorpheusUrl)
 	}
 
-	token, ok := os.LookupEnv("TF_VAR_testacc_morpheus_access_token")
+	token, ok := os.LookupEnv(testhelpers.EnvTFVarTestAccMorpheusAccessToken)
 	if !ok {
-		username, ok = os.LookupEnv("TF_VAR_testacc_morpheus_username")
+		username, ok = os.LookupEnv(testhelpers.EnvTFVarTestAccMorpheusUsername)
 		if !ok {
-			return nil, errors.New(
-				"one of TF_VAR_testacc_morpheus_access_token or " +
-					"TF_VAR_testacc_morpheus_username must be set",
+			return nil, fmt.Errorf(
+				"one of %s or %s must be set",
+				testhelpers.EnvTFVarTestAccMorpheusAccessToken,
+				testhelpers.EnvTFVarTestAccMorpheusUsername,
 			)
 		}
 
-		password, ok = os.LookupEnv("TF_VAR_testacc_morpheus_password")
+		password, ok = os.LookupEnv(testhelpers.EnvTFVarTestAccMorpheusPassword)
 		if !ok {
-			return nil, errors.New(
-				"one of TF_VAR_testacc_morpheus_access_token or " +
-					"TF_VAR_testacc_morpheus_password must be set",
+			return nil, fmt.Errorf(
+				"one of %s or %s must be set",
+				testhelpers.EnvTFVarTestAccMorpheusAccessToken,
+				testhelpers.EnvTFVarTestAccMorpheusPassword,
 			)
 		}
 	}
 
-	_, insecure := os.LookupEnv("TF_VAR_testacc_morpheus_insecure")
+	_, insecure := os.LookupEnv(testhelpers.EnvTFVarTestAccMorpheusInsecure)
 	var opts []clientfactory.ClientOption
 	if insecure {
 		opts = append(opts, clientfactory.WithInsecureTLS())


### PR DESCRIPTION
We may want to have these as consts we can access from a package to avoid mistakes.

Might also be useful to have these for certain tests.
