### PR TITLE
Add v1.5.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,72 @@
+# v1.5.0 Release Notes
+
+In this release (v1.5.0) we have added the following resources:
+
+### Networking
+
+- hpe_morpheus_load_balancer_pool
+
+### Compute & Instances
+
+- hpe_morpheus_instance_clone
+- hpe_morpheus_instance_power_state
+- hpe_morpheus_instance_snapshot
+
+### Backup
+
+- hpe_morpheus_backup_host
+- hpe_morpheus_backup_instance
+
+In this release (v1.5.0) we have added the following data sources:
+
+- hpe_morpheus_backup
+- hpe_morpheus_backup_type
+- hpe_morpheus_instance_snapshot
+- hpe_morpheus_load_balancer_pool
+- hpe_morpheus_network_edge_cluster
+- hpe_morpheus_network_pool
+- hpe_morpheus_network_server
+- hpe_morpheus_network_transport_zone
+- hpe_morpheus_network_type
+
+## Enhancements to existing resources
+
+- hpe_morpheus_instance — Added `subnet_id` to `network_interfaces` (required by some clouds, e.g. Azure); added a computed `status` attribute and out-of-band deletion detection (the instance is removed from state when the underlying VM no longer exists)
+- hpe_morpheus_service_plan (data source) — Added a `cloud_id` filter (region/zone)
+- hpe_morpheus_identity_source_saml — Exposed the SP metadata (`entity_id`, `acs_url`) as computed outputs
+- hpe_morpheus_option_list_rest — Added `inject_system_authorization_header` and `use_owner_auth`
+- Option type resources and hpe_morpheus_form — Reject a self-referential `dependent_field` (circular `dependsOnCode`) at plan time
+
+## Resolved issues
+
+- `hpe_morpheus_form` dropped attributes on read for the secGroup field
+- `hpe_morpheus_form` cross-field leakage between option_type reads
+- `hpe_morpheus_form` no attribute generated for plain cascade keys
+- `hpe_morpheus_price_set` type enum and create/update failure handling
+- Appliance URLs with trailing slashes now authenticate correctly against Morpheus 9.0
+- New resources re-read via GET after POST and taint their state on failure, improving reliability
+
+## Known issues
+
+- `hpe_morpheus_cluster_namespace`: `active` is not supported on import. `name` update is not supported.
+- `hpe_morpheus_cluster_hks_hvm` Destroy may return an error but the cluster will be deleted successfully, this is being investigated.
+- `hpe_morpheus_instance` updates fail when removing optional fields.
+  This will be addressed in a future release.
+- `hpe_morpheus_instance` updates fail when removing `evars`.
+  This will be addressed in a future release.
+- Long running operations can fail when using username and password.
+- `hpe_morpheus_instance` depending on the layout used may require one or more `volumes` to be specified,
+  in these cases not specifying the correct number of `volumes` will cause instance creation to fail.
+- There are intermittent issues with the provider failing to authenticate, a 500 error is returned from the Morpheus API.
+  If this happens please retry the operation.  This is being investigated.
+- `hpe_morpheus_datastore` when creating a datastore of type NFS the creation will silently fail if the NFS server is not reachable or the share is not accessible.
+  The datastore will remain in a `provisioning` state indefinitely. Ensure the Morpheus appliance can reach the NFS server
+  and that the share is accessible before creating.
+- `hpe_morpheus_datastore` delete is not guaranteed to succeed.  Alletra MP HVM and Alletra MP BM datastores will delete but NFS datastores
+  may fail to delete.  Always delete VMs and other resources using the datastore before deleting the datastore itself.
+- `hpe_morpheus_instance` in Morpheus versions prior to 8.0.11 requires that the `root` volume is the first entry in
+  the `volumes` block list
+
 # v1.4.0 Release Notes
 
 In this release (v1.4.0) we have added the following resources:

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Initially this provider will support Morpheus, but will in time expand to cover 
 
 This provider requires 64-bit versions of the Terraform binary to work properly.
 
