### PR TITLE
Fix app blueprint kubernetes read panic and docker registry example URL

### DIFF
--- a/docs/resources/morpheus_app_blueprint_kubernetes.md
+++ b/docs/resources/morpheus_app_blueprint_kubernetes.md
@@ -48,7 +48,7 @@ TFEOF
 Creating the Kubernetes app blueprint with Kubernetes spec templates:
 
 ```terraform
-resource "hpe_morpheus_app_blueprint_kubernetes" "tfexample_kubernetes_app_blueprint_spec" {
+resource "hpe_morpheus_app_blueprint_kubernetes" "example" {
   name              = "tf-kubernetes-app-blueprint-example-spec"
   description       = "tf example kubernetes app blueprint"
   category          = "k8s"
@@ -60,7 +60,7 @@ resource "hpe_morpheus_app_blueprint_kubernetes" "tfexample_kubernetes_app_bluep
 Creating the Kubernetes app blueprint with the blueprint fetched via git:
 
 ```terraform
-resource "hpe_morpheus_app_blueprint_kubernetes" "tfexample_kubernetes_app_blueprint_git" {
+resource "hpe_morpheus_app_blueprint_kubernetes" "example" {
   name           = "tf-kubernetes-app-blueprint-example-git"
   description    = "tf example kubernetes app blueprint"
   category       = "k8s"

--- a/docs/resources/morpheus_integration_docker_registry.md
+++ b/docs/resources/morpheus_integration_docker_registry.md
@@ -14,7 +14,7 @@ Provides a Docker registry integration resource
 resource "hpe_morpheus_integration_docker_registry" "tf_example_docker_registry_integration" {
   name     = "tfexampledockerregistry"
   enabled  = true
-  url      = "https://index.docker.io/v1/"
+  url      = "https://index.docker.io/v1"
   username = "admin"
   password = "password123"
 }

--- a/examples/resources/morpheus_app_blueprint_kubernetes/resource_git.tf
+++ b/examples/resources/morpheus_app_blueprint_kubernetes/resource_git.tf
@@ -1,4 +1,4 @@
-resource "hpe_morpheus_app_blueprint_kubernetes" "tfexample_kubernetes_app_blueprint_git" {
+resource "hpe_morpheus_app_blueprint_kubernetes" "example" {
   name           = "tf-kubernetes-app-blueprint-example-git"
   description    = "tf example kubernetes app blueprint"
   category       = "k8s"

--- a/examples/resources/morpheus_app_blueprint_kubernetes/resource_spec.tf
+++ b/examples/resources/morpheus_app_blueprint_kubernetes/resource_spec.tf
@@ -1,4 +1,4 @@
-resource "hpe_morpheus_app_blueprint_kubernetes" "tfexample_kubernetes_app_blueprint_spec" {
+resource "hpe_morpheus_app_blueprint_kubernetes" "example" {
   name              = "tf-kubernetes-app-blueprint-example-spec"
   description       = "tf example kubernetes app blueprint"
   category          = "k8s"

--- a/examples/resources/morpheus_integration_docker_registry/resource.tf
+++ b/examples/resources/morpheus_integration_docker_registry/resource.tf
@@ -1,7 +1,7 @@
 resource "hpe_morpheus_integration_docker_registry" "tf_example_docker_registry_integration" {
   name     = "tfexampledockerregistry"
   enabled  = true
-  url      = "https://index.docker.io/v1/"
+  url      = "https://index.docker.io/v1"
   username = "admin"
   password = "password123"
 }

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_git.tf.tmpl
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_git.tf.tmpl
@@ -1,4 +1,4 @@
-resource "hpe_morpheus_app_blueprint_kubernetes" "tfexample_kubernetes_app_blueprint_git" {
+resource "hpe_morpheus_app_blueprint_kubernetes" "example" {
   name           = "{{.Name}}"
   description    = "{{.Description}}"
   category       = "{{.Category}}"

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_git_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_git_test.go
@@ -62,7 +62,7 @@ func TestAccMorpheusAppBlueprintKubernetesGitExampleOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_app_blueprint_kubernetes.example",
 			"name",
-			"tf-kubernetes-app-blueprint-example-git",
+			name,
 		),
 
 		resource.TestCheckResourceAttr(

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_spec.tf.tmpl
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_spec.tf.tmpl
@@ -1,4 +1,4 @@
-resource "hpe_morpheus_app_blueprint_kubernetes" "tfexample_kubernetes_app_blueprint_spec" {
+resource "hpe_morpheus_app_blueprint_kubernetes" "example" {
   name              = "{{.Name}}"
   description       = "{{.Description}}"
   category          = "{{.Category}}"

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_spec_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_spec_test.go
@@ -56,7 +56,7 @@ func TestAccMorpheusAppBlueprintKubernetesSpecExampleOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_app_blueprint_kubernetes.example",
 			"name",
-			"tf-kubernetes-app-blueprint-example-spec",
+			name,
 		),
 
 		resource.TestCheckResourceAttr(
@@ -67,8 +67,20 @@ func TestAccMorpheusAppBlueprintKubernetesSpecExampleOk(t *testing.T) {
 
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_app_blueprint_kubernetes.example",
-			"spec_template_ids",
-			"[2, 3]",
+			"spec_template_ids.#",
+			"2",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_app_blueprint_kubernetes.example",
+			"spec_template_ids.0",
+			"2",
+		),
+
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_app_blueprint_kubernetes.example",
+			"spec_template_ids.1",
+			"3",
 		),
 	}
 

--- a/morpheus/sdkv2/resources/blueprint/resource_app_blueprint_kubernetes.go
+++ b/morpheus/sdkv2/resources/blueprint/resource_app_blueprint_kubernetes.go
@@ -343,7 +343,7 @@ func resourceAppBlueprintKubernetesRead(
 				specTemplates = append(specTemplates, int64(specTemplate.ID))
 			}
 		}
-		d.Set("spec_templates_ids", specTemplates)
+		d.Set("spec_template_ids", specTemplates)
 	}
 
 	return diags
@@ -550,7 +550,7 @@ type AppBlueprintKubernetes struct {
 			Config struct {
 				Specs []struct {
 					ID    int    `json:"id"`
-					Value string `json:"value"`
+					Value int    `json:"value"`
 					Name  string `json:"name"`
 				} `json:"specs"`
 			} `json:"config"`

--- a/morpheus/sdkv2/resources/blueprint/resource_app_blueprint_terraform.go
+++ b/morpheus/sdkv2/resources/blueprint/resource_app_blueprint_terraform.go
@@ -633,7 +633,7 @@ type AppBlueprintTerraform struct {
 			Config struct {
 				Specs []struct {
 					ID    int    `json:"id"`
-					Value string `json:"value"`
+					Value int    `json:"value"`
 					Name  string `json:"name"`
 				} `json:"specs"`
 			} `json:"config"`

--- a/morpheus/sdkv2/resources/integration/morpheus_integration_docker_registry_resource_example.go
+++ b/morpheus/sdkv2/resources/integration/morpheus_integration_docker_registry_resource_example.go
@@ -11,7 +11,7 @@ import (
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 )
 
-//go:generate../../../../bin/render -out examples/resources/morpheus_integration_docker_registry/resource.tf morpheus_integration_docker_registry_resource.tf.tmpl Name tfexampledockerregistry Enabled true Url https://index.docker.io/v1/ Username admin Password password123
+//go:generate../../../../bin/render -out examples/resources/morpheus_integration_docker_registry/resource.tf morpheus_integration_docker_registry_resource.tf.tmpl Name tfexampledockerregistry Enabled true Url https://index.docker.io/v1 Username admin Password password123
 
 // RenderIntegrationDockerRegistryConfig renders the Docker Registry integration
 // resource configuration with the provided field overrides. Default values are used for any
@@ -22,7 +22,7 @@ func RenderIntegrationDockerRegistryConfig(t *testing.T, overrides map[string]st
 	defaults := map[string]string{
 		"Name":     "Example",
 		"Enabled":  "true",
-		"Url":      "https://index.docker.io/v1/",
+		"Url":      "https://index.docker.io/v1",
 		"Username": "admin",
 		"Password": "password123",
 	}

--- a/morpheus/sdkv2/resources/integration/morpheus_integration_docker_registry_resource_test.go
+++ b/morpheus/sdkv2/resources/integration/morpheus_integration_docker_registry_resource_test.go
@@ -52,7 +52,7 @@ func TestAccMorpheusIntegrationDockerRegistryExampleOk(t *testing.T) {
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_integration_docker_registry.tf_example_docker_registry_integration",
 			"url",
-			"https://index.docker.io/v1/",
+			"https://index.docker.io/v1",
 		),
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_integration_docker_registry.tf_example_docker_registry_integration",


### PR DESCRIPTION
## Summary

Two fixes surfaced while running the acceptance suite.

### App blueprint (Kubernetes)
- **Fix a provider panic** when reading a Kubernetes *spec* app blueprint: the read called `d.Set` with an attribute key not present in the schema (`spec_templates_ids`), which panics and crashed the whole package test binary. Corrected to the defined attribute `spec_template_ids`.
- **Fix JSON decoding** of the spec template `value` field, which the API returns as a number but was modeled as a string.
- **Fix the Kubernetes spec and git acceptance tests** (previously masked by the panic):
  - Align the test resource address with the example resource name (`example`).
  - Assert the generated (random) name instead of a hard-coded value.
  - Check `spec_template_ids` as a list (`.#` / `.0` / `.1`).

### Docker registry integration
- The API stores the registry URL without a trailing slash, causing a perpetual diff and a failing example test. Update the example and assertion to the normalized URL (`https://index.docker.io/v1`).

## Testing
- `go build ./...` and `golangci-lint run` (0 issues).
- Docs regenerated with `tfplugindocs` (stable, no diff).
- Acceptance tests pass against a live appliance:
  - `TestAccMorpheusAppBlueprintKubernetesSpecExampleOk`
  - `TestAccMorpheusAppBlueprintKubernetesGitExampleOk`
  - `TestAccMorpheusIntegrationDockerRegistryExampleOk`
  - Full `morpheus/sdkv2/resources/blueprint` package green (no panic).

## Notes
- A harmless log line may still appear from the legacy SDK when decoding spec blueprints; the resource read uses its own decoding and is unaffected. A follow-up in `hpe-morpheus-go-sdk` can remove the noise.