### PR TITLE
Adding ability to direct sweeper onto different systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 .PHONY: build linter lint test docs sweep build-render-tool
 
 SWEEP ?= all
+SWEEP_SYSTEMS ?= zodiac,feature
 SWEEP_RUN_ARGS = $(if $(filter all,$(SWEEP)),,-sweep-run=$(SWEEP))
 
 build:
@@ -38,4 +39,4 @@ docs: build-render-tool
 	cd tools && go generate
 
 sweep:
-	go test -v -tags sweep ./morpheus/testhelpers/sweep/... -sweep=all $(SWEEP_RUN_ARGS)
+	go test -v -tags sweep ./morpheus/testhelpers/sweep/... -sweep=$(SWEEP_SYSTEMS) $(SWEEP_RUN_ARGS)

--- a/morpheus/testhelpers/client.go
+++ b/morpheus/testhelpers/client.go
@@ -57,6 +57,8 @@ func NewClientForServer(ctx context.Context, preferredSystem string) (*sdk.APICl
 		}
 	}
 
+	tenantSubdomain, _ := LookupProviderEnv(preferredSystem, "tenant_subdomain")
+
 	_, insecure := LookupProviderEnv(preferredSystem, "insecure")
 	var opts []clientfactory.ClientOption
 	if insecure {
@@ -68,7 +70,7 @@ func NewClientForServer(ctx context.Context, preferredSystem string) (*sdk.APICl
 		url,
 		username,
 		password,
-		"",
+		tenantSubdomain,
 		token,
 		opts...,
 	)

--- a/morpheus/testhelpers/client.go
+++ b/morpheus/testhelpers/client.go
@@ -4,7 +4,10 @@ package testhelpers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
@@ -15,12 +18,83 @@ import (
 func newClient(ctx context.Context, t *testing.T) *sdk.APIClient {
 	t.Helper()
 
-	return clientfactory.NewAPIClient(
+	client, err := NewClientForServer(ctx, "")
+	if err != nil {
+		t.Fatalf("failed to create test client: %v", err)
+	}
+
+	return client
+}
+
+// NewClientForServer constructs an API client using the same TF_VAR naming
+// convention as ProviderBlockForServer. When preferredSystem is empty, it uses
+// the non-server-specific test variable names.
+func NewClientForServer(ctx context.Context, preferredSystem string) (*sdk.APIClient, error) {
+	var username, password string
+
+	url, ok := LookupProviderEnv(preferredSystem, "url")
+	if !ok {
+		return nil, fmt.Errorf("%s not set", ProviderEnvName(preferredSystem, "url"))
+	}
+
+	token, ok := LookupProviderEnv(preferredSystem, "access_token")
+	if !ok {
+		username, ok = LookupProviderEnv(preferredSystem, "username")
+		if !ok {
+			return nil, errors.New(
+				"one of " + ProviderEnvName(preferredSystem, "access_token") + " or " +
+					ProviderEnvName(preferredSystem, "username") + " must be set",
+			)
+		}
+
+		password, ok = LookupProviderEnv(preferredSystem, "password")
+		if !ok {
+			return nil, errors.New(
+				"one of " + ProviderEnvName(preferredSystem, "access_token") + " or " +
+					ProviderEnvName(preferredSystem, "password") + " must be set",
+			)
+		}
+	}
+
+	_, insecure := LookupProviderEnv(preferredSystem, "insecure")
+	var opts []clientfactory.ClientOption
+	if insecure {
+		opts = append(opts, clientfactory.WithInsecureTLS())
+	}
+
+	client := clientfactory.NewAPIClient(
 		ctx,
-		os.Getenv("TF_VAR_testacc_morpheus_url"),
-		os.Getenv("TF_VAR_testacc_morpheus_username"),
-		os.Getenv("TF_VAR_testacc_morpheus_password"),
-		os.Getenv("TF_VAR_testacc_morpheus_tenant_subdomain"),
-		os.Getenv("TF_VAR_testacc_morpheus_access_token"),
-		clientfactory.WithInsecureTLS())
+		url,
+		username,
+		password,
+		"",
+		token,
+		opts...,
+	)
+
+	return client, nil
+}
+
+// LookupProviderEnv looks up a TF_VAR provider input using the same naming
+// convention as ProviderBlock and ProviderBlockForServer, falling back to the
+// shared non-server-specific name when a server-specific value is absent.
+func LookupProviderEnv(preferredSystem string, suffix string) (string, bool) {
+	if name := ProviderEnvName(preferredSystem, suffix); name != "" {
+		if value, ok := os.LookupEnv(name); ok {
+			return value, true
+		}
+	}
+
+	return os.LookupEnv("TF_VAR_testacc_morpheus_" + suffix)
+}
+
+// ProviderEnvName returns the TF_VAR name used by the acceptance-test provider
+// config for the given server-specific suffix.
+func ProviderEnvName(preferredSystem string, suffix string) string {
+	preferredSystem = strings.TrimSpace(preferredSystem)
+	if preferredSystem == "" || strings.EqualFold(preferredSystem, "all") {
+		return "TF_VAR_testacc_morpheus_" + suffix
+	}
+
+	return fmt.Sprintf("TF_VAR_testacc_morpheus_%s_%s", preferredSystem, suffix)
 }

--- a/morpheus/testhelpers/client.go
+++ b/morpheus/testhelpers/client.go
@@ -12,13 +12,14 @@ import (
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/systemoverride"
 	"github.com/HPE/terraform-provider-hpe/morpheus/utils/clientfactory"
 )
 
 func newClient(ctx context.Context, t *testing.T) *sdk.APIClient {
 	t.Helper()
 
-	client, err := NewClientForServer(ctx, "")
+	client, err := NewClientForServer(ctx, systemoverride.GetPreferred(t, ""))
 	if err != nil {
 		t.Fatalf("failed to create test client: %v", err)
 	}

--- a/morpheus/testhelpers/sweep/sweep.go
+++ b/morpheus/testhelpers/sweep/sweep.go
@@ -8,13 +8,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"slices"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/HPE/terraform-provider-hpe/morpheus/utils/clientfactory"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 	"github.com/HPE/terraform-provider-hpe/morpheus/utils/errfmt"
 )
 
@@ -41,15 +40,15 @@ type typedSweepConfig[T any] struct {
 	ignoreListStatuses []int
 }
 
-func registerSweeper(resourceName string, sweep func() error) {
+func registerSweeper(resourceName string, sweep func(string) error) {
 	resource.AddTestSweepers(
 		resourceName,
 		&resource.Sweeper{
 			Name: resourceName,
-			F: func(_ string) (retErr error) {
+			F: func(system string) (retErr error) {
 				defer recoverSweepPanic(resourceName, &retErr)
 
-				return sweep()
+				return sweep(system)
 			},
 		},
 	)
@@ -75,12 +74,12 @@ func RegisterTypedAPISweeper[T any](
 		option(&config)
 	}
 
-	registerSweeper(resourceName, func() error {
+	registerSweeper(resourceName, func(system string) error {
 		ctx := context.Background()
 
-		client, err := newSweepClient(ctx)
+		client, err := testhelpers.NewClientForServer(ctx, system)
 		if err != nil {
-			log.Printf("[WARN] Cannot create sweep client: %v", err)
+			log.Printf("[WARN] Cannot create sweep client for %q: %v", system, err)
 
 			return nil
 		}
@@ -161,52 +160,6 @@ func WithIgnoreListStatuses[T any](statuses ...int) TypedSweepOption[T] {
 	return func(config *typedSweepConfig[T]) {
 		config.ignoreListStatuses = append(config.ignoreListStatuses, statuses...)
 	}
-}
-
-func newSweepClient(ctx context.Context) (*sdk.APIClient, error) {
-	var username, password string
-
-	url, ok := os.LookupEnv("TF_VAR_testacc_morpheus_url")
-	if !ok {
-		return nil, errors.New("TF_VAR_testacc_morpheus_url not set")
-	}
-
-	token, ok := os.LookupEnv("TF_VAR_testacc_morpheus_access_token")
-	if !ok {
-		username, ok = os.LookupEnv("TF_VAR_testacc_morpheus_username")
-		if !ok {
-			return nil, errors.New(
-				"one of TF_VAR_testacc_morpheus_access_token or " +
-					"TF_VAR_testacc_morpheus_username must be set",
-			)
-		}
-
-		password, ok = os.LookupEnv("TF_VAR_testacc_morpheus_password")
-		if !ok {
-			return nil, errors.New(
-				"one of TF_VAR_testacc_morpheus_access_token or " +
-					"TF_VAR_testacc_morpheus_password must be set",
-			)
-		}
-	}
-
-	_, insecure := os.LookupEnv("TF_VAR_testacc_morpheus_insecure")
-	var opts []clientfactory.ClientOption
-	if insecure {
-		opts = append(opts, clientfactory.WithInsecureTLS())
-	}
-
-	client := clientfactory.NewAPIClient(
-		ctx,
-		url,
-		username,
-		password,
-		"",
-		token,
-		opts...,
-	)
-
-	return client, nil
 }
 
 // RecoverSweepPanic recovers from panics during sweep execution and converts them to errors.


### PR DESCRIPTION
Sweepers now run against each system listed in SWEEP_SYSTEMS (default: zodiac,feature) by passing that value to the upstream `sweep` flag. Credential lookup follows the same naming convention as ProviderBlockForServer (i.e .`TF_VAR_testacc_morpheus_zodiac_*` or `TF_VAR_testacc_morpheus_feature_*`, with a fallback to the generic `TF_VAR_testacc_morpheus_*` vars. )
The shared helpers NewClientForServer, LookupProviderEnv, and ProviderEnvName in client.go centralise this resolution and are used by both the sweepers and the direct testhelper API calls (CreateEnvironment, DeleteEnvironment, etc.). 

This also changes the client under testhelpers to look up envvars with the same scheme. Previously - I assume testhelpers weren't actually looking up the relevant creds if their corresponding test was redirected as it just looked up variables using the `TF_VAR_testacc_morpheus_*` scheme.
`make sweep SWEEP=hpe_morpheus_cloud SWEEP_SYSTEMS=zodiac `