### PR TITLE
Add inject_system_authorization_header and use_owner_auth to option_list_rest (MORPH-10795)

### DIFF
--- a/docs/resources/morpheus_option_list_rest.md
+++ b/docs/resources/morpheus_option_list_rest.md
@@ -12,20 +12,22 @@ Provides a Morpheus REST option list resource.
 
 ```terraform
 resource "hpe_morpheus_option_list_rest" "tf_example_rest_option_list" {
-  name               = "tf_example_rest_option_list"
-  description        = "Terraform REST option list example"
-  visibility         = "private"
-  source_url         = "https://api.github.com/repos/hashicorp/consul/releases"
-  real_time          = true
-  ignore_ssl_errors  = true
-  source_method      = "GET"
-  initial_dataset    = <<POLICY
+  name                               = "tf_example_rest_option_list"
+  description                        = "Terraform REST option list example"
+  visibility                         = "private"
+  source_url                         = "https://api.github.com/repos/hashicorp/consul/releases"
+  real_time                          = true
+  ignore_ssl_errors                  = true
+  inject_system_authorization_header = true
+  use_owner_auth                     = false
+  source_method                      = "GET"
+  initial_dataset                    = <<POLICY
   [{"name": "Level 1","value":"level1"},
   {"name": "Level 2","value":"level2"},
   {"name": "Level 3","value":"level3"}
   ]
   POLICY
-  translation_script = <<POLICY
+  translation_script                 = <<POLICY
       for(var x=0;x < 5; x++) {
           results.push({name: data[x].name,value:data[x].name});
         }
@@ -54,6 +56,7 @@ resource "hpe_morpheus_option_list_rest" "tf_example_rest_option_list" {
 - `description` (String) The description of the option list
 - `ignore_ssl_errors` (Boolean) Whether to ignore SSL errors with the REST API endpoint
 - `initial_dataset` (String) The initial dataset used to populate the option list
+- `inject_system_authorization_header` (Boolean) When enabled, injects a system execution authorization header so the REST source request can call back into Morpheus APIs
 - `labels` (Set of String) The organization labels associated with the option list (Only supported on Morpheus 5.5.3 or higher)
 - `real_time` (Boolean) Whether the list is refreshed every time an associated option type is requested
 - `request_script` (String) A js script to prepare the API request
@@ -61,6 +64,7 @@ resource "hpe_morpheus_option_list_rest" "tf_example_rest_option_list" {
 - `source_method` (String) The HTTP method used for the API request
 - `source_url` (String) The HTTP URL used for the API request
 - `translation_script` (String) A js script to translate the result data object into an Array containing objects with properties 'name' and 'value'.
+- `use_owner_auth` (Boolean) When enabled alongside inject_system_authorization_header, authenticates as the option list's owner rather than the requesting user
 - `visibility` (String) Whether the option list is visible in sub-tenants or not
 
 ### Read-Only

--- a/examples/resources/morpheus_option_list_rest/resource.tf
+++ b/examples/resources/morpheus_option_list_rest/resource.tf
@@ -1,18 +1,20 @@
 resource "hpe_morpheus_option_list_rest" "tf_example_rest_option_list" {
-  name               = "tf_example_rest_option_list"
-  description        = "Terraform REST option list example"
-  visibility         = "private"
-  source_url         = "https://api.github.com/repos/hashicorp/consul/releases"
-  real_time          = true
-  ignore_ssl_errors  = true
-  source_method      = "GET"
-  initial_dataset    = <<POLICY
+  name                               = "tf_example_rest_option_list"
+  description                        = "Terraform REST option list example"
+  visibility                         = "private"
+  source_url                         = "https://api.github.com/repos/hashicorp/consul/releases"
+  real_time                          = true
+  ignore_ssl_errors                  = true
+  inject_system_authorization_header = true
+  use_owner_auth                     = false
+  source_method                      = "GET"
+  initial_dataset                    = <<POLICY
   [{"name": "Level 1","value":"level1"},
   {"name": "Level 2","value":"level2"},
   {"name": "Level 3","value":"level3"}
   ]
   POLICY
-  translation_script = <<POLICY
+  translation_script                 = <<POLICY
       for(var x=0;x < 5; x++) {
           results.push({name: data[x].name,value:data[x].name});
         }

--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource.tf.tmpl
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource.tf.tmpl
@@ -1,11 +1,13 @@
 resource "hpe_morpheus_option_list_rest" "tf_example_rest_option_list" {
-  name               = "{{.Name}}"
-  description        = "{{.Description}}"
-  visibility         = "{{.Visibility}}"
-  source_url         = "{{.SourceUrl}}"
-  real_time          = {{.RealTime}}
-  ignore_ssl_errors  = {{.IgnoreSslErrors}}
-  source_method      = "{{.SourceMethod}}"
+  name                                 = "{{.Name}}"
+  description                          = "{{.Description}}"
+  visibility                           = "{{.Visibility}}"
+  source_url                           = "{{.SourceUrl}}"
+  real_time                            = {{.RealTime}}
+  ignore_ssl_errors                    = {{.IgnoreSslErrors}}
+  inject_system_authorization_header   = {{.InjectSystemAuthorizationHeader}}
+  use_owner_auth                       = {{.UseOwnerAuth}}
+  source_method                        = "{{.SourceMethod}}"
   initial_dataset    = <<POLICY
 {{.InitialDataset}}
   POLICY

--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource_example.go
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource_example.go
@@ -11,24 +11,26 @@ import (
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 )
 
-//go:generate../../../../bin/render -out examples/resources/morpheus_option_list_rest/resource.tf morpheus_option_list_rest_resource.tf.tmpl Name tf_example_rest_option_list Description "Terraform REST option list example" Visibility private SourceUrl https://api.github.com/repos/hashicorp/consul/releases RealTime true IgnoreSslErrors true SourceMethod GET InitialDataset "  [{\"name\": \"Level 1\",\"value\":\"level1\"},\n  {\"name\": \"Level 2\",\"value\":\"level2\"},\n  {\"name\": \"Level 3\",\"value\":\"level3\"}\n  ]" TranslationScript "      for(var x=0;x < 5; x++) {\n          results.push({name: data[x].name,value:data[x].name});\n        }" SourceHeaderName1 Accept SourceHeaderValue1 application/json SourceHeaderName2 Authorization SourceHeaderValue2 "Basic YWRtaW46YWRtaW4="
+//go:generate../../../../bin/render -out examples/resources/morpheus_option_list_rest/resource.tf morpheus_option_list_rest_resource.tf.tmpl Name tf_example_rest_option_list Description "Terraform REST option list example" Visibility private SourceUrl https://api.github.com/repos/hashicorp/consul/releases RealTime true IgnoreSslErrors true InjectSystemAuthorizationHeader true UseOwnerAuth false SourceMethod GET InitialDataset "  [{\"name\": \"Level 1\",\"value\":\"level1\"},\n  {\"name\": \"Level 2\",\"value\":\"level2\"},\n  {\"name\": \"Level 3\",\"value\":\"level3\"}\n  ]" TranslationScript "      for(var x=0;x < 5; x++) {\n          results.push({name: data[x].name,value:data[x].name});\n        }" SourceHeaderName1 Accept SourceHeaderValue1 application/json SourceHeaderName2 Authorization SourceHeaderValue2 "Basic YWRtaW46YWRtaW4="
 
 // RenderOptionListRestConfig generates a Terraform configuration for the morpheus_option_list_rest resource.
 // It accepts an optional map of field overrides to customize the default values.
 // Supported override keys: "Name", "Description", "Visibility", "SourceUrl", "RealTime", "IgnoreSslErrors",
-// "SourceMethod", "InitialDataset", "TranslationScript", "SourceHeaderName1", "SourceHeaderValue1",
-// "SourceHeaderName2", "SourceHeaderValue2"
+// "InjectSystemAuthorizationHeader", "UseOwnerAuth", "SourceMethod", "InitialDataset", "TranslationScript",
+// "SourceHeaderName1", "SourceHeaderValue1", "SourceHeaderName2", "SourceHeaderValue2"
 func RenderOptionListRestConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
-		"Name":            "Example",
-		"Description":     "Terraform REST option list example",
-		"Visibility":      "private",
-		"SourceUrl":       "https://api.github.com/repos/hashicorp/consul/releases",
-		"RealTime":        "true",
-		"IgnoreSslErrors": "true",
-		"SourceMethod":    "GET",
+		"Name":                            "Example",
+		"Description":                     "Terraform REST option list example",
+		"Visibility":                      "private",
+		"SourceUrl":                       "https://api.github.com/repos/hashicorp/consul/releases",
+		"RealTime":                        "true",
+		"IgnoreSslErrors":                 "true",
+		"InjectSystemAuthorizationHeader": "true",
+		"UseOwnerAuth":                    "false",
+		"SourceMethod":                    "GET",
 		"InitialDataset": "  [{\"name\": \"Level 1\",\"value\":\"level1\"},\n" +
 			"  {\"name\": \"Level 2\",\"value\":\"level2\"},\n" +
 			"  {\"name\": \"Level 3\",\"value\":\"level3\"}\n  ]",

--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource_test.go
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource_test.go
@@ -97,6 +97,16 @@ func TestAccMorpheusOptionListRestExampleOk(t *testing.T) {
 			"source_method",
 			"GET",
 		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_option_list_rest.tf_example_rest_option_list",
+			"inject_system_authorization_header",
+			"true",
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_option_list_rest.tf_example_rest_option_list",
+			"use_owner_auth",
+			"false",
+		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)

--- a/morpheus/sdkv2/resources/optionlist/option_list_rest.go
+++ b/morpheus/sdkv2/resources/optionlist/option_list_rest.go
@@ -127,6 +127,20 @@ func ResourceOptionListREST() *schema.Resource {
 				DiffSuppressFunc: helpers.SuppressEquivalentJSONDiffs,
 				Optional:         true,
 			},
+			"inject_system_authorization_header": {
+				Type: schema.TypeBool,
+				Description: "When enabled, injects a system execution authorization header " +
+					"so the REST source request can call back into Morpheus APIs",
+				Optional: true,
+				Default:  false,
+			},
+			"use_owner_auth": {
+				Type: schema.TypeBool,
+				Description: "When enabled alongside inject_system_authorization_header, " +
+					"authenticates as the option list's owner rather than the requesting user",
+				Optional: true,
+				Default:  false,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -273,21 +287,39 @@ func resourceOptionListRESTCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(helpers.TypeAssertFailError("request_script", d.Get("request_script")))
 	}
 
+	var injectSystemAuthorizationHeader bool
+	if v, ok := d.Get("inject_system_authorization_header").(bool); ok {
+		injectSystemAuthorizationHeader = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError(
+			"inject_system_authorization_header",
+			d.Get("inject_system_authorization_header")))
+	}
+
+	var useOwnerAuth bool
+	if v, ok := d.Get("use_owner_auth").(bool); ok {
+		useOwnerAuth = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("use_owner_auth", d.Get("use_owner_auth")))
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"optionTypeList": map[string]any{
-				"name":              name,
-				"description":       description,
-				"labels":            labelsPayload,
-				"type":              "rest",
-				"visibility":        visibility,
-				"sourceUrl":         sourceURL,
-				"realTime":          realTime,
-				"ignoreSSLErrors":   ignoreSSLErrors,
-				"sourceMethod":      sourceMethod,
-				"initialDataset":    initialDataset,
-				"translationScript": translationScript,
-				"requestScript":     requestScript,
+				"name":                     name,
+				"description":              description,
+				"labels":                   labelsPayload,
+				"type":                     "rest",
+				"visibility":               visibility,
+				"sourceUrl":                sourceURL,
+				"realTime":                 realTime,
+				"ignoreSSLErrors":          ignoreSSLErrors,
+				"sourceMethod":             sourceMethod,
+				"initialDataset":           initialDataset,
+				"translationScript":        translationScript,
+				"requestScript":            requestScript,
+				"injectExecutionLeaseAuth": injectSystemAuthorizationHeader,
+				"useOwnerAuth":             useOwnerAuth,
 				"config": map[string]any{
 					"sourceHeaders": sourceHeaders,
 				},
@@ -543,21 +575,39 @@ func resourceOptionListRESTUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(helpers.TypeAssertFailError("request_script", d.Get("request_script")))
 	}
 
+	var injectSystemAuthorizationHeader bool
+	if v, ok := d.Get("inject_system_authorization_header").(bool); ok {
+		injectSystemAuthorizationHeader = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError(
+			"inject_system_authorization_header",
+			d.Get("inject_system_authorization_header")))
+	}
+
+	var useOwnerAuth bool
+	if v, ok := d.Get("use_owner_auth").(bool); ok {
+		useOwnerAuth = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("use_owner_auth", d.Get("use_owner_auth")))
+	}
+
 	req := &morpheus.Request{
 		Body: map[string]any{
 			"optionTypeList": map[string]any{
-				"name":              name,
-				"description":       description,
-				"labels":            labelsPayload,
-				"type":              "rest",
-				"visibility":        visibility,
-				"sourceUrl":         sourceURL,
-				"realTime":          realTime,
-				"ignoreSSLErrors":   ignoreSSLErrors,
-				"sourceMethod":      sourceMethod,
-				"initialDataset":    initialDataset,
-				"translationScript": translationScript,
-				"requestScript":     requestScript,
+				"name":                     name,
+				"description":              description,
+				"labels":                   labelsPayload,
+				"type":                     "rest",
+				"visibility":               visibility,
+				"sourceUrl":                sourceURL,
+				"realTime":                 realTime,
+				"ignoreSSLErrors":          ignoreSSLErrors,
+				"sourceMethod":             sourceMethod,
+				"initialDataset":           initialDataset,
+				"translationScript":        translationScript,
+				"requestScript":            requestScript,
+				"injectExecutionLeaseAuth": injectSystemAuthorizationHeader,
+				"useOwnerAuth":             useOwnerAuth,
 				"config": map[string]any{
 					"sourceHeaders": sourceHeaders,
 				},


### PR DESCRIPTION
## Summary

Adds support for the **"Inject System Authorization Header"** option (and its companion "Use Owner Auth") to the `hpe_morpheus_option_list_rest` resource. These options exist in the Morpheus UI but were not previously exposed in the Terraform provider.

Resolves MORPH-10795.

## Changes

Two new optional boolean attributes on `hpe_morpheus_option_list_rest`:

- `inject_system_authorization_header` — when enabled, injects a system execution authorization header so the REST source request can call back into Morpheus APIs (API field `injectExecutionLeaseAuth`).
- `use_owner_auth` — when enabled alongside the above, authenticates as the option list's owner rather than the requesting user (API field `useOwnerAuth`).

Both map to existing Morpheus API fields. They are write-only (not read back), consistent with the existing handling of `ignore_ssl_errors`.

## Files changed

- `option_list_rest.go` — schema attributes + Create/Update request maps
- `morpheus_option_list_rest_resource.tf.tmpl` — example template
- `morpheus_option_list_rest_resource_example.go` — example renderer defaults
- `morpheus_option_list_rest_resource_test.go` — acceptance test checks

## Testing

- `go build ./...` — passes
- `golangci-lint run` — 0 issues
- `go test -short` — passes

