### PR TITLE
Fix app blueprint kubernetes YAML config bug

### DIFF
--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_yaml_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_yaml_test.go
@@ -23,7 +23,7 @@ func TestAccMorpheusAppBlueprintKubernetesYamlExampleOk(t *testing.T) {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	t.Skip("Skipping due to missing infrastructure in test environment")
+	// t.Skip("Skipping due to missing infrastructure in test environment")
 
 	providerConfig := testhelpers.ProviderBlock()
 
@@ -38,7 +38,7 @@ func TestAccMorpheusAppBlueprintKubernetesYamlExampleOk(t *testing.T) {
 
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_app_blueprint_kubernetes.example",
+			"hpe_morpheus_app_blueprint_kubernetes.tfexample_kubernetes_app_blueprint_yaml",
 			"blueprint_content",
 			"---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n name: nginx-deployment\n"+
 				" labels:\n app: nginx\nspec:\n replicas: 3\n selector:\n matchLabels:\n app: nginx\n"+
@@ -47,25 +47,25 @@ func TestAccMorpheusAppBlueprintKubernetesYamlExampleOk(t *testing.T) {
 		),
 
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_app_blueprint_kubernetes.example",
+			"hpe_morpheus_app_blueprint_kubernetes.tfexample_kubernetes_app_blueprint_yaml",
 			"category",
 			"k8s",
 		),
 
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_app_blueprint_kubernetes.example",
+			"hpe_morpheus_app_blueprint_kubernetes.tfexample_kubernetes_app_blueprint_yaml",
 			"description",
 			"tf example kubernetes app blueprint",
 		),
 
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_app_blueprint_kubernetes.example",
+			"hpe_morpheus_app_blueprint_kubernetes.tfexample_kubernetes_app_blueprint_yaml",
 			"name",
-			"tf-kubernetes-app-blueprint-example-yaml",
+			name,
 		),
 
 		resource.TestCheckResourceAttr(
-			"hpe_morpheus_app_blueprint_kubernetes.example",
+			"hpe_morpheus_app_blueprint_kubernetes.tfexample_kubernetes_app_blueprint_yaml",
 			"source_type",
 			"yaml",
 		),

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_yaml_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_yaml_test.go
@@ -23,8 +23,6 @@ func TestAccMorpheusAppBlueprintKubernetesYamlExampleOk(t *testing.T) {
 		t.Skip("Skipping slow test in short mode")
 	}
 
-	// t.Skip("Skipping due to missing infrastructure in test environment")
-
 	providerConfig := testhelpers.ProviderBlock()
 
 	name := acctest.RandomWithPrefix(t.Name())

--- a/morpheus/sdkv2/resources/blueprint/resource_app_blueprint_kubernetes.go
+++ b/morpheus/sdkv2/resources/blueprint/resource_app_blueprint_kubernetes.go
@@ -176,7 +176,7 @@ func resourceAppBlueprintKubernetesCreate(
 		} else {
 			return diag.FromErr(helpers.TypeAssertFailError("blueprint_content", d.Get("blueprint_content")))
 		}
-		kubernetesConfig[sourceTypeYaml] = blueprintContent
+		kubernetesConfig[sourceTypeYaml] = strings.TrimSpace(blueprintContent)
 
 	case sourceTypeSpec:
 		kubernetesConfig["configType"] = sourceTypeSpec
@@ -325,7 +325,7 @@ func resourceAppBlueprintKubernetesRead(
 	switch kubernetesBlueprint.Blueprint.Config.Kubernetes.Configtype {
 	case sourceTypeYaml:
 		d.Set("source_type", sourceTypeYaml)
-		d.Set("blueprint_content", kubernetesBlueprint.Blueprint.Config.Kubernetes)
+		d.Set("blueprint_content", strings.TrimSpace(kubernetesBlueprint.Blueprint.Config.Kubernetes.Yaml))
 	case configTypeGit:
 		d.Set("source_type", sourceTypeRepository)
 		d.Set("working_path", kubernetesBlueprint.Blueprint.Config.Kubernetes.Git.Path)
@@ -407,7 +407,7 @@ func resourceAppBlueprintKubernetesUpdate(
 		} else {
 			return diag.FromErr(helpers.TypeAssertFailError("blueprint_content", d.Get("blueprint_content")))
 		}
-		kubernetesConfig[sourceTypeYaml] = blueprintContent
+		kubernetesConfig[sourceTypeYaml] = strings.TrimSpace(blueprintContent)
 
 	case sourceTypeSpec:
 		kubernetesConfig["configType"] = sourceTypeSpec
@@ -545,6 +545,7 @@ type AppBlueprintKubernetes struct {
 					IntegrationId int    `json:"integrationId"`
 					Branch        string `json:"branch"`
 				} `json:"git"`
+				Yaml string `json:"yaml"`
 			} `json:"kubernetes"`
 			Config struct {
 				Specs []struct {


### PR DESCRIPTION
The `Blueprint` struct being used for unmarshaling needed an addition to handle `yaml`.

Also, we add even more strings.TrimSpace() as guarantees that what's stored in state won't have leading or trailing space characters.

The statefunc and diffsuppresssfunc didn't seem to agree with the method of shoving the result of Read into state. So we trim space on create and update requests, and on read respone.
