### PR TITLE
Reject self-referential dependent_field on option types and forms

### DIFF
--- a/morpheus/sdkv2/helpers/validators.go
+++ b/morpheus/sdkv2/helpers/validators.go
@@ -1,0 +1,48 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ValidateDependentFieldNotSelf is a CustomizeDiff function for option type
+// resources that expose both field_name and dependent_field. It rejects a
+// configuration where dependent_field equals field_name: a field cannot depend
+// on itself, which produces a circular dependsOnCode and an unstable form
+// reload. Morpheus stores a submitted dependsOnCode verbatim and provides no
+// guard against self-reference, so the provider rejects it at plan time.
+//
+// The check reads the raw config, so it never fires on a computed read-back of
+// dependent_field.
+func ValidateDependentFieldNotSelf(
+	_ context.Context, d *schema.ResourceDiff, _ any,
+) error {
+	raw := d.GetRawConfig()
+	if raw.IsNull() || !raw.IsKnown() {
+		return nil
+	}
+
+	fieldNameVal := raw.GetAttr("field_name")
+	dependentFieldVal := raw.GetAttr("dependent_field")
+	if fieldNameVal.IsNull() || !fieldNameVal.IsKnown() ||
+		dependentFieldVal.IsNull() || !dependentFieldVal.IsKnown() {
+		return nil
+	}
+
+	fieldName := fieldNameVal.AsString()
+	dependentField := dependentFieldVal.AsString()
+	if dependentField != "" && dependentField == fieldName {
+		return fmt.Errorf(
+			"dependent_field must not equal field_name (%q): a field cannot depend "+
+				"on itself, which creates a circular dependsOnCode; point "+
+				"dependent_field at a different field",
+			fieldName,
+		)
+	}
+
+	return nil
+}

--- a/morpheus/sdkv2/resources/form/dependent_field_test.go
+++ b/morpheus/sdkv2/resources/form/dependent_field_test.go
@@ -1,0 +1,55 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package form_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus"
+	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+)
+
+// TestAccMorpheusFormRejectsSelfReferentialDependentField verifies the plan-time
+// guard that rejects an option type whose dependent_field equals its own
+// field_name (a field cannot depend on itself, which would create a circular
+// dependsOnCode). This is a pure plan-time validation, so it needs no live
+// appliance.
+func TestAccMorpheusFormRejectsSelfReferentialDependentField(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	invalidConfig := `
+resource "hpe_morpheus_form" "bad_self_ref" {
+  name        = "bad-self-ref-test"
+  code        = "bad-self-ref-test"
+  description = "test"
+
+  option_type {
+    name            = "bad option"
+    code            = "bad-option"
+    type            = "text"
+    field_name      = "myField"
+    field_label     = "My Field"
+    dependent_field = "myField"
+  }
+}
+`
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + invalidConfig,
+				ExpectError: regexp.MustCompile(`dependent_field must not equal field_name`),
+			},
+		},
+	})
+}

--- a/morpheus/sdkv2/resources/form/form.go
+++ b/morpheus/sdkv2/resources/form/form.go
@@ -54,9 +54,42 @@ const (
 	typeVMWFolders     = "vmwFolders"
 )
 