-->This v1.4.0 release includes all functionality from the [Morpheus Terraform Provider](https://registry.terraform.io/providers/gomorpheus/morpheus/latest).
+->This v1.5.0 release includes all functionality from the [Morpheus Terraform Provider](https://registry.terraform.io/providers/gomorpheus/morpheus/latest).
 This provider can now serve as a replacement for the Morpheus provider, and users are encouraged to migrate, as
 the Morpheus provider will be deprecated in the future.<br><br>
 We have developed tooling [tfmigrator](https://registry.terraform.io/providers/HPE/hpe/latest/docs/guides/tfmigrator_migration)
@@ -29,7 +29,7 @@ See [below](#morpheus-provider-mapping) for the mapping of Morpheus provider res
 ## Morpheus
 
 This provider can be used to manage Morpheus resources.  Support will grow over time.  See below for
-release notes for the current version (v1.4.0).
+release notes for the current version (v1.5.0).
 
 ### Authentication
 
@@ -56,7 +56,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
     }
   }
 }
@@ -80,7 +80,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
     }
   }
 }
@@ -105,7 +105,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
     }
   }
 }
@@ -128,7 +128,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
     }
   }
 }
@@ -146,10 +146,12 @@ provider "hpe" {
 ## Release Notes
 
 ->The following resources use `WriteOnly` attributes:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_backup_host<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cloud<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cluster<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_image<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_monitor<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_pool<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network_pool_server<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network_router_bgp_neighbor<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_storage_bucket<br>
@@ -163,8 +165,10 @@ provider "hpe" {
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cluster<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_datastore<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_instance<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_instance_clone<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_monitor<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_pool<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_virtual_server<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network_dhcp_server<br>
@@ -181,98 +185,53 @@ That is, the attribute names are case-sensitive and must match exactly.
 
 ### New resources
 
-In this release (v1.4.0) we have added the following resources:
+In this release (v1.5.0) we have added the following resources:
 
 #### Networking
 
-- hpe_morpheus_load_balancer_monitor
-- hpe_morpheus_load_balancer_virtual_server
-- hpe_morpheus_network_dhcp_server
-- hpe_morpheus_network_firewall_rule
-- hpe_morpheus_network_firewall_rule_group
-- hpe_morpheus_network_group
-- hpe_morpheus_network_pool
-- hpe_morpheus_network_pool_server
-- hpe_morpheus_network_router
-- hpe_morpheus_network_router_bgp_neighbor
-- hpe_morpheus_network_router_firewall_rule
-- hpe_morpheus_network_router_nat
-- hpe_morpheus_network_router_route
-- hpe_morpheus_security_group
-- hpe_morpheus_security_group_rule
-- hpe_morpheus_subnet
+- hpe_morpheus_load_balancer_pool
 
-#### Monitoring & Operations
+#### Compute & Instances
 
-- hpe_morpheus_backup_job
-- hpe_morpheus_budget
-- hpe_morpheus_monitoring_alert
-- hpe_morpheus_monitoring_check
-- hpe_morpheus_monitoring_group
+- hpe_morpheus_instance_clone
+- hpe_morpheus_instance_power_state
+- hpe_morpheus_instance_snapshot
 
-#### Storage
+#### Backup
 
-- hpe_morpheus_storage_bucket
-- hpe_morpheus_storage_server
-- hpe_morpheus_storage_volume
-
-#### Library & Provisioning
-
-- hpe_morpheus_container_script
-- hpe_morpheus_option_list
-- hpe_morpheus_provisioning_license
-
-#### VDI
-
-- hpe_morpheus_vdi_app
-- hpe_morpheus_vdi_gateway
-- hpe_morpheus_vdi_pool
-
-#### Compute & Cluster
-
-- hpe_morpheus_cluster_affinity_group
-- hpe_morpheus_cluster_namespace
-
-#### Identity & Governance
-
-- hpe_morpheus_setting_whitelabel
-
-#### Other
-
-- hpe_morpheus_certificate
-- hpe_morpheus_deployment
-- hpe_morpheus_power_schedule
+- hpe_morpheus_backup_host
+- hpe_morpheus_backup_instance
 
 ### New data sources
 
-In this release (v1.4.0) we have added the following data sources:
+In this release (v1.5.0) we have added the following data sources:
 
-- hpe_morpheus_load_balancer_monitor
-- hpe_morpheus_load_balancer_virtual_server
-- hpe_morpheus_network_dhcp_server
-- hpe_morpheus_network_domain (reimplemented)
-- hpe_morpheus_network_firewall_rule
-- hpe_morpheus_network_firewall_rule_group
-- hpe_morpheus_network_router
-- hpe_morpheus_network_router_bgp_neighbor
-- hpe_morpheus_network_router_route
+- hpe_morpheus_backup
+- hpe_morpheus_backup_type
+- hpe_morpheus_instance_snapshot
+- hpe_morpheus_load_balancer_pool
+- hpe_morpheus_network_edge_cluster
+- hpe_morpheus_network_pool
+- hpe_morpheus_network_server
+- hpe_morpheus_network_transport_zone
+- hpe_morpheus_network_type
 
 ### Enhancements to existing resources
 
-- hpe_morpheus_cloud — Added `config_azure` static config block; added 6 inventory discovery sync fields (`default_*_sync_active`)
-- hpe_morpheus_instance — Added `config_azure` static config block; added `network_domain_id` attribute (change forces recreation)
-- hpe_morpheus_load_balancer — Added tainting support; added `config` Dynamic attribute
-- hpe_morpheus_task — Allow null `else` in conditional_workflow task
-- All password/secret fields across 10 resources now enforce Sensitive + WriteOnly + PlanModifiers
+- hpe_morpheus_instance — Added `subnet_id` to `network_interfaces` (required by some clouds, e.g. Azure); added a computed `status` attribute and out-of-band deletion detection (the instance is removed from state when the underlying VM no longer exists)
+- hpe_morpheus_service_plan (data source) — Added a `cloud_id` filter (region/zone)
+- hpe_morpheus_identity_source_saml — Exposed the SP metadata (`entity_id`, `acs_url`) as computed outputs
+- hpe_morpheus_option_list_rest — Added `inject_system_authorization_header` and `use_owner_auth`
+- Option type resources and hpe_morpheus_form — Reject a self-referential `dependent_field` (circular `dependsOnCode`) at plan time
 
 ### Resolved issues
 
-- `hpe_morpheus_cloud` import fails with unknown values in static config blocks
-- `hpe_morpheus_task` conditional_workflow doesn't support null else clause
-- `hpe_morpheus_app_blueprint_kubernetes` YAML config not properly parsed
-- `hpe_morpheus_ansible_tower_inventory` data source type assertions fail intermittently
-- `hpe_morpheus_cluster` delete polling can report false failures
-- Import syntax standardised to dot-notation for multi-ID resources
+- `hpe_morpheus_form` dropped attributes on read for the secGroup field
+- `hpe_morpheus_form` cross-field leakage between option_type reads
+- `hpe_morpheus_form` no attribute generated for plain cascade keys
+- `hpe_morpheus_price_set` type enum and create/update failure handling
+- Appliance URLs with trailing slashes now authenticate correctly against Morpheus 9.0
+- New resources re-read via GET after POST and taint their state on failure, improving reliability
 
 ### Known issues
 

--- a/examples/provider/morpheus/provider-accesstoken.tf
+++ b/examples/provider/morpheus/provider-accesstoken.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
     }
   }
 }

