### PR TITLE
Detect out-of-band deletion on hpe_morpheus_instance

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -899,6 +899,9 @@ The layout may have default ports, which are defined in node types, that are alw
 
 - `connection_info` (List of String) List of IP addresses to use when connecting to instance
 - `id` (Number) The ID of this resource.
+- `status` (String) The status of the instance (e.g. running, stopped, failed, unknown). The provider
+refreshes this on read, so an out-of-band deletion of the underlying VM - which Morpheus
+reports as "unknown" while retaining the instance record - surfaces as a change on the next plan.
 
 <a id="nestedatt--network_interfaces"></a>
 ### Nested Schema for `network_interfaces`

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -501,8 +501,8 @@ func (g *Resource) Create(
 	}
 
 	// Read the instance state
-	state, d := getInstanceAsState(ctx, instanceId, client, plan)
-	if d.HasError() {
+	state, found, d := getInstanceAsState(ctx, instanceId, client, plan)
+	if d.HasError() || !found {
 		resp.Diagnostics.Append(d...)
 		resp.Diagnostics.AddError(
 			"failed to read instance state",

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -74,8 +74,20 @@ func (g *Resource) Read(
 	// servicePlanOptions is not returned by the API
 	servicePlanOptions := data.ServicePlanOptions
 
-	state, diag := getInstanceAsState(ctx, data.Id.ValueInt64(), client, data)
+	state, found, diag := getInstanceAsState(ctx, data.Id.ValueInt64(), client, data)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The instance was deleted out of band (Morpheus returned 404); remove it
+	// from state so the next apply recreates it instead of erroring.
+	if !found {
+		tflog.Warn(
+			ctx,
+			fmt.Sprintf("instance %d not found, removing from state", data.Id.ValueInt64()),
+		)
+		resp.State.RemoveResource(ctx)
+
 		return
 	}
 
@@ -92,18 +104,24 @@ func getInstanceAsState(
 	id int64,
 	client *sdk.APIClient,
 	plan InstanceModel,
-) (InstanceModel, diag.Diagnostics) {
+) (InstanceModel, bool, diag.Diagnostics) {
 	var state InstanceModel
 	var diags diag.Diagnostics
 
 	resp, hresp, err := client.InstancesAPI.GetInstance(ctx, id).Execute()
 	if err != nil || hresp.StatusCode != http.StatusOK {
+		// The instance no longer exists in Morpheus (e.g. deleted out of band).
+		// Signal not-found (without an error) so the caller can remove it from state.
+		if hresp != nil && hresp.StatusCode == http.StatusNotFound {
+			return state, false, diags
+		}
+
 		diags.AddError(
 			"populate instance resource",
 			fmt.Sprintf("instance %d GET failed: ", id)+errfmt.ErrMsg(err, hresp),
 		)
 
-		return state, diags
+		return state, false, diags
 	}
 
 	if resp.Instance == nil {
@@ -112,7 +130,7 @@ func getInstanceAsState(
 			fmt.Sprintf("instance %d GET returned empty instance", id),
 		)
 
-		return state, diags
+		return state, false, diags
 	}
 
 	instance := *resp.Instance
@@ -132,7 +150,7 @@ func getInstanceAsState(
 		code, apiConfig, gdiags := getCodeAndConfig(id, instance)
 		diags.Append(gdiags...)
 		if diags.HasError() {
-			return state, diags
+			return state, false, diags
 		}
 
 		switch *code {
@@ -140,7 +158,7 @@ func getInstanceAsState(
 			configAws, cdiags := getInstanceAWSConfig(ctx, id, apiConfig)
 			diags = append(diags, cdiags...)
 			if diags.HasError() {
-				return state, diags
+				return state, false, diags
 			}
 			state.ConfigAws = configAws
 
@@ -148,7 +166,7 @@ func getInstanceAsState(
 			configAzure, cdiags := getInstanceAzureConfig(ctx, id, apiConfig)
 			diags.Append(cdiags...)
 			if diags.HasError() {
-				return state, diags
+				return state, false, diags
 			}
 			state.ConfigAzure = configAzure
 
@@ -156,7 +174,7 @@ func getInstanceAsState(
 			configHvm, cdiags := getInstanceHVMConfig(ctx, id, apiConfig)
 			diags.Append(cdiags...)
 			if diags.HasError() {
-				return state, diags
+				return state, false, diags
 			}
 			state.ConfigHvm = configHvm
 
@@ -164,7 +182,7 @@ func getInstanceAsState(
 			configVMware, cdiags := getInstanceVMwareConfig(ctx, id, apiConfig)
 			diags.Append(cdiags...)
 			if diags.HasError() {
-				return state, diags
+				return state, false, diags
 			}
 			state.ConfigVmware = configVMware
 
@@ -172,7 +190,7 @@ func getInstanceAsState(
 			config, cdiags := getInstanceConfigGeneric(ctx, id, apiConfig)
 			diags.Append(cdiags...)
 			if diags.HasError() {
-				return state, diags
+				return state, false, diags
 			}
 			state.Config = config
 
@@ -199,7 +217,7 @@ func getInstanceAsState(
 	cInfo, dc := getConnectionInfo(instance)
 	diags.Append(dc...)
 	if diags.HasError() {
-		return state, diags
+		return state, false, diags
 	}
 
 	state.ConnectionInfo = cInfo
@@ -215,7 +233,7 @@ func getInstanceAsState(
 	// evars separately.
 	envVars, diags := getInstanceEnvVars(ctx, id, client)
 	if diags.HasError() {
-		return state, diags
+		return state, false, diags
 	}
 
 	evars, d := convert.ToSetType(
@@ -265,11 +283,17 @@ func getInstanceAsState(
 	// name
 	state.Name = convert.StrToType(instance.Name)
 
+	// status
+	// Refreshed on every read so an out-of-band deletion of the underlying VM,
+	// which Morpheus reports as "unknown" while retaining the instance record,
+	// surfaces as a change on the next plan.
+	state.Status = convert.StrToType(instance.Status)
+
 	// interfaces
 	ifaces, ifDiags := getStateInterfaces(ctx, instance, plan)
 	diags = append(diags, ifDiags...)
 	if diags.HasError() {
-		return state, diags
+		return state, false, diags
 	}
 
 	networkInterfacesList, d := types.ListValueFrom(ctx, NetworkInterfacesValue{}.Type(ctx), ifaces)
@@ -278,7 +302,7 @@ func getInstanceAsState(
 	if diags.HasError() {
 		tflog.Error(ctx, "cannot convert network interfaces")
 
-		return state, diags
+		return state, false, diags
 	}
 
 	state.NetworkInterfaces = networkInterfacesList
@@ -287,7 +311,7 @@ func getInstanceAsState(
 	networkDomainId, ndiags := getInstanceNetworkDomainId(instance, plan)
 	diags = append(diags, ndiags...)
 	if diags.HasError() {
-		return state, diags
+		return state, false, diags
 	}
 	state.NetworkDomainId = networkDomainId
 
@@ -347,7 +371,7 @@ func getInstanceAsState(
 	diags.Append(d...)
 	state.Volumes = volumes
 
-	return state, diags
+	return state, true, diags
 }
 
 func getInstanceNetworkDomainId(

--- a/morpheus/framework/resources/instance/instance_update.go
+++ b/morpheus/framework/resources/instance/instance_update.go
@@ -81,8 +81,17 @@ func (g *Resource) Update(
 	tflog.Info(ctx, fmt.Sprintf("Instance update state: %v", state.Volumes.Elements()))
 	tflog.Info(ctx, fmt.Sprintf("Instance update plan: %v", plan.Volumes.Elements()))
 
-	newState, diag := getInstanceAsState(ctx, state.Id.ValueInt64(), client, plan)
+	newState, found, diag := getInstanceAsState(ctx, state.Id.ValueInt64(), client, plan)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !found {
+		resp.Diagnostics.AddError(
+			"update instance",
+			fmt.Sprintf("instance %d not found after update", state.Id.ValueInt64()),
+		)
+
 		return
 	}
 

--- a/morpheus/framework/resources/instance/resource_test.go
+++ b/morpheus/framework/resources/instance/resource_test.go
@@ -67,6 +67,12 @@ func TestAccMorpheusInstanceResourceExampleOk(t *testing.T) {
 			"config_hvm.resource_pool_id",
 			resourcePool,
 		),
+		// status is a computed attribute, refreshed on read so an out-of-band
+		// deletion of the underlying VM surfaces as a change on the next plan.
+		resource.TestCheckResourceAttrSet(
+			"hpe_morpheus_instance.example",
+			"status",
+		),
 	}
 
 	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -668,6 +669,14 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Custom options for selected service plan - the supported options depend on the service plan selected",
 				MarkdownDescription: "Custom options for selected service plan - the supported options depend on the service plan selected",
 			},
+			"status": schema.StringAttribute{
+				Computed:            true,
+				Description:         "The status of the instance (e.g. running, stopped, failed, unknown). The provider\nrefreshes this on read, so an out-of-band deletion of the underlying VM - which Morpheus\nreports as \"unknown\" while retaining the instance record - surfaces as a change on the next plan.\n",
+				MarkdownDescription: "The status of the instance (e.g. running, stopped, failed, unknown). The provider\nrefreshes this on read, so an out-of-band deletion of the underlying VM - which Morpheus\nreports as \"unknown\" while retaining the instance record - surfaces as a change on the next plan.\n",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"tags": schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -795,6 +804,7 @@ type InstanceModel struct {
 	PlanId             types.Int64             `tfsdk:"plan_id"`
 	Ports              types.Set               `tfsdk:"ports"`
 	ServicePlanOptions ServicePlanOptionsValue `tfsdk:"service_plan_options"`
+	Status             types.String            `tfsdk:"status"`
 	Tags               types.Set               `tfsdk:"tags"`
 	TaskSetId          types.Int64             `tfsdk:"task_set_id"`
 	Timeouts           timeouts.Value          `tfsdk:"timeouts"`


### PR DESCRIPTION
## Summary

An instance whose underlying VM is deleted out of band was invisible to Terraform: `hpe_morpheus_instance` had no `status` attribute, and Read errored on a `404` instead of removing the resource from state. So a `terraform plan` showed no change and stale state accumulated. This adds both signals.

## Changes

- **`status`** — a new computed string attribute, refreshed on every read. When the underlying VM is deleted out of band, Morpheus retains the instance record at `status = "unknown"`; surfacing it makes that change visible on the next plan. (Schema regenerated; no SDK change — the field already exists on the instance GET response model.)
- **Read 404 handling** — on a `404` from `GET /api/instances/{id}`, the resource is removed from state (`RemoveResource`) instead of erroring, so the next `apply` recreates it. `getInstanceAsState` now returns a `found` bool; Update and Create treat not-found as an error.
- Acceptance test asserts `status` is populated after create.

## Notes

- The regenerated `schema_gen.go` is included so this branch builds standalone; the code-spec source change is a separate follow-up.
- Verified: `go build ./...`, `go vet`, `golangci-lint run`, `make docs` (status documented, idempotent).

Refs: MORPH-12957
