### PR TITLE
Follow-up for tainting to avoid nil ID on GET

### DIFF
--- a/morpheus/framework/resources/backup_job/resource.go
+++ b/morpheus/framework/resources/backup_job/resource.go
@@ -74,10 +74,13 @@ func (r *backupJobResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	var id int64
-	if result.Job != nil && result.Job.Id != nil {
-		id = *result.Job.Id
+	if result.Job == nil || result.Job.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Job ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Job.Id
 
 	readResult, httpResp, err := client.BackupsAPI.GetBackupJobs(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/budget/resource.go
+++ b/morpheus/framework/resources/budget/resource.go
@@ -79,10 +79,13 @@ func (r *budgetResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	var id int64
-	if result.Budget != nil && result.Budget.Id != nil {
-		id = *result.Budget.Id
+	if result.Budget == nil || result.Budget.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Budget ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Budget.Id
 
 	readResult, httpResp, err := client.BudgetsAPI.GetBudgets(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/certificate/resource.go
+++ b/morpheus/framework/resources/certificate/resource.go
@@ -76,10 +76,13 @@ func (r *certificateResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	var id int64
-	if result.Certificate != nil && result.Certificate.Id != nil {
-		id = *result.Certificate.Id
+	if result.Certificate == nil || result.Certificate.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Certificate ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Certificate.Id
 
 	readResult, httpResp, err := client.SSLCertificatesAPI.GetCertificate(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/cluster_affinity_group/resource.go
+++ b/morpheus/framework/resources/cluster_affinity_group/resource.go
@@ -111,12 +111,7 @@ func (r *clusterAffinityGroupResource) Create(
 
 		return
 	}
-	if readAg.Id != nil {
-		plan.ID = types.Int64Value(*readAg.Id)
-	}
-	if readAg.Name != nil {
-		plan.Name = types.StringValue(*readAg.Name)
-	}
+	mapGetResponseToModel(&plan, readAg)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -155,14 +150,13 @@ func (r *clusterAffinityGroupResource) Read(
 	}
 
 	ag := result.AffinityGroup
-	if ag != nil {
-		if ag.Id != nil {
-			state.ID = types.Int64Value(*ag.Id)
-		}
-		if ag.Name != nil {
-			state.Name = types.StringValue(*ag.Name)
-		}
+	if ag == nil {
+		resp.Diagnostics.AddError("API returned nil", "AffinityGroup is nil in the response")
+
+		return
 	}
+
+	mapGetResponseToModel(&state, ag)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -219,12 +213,7 @@ func (r *clusterAffinityGroupResource) Update(
 
 		return
 	}
-	if readAg.Id != nil {
-		plan.ID = types.Int64Value(*readAg.Id)
-	}
-	if readAg.Name != nil {
-		plan.Name = types.StringValue(*readAg.Name)
-	}
+	mapGetResponseToModel(&plan, readAg)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -290,3 +279,12 @@ func (r *clusterAffinityGroupResource) ImportState(
 
 // Ensure unused imports are satisfied.
 var _ *http.Response
+
+func mapGetResponseToModel(model *clusterAffinityGroupModel, ag *sdk.GetClusterAffinityGroup200ResponseAffinityGroup) {
+	if ag.Id != nil {
+		model.ID = types.Int64Value(*ag.Id)
+	}
+	if ag.Name != nil {
+		model.Name = types.StringValue(*ag.Name)
+	}
+}

--- a/morpheus/framework/resources/cluster_affinity_group/resource.go
+++ b/morpheus/framework/resources/cluster_affinity_group/resource.go
@@ -84,10 +84,13 @@ func (r *clusterAffinityGroupResource) Create(
 		return
 	}
 
-	var id int64
-	if result.AffinityGroup != nil && result.AffinityGroup.Id != nil {
-		id = *result.AffinityGroup.Id
+	if result.AffinityGroup == nil || result.AffinityGroup.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "AffinityGroup ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.AffinityGroup.Id
 
 	readResult, httpResp, err := client.ClustersAPI.GetClusterAffinityGroup(ctx, clusterID, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/cluster_namespace/resource.go
+++ b/morpheus/framework/resources/cluster_namespace/resource.go
@@ -117,16 +117,7 @@ func (r *clusterNamespaceResource) Create(
 
 		return
 	}
-	if readNs.Id != nil {
-		plan.ID = types.Int64Value(*readNs.Id)
-	}
-	if readNs.Name != nil {
-		plan.Name = types.StringValue(*readNs.Name)
-	}
-	if readNs.Description != nil {
-		plan.Description = types.StringValue(*readNs.Description)
-	}
-	// NOTE: Active is not in the API GET at all. Config value is preserved in state
+	mapGetResponseToModel(&plan, readNs)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -161,18 +152,13 @@ func (r *clusterNamespaceResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	ns := result.Namespace
-	if ns != nil {
-		if ns.Id != nil {
-			state.ID = types.Int64Value(*ns.Id)
-		}
-		if ns.Name != nil {
-			state.Name = types.StringValue(*ns.Name)
-		}
-		if ns.Description != nil {
-			state.Description = types.StringValue(*ns.Description)
-		}
-		// NOTE: Active is not in the API GET at all. Config value is preserved in state
+	if ns == nil {
+		resp.Diagnostics.AddError("API returned nil", "Namespace is nil in the response")
+
+		return
 	}
+
+	mapGetResponseToModel(&state, ns)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -236,16 +222,7 @@ func (r *clusterNamespaceResource) Update(
 
 		return
 	}
-	if readNs.Id != nil {
-		plan.ID = types.Int64Value(*readNs.Id)
-	}
-	if readNs.Name != nil {
-		plan.Name = types.StringValue(*readNs.Name)
-	}
-	if readNs.Description != nil {
-		plan.Description = types.StringValue(*readNs.Description)
-	}
-	// NOTE: Active is not in the API GET at all. Config value is preserved in state
+	mapGetResponseToModel(&plan, readNs)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -311,3 +288,16 @@ func (r *clusterNamespaceResource) ImportState(
 
 // Ensure unused imports are satisfied.
 var _ *http.Response
+
+func mapGetResponseToModel(model *clusterNamespaceModel, ns *sdk.GetClusterNamespace200ResponseNamespace) {
+	if ns.Id != nil {
+		model.ID = types.Int64Value(*ns.Id)
+	}
+	if ns.Name != nil {
+		model.Name = types.StringValue(*ns.Name)
+	}
+	if ns.Description != nil {
+		model.Description = types.StringValue(*ns.Description)
+	}
+	// NOTE: Active is not in the API GET at all. Config value is preserved in state.
+}

--- a/morpheus/framework/resources/cluster_namespace/resource.go
+++ b/morpheus/framework/resources/cluster_namespace/resource.go
@@ -90,10 +90,13 @@ func (r *clusterNamespaceResource) Create(
 		return
 	}
 
-	var id int64
-	if result.Namespace != nil && result.Namespace.Id != nil {
-		id = *result.Namespace.Id
+	if result.Namespace == nil || result.Namespace.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Namespace ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Namespace.Id
 
 	readResult, httpResp, err := client.ClustersAPI.GetClusterNamespace(ctx, clusterID, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/deployment/resource.go
+++ b/morpheus/framework/resources/deployment/resource.go
@@ -71,10 +71,13 @@ func (r *deploymentResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	var id int64
-	if result.Deployment != nil && result.Deployment.Id != nil {
-		id = *result.Deployment.Id
+	if result.Deployment == nil || result.Deployment.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Deployment ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Deployment.Id
 
 	readResult, httpResp, err := client.DeploymentsAPI.GetDeployment(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/monitoring_alert/resource.go
+++ b/morpheus/framework/resources/monitoring_alert/resource.go
@@ -88,10 +88,13 @@ func (r *monitoringAlertResource) Create(
 		return
 	}
 
-	var id int64
-	if result.Alert != nil && result.Alert.Id != nil {
-		id = *result.Alert.Id
+	if result.Alert == nil || result.Alert.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Alert ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Alert.Id
 
 	readResult, httpResp, err := client.AlertsAPI.GetAlerts(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/monitoring_check/resource.go
+++ b/morpheus/framework/resources/monitoring_check/resource.go
@@ -139,32 +139,7 @@ func (r *monitoringCheckResource) Create(
 
 		return
 	}
-	if check.Id != nil {
-		plan.ID = types.Int64Value(*check.Id)
-	}
-	if check.Name != nil {
-		plan.Name = types.StringValue(*check.Name)
-	}
-	if check.Description.IsSet() && check.Description.Get() != nil {
-		plan.Description = types.StringValue(*check.Description.Get())
-	} else {
-		plan.Description = types.StringNull()
-	}
-	if check.CheckInterval.IsSet() {
-		plan.CheckInterval = types.Int64Value(*check.CheckInterval.Get())
-	}
-	if check.InUptime != nil {
-		plan.InUptime = types.BoolValue(*check.InUptime)
-	}
-	if check.Active != nil {
-		plan.Active = types.BoolValue(*check.Active)
-	}
-	if check.Severity != nil {
-		plan.Severity = types.StringValue(*check.Severity)
-	}
-	if check.CheckType != nil && check.CheckType.Id != nil {
-		plan.CheckTypeID = types.Int64Value(*check.CheckType.Id)
-	}
+	mapGetResponseToModel(&plan, check)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -203,32 +178,7 @@ func (r *monitoringCheckResource) Read(ctx context.Context, req resource.ReadReq
 
 		return
 	}
-	if check.Id != nil {
-		state.ID = types.Int64Value(*check.Id)
-	}
-	if check.Name != nil {
-		state.Name = types.StringValue(*check.Name)
-	}
-	if check.Description.IsSet() && check.Description.Get() != nil {
-		state.Description = types.StringValue(*check.Description.Get())
-	} else {
-		state.Description = types.StringNull()
-	}
-	if check.CheckInterval.IsSet() {
-		state.CheckInterval = types.Int64Value(*check.CheckInterval.Get())
-	}
-	if check.InUptime != nil {
-		state.InUptime = types.BoolValue(*check.InUptime)
-	}
-	if check.Active != nil {
-		state.Active = types.BoolValue(*check.Active)
-	}
-	if check.Severity != nil {
-		state.Severity = types.StringValue(*check.Severity)
-	}
-	if check.CheckType != nil && check.CheckType.Id != nil {
-		state.CheckTypeID = types.Int64Value(*check.CheckType.Id)
-	}
+	mapGetResponseToModel(&state, check)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -298,32 +248,7 @@ func (r *monitoringCheckResource) Update(
 
 		return
 	}
-	if check.Id != nil {
-		plan.ID = types.Int64Value(*check.Id)
-	}
-	if check.Name != nil {
-		plan.Name = types.StringValue(*check.Name)
-	}
-	if check.Description.IsSet() && check.Description.Get() != nil {
-		plan.Description = types.StringValue(*check.Description.Get())
-	} else {
-		plan.Description = types.StringNull()
-	}
-	if check.CheckInterval.IsSet() {
-		plan.CheckInterval = types.Int64Value(*check.CheckInterval.Get())
-	}
-	if check.InUptime != nil {
-		plan.InUptime = types.BoolValue(*check.InUptime)
-	}
-	if check.Active != nil {
-		plan.Active = types.BoolValue(*check.Active)
-	}
-	if check.Severity != nil {
-		plan.Severity = types.StringValue(*check.Severity)
-	}
-	if check.CheckType != nil && check.CheckType.Id != nil {
-		plan.CheckTypeID = types.Int64Value(*check.CheckType.Id)
-	}
+	mapGetResponseToModel(&plan, check)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -368,4 +293,33 @@ func (r *monitoringCheckResource) ImportState(
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+}
+
+func mapGetResponseToModel(model *monitoringCheckModel, check *sdk.GetChecks200ResponseCheck) {
+	if check.Id != nil {
+		model.ID = types.Int64Value(*check.Id)
+	}
+	if check.Name != nil {
+		model.Name = types.StringValue(*check.Name)
+	}
+	if check.Description.IsSet() && check.Description.Get() != nil {
+		model.Description = types.StringValue(*check.Description.Get())
+	} else {
+		model.Description = types.StringNull()
+	}
+	if check.CheckInterval.IsSet() {
+		model.CheckInterval = types.Int64Value(*check.CheckInterval.Get())
+	}
+	if check.InUptime != nil {
+		model.InUptime = types.BoolValue(*check.InUptime)
+	}
+	if check.Active != nil {
+		model.Active = types.BoolValue(*check.Active)
+	}
+	if check.Severity != nil {
+		model.Severity = types.StringValue(*check.Severity)
+	}
+	if check.CheckType != nil && check.CheckType.Id != nil {
+		model.CheckTypeID = types.Int64Value(*check.CheckType.Id)
+	}
 }

--- a/morpheus/framework/resources/monitoring_check/resource.go
+++ b/morpheus/framework/resources/monitoring_check/resource.go
@@ -112,10 +112,13 @@ func (r *monitoringCheckResource) Create(
 		return
 	}
 
-	var id int64
-	if result.Check != nil && result.Check.Id != nil {
-		id = *result.Check.Id
+	if result.Check == nil || result.Check.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Check ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Check.Id
 
 	readResult, httpResp, err := client.ChecksAPI.GetChecks(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/monitoring_group/resource.go
+++ b/morpheus/framework/resources/monitoring_group/resource.go
@@ -85,10 +85,13 @@ func (r *monitoringGroupResource) Create(
 		return
 	}
 
-	var id int64
-	if result.CheckGroup != nil && result.CheckGroup.Id != nil {
-		id = *result.CheckGroup.Id
+	if result.CheckGroup == nil || result.CheckGroup.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "CheckGroup ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.CheckGroup.Id
 
 	readResult, httpResp, err := client.ChecksAPI.GetCheckGroups(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/network_pool/resource.go
+++ b/morpheus/framework/resources/network_pool/resource.go
@@ -106,10 +106,13 @@ func (r *networkPoolResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	var id int64
-	if result.NetworkPool != nil && result.NetworkPool.Id != nil {
-		id = *result.NetworkPool.Id
+	if result.NetworkPool == nil || result.NetworkPool.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "NetworkPool ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.NetworkPool.Id
 
 	readResult, httpResp, err := client.NetworksAPI.GetNetworkPool(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/network_pool_server/resource.go
+++ b/morpheus/framework/resources/network_pool_server/resource.go
@@ -124,10 +124,13 @@ func (r *networkPoolServerResource) Create(
 		return
 	}
 
-	var id int64
-	if result.NetworkPoolServer != nil && result.NetworkPoolServer.Id != nil {
-		id = *result.NetworkPoolServer.Id
+	if result.NetworkPoolServer == nil || result.NetworkPoolServer.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "NetworkPoolServer ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.NetworkPoolServer.Id
 
 	readResult, httpResp, err := client.NetworksAPI.GetNetworkPoolServer(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/option_list/resource.go
+++ b/morpheus/framework/resources/option_list/resource.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	sdk "github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -109,37 +110,9 @@ func (r *optionListResource) Create(
 	}
 
 	// SDK field mismatch: API returns "optionTypeLists" but SDK expects "optionTypes"
-	var id int64
-	optionLists := listResult.OptionTypes
-	if len(optionLists) == 0 {
-		if rawLists, ok := listResult.AdditionalProperties["optionTypeLists"]; ok {
-			if listsSlice, ok := rawLists.([]interface{}); ok && len(listsSlice) > 0 {
-				if firstMap, ok := listsSlice[0].(map[string]interface{}); ok {
-					if v, ok := firstMap["id"].(float64); ok {
-						id = int64(v)
-					}
-				}
-			}
-		}
-		if id == 0 {
-			resp.Diagnostics.AddError(
-				"Not Found After Create",
-				"Option type list was created successfully but could not be found by name. "+
-					"The resource may exist in Morpheus. Check the Morpheus UI and import manually if needed: "+
-					"'terraform import <resource_type>.<name> <id>'",
-			)
-
-			return
-		}
-	} else {
-		ol := optionLists[0]
-		if ol.Id == nil {
-			resp.Diagnostics.AddError("API returned nil ID", "OptionList ID is nil in the list response")
-
-			return
-		}
-
-		id = *ol.Id
+	id := extractOptionListID(listResult, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// GET by ID with SDK mismatch workaround (same as Read)
@@ -156,17 +129,7 @@ func (r *optionListResource) Create(
 		return
 	}
 
-	readOptionTypes := readResult.OptionTypes
-	if len(readOptionTypes) == 0 {
-		// SDK field mismatch: API returns "optionTypeList" but SDK expects "optionTypes"
-		if rawOL, ok := readResult.AdditionalProperties["optionTypeList"]; ok {
-			if olMap, ok := rawOL.(map[string]interface{}); ok {
-				mapOptionTypeListFromRaw(&plan, olMap)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-				return
-			}
-		}
+	if !applyGetOptionListResponse(readResult, &plan) {
 		resp.Diagnostics.AddError(
 			"Not Found After Create",
 			"Option type list was created but could not be read by ID. "+
@@ -176,9 +139,6 @@ func (r *optionListResource) Create(
 
 		return
 	}
-
-	readOL := readOptionTypes[0]
-	mapGetOptionListToModel(&plan, &readOL)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -215,24 +175,11 @@ func (r *optionListResource) Read(
 		return
 	}
 
-	optionTypes := result.OptionTypes
-	if len(optionTypes) == 0 {
-		// SDK field mismatch: API returns "optionTypeList" but SDK expects "optionTypes"
-		if rawOL, ok := result.AdditionalProperties["optionTypeList"]; ok {
-			if olMap, ok := rawOL.(map[string]interface{}); ok {
-				mapOptionTypeListFromRaw(&state, olMap)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
-				return
-			}
-		}
+	if !applyGetOptionListResponse(result, &state) {
 		resp.State.RemoveResource(ctx)
 
 		return
 	}
-
-	ol := optionTypes[0]
-	mapGetOptionListToModel(&state, &ol)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -297,17 +244,7 @@ func (r *optionListResource) Update(
 		return
 	}
 
-	readOptionTypes := readResult.OptionTypes
-	if len(readOptionTypes) == 0 {
-		// SDK field mismatch: API returns "optionTypeList" but SDK expects "optionTypes"
-		if rawOL, ok := readResult.AdditionalProperties["optionTypeList"]; ok {
-			if olMap, ok := rawOL.(map[string]interface{}); ok {
-				mapOptionTypeListFromRaw(&plan, olMap)
-				resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-				return
-			}
-		}
+	if !applyGetOptionListResponse(readResult, &plan) {
 		resp.Diagnostics.AddError(
 			"Read Error After Update",
 			"Option type list was updated successfully but could not be read back by ID.",
@@ -315,9 +252,6 @@ func (r *optionListResource) Update(
 
 		return
 	}
-
-	readOL := readOptionTypes[0]
-	mapGetOptionListToModel(&plan, &readOL)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -441,4 +375,63 @@ func mapOptionTypeListFromRaw(model *optionListModel, m map[string]interface{}) 
 	if v, ok := m["realTime"].(bool); ok {
 		model.RealTime = types.BoolValue(v)
 	}
+}
+
+// extractOptionListID extracts the option list ID from a list-by-name response,
+// handling the SDK field mismatch where the API may return "optionTypeLists" instead of "optionTypes".
+// Returns 0 and appends to diags on failure.
+func extractOptionListID(result *sdk.ListOptionLists200Response, diags *diag.Diagnostics) int64 {
+	if len(result.OptionTypes) > 0 {
+		ol := result.OptionTypes[0]
+		if ol.Id == nil {
+			diags.AddError("API returned nil ID", "OptionList ID is nil in the list response")
+
+			return 0
+		}
+
+		return *ol.Id
+	}
+
+	// Fallback: SDK field mismatch - API returns "optionTypeLists", SDK expects "optionTypes"
+	if rawLists, ok := result.AdditionalProperties["optionTypeLists"]; ok {
+		if listsSlice, ok := rawLists.([]interface{}); ok && len(listsSlice) > 0 {
+			if firstMap, ok := listsSlice[0].(map[string]interface{}); ok {
+				if v, ok := firstMap["id"].(float64); ok {
+					return int64(v)
+				}
+			}
+		}
+	}
+
+	diags.AddError(
+		"Not Found After Create",
+		"Option type list was created successfully but could not be found by name. "+
+			"The resource may exist in Morpheus. Check the Morpheus UI and import manually if needed: "+
+			"'terraform import <resource_type>.<name> <id>'",
+	)
+
+	return 0
+}
+
+// applyGetOptionListResponse populates model from a GetOptionList response,
+// handling the SDK field mismatch where the API returns "optionTypeList" instead of "optionTypes".
+// Returns true if the model was populated (caller should set state).
+// Returns false if not found (caller handles via AddError or RemoveResource).
+func applyGetOptionListResponse(result *sdk.GetOptionList200Response, model *optionListModel) bool {
+	if len(result.OptionTypes) > 0 {
+		mapGetOptionListToModel(model, &result.OptionTypes[0])
+
+		return true
+	}
+
+	// Fallback: SDK field mismatch - API returns "optionTypeList", SDK expects "optionTypes"
+	if rawOL, ok := result.AdditionalProperties["optionTypeList"]; ok {
+		if olMap, ok := rawOL.(map[string]interface{}); ok {
+			mapOptionTypeListFromRaw(model, olMap)
+
+			return true
+		}
+	}
+
+	return false
 }

--- a/morpheus/framework/resources/option_list/resource.go
+++ b/morpheus/framework/resources/option_list/resource.go
@@ -133,9 +133,13 @@ func (r *optionListResource) Create(
 		}
 	} else {
 		ol := optionLists[0]
-		if ol.Id != nil {
-			id = *ol.Id
+		if ol.Id == nil {
+			resp.Diagnostics.AddError("API returned nil ID", "OptionList ID is nil in the list response")
+
+			return
 		}
+
+		id = *ol.Id
 	}
 
 	// GET by ID with SDK mismatch workaround (same as Read)

--- a/morpheus/framework/resources/power_schedule/resource.go
+++ b/morpheus/framework/resources/power_schedule/resource.go
@@ -121,10 +121,13 @@ func (r *powerScheduleResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	var id int64
-	if result.Schedule != nil && result.Schedule.Id != nil {
-		id = *result.Schedule.Id
+	if result.Schedule == nil || result.Schedule.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Schedule ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Schedule.Id
 
 	readResult, httpResp, err := client.AutomationAPI.GetPowerSchedules(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/provisioning_license/resource.go
+++ b/morpheus/framework/resources/provisioning_license/resource.go
@@ -104,10 +104,13 @@ func (r *provisioningLicenseResource) Create(
 		return
 	}
 
-	var id int64
-	if result.License != nil && result.License.Id != nil {
-		id = *result.License.Id
+	if result.License == nil || result.License.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "License ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.License.Id
 
 	readResult, httpResp, err := client.ProvisioningLicensesAPI.GetProvisioningLicense(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/provisioning_license/resource.go
+++ b/morpheus/framework/resources/provisioning_license/resource.go
@@ -131,20 +131,7 @@ func (r *provisioningLicenseResource) Create(
 
 		return
 	}
-	if readLicense.Id != nil {
-		plan.ID = types.Int64Value(*readLicense.Id)
-	}
-	if readLicense.Name != nil {
-		plan.Name = types.StringValue(*readLicense.Name)
-	}
-	if readLicense.Description != nil {
-		plan.Description = types.StringValue(*readLicense.Description)
-	} else {
-		plan.Description = types.StringNull()
-	}
-	if readLicense.LicenseType != nil && readLicense.LicenseType.Code != nil {
-		plan.LicenseType = types.StringValue(*readLicense.LicenseType.Code)
-	}
+	mapGetResponseToModel(&plan, readLicense)
 	plan.LicenseKeyWoVersion = config.LicenseKeyWoVersion
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -184,20 +171,7 @@ func (r *provisioningLicenseResource) Read(ctx context.Context, req resource.Rea
 
 		return
 	}
-	if license.Id != nil {
-		state.ID = types.Int64Value(*license.Id)
-	}
-	if license.Name != nil {
-		state.Name = types.StringValue(*license.Name)
-	}
-	if license.Description != nil {
-		state.Description = types.StringValue(*license.Description)
-	} else {
-		state.Description = types.StringNull()
-	}
-	if license.LicenseType != nil && license.LicenseType.Code != nil {
-		state.LicenseType = types.StringValue(*license.LicenseType.Code)
-	}
+	mapGetResponseToModel(&state, license)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -285,20 +259,7 @@ func (r *provisioningLicenseResource) Update(
 
 		return
 	}
-	if readLicense.Id != nil {
-		plan.ID = types.Int64Value(*readLicense.Id)
-	}
-	if readLicense.Name != nil {
-		plan.Name = types.StringValue(*readLicense.Name)
-	}
-	if readLicense.Description != nil {
-		plan.Description = types.StringValue(*readLicense.Description)
-	} else {
-		plan.Description = types.StringNull()
-	}
-	if readLicense.LicenseType != nil && readLicense.LicenseType.Code != nil {
-		plan.LicenseType = types.StringValue(*readLicense.LicenseType.Code)
-	}
+	mapGetResponseToModel(&plan, readLicense)
 	plan.LicenseKeyWoVersion = config.LicenseKeyWoVersion
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -344,4 +305,21 @@ func (r *provisioningLicenseResource) ImportState(
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+}
+
+func mapGetResponseToModel(model *provisioningLicenseModel, license *sdk.GetProvisioningLicense200ResponseLicense) {
+	if license.Id != nil {
+		model.ID = types.Int64Value(*license.Id)
+	}
+	if license.Name != nil {
+		model.Name = types.StringValue(*license.Name)
+	}
+	if license.Description != nil {
+		model.Description = types.StringValue(*license.Description)
+	} else {
+		model.Description = types.StringNull()
+	}
+	if license.LicenseType != nil && license.LicenseType.Code != nil {
+		model.LicenseType = types.StringValue(*license.LicenseType.Code)
+	}
 }

--- a/morpheus/framework/resources/security_group_rule/resource.go
+++ b/morpheus/framework/resources/security_group_rule/resource.go
@@ -105,10 +105,13 @@ func (r *securityGroupRuleResource) Create(
 		return
 	}
 
-	var id int64
-	if result.Rule != nil && result.Rule.Id != nil {
-		id = *result.Rule.Id
+	if result.Rule == nil || result.Rule.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "Rule ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.Rule.Id
 	ruleIDParam := float32(id) //nolint:gosec // value range is safe
 
 	readResult, httpResp, err := client.SecurityGroupsAPI.GetSecurityGroupRules(ctx, sgID, ruleIDParam).Execute()

--- a/morpheus/framework/resources/storage_bucket/resource.go
+++ b/morpheus/framework/resources/storage_bucket/resource.go
@@ -94,10 +94,13 @@ func (r *storageBucketResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	var id int64
-	if result.StorageBucket != nil && result.StorageBucket.Id != nil {
-		id = *result.StorageBucket.Id
+	if result.StorageBucket == nil || result.StorageBucket.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "StorageBucket ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.StorageBucket.Id
 
 	readResult, httpResp, err := client.StorageAPI.GetStorageBuckets(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/storage_volume/resource.go
+++ b/morpheus/framework/resources/storage_volume/resource.go
@@ -83,10 +83,13 @@ func (r *storageVolumeResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	var id int64
-	if result.StorageVolume != nil && result.StorageVolume.Id != nil {
-		id = *result.StorageVolume.Id
+	if result.StorageVolume == nil || result.StorageVolume.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "StorageVolume ID is nil in the create response")
+
+		return
 	}
+
+	id := *result.StorageVolume.Id
 	idParam := sdk.GetStorageVolumesIdParameter{Int64: &id}
 
 	readResult, httpResp, err := client.StorageAPI.GetStorageVolumes(ctx, idParam).Execute()

--- a/morpheus/framework/resources/task/create.go
+++ b/morpheus/framework/resources/task/create.go
@@ -181,11 +181,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	plan.Id = convert.Int64ToType(taskResp.Task.Id)
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	state, diag := getTaskAsState(ctx, plan.Id.ValueInt64(), client, plan)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
 		cleanup.TaintResourceState(ctx, cleanup.TaintResourceStateConfig{

--- a/morpheus/framework/resources/vdi_app/resource.go
+++ b/morpheus/framework/resources/vdi_app/resource.go
@@ -70,11 +70,14 @@ func (r *vdiAppResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	var id int64
 	anyOf := result.AddVDIApps200ResponseAnyOf
-	if anyOf != nil && anyOf.VdiApp != nil && anyOf.VdiApp.Id != nil {
-		id = *anyOf.VdiApp.Id
+	if anyOf == nil || anyOf.VdiApp == nil || anyOf.VdiApp.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "VdiApp ID is nil in the create response")
+
+		return
 	}
+
+	id := *anyOf.VdiApp.Id
 
 	readResult, httpResp, err := client.VDIAPI.GetVDIApps(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {

--- a/morpheus/framework/resources/vdi_gateway/resource.go
+++ b/morpheus/framework/resources/vdi_gateway/resource.go
@@ -72,11 +72,14 @@ func (r *vdiGatewayResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	var id int64
 	anyOf := result.AddVDIGateways200ResponseAnyOf
-	if anyOf != nil && anyOf.VdiGateway != nil && anyOf.VdiGateway.Id != nil {
-		id = *anyOf.VdiGateway.Id
+	if anyOf == nil || anyOf.VdiGateway == nil || anyOf.VdiGateway.Id == nil {
+		resp.Diagnostics.AddError("API returned nil ID", "VdiGateway ID is nil in the create response")
+
+		return
 	}
+
+	id := *anyOf.VdiGateway.Id
 
 	readResult, httpResp, err := client.VDIAPI.GetVDIGateways(ctx, id).Execute()
 	if err := errfmt.CheckResponse(err, httpResp); err != nil {


### PR DESCRIPTION
Adding a nil check for the ID in the GET method to avoid the case of a nil/0 ID causing errors. While unlikely, tainting the state with 0 would cause it to perpetually fail as it attempts to destroy a resource with an ID of 0.

Also removes a duplicate state.Set call in the Create method for the task resource.