+// validateDependentFieldNotSelf rejects a form option type whose dependent_field
+// equals its own field_name. Such a self-reference produces a circular
+// dependsOnCode and an unstable form reload; Morpheus stores a submitted value
+// verbatim with no guard, so the provider rejects it at plan time.
+func validateDependentFieldNotSelf(optionType cty.Value, path string, index int) error {
+	fieldNameVal := optionType.GetAttr("field_name")
+	dependentFieldVal := optionType.GetAttr("dependent_field")
+	if !fieldNameVal.IsKnown() || fieldNameVal.IsNull() ||
+		!dependentFieldVal.IsKnown() || dependentFieldVal.IsNull() {
+		return nil
+	}
+
+	fieldName := fieldNameVal.AsString()
+	dependentField := dependentFieldVal.AsString()
+	if dependentField != "" && dependentField == fieldName {
+		return fmt.Errorf(
+			"dependent_field must not equal field_name (%q) at %s[%d]: a field "+
+				"cannot depend on itself, which creates a circular dependsOnCode; "+
+				"point dependent_field at a different field",
+			fieldName, path, index,
+		)
+	}
+
+	return nil
+}
+
 func validateOptionTypeConfig(optionType cty.Value, path string, index int) error {
 	if !optionType.IsKnown() || optionType.IsNull() {
 		return nil
+	}
+
+	// A field cannot depend on itself: dependent_field (-> dependsOnCode) must
+	// not equal field_name, otherwise the form reload is circular. This applies
+	// to every option type, regardless of its type.
+	if err := validateDependentFieldNotSelf(optionType, path, index); err != nil {
+		return err
 	}
 
 	optionTypeValue := optionType.GetAttr("type")

--- a/morpheus/sdkv2/resources/optiontype/option_type_checkbox.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_checkbox.go
@@ -23,6 +23,8 @@ func ResourceOptionTypeCheckbox() *schema.Resource {
 		UpdateContext: resourceOptionTypeCheckboxUpdate,
 		DeleteContext: resourceOptionTypeCheckboxDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/optiontype/option_type_hidden.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_hidden.go
@@ -22,6 +22,8 @@ func ResourceOptionTypeHidden() *schema.Resource {
 		UpdateContext: resourceOptionTypeHiddenUpdate,
 		DeleteContext: resourceOptionTypeHiddenDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/optiontype/option_type_number.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_number.go
@@ -23,6 +23,8 @@ func ResourceOptionTypeNumber() *schema.Resource {
 		UpdateContext: resourceOptionTypeNumberUpdate,
 		DeleteContext: resourceOptionTypeNumberDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/optiontype/option_type_password.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_password.go
@@ -23,6 +23,8 @@ func ResourceOptionTypePassword() *schema.Resource {
 		UpdateContext: resourceOptionTypePasswordUpdate,
 		DeleteContext: resourceOptionTypePasswordDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/optiontype/option_type_radio_list.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_radio_list.go
@@ -23,6 +23,8 @@ func ResourceOptionTypeRadioList() *schema.Resource {
 		UpdateContext: resourceOptionTypeRadioListUpdate,
 		DeleteContext: resourceOptionTypeRadioListDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/optiontype/option_type_select_list.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_select_list.go
@@ -23,6 +23,8 @@ func ResourceOptionTypeSelectList() *schema.Resource {
 		UpdateContext: resourceOptionTypeSelectListUpdate,
 		DeleteContext: resourceOptionTypeSelectListDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/optiontype/option_type_text.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_text.go
@@ -23,6 +23,8 @@ func ResourceOptionTypeText() *schema.Resource {
 		UpdateContext: resourceOptionTypeTextUpdate,
 		DeleteContext: resourceOptionTypeTextDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/optiontype/option_type_text_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_text_resource_test.go
@@ -3,6 +3,7 @@
 package optiontype_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -171,6 +172,38 @@ func TestAccMorpheusOptionTypeTextExampleOk(t *testing.T) {
 				Config:             providerConfig + resourceConfig,
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
+			},
+		},
+	})
+}
+
+// TestAccMorpheusOptionTypeTextRejectsSelfReferentialDependentField verifies the
+// plan-time guard that rejects dependent_field == field_name (a field cannot
+// depend on itself, which would create a circular dependsOnCode). This is a
+// pure plan-time validation, so it needs no live appliance.
+func TestAccMorpheusOptionTypeTextRejectsSelfReferentialDependentField(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	invalidConfig := `
+resource "hpe_morpheus_option_type_text" "bad_self_ref" {
+  name            = "bad-self-ref-test"
+  field_name      = "myField"
+  field_label     = "My Field"
+  dependent_field = "myField"
+}
+`
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + invalidConfig,
+				ExpectError: regexp.MustCompile(`dependent_field must not equal field_name`),
 			},
 		},
 	})

--- a/morpheus/sdkv2/resources/optiontype/option_type_textarea.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_textarea.go
@@ -23,6 +23,8 @@ func ResourceOptionTypeTextarea() *schema.Resource {
 		UpdateContext: resourceOptionTypeTextareaUpdate,
 		DeleteContext: resourceOptionTypeTextareaDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/morpheus/sdkv2/resources/optiontype/option_type_typeahead.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_typeahead.go
@@ -28,6 +28,8 @@ func ResourceOptionTypeTypeahead() *schema.Resource {
 		UpdateContext: resourceOptionTypeTypeaheadUpdate,
 		DeleteContext: resourceOptionTypeTypeaheadDelete,
 
+		CustomizeDiff: helpers.ValidateDependentFieldNotSelf,
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## Summary

A form field / option type configured with `dependent_field` equal to its own `field_name` makes the field depend on itself, producing a circular `dependsOnCode` and an unstable form reload. Morpheus stores a submitted `dependsOnCode` verbatim and provides no guard against self-reference, so this adds a plan-time validator.

## Changes

- **`helpers.ValidateDependentFieldNotSelf`** — a `CustomizeDiff` that rejects `dependent_field == field_name`. It reads the raw config, so it never fires on a computed read-back of `dependent_field`. Wired into the nine standalone option type resources: `checkbox`, `hidden`, `number`, `password`, `radio_list`, `select_list`, `text`, `textarea`, `typeahead`.
- **`hpe_morpheus_form`** — the same check added to `validateOptionTypeConfig`, so inline form fields (root and field-group) are covered.
- Plan-time `ExpectError` acceptance tests for both the standalone-resource and form paths.

## Behaviour

- **Rejected** at plan time: `dependent_field` equal to the field's own `field_name`.
- **Still allowed**: `dependent_field` pointing at a *different* field (the normal cascade/reload case).

## Testing

- `go build ./...`, `go vet`, `golangci-lint run` — all clean.
- New `ExpectError` tests assert the plan-time rejection; no schema change, so docs are unchanged.

Refs: MORPH-12958
