### PR TITLE
Fix stale sentinel values in state when importing tag policies

### DIFF
--- a/morpheus/framework/resources/policy/read.go
+++ b/morpheus/framework/resources/policy/read.go
@@ -573,11 +573,18 @@ func mapPolicyConfigToState(
 		}
 
 	case "tags":
+		if apiConfig.TagsPolicyTypeConfiguration3 == nil {
+			diags.AddError("Failed to parse tag policy configuration",
+				"The API returned a tag policy with no configuration data")
+
+			return diags
+		}
+
 		tagsAttrs := map[string]attr.Value{
 			"key":           convert.StrToType(apiConfig.TagsPolicyTypeConfiguration3.Key),
 			"strict":        types.BoolValue(apiConfig.TagsPolicyTypeConfiguration3.Strict),
-			"value":         convert.StrToType(apiConfig.TagsPolicyTypeConfiguration3.Value),
-			"value_list_id": convert.StrToType(apiConfig.TagsPolicyTypeConfiguration3.ValueListId),
+			"value":         convert.StrToTypeEmptyAsNull(apiConfig.TagsPolicyTypeConfiguration3.Value),
+			"value_list_id": convert.StrToTypeZeroIDAsNull(apiConfig.TagsPolicyTypeConfiguration3.ValueListId),
 		}
 
 		tagsValue, tagsDiags := NewConfigTagsValue(ConfigTagsValue{}.AttributeTypes(ctx), tagsAttrs)

--- a/utils/convert/convert.go
+++ b/utils/convert/convert.go
@@ -23,6 +23,30 @@ func StrToType(s *string) types.String {
 	return types.StringValue(*s)
 }
 
+// StrToTypeEmptyAsNull converts a *string to types.String, treating
+// empty strings as null. Use for optional text fields where "" semantically
+// means "not set" (common in Morpheus policy configs created by the UI or
+// community provider).
+func StrToTypeEmptyAsNull(s *string) types.String {
+	if s == nil || *s == "" {
+		return types.StringNull()
+	}
+
+	return types.StringValue(*s)
+}
+
+// StrToTypeZeroIDAsNull converts a *string to types.String, treating
+// "0" and "" as null. Use for optional reference ID fields where "0" is a
+// sentinel meaning "no reference" (common when migrating from the community
+// provider which sends TypeInt 0 for unset optional IDs).
+func StrToTypeZeroIDAsNull(s *string) types.String {
+	if s == nil || *s == "" || *s == "0" {
+		return types.StringNull()
+	}
+
+	return types.StringValue(*s)
+}
+
 func StrSliceToSet(items []string) types.Set {
 	if len(items) == 0 {
 		return types.SetNull(types.StringType)

--- a/utils/convert/convert_test.go
+++ b/utils/convert/convert_test.go
@@ -1,0 +1,136 @@
+// (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ptr(s string) *string {
+	return &s
+}
+
+func TestStrToType(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input    *string
+		expected types.String
+	}{
+		"nil": {
+			input:    nil,
+			expected: types.StringNull(),
+		},
+		"empty": {
+			input:    ptr(""),
+			expected: types.StringValue(""),
+		},
+		"zero": {
+			input:    ptr("0"),
+			expected: types.StringValue("0"),
+		},
+		"value": {
+			input:    ptr("hello"),
+			expected: types.StringValue("hello"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := StrToType(tc.input)
+			if !result.Equal(tc.expected) {
+				t.Errorf("StrToType(%v) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestStrToTypeEmptyAsNull(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input    *string
+		expected types.String
+	}{
+		"nil": {
+			input:    nil,
+			expected: types.StringNull(),
+		},
+		"empty string is null": {
+			input:    ptr(""),
+			expected: types.StringNull(),
+		},
+		"zero is not null": {
+			input:    ptr("0"),
+			expected: types.StringValue("0"),
+		},
+		"normal value": {
+			input:    ptr("hello"),
+			expected: types.StringValue("hello"),
+		},
+		"whitespace is not empty": {
+			input:    ptr(" "),
+			expected: types.StringValue(" "),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := StrToTypeEmptyAsNull(tc.input)
+			if !result.Equal(tc.expected) {
+				t.Errorf("StrToTypeEmptyAsNull(%v) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestStrToTypeZeroIDAsNull(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input    *string
+		expected types.String
+	}{
+		"nil": {
+			input:    nil,
+			expected: types.StringNull(),
+		},
+		"empty string is null": {
+			input:    ptr(""),
+			expected: types.StringNull(),
+		},
+		"zero is null": {
+			input:    ptr("0"),
+			expected: types.StringNull(),
+		},
+		"valid ID": {
+			input:    ptr("42"),
+			expected: types.StringValue("42"),
+		},
+		"large ID": {
+			input:    ptr("99999"),
+			expected: types.StringValue("99999"),
+		},
+		"non-numeric string": {
+			input:    ptr("abc"),
+			expected: types.StringValue("abc"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := StrToTypeZeroIDAsNull(tc.input)
+			if !result.Equal(tc.expected) {
+				t.Errorf("StrToTypeZeroIDAsNull(%v) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a tag policy created by morpheus_tag_policy (gomorpheus provider) is imported into hpe_morpheus_policy, the Read path could produce state values that don't match the user's HCL, causing a perpetual diff that terraform apply cannot resolve.

Root cause: The community provider sends option_list_id as integer 0 (the Go zero-value for unset TypeInt Optional fields) and tag_value as empty string. The Morpheus API stores these verbatim and never strips them on update. On import, the HPE provider reads '0' and '' as real values rather than treating them as 'not set', producing state drift against HCL that (correctly) omits these optional fields.

Changes:
- Add convert.StrToTypeEmptyAsNull: treats '' as null for optional text fields where empty string semantically means 'not set'
- Add convert.StrToTypeZeroIDAsNull: treats '0' and '' as null for optional reference ID fields where 0 is a sentinel for 'no reference'
- Update policy read.go tags case to use new helpers for value and value_list_id fields
- Add nil guard for TagsPolicyTypeConfiguration3 to prevent potential nil pointer dereference on malformed API responses
- Add unit tests for all three StrToType* conversion functions