### PR TITLE
Fix provider config related tests

### DIFF
--- a/morpheus/testhelpers/config_test.go
+++ b/morpheus/testhelpers/config_test.go
@@ -76,11 +76,11 @@ func TestAccMorpheusProviderBlockWithAccessToken(t *testing.T) {
 		Steps: []testresource.TestStep{
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          config.StringVariable("https://test.morpheus.com"),
-					"testacc_morpheus_feature_username":     nil,
-					"testacc_morpheus_feature_password":     nil,
-					"testacc_morpheus_feature_access_token": config.StringVariable("abcdefg"),
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          config.StringVariable("https://test.morpheus.com"),
+					"testacc_morpheus_username":     nil,
+					"testacc_morpheus_password":     nil,
+					"testacc_morpheus_access_token": config.StringVariable("abcdefg"),
+					"insecure":                      config.BoolVariable(false),
 				},
 				Config:             providerConfig + resourceConfig,
 				ExpectNonEmptyPlan: false,
@@ -115,11 +115,11 @@ func TestAccMorpheusProviderBlockWithCredentials(t *testing.T) {
 		Steps: []testresource.TestStep{
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          config.StringVariable("https://test.morpheus.com"),
-					"testacc_morpheus_feature_username":     config.StringVariable("foo@test.com"),
-					"testacc_morpheus_feature_password":     config.StringVariable("testpass"),
-					"testacc_morpheus_feature_access_token": nil,
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          config.StringVariable("https://test.morpheus.com"),
+					"testacc_morpheus_username":     config.StringVariable("foo@test.com"),
+					"testacc_morpheus_password":     config.StringVariable("testpass"),
+					"testacc_morpheus_access_token": nil,
+					"insecure":                      config.BoolVariable(false),
 				},
 				Config:             providerConfig + resourceConfig,
 				ExpectNonEmptyPlan: false,
@@ -156,11 +156,11 @@ func TestAccMorpheusProviderBlockAllAuth(t *testing.T) {
 		Steps: []testresource.TestStep{
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          config.StringVariable("https://test.morpheus.com"),
-					"testacc_morpheus_feature_username":     config.StringVariable("foo@test.com"),
-					"testacc_morpheus_feature_password":     config.StringVariable("testpass"),
-					"testacc_morpheus_feature_access_token": config.StringVariable("abcdefg"),
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          config.StringVariable("https://test.morpheus.com"),
+					"testacc_morpheus_username":     config.StringVariable("foo@test.com"),
+					"testacc_morpheus_password":     config.StringVariable("testpass"),
+					"testacc_morpheus_access_token": config.StringVariable("abcdefg"),
+					"insecure":                      config.BoolVariable(false),
 				},
 				Config:             providerConfig + resourceConfig,
 				ExpectNonEmptyPlan: false,
@@ -188,11 +188,11 @@ func TestAccMorpheusProviderBlockMissingURL(t *testing.T) {
 		Steps: []testresource.TestStep{
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          nil,
-					"testacc_morpheus_feature_username":     config.StringVariable("foo@test.com"),
-					"testacc_morpheus_feature_password":     config.StringVariable("testpass"),
-					"testacc_morpheus_feature_access_token": nil,
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          nil,
+					"testacc_morpheus_username":     config.StringVariable("foo@test.com"),
+					"testacc_morpheus_password":     config.StringVariable("testpass"),
+					"testacc_morpheus_access_token": nil,
+					"insecure":                      config.BoolVariable(false),
 				},
 				ExpectError:        regexp.MustCompile(expected),
 				Config:             providerConfig + resourceConfig,
@@ -200,11 +200,11 @@ func TestAccMorpheusProviderBlockMissingURL(t *testing.T) {
 			},
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          nil,
-					"testacc_morpheus_feature_username":     nil,
-					"testacc_morpheus_feature_password":     nil,
-					"testacc_morpheus_feature_access_token": config.StringVariable("abcdefg"),
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          nil,
+					"testacc_morpheus_username":     nil,
+					"testacc_morpheus_password":     nil,
+					"testacc_morpheus_access_token": config.StringVariable("abcdefg"),
+					"insecure":                      config.BoolVariable(false),
 				},
 				ExpectError:        regexp.MustCompile(expected),
 				Config:             providerConfig + resourceConfig,
@@ -233,11 +233,11 @@ func TestAccMorpheusProviderBlockMissingAuth(t *testing.T) {
 		Steps: []testresource.TestStep{
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          config.StringVariable("https://test.morpheus.com"),
-					"testacc_morpheus_feature_username":     nil,
-					"testacc_morpheus_feature_password":     nil,
-					"testacc_morpheus_feature_access_token": nil,
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          config.StringVariable("https://test.morpheus.com"),
+					"testacc_morpheus_username":     nil,
+					"testacc_morpheus_password":     nil,
+					"testacc_morpheus_access_token": nil,
+					"insecure":                      config.BoolVariable(false),
 				},
 				ExpectError:        regexp.MustCompile(expected),
 				Config:             providerConfig + resourceConfig,
@@ -269,11 +269,11 @@ func TestAccMorpheusProviderBlockMissingUsername(t *testing.T) {
 		Steps: []testresource.TestStep{
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          config.StringVariable("https://test.morpheus.com"),
-					"testacc_morpheus_feature_username":     nil,
-					"testacc_morpheus_feature_password":     nil,
-					"testacc_morpheus_feature_access_token": nil,
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          config.StringVariable("https://test.morpheus.com"),
+					"testacc_morpheus_username":     nil,
+					"testacc_morpheus_password":     nil,
+					"testacc_morpheus_access_token": nil,
+					"insecure":                      config.BoolVariable(false),
 				},
 				ExpectError:        regexp.MustCompile(expectedA),
 				Config:             providerConfig + resourceConfig,
@@ -281,11 +281,11 @@ func TestAccMorpheusProviderBlockMissingUsername(t *testing.T) {
 			},
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          config.StringVariable("https://test.morpheus.com"),
-					"testacc_morpheus_feature_username":     nil,
-					"testacc_morpheus_feature_password":     config.StringVariable("testpass"),
-					"testacc_morpheus_feature_access_token": nil,
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          config.StringVariable("https://test.morpheus.com"),
+					"testacc_morpheus_username":     nil,
+					"testacc_morpheus_password":     config.StringVariable("testpass"),
+					"testacc_morpheus_access_token": nil,
+					"insecure":                      config.BoolVariable(false),
 				},
 				ExpectError:        regexp.MustCompile(expectedB),
 				Config:             providerConfig + resourceConfig,
@@ -315,11 +315,11 @@ func TestAccMorpheusProviderBlockMissingPassword(t *testing.T) {
 		Steps: []testresource.TestStep{
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          nil,
-					"testacc_morpheus_feature_username":     config.StringVariable("foo@test.com"),
-					"testacc_morpheus_feature_password":     nil,
-					"testacc_morpheus_feature_access_token": nil,
-					"insecure":                              config.BoolVariable(false),
+					"testacc_morpheus_url":          nil,
+					"testacc_morpheus_username":     config.StringVariable("foo@test.com"),
+					"testacc_morpheus_password":     nil,
+					"testacc_morpheus_access_token": nil,
+					"insecure":                      config.BoolVariable(false),
 				},
 				ExpectError:        regexp.MustCompile(expected),
 				Config:             providerConfig + resourceConfig,
@@ -349,11 +349,11 @@ func TestAccMorpheusProviderBlockNoneSet(t *testing.T) {
 		Steps: []testresource.TestStep{
 			{
 				ConfigVariables: config.Variables{
-					"testacc_morpheus_feature_url":          nil,
-					"testacc_morpheus_feature_username":     nil,
-					"testacc_morpheus_feature_password":     nil,
-					"testacc_morpheus_feature_access_token": nil,
-					"insecure":                              nil,
+					"testacc_morpheus_url":          nil,
+					"testacc_morpheus_username":     nil,
+					"testacc_morpheus_password":     nil,
+					"testacc_morpheus_access_token": nil,
+					"insecure":                      nil,
 				},
 				ExpectError:        regexp.MustCompile(expected),
 				Config:             providerConfig + resourceConfig,


### PR DESCRIPTION
These tests probably broke with #1143, we forgot to remove `_feature` in our checks.
