### PR TITLE
Update to integration id

### DIFF
--- a/docs/data-sources/morpheus_network_dhcp_server.md
+++ b/docs/data-sources/morpheus_network_dhcp_server.md
@@ -12,15 +12,15 @@ description: |-
 
 ```terraform
 data "hpe_morpheus_network_dhcp_server" "example" {
-  id                = 99
-  network_server_id = 1
+  id                     = 99
+  network_integration_id = 1
 }
 ```
 
 ```terraform
 data "hpe_morpheus_network_dhcp_server" "example" {
-  name              = "Example name"
-  network_server_id = 1
+  name                   = "Example name"
+  network_integration_id = 1
 }
 ```
 
@@ -29,7 +29,7 @@ data "hpe_morpheus_network_dhcp_server" "example" {
 
 ### Required
 
-- `network_server_id` (Number) The ID of the network server this DHCP server belongs to
+- `network_integration_id` (Number) The ID of the network integration this DHCP server belongs to
 
 ### Optional
 

--- a/examples/data-sources/morpheus_network_dhcp_server/example-id.tf
+++ b/examples/data-sources/morpheus_network_dhcp_server/example-id.tf
@@ -1,4 +1,4 @@
 data "hpe_morpheus_network_dhcp_server" "example" {
-  id                = 99
-  network_server_id = 1
+  id                     = 99
+  network_integration_id = 1
 }

--- a/examples/data-sources/morpheus_network_dhcp_server/example-name.tf
+++ b/examples/data-sources/morpheus_network_dhcp_server/example-name.tf
@@ -1,4 +1,4 @@
 data "hpe_morpheus_network_dhcp_server" "example" {
-  name              = "Example name"
-  network_server_id = 1
+  name                   = "Example name"
+  network_integration_id = 1
 }

--- a/morpheus/framework/datasources/networkdhcpserver/datasource.go
+++ b/morpheus/framework/datasources/networkdhcpserver/datasource.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 
 	"github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
@@ -58,20 +59,20 @@ func (d *DataSource) Schema(
 	_ datasource.SchemaRequest,
 	resp *datasource.SchemaResponse,
 ) {
-	resp.Schema = NetworkDhcpServersDataSourceSchema(ctx)
+	resp.Schema = NetworkDhcpServerDataSourceSchema(ctx)
 }
 
 func dhcpServerAsState(
 	ctx context.Context,
 	dhcp *sdk.GetNetworkDhcpServer200ResponseNetworkDhcpServer,
-	networkServerId int64,
-) (NetworkDhcpServersModel, error) {
-	state := NetworkDhcpServersModel{
-		Id:              convert.Int64ToType(dhcp.Id),
-		Name:            convert.StrToType(dhcp.Name),
-		LeaseTime:       convert.Int64ToType(dhcp.LeaseTime),
-		ServerIpAddress: convert.StrToType(dhcp.ServerIpAddress),
-		NetworkServerId: types.Int64Value(networkServerId),
+	networkIntegrationId int64,
+) (NetworkDhcpServerModel, error) {
+	state := NetworkDhcpServerModel{
+		Id:                   convert.Int64ToType(dhcp.Id),
+		Name:                 convert.StrToType(dhcp.Name),
+		LeaseTime:            convert.Int64ToType(dhcp.LeaseTime),
+		ServerIpAddress:      convert.StrToType(dhcp.ServerIpAddress),
+		NetworkIntegrationId: types.NumberValue(new(big.Float).SetInt64(networkIntegrationId)),
 	}
 
 	state.Config = types.DynamicNull()
@@ -88,14 +89,14 @@ func dhcpServerAsState(
 				},
 			)
 			if diags.HasError() {
-				return NetworkDhcpServersModel{}, fmt.Errorf("error creating config_nsx value")
+				return NetworkDhcpServerModel{}, fmt.Errorf("error creating config_nsx value")
 			}
 
 			state.ConfigNsx = v
 		} else if dhcp.Config.MapmapOfStringAny != nil {
 			raw, err := json.Marshal(*dhcp.Config.MapmapOfStringAny)
 			if err != nil {
-				return NetworkDhcpServersModel{}, fmt.Errorf("error marshalling config: %w", err)
+				return NetworkDhcpServerModel{}, fmt.Errorf("error marshalling config: %w", err)
 			}
 
 			state.Config = types.DynamicValue(types.StringValue(string(raw)))
@@ -170,10 +171,10 @@ func getDhcpServerByName(
 
 func getDhcpServer(
 	ctx context.Context,
-	config *NetworkDhcpServersModel,
+	config *NetworkDhcpServerModel,
 	apiClient *sdk.APIClient,
 ) (*sdk.GetNetworkDhcpServer200ResponseNetworkDhcpServer, error) {
-	serverId := config.NetworkServerId.ValueInt64()
+	serverId, _ := config.NetworkIntegrationId.ValueBigFloat().Int64()
 
 	if !config.Id.IsNull() {
 		return getDhcpServerByID(ctx, config.Id.ValueInt64(), serverId, apiClient)
@@ -190,7 +191,7 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	var config NetworkDhcpServersModel
+	var config NetworkDhcpServerModel
 
 	// Read config
 	diags := req.Config.Get(ctx, &config)
@@ -219,7 +220,8 @@ func (d *DataSource) Read(
 		return
 	}
 
-	state, err := dhcpServerAsState(ctx, dhcp, config.NetworkServerId.ValueInt64())
+	networkIntegrationId, _ := config.NetworkIntegrationId.ValueBigFloat().Int64()
+	state, err := dhcpServerAsState(ctx, dhcp, networkIntegrationId)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			summary,

--- a/morpheus/framework/datasources/networkdhcpserver/datasource_test.go
+++ b/morpheus/framework/datasources/networkdhcpserver/datasource_test.go
@@ -137,7 +137,7 @@ func TestAccMorpheusFindNetworkDhcpServerNoSearchAttrs(t *testing.T) {
 
 	config := providerConfigOffline + `
       data "hpe_morpheus_network_dhcp_server" "test" {
-        network_server_id = 1
+        network_integration_id = 1
       }`
 
 	expected := networkdhcpserver.ErrorNoValidSearchTerms
@@ -160,9 +160,9 @@ func TestAccMorpheusFindNetworkDhcpServerBothSearchAttrs(t *testing.T) {
 
 	config := providerConfigOffline + `
       data "hpe_morpheus_network_dhcp_server" "test" {
-        id                = 1
-        name              = "______"
-        network_server_id = 1
+        id                     = 1
+        name                   = "______"
+        network_integration_id = 1
       }`
 
 	expected := networkdhcpserver.ErrorRunningPreApply
@@ -184,7 +184,7 @@ func networkDhcpServerChecks() []resource.TestCheckFunc {
 	return []resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(ds, "id"),
 		resource.TestCheckResourceAttrSet(ds, "name"),
-		resource.TestCheckResourceAttrSet(ds, "network_server_id"),
+		resource.TestCheckResourceAttrSet(ds, "network_integration_id"),
 		resource.TestCheckResourceAttrSet(ds, "lease_time"),
 	}
 }

--- a/morpheus/framework/datasources/networkdhcpserver/example-id.tf.tmpl
+++ b/morpheus/framework/datasources/networkdhcpserver/example-id.tf.tmpl
@@ -1,4 +1,4 @@
 data "hpe_morpheus_network_dhcp_server" "example" {
-  id                = {{.Id}}
-  network_server_id = {{.NetworkServerId}}
+  id                     = {{.Id}}
+  network_integration_id = {{.NetworkIntegrationId}}
 }

--- a/morpheus/framework/datasources/networkdhcpserver/example-name.tf.tmpl
+++ b/morpheus/framework/datasources/networkdhcpserver/example-name.tf.tmpl
@@ -1,4 +1,4 @@
 data "hpe_morpheus_network_dhcp_server" "example" {
-  name              = "{{.Name}}"
-  network_server_id = {{.NetworkServerId}}
+  name                   = "{{.Name}}"
+  network_integration_id = {{.NetworkIntegrationId}}
 }

--- a/morpheus/framework/datasources/networkdhcpserver/example.go
+++ b/morpheus/framework/datasources/networkdhcpserver/example.go
@@ -11,15 +11,15 @@ import (
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 )
 
-//go:generate ../../../../bin/render -out examples/data-sources/morpheus_network_dhcp_server/example-id.tf example-id.tf.tmpl Id 99 NetworkServerId 1
-//go:generate ../../../../bin/render -out examples/data-sources/morpheus_network_dhcp_server/example-name.tf example-name.tf.tmpl Name "Example name" NetworkServerId 1
+//go:generate ../../../../bin/render -out examples/data-sources/morpheus_network_dhcp_server/example-id.tf example-id.tf.tmpl Id 99 NetworkIntegrationId 1
+//go:generate ../../../../bin/render -out examples/data-sources/morpheus_network_dhcp_server/example-name.tf example-name.tf.tmpl Name "Example name" NetworkIntegrationId 1
 
 func RenderNetworkDhcpServerByNameConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":            "qa-dhcp-profile-vlan30",
-		"NetworkServerId": "16",
+		"Name":                 "qa-dhcp-profile-vlan30",
+		"NetworkIntegrationId": "16",
 	}
 
 	for key, value := range overrides {
@@ -50,8 +50,8 @@ func RenderNetworkDhcpServerByIdConfig(t *testing.T, overrides map[string]string
 	t.Helper()
 
 	defaults := map[string]string{
-		"Id":              "5",
-		"NetworkServerId": "16",
+		"Id":                   "5",
+		"NetworkIntegrationId": "16",
 	}
 
 	for key, value := range overrides {

--- a/morpheus/framework/datasources/networkdhcpserver/schema_gen.go
+++ b/morpheus/framework/datasources/networkdhcpserver/schema_gen.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 )
 
-func NetworkDhcpServersDataSourceSchema(ctx context.Context) schema.Schema {
+func NetworkDhcpServerDataSourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"config": schema.DynamicAttribute{
@@ -77,10 +77,10 @@ func NetworkDhcpServersDataSourceSchema(ctx context.Context) schema.Schema {
 					stringvalidator.ConflictsWith(path.Expressions{path.MatchRoot("id")}...),
 				},
 			},
-			"network_server_id": schema.Int64Attribute{
+			"network_integration_id": schema.NumberAttribute{
 				Required:            true,
-				Description:         "The ID of the network server this DHCP server belongs to",
-				MarkdownDescription: "The ID of the network server this DHCP server belongs to",
+				Description:         "The ID of the network integration this DHCP server belongs to",
+				MarkdownDescription: "The ID of the network integration this DHCP server belongs to",
 			},
 			"server_ip_address": schema.StringAttribute{
 				Computed:            true,
@@ -91,14 +91,14 @@ func NetworkDhcpServersDataSourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
-type NetworkDhcpServersModel struct {
-	Config          types.Dynamic  `tfsdk:"config"`
-	ConfigNsx       ConfigNsxValue `tfsdk:"config_nsx"`
-	Id              types.Int64    `tfsdk:"id"`
-	LeaseTime       types.Int64    `tfsdk:"lease_time"`
-	Name            types.String   `tfsdk:"name"`
-	NetworkServerId types.Int64    `tfsdk:"network_server_id"`
-	ServerIpAddress types.String   `tfsdk:"server_ip_address"`
+type NetworkDhcpServerModel struct {
+	Config               types.Dynamic  `tfsdk:"config"`
+	ConfigNsx            ConfigNsxValue `tfsdk:"config_nsx"`
+	Id                   types.Int64    `tfsdk:"id"`
+	LeaseTime            types.Int64    `tfsdk:"lease_time"`
+	Name                 types.String   `tfsdk:"name"`
+	NetworkIntegrationId types.Number   `tfsdk:"network_integration_id"`
+	ServerIpAddress      types.String   `tfsdk:"server_ip_address"`
 }
 
 var _ basetypes.ObjectTypable = ConfigNsxType{}


### PR DESCRIPTION
This PR aims to clarify and add consistency to the naming convention around `networkIntegrationId`.