### PR TITLE
Fix hpe_morpheus_price_set type enum and create/update failure handling (MORPH-11013)

### DIFF
--- a/docs/resources/morpheus_price_set.md
+++ b/docs/resources/morpheus_price_set.md
@@ -31,7 +31,7 @@ resource "hpe_morpheus_price_set" "example" {
 - `price_ids` (List of Number) The list of price ids associated with the price set
 - `price_unit` (String) The price unit (minute, hour, day, month, year, two year, three year, four year, five year)
 - `region_code` (String) The region code of the price set
-- `type` (String) The price type (fixed, compute, memory, cores, storage, datastore, platform, software_or_service, load_balancer, load_balancer_virtual_server)
+- `type` (String) The price set type (fixed, compute_plus_storage, component, load_balancer, virtual_image, snapshot, software_or_service)
 
 ### Optional
 

--- a/morpheus/sdkv2/resources/plan/price_set.go
+++ b/morpheus/sdkv2/resources/plan/price_set.go
@@ -5,6 +5,7 @@ package plan
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -62,12 +63,12 @@ func ResourcePriceSet() *schema.Resource {
 			},
 			"type": {
 				Type: schema.TypeString,
-				Description: "The price type (fixed, compute, memory, cores, storage, datastore, platform, " +
-					"software_or_service, load_balancer, load_balancer_virtual_server)",
+				Description: "The price set type (fixed, compute_plus_storage, component, " +
+					"load_balancer, virtual_image, snapshot, software_or_service)",
 				ValidateFunc: validation.StringInSlice(
 					[]string{
-						"fixed", "compute", "memory", "cores", "storage", "datastore", "platform",
-						"software_or_service", "load_balancer", "load_balancer_virtual_server",
+						"fixed", "compute_plus_storage", "component",
+						"load_balancer", "virtual_image", "snapshot", "software_or_service",
 					},
 					false,
 				),
@@ -211,6 +212,24 @@ func resourcePriceSetCreate(ctx context.Context, d *schema.ResourceData, meta an
 		result = v
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
+	}
+
+	// The Morpheus API returns HTTP 200 with success:true even on validation
+	// failure (a server-side bug). Detect failure by checking for a missing/zero
+	// id or non-empty errors map.
+	if result.ID == 0 || len(result.Errors) > 0 {
+		errMsg := "API reported success but failed to create price set"
+		if result.Message != "" {
+			errMsg = result.Message
+		}
+
+		if len(result.Errors) > 0 {
+			for field, msg := range result.Errors {
+				errMsg += fmt.Sprintf("; %s: %s", field, msg)
+			}
+		}
+
+		return diag.Errorf("%s", errMsg)
 	}
 
 	d.SetId(convert.Int64ToString(result.ID))
@@ -411,9 +430,30 @@ func resourcePriceSetUpdate(ctx context.Context, d *schema.ResourceData, meta an
 	}
 	log.Printf("API RESPONSE: %s", resp)
 
-	var result map[string]any
-	if err := json.Unmarshal(resp.Body, &result); err != nil {
-		log.Fatal(err)
+	if resp.Result == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
+	}
+
+	var updateResult *morpheus.UpdatePriceSetResult
+	if v, ok := resp.Result.(*morpheus.UpdatePriceSetResult); ok {
+		updateResult = v
+	} else {
+		return diag.FromErr(helpers.TypeAssertFailError("Result", resp.Result))
+	}
+
+	if !updateResult.Success || len(updateResult.Errors) > 0 {
+		errMsg := "Failed to update price set"
+		if updateResult.Message != "" {
+			errMsg = updateResult.Message
+		}
+
+		if len(updateResult.Errors) > 0 {
+			for field, msg := range updateResult.Errors {
+				errMsg += fmt.Sprintf("; %s: %s", field, msg)
+			}
+		}
+
+		return diag.Errorf("%s", errMsg)
 	}
 
 	d.SetId(id)

--- a/morpheus/sdkv2/resources/plan/price_set_test.go
+++ b/morpheus/sdkv2/resources/plan/price_set_test.go
@@ -3,6 +3,7 @@
 package plan_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -102,6 +103,38 @@ func TestAccMorpheusPriceSetExampleOk(t *testing.T) {
 				Config:             providerConfig + dependencyConfig + resourceConfig,
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
+			},
+		},
+	})
+}
+
+func TestAccMorpheusPriceSetInvalidTypeRejected(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	// Use an invalid type that was previously accepted by the provider but
+	// rejected by the API (a price type, not a price-set type).
+	invalidConfig := `
+resource "hpe_morpheus_price_set" "bad" {
+  name        = "invalid-type-test"
+  code        = "invalid-type-test"
+  region_code = "us-west-2"
+  type        = "compute"
+  price_unit  = "hour"
+  price_ids   = [1]
+}
+`
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + invalidConfig,
+				ExpectError: regexp.MustCompile(`expected type to be one of`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Fixes two reported bugs with `hpe_morpheus_price_set` plus hardens the update path.

Resolves MORPH-11013.

## Changes

**Bug A — Wrong type enum:** The `type` attribute validator was using price types (`AccountPrice.PRICE_TYPE`) instead of price-set types (`AccountPriceSet.PRICE_SET_TYPE`). Corrected to: `fixed`, `compute_plus_storage`, `component`, `load_balancer`, `virtual_image`, `snapshot`, `software_or_service`.

**Bug B — Create failure not detected:** The Morpheus API returns HTTP 200 with `success:true` even on validation failure (no `id` in body). The provider now treats `id=0` or non-empty `errors` as a failure, surfacing the API error instead of silently storing `id=0`. Root API bug filed as MORPH-12586.

**Update hardening:** Replaced `log.Fatal` (process crash) with proper error handling using the typed SDK result.

**Negative test:** Added acceptance test asserting invalid type values are rejected by the schema validator.

## Files changed

- `morpheus/sdkv2/resources/plan/price_set.go` — type enum, create detection, update hardening
- `morpheus/sdkv2/resources/plan/price_set_test.go` — negative acceptance test

## Testing

- `go build ./...` — passes
- `golangci-lint run` — 0 issues
- `go test -short` — passes
