### PR TITLE
Switching sweeper to accept TF_VAR_testacc_morpheus_* envvars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 # Usage: make sweep SWEEP=resource_name SWEEP_SYSTEMS=systemname
 SWEEP ?= all
-SWEEP_SYSTEMS ?= zodiac
+SWEEP_SYSTEMS ?= all
 SWEEP_RUN_ARGS = $(if $(filter all,$(SWEEP)),,-sweep-run=$(SWEEP))
 
 build:


### PR DESCRIPTION
Switching sweepers to accept TF_VAR_testacc_morpheus_* envvars instead of system-specific envvars to simplify envvars for the test runner by default.

This is accomplished by simply switching the SWEEP_SYSTEMS variable to "all" which accepts generic envvars. The system-specific envvars are still supported but not the default and should be explicitly set if desired and SWEEP_SYSTEMS should be set to the system name(s) to run.