--- a/examples/provider/morpheus/provider-insecure.tf
+++ b/examples/provider/morpheus/provider-insecure.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
     }
   }
 }

--- a/examples/provider/morpheus/provider-tenant.tf
+++ b/examples/provider/morpheus/provider-tenant.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
     }
   }
 }

--- a/examples/provider/morpheus/provider-unamepasswd.tf
+++ b/examples/provider/morpheus/provider-unamepasswd.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.4.0"
+      version = ">= 1.5.0"
     }
   }
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -16,7 +16,7 @@ Initially this provider will support Morpheus, but will in time expand to cover 
 
 This provider requires 64-bit versions of the Terraform binary to work properly.
 
-->This v1.4.0 release includes all functionality from the [Morpheus Terraform Provider](https://registry.terraform.io/providers/gomorpheus/morpheus/latest).
+->This v1.5.0 release includes all functionality from the [Morpheus Terraform Provider](https://registry.terraform.io/providers/gomorpheus/morpheus/latest).
 This provider can now serve as a replacement for the Morpheus provider, and users are encouraged to migrate, as
 the Morpheus provider will be deprecated in the future.<br><br>
 We have developed tooling [tfmigrator](https://registry.terraform.io/providers/HPE/hpe/latest/docs/guides/tfmigrator_migration)
@@ -29,7 +29,7 @@ See [below](#morpheus-provider-mapping) for the mapping of Morpheus provider res
 ## Morpheus
 
 This provider can be used to manage Morpheus resources.  Support will grow over time.  See below for
-release notes for the current version (v1.4.0).
+release notes for the current version (v1.5.0).
 
 ### Authentication
 
@@ -66,10 +66,12 @@ be toggled off by setting `insecure` to `true` in the provider block.
 ## Release Notes
 
 ->The following resources use `WriteOnly` attributes:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_backup_host<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cloud<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cluster<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_image<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_monitor<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_pool<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network_pool_server<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network_router_bgp_neighbor<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_storage_bucket<br>
@@ -83,8 +85,10 @@ be toggled off by setting `insecure` to `true` in the provider block.
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_cluster<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_datastore<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_instance<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_instance_clone<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_monitor<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_pool<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_load_balancer_virtual_server<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_network_dhcp_server<br>
@@ -101,98 +105,53 @@ That is, the attribute names are case-sensitive and must match exactly.
 
 ### New resources
 
-In this release (v1.4.0) we have added the following resources:
+In this release (v1.5.0) we have added the following resources:
 
 #### Networking
 
-- hpe_morpheus_load_balancer_monitor
-- hpe_morpheus_load_balancer_virtual_server
-- hpe_morpheus_network_dhcp_server
-- hpe_morpheus_network_firewall_rule
-- hpe_morpheus_network_firewall_rule_group
-- hpe_morpheus_network_group
-- hpe_morpheus_network_pool
-- hpe_morpheus_network_pool_server
-- hpe_morpheus_network_router
-- hpe_morpheus_network_router_bgp_neighbor
-- hpe_morpheus_network_router_firewall_rule
-- hpe_morpheus_network_router_nat
-- hpe_morpheus_network_router_route
-- hpe_morpheus_security_group
-- hpe_morpheus_security_group_rule
-- hpe_morpheus_subnet
+- hpe_morpheus_load_balancer_pool
 
-#### Monitoring & Operations
+#### Compute & Instances
 
-- hpe_morpheus_backup_job
-- hpe_morpheus_budget
-- hpe_morpheus_monitoring_alert
-- hpe_morpheus_monitoring_check
-- hpe_morpheus_monitoring_group
+- hpe_morpheus_instance_clone
+- hpe_morpheus_instance_power_state
+- hpe_morpheus_instance_snapshot
 
-#### Storage
+#### Backup
 
-- hpe_morpheus_storage_bucket
-- hpe_morpheus_storage_server
-- hpe_morpheus_storage_volume
-
-#### Library & Provisioning
-
-- hpe_morpheus_container_script
-- hpe_morpheus_option_list
-- hpe_morpheus_provisioning_license
-
-#### VDI
-
-- hpe_morpheus_vdi_app
-- hpe_morpheus_vdi_gateway
-- hpe_morpheus_vdi_pool
-
-#### Compute & Cluster
-
-- hpe_morpheus_cluster_affinity_group
-- hpe_morpheus_cluster_namespace
-
-#### Identity & Governance
-
-- hpe_morpheus_setting_whitelabel
-
-#### Other
-
-- hpe_morpheus_certificate
-- hpe_morpheus_deployment
-- hpe_morpheus_power_schedule
+- hpe_morpheus_backup_host
+- hpe_morpheus_backup_instance
 
 ### New data sources
 
-In this release (v1.4.0) we have added the following data sources:
+In this release (v1.5.0) we have added the following data sources:
 
-- hpe_morpheus_load_balancer_monitor
-- hpe_morpheus_load_balancer_virtual_server
-- hpe_morpheus_network_dhcp_server
-- hpe_morpheus_network_domain (reimplemented)
-- hpe_morpheus_network_firewall_rule
-- hpe_morpheus_network_firewall_rule_group
-- hpe_morpheus_network_router
-- hpe_morpheus_network_router_bgp_neighbor
-- hpe_morpheus_network_router_route
+- hpe_morpheus_backup
+- hpe_morpheus_backup_type
+- hpe_morpheus_instance_snapshot
+- hpe_morpheus_load_balancer_pool
+- hpe_morpheus_network_edge_cluster
+- hpe_morpheus_network_pool
+- hpe_morpheus_network_server
+- hpe_morpheus_network_transport_zone
+- hpe_morpheus_network_type
 
 ### Enhancements to existing resources
 
-- hpe_morpheus_cloud — Added `config_azure` static config block; added 6 inventory discovery sync fields (`default_*_sync_active`)
-- hpe_morpheus_instance — Added `config_azure` static config block; added `network_domain_id` attribute (change forces recreation)
-- hpe_morpheus_load_balancer — Added tainting support; added `config` Dynamic attribute
-- hpe_morpheus_task — Allow null `else` in conditional_workflow task
-- All password/secret fields across 10 resources now enforce Sensitive + WriteOnly + PlanModifiers
+- hpe_morpheus_instance — Added `subnet_id` to `network_interfaces` (required by some clouds, e.g. Azure); added a computed `status` attribute and out-of-band deletion detection (the instance is removed from state when the underlying VM no longer exists)
+- hpe_morpheus_service_plan (data source) — Added a `cloud_id` filter (region/zone)
+- hpe_morpheus_identity_source_saml — Exposed the SP metadata (`entity_id`, `acs_url`) as computed outputs
+- hpe_morpheus_option_list_rest — Added `inject_system_authorization_header` and `use_owner_auth`
+- Option type resources and hpe_morpheus_form — Reject a self-referential `dependent_field` (circular `dependsOnCode`) at plan time
 
 ### Resolved issues
 
-- `hpe_morpheus_cloud` import fails with unknown values in static config blocks
-- `hpe_morpheus_task` conditional_workflow doesn't support null else clause
-- `hpe_morpheus_app_blueprint_kubernetes` YAML config not properly parsed
-- `hpe_morpheus_ansible_tower_inventory` data source type assertions fail intermittently
-- `hpe_morpheus_cluster` delete polling can report false failures
-- Import syntax standardised to dot-notation for multi-ID resources
+- `hpe_morpheus_form` dropped attributes on read for the secGroup field
+- `hpe_morpheus_form` cross-field leakage between option_type reads
+- `hpe_morpheus_form` no attribute generated for plain cascade keys
+- `hpe_morpheus_price_set` type enum and create/update failure handling
+- Appliance URLs with trailing slashes now authenticate correctly against Morpheus 9.0
+- New resources re-read via GET after POST and taint their state on failure, improving reliability
 
 ### Known issues
 


### PR DESCRIPTION
Adds the v1.5.0 release notes to `CHANGELOG.md` and the provider index page (`templates/index.md.tmpl` → `docs/index.md`), and bumps the provider version in the index provider examples to `>= 1.5.0`.

### New resources (6)
- `hpe_morpheus_load_balancer_pool`
- `hpe_morpheus_instance_clone`
- `hpe_morpheus_instance_power_state`
- `hpe_morpheus_instance_snapshot`
- `hpe_morpheus_backup_host`
- `hpe_morpheus_backup_instance`

### New data sources (9)
`hpe_morpheus_backup`, `hpe_morpheus_backup_type`, `hpe_morpheus_instance_snapshot`, `hpe_morpheus_load_balancer_pool`, `hpe_morpheus_network_edge_cluster`, `hpe_morpheus_network_pool`, `hpe_morpheus_network_server`, `hpe_morpheus_network_transport_zone`, `hpe_morpheus_network_type`

### Also includes
- **Enhancements to existing resources**: instance `subnet_id` + `status`/out-of-band-delete detection; `service_plan` data source `cloud_id` filter; `identity_source_saml` SP metadata outputs; `option_list_rest` auth flags; self-referential `dependent_field` rejection.
- **Resolved issues**: three `hpe_morpheus_form` read bugs, `price_set` fixes, Morpheus 9.0 trailing-slash auth, GET-after-POST/taint reliability.
- Updated the `WriteOnly` and `Dynamic config` callout lists for the new resources; bumped the two "current version" references to v1.5.0.

Derived from the `dev-1.4..dev-1.5` registration diff (resources 51 → 57, data sources 25 → 34). `docs/index.md` regenerated via `make docs` (idempotent).
