### PR TITLE
Trim trailing slashes from appliance URL for Morpheus 9.0 auth

### DIFF
--- a/morpheus/sdkv2/client/client.go
+++ b/morpheus/sdkv2/client/client.go
@@ -27,6 +27,7 @@ func NewLegacyClient(
 	token string,
 	opts ...sdklegacy.ClientOption,
 ) *sdklegacy.Client {
+	url = auth.NormalizeBaseURL(url)
 	c := sdklegacy.NewClient(url, opts...)
 
 	transport := &http.Transport{

--- a/morpheus/utils/auth/creds.go
+++ b/morpheus/utils/auth/creds.go
@@ -125,6 +125,7 @@ func NewCredsRoundTripper(
 	username string,
 	password string,
 ) http.RoundTripper {
+	url = NormalizeBaseURL(url)
 	morpheusCfg := sdk.NewConfiguration()
 	morpheusCfg.Servers[0].URL = url
 

--- a/morpheus/utils/auth/url.go
+++ b/morpheus/utils/auth/url.go
@@ -1,0 +1,23 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+package auth
+
+import "strings"
+
+// NormalizeBaseURL trims trailing slashes from the Morpheus appliance base URL.
+//
+// The generated SDK builds request paths by concatenating the configured base
+// URL with an absolute path, e.g. baseURL + "/oauth/token". If the configured
+// URL carries a trailing slash (e.g. "https://morpheus.example.com/") the
+// result is a double slash ("https://morpheus.example.com//oauth/token").
+//
+// Morpheus 9.0 serves its OAuth2 token endpoint from a Spring Authorization
+// Server mounted at the servlet path "/oauth/*". A double-slash request such as
+// "//oauth/token" does not match that mapping, so the request bypasses the
+// authorization server and Morpheus returns a non-JSON error page. The SDK then
+// fails to decode the response ("undefined response type"), which surfaces as an
+// authentication failure. The same applies to "//api/..." requests once the
+// token is obtained. Trimming trailing slashes keeps every request path
+// single-slashed and routable.
+func NormalizeBaseURL(url string) string {
+	return strings.TrimRight(url, "/")
+}

--- a/morpheus/utils/auth/url.go
+++ b/morpheus/utils/auth/url.go
@@ -18,6 +18,10 @@ import "strings"
 // authentication failure. The same applies to "//api/..." requests once the
 // token is obtained. Trimming trailing slashes keeps every request path
 // single-slashed and routable.
+//
+// Surrounding whitespace is also trimmed first so a misconfigured URL such as
+// "https://morpheus.example.com/ " (note the trailing space) still has its
+// trailing slash removed.
 func NormalizeBaseURL(url string) string {
-	return strings.TrimRight(url, "/")
+	return strings.TrimRight(strings.TrimSpace(url), "/")
 }

--- a/morpheus/utils/auth/url_test.go
+++ b/morpheus/utils/auth/url_test.go
@@ -1,0 +1,29 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus/utils/auth"
+)
+
+func TestNormalizeBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no trailing slash", "https://morpheus.example.com", "https://morpheus.example.com"},
+		{"single trailing slash", "https://morpheus.example.com/", "https://morpheus.example.com"},
+		{"multiple trailing slashes", "https://morpheus.example.com///", "https://morpheus.example.com"},
+		{"trailing slash with path", "https://morpheus.example.com/sub/", "https://morpheus.example.com/sub"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := auth.NormalizeBaseURL(tt.in); got != tt.want {
+				t.Errorf("NormalizeBaseURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/morpheus/utils/auth/url_test.go
+++ b/morpheus/utils/auth/url_test.go
@@ -17,6 +17,9 @@ func TestNormalizeBaseURL(t *testing.T) {
 		{"single trailing slash", "https://morpheus.example.com/", "https://morpheus.example.com"},
 		{"multiple trailing slashes", "https://morpheus.example.com///", "https://morpheus.example.com"},
 		{"trailing slash with path", "https://morpheus.example.com/sub/", "https://morpheus.example.com/sub"},
+		{"trailing whitespace after slash", "https://morpheus.example.com/ ", "https://morpheus.example.com"},
+		{"leading and trailing whitespace", "  https://morpheus.example.com/  ", "https://morpheus.example.com"},
+		{"whitespace only", "   ", ""},
 		{"empty string", "", ""},
 	}
 	for _, tt := range tests {

--- a/morpheus/utils/clientfactory/clientfactory.go
+++ b/morpheus/utils/clientfactory/clientfactory.go
@@ -105,6 +105,7 @@ func NewAPIClient(
 ) *sdk.APIClient {
 	var options clientOpts
 
+	url = auth.NormalizeBaseURL(url)
 	morpheusCfg := sdk.NewConfiguration()
 	morpheusCfg.Servers[0].URL = url
 

--- a/morpheus/utils/clientfactory/clientfactory_test.go
+++ b/morpheus/utils/clientfactory/clientfactory_test.go
@@ -57,6 +57,33 @@ func TestSecureTLS(t *testing.T) {
 	}
 }
 
+// TestNewClientTrimsTrailingSlashFromURL verifies the appliance URL is
+// normalized so the SDK builds single-slash request paths. A trailing slash
+// would otherwise yield "//oauth/token", which Morpheus 9.0's Spring
+// Authorization Server (mounted at servlet path "/oauth/*") fails to route,
+// breaking authentication with "undefined response type".
+func TestNewClientTrimsTrailingSlashFromURL(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	m := model.SubModel{
+		URL:      types.StringValue("https://morpheus.example.com/"),
+		Username: types.StringValue("user"),
+		Password: types.StringValue("secret"),
+		Insecure: types.BoolValue(false),
+	}
+	cf := clientfactory.New(m)
+	c, err := cf.NewClient(context.Background())
+	if err != nil {
+		t.Fatal("Failed to create client", err)
+	}
+
+	got := c.GetConfig().Servers[0].URL
+	want := "https://morpheus.example.com"
+	if got != want {
+		t.Fatalf("base URL = %q, want %q", got, want)
+	}
+}
+
 func TestInsecureTLS(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 	server := httptest.NewTLSServer(


### PR DESCRIPTION
## Problem

Authentication against Morpheus 9.0 fails when the configured appliance `url` has a trailing slash. It surfaces as:

```
could not authenticate with the Morpheus API ... : undefined response type
```

## Root cause

The generated SDK builds request paths by concatenating the configured base URL with an absolute path (e.g. `baseURL + "/oauth/token"`). When the configured URL ends in a slash (`https://host/`), the result is a **double-slash** path: `//oauth/token` (and likewise `//api/...`).

Morpheus 9.0 changed how its OAuth2 token endpoint is served, and the double-slash path no longer routes to the token endpoint — it returns a non-JSON error page. The SDK cannot decode that response and reports `undefined response type`, which the provider surfaces as an authentication failure. Earlier Morpheus versions tolerated the double slash, so the bug was previously latent.

## Fix

Add `auth.NormalizeBaseURL` (trims trailing slashes) and apply it at every SDK client construction site so request paths are always single-slashed and routable:

- `clientfactory.NewAPIClient` — framework API client
- `auth.NewCredsRoundTripper` — token-request client
- `client.NewLegacyClient` — legacy SDK client

## Testing

- `go build ./...`
- `make lint` — 0 issues
- `go test ./morpheus/utils/auth/... ./morpheus/utils/clientfactory/...` — added unit tests for `NormalizeBaseURL` and for the client trimming a trailing slash from the configured URL