### PR TITLE
Add user_group and storage_profile to instance resources (MORPH-13001)

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -1101,8 +1101,10 @@ Use /api/provision-types?code=vmware to see the available controllerTypes for vm
 - `root_volume` (Boolean) If set to false then a non-root LV will be created.
 - `size` (Number) Size of the LV to be created in GBs.  Uses default from service plan.
 - `size_id` (Number) Can be used to select pre-existing LV choices from Morpheus.
-- `storage_profile` (String) Storage Profile Code for the volume storage profile assignment. eg. `"kvm-cache-none"` or `"kvm-cache-directsync"`.
-Use `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.
+- `storage_profile` (String) Storage profile code for the volume. The available codes depend on the
+provision type; query `/api/provision-types` to list the `storageProfiles`
+for a type. For example, KVM/HVM volumes use cache-mode profiles such as
+`"kvm-cache-none"` or `"kvm-cache-directsync"` (`/api/provision-types?code=kvm`).
 - `storage_type_id` (Number) Identifier for LV type
 
 Read-Only:

--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -893,6 +893,10 @@ The layout may have default ports, which are defined in node types, that are alw
 - `tags` (Attributes Set) Metadata tags, Array of objects having a name and value. (see [below for nested schema](#nestedatt--tags))
 - `task_set_id` (Number) The Workflow ID to execute.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
+- `user_group` (Number) The id of the user group to associate with the instance. When create_user is enabled on
+the relevant config_* block, the user group's members can be created as users on the
+provisioned instance. The user group can only be set at provision time; changing it forces
+replacement of the instance.
 - `volumes` (Attributes List) Logical Volume configuration to create additional LVs at provision time (see [below for nested schema](#nestedatt--volumes))
 
 ### Read-Only

--- a/docs/resources/morpheus_instance_clone.md
+++ b/docs/resources/morpheus_instance_clone.md
@@ -388,8 +388,10 @@ For a new controller the id is -1, e.g. "-1:1:6:0". Use /api/provision-types?cod
 - `datastore_id` (Number) The ID of the datastore to place the volume on.
 - `root_volume` (Boolean) Whether this is the root volume. Exactly one volume must be the root volume.
 - `size_id` (Number) Selects a pre-existing logical volume size choice from Morpheus. Not returned by the API.
-- `storage_profile` (String) Storage Profile Code for the volume storage profile assignment. eg. `"kvm-cache-none"` or `"kvm-cache-directsync"`.
-Use `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.
+- `storage_profile` (String) Storage profile code for the volume. The available codes depend on the
+provision type; query `/api/provision-types` to list the `storageProfiles`
+for a type. For example, KVM/HVM volumes use cache-mode profiles such as
+`"kvm-cache-none"` or `"kvm-cache-directsync"` (`/api/provision-types?code=kvm`).
 - `storage_type` (Number) The storage volume type ID.
 
 Read-Only:

--- a/docs/resources/morpheus_instance_clone.md
+++ b/docs/resources/morpheus_instance_clone.md
@@ -325,6 +325,7 @@ combined with a typed config_* block.
 - `group_id` (Number) The ID of the group to clone into. Defaults to the source instance's group.
 - `plan_id` (Number) The ID of the service plan override for the clone. Defaults to the source instance's service plan.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
+- `user_group` (Number) The id of the user group to associate with the clone. Can only be set at clone time; changing it forces replacement.
 
 ### Read-Only
 
@@ -387,6 +388,8 @@ For a new controller the id is -1, e.g. "-1:1:6:0". Use /api/provision-types?cod
 - `datastore_id` (Number) The ID of the datastore to place the volume on.
 - `root_volume` (Boolean) Whether this is the root volume. Exactly one volume must be the root volume.
 - `size_id` (Number) Selects a pre-existing logical volume size choice from Morpheus. Not returned by the API.
+- `storage_profile` (String) Storage Profile Code for the volume storage profile assignment. eg. `"kvm-cache-none"` or `"kvm-cache-directsync"`.
+Use `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.
 - `storage_type` (Number) The storage volume type ID.
 
 Read-Only:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/HewlettPackard/hpe-morpheus-go-sdk/legacy v0.0.0-20260519114622-05016d74fdfe
-	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.74.0
+	github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.75.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.73.0 h1:3SjFpH3oCRKtg1Q
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.73.0/go.mod h1:b6E29JKzlWyMCIEjwUz/KstqXIBna2qdcTwvSJQF5bI=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.74.0 h1:CSRvu6EwoabQZM60zRWhiZHIiWJuYz1hBqM8TwbdSuo=
 github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.74.0/go.mod h1:b6E29JKzlWyMCIEjwUz/KstqXIBna2qdcTwvSJQF5bI=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.75.0 h1:o+79FdXVyGxc/Lp82xwHvjxRum17hqMHGM+252Wrj7w=
+github.com/HewlettPackard/hpe-morpheus-go-sdk/oapigen v0.75.0/go.mod h1:b6E29JKzlWyMCIEjwUz/KstqXIBna2qdcTwvSJQF5bI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=

--- a/morpheus/framework/resources/instance/example.tf.tmpl
+++ b/morpheus/framework/resources/instance/example.tf.tmpl
@@ -17,6 +17,9 @@ resource "hpe_morpheus_instance" "example" {
   plan_id  = data.hpe_morpheus_service_plan.vme_512mb.id # kvm-vm-512
 
   instance_context = "{{.InstanceContext}}"
+{{- if .UserGroup}}
+  user_group = {{.UserGroup}}
+{{- end}}
   network_interfaces = [
     {
       network_id = {{.NetworkId}}
@@ -30,6 +33,9 @@ resource "hpe_morpheus_instance" "example" {
       size            = 10
       storage_type_id = 1
       datastore_id    = {{.DatastoreId}}
+{{- if .StorageProfile}}
+      storage_profile = "{{.StorageProfile}}"
+{{- end}}
     },
     {
       root_volume     = false

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -83,6 +83,7 @@ func (g *Resource) Create(
 	// AWS config
 	case !plan.ConfigAws.IsNull() && !plan.ConfigAws.IsUnknown():
 		noAgent := plan.ConfigAws.NoAgent.ValueBool()
+		createUser := plan.ConfigAws.CreateUser.ValueBool()
 		isEC2 := convert.BoolToStringTrueFalse(plan.ConfigAws.IsEc2.ValueBool()).ValueString()
 		kmsKeyId := plan.ConfigAws.KmsKeyId.ValueString()
 		instanceProfile := plan.ConfigAws.InstanceProfile.ValueString()
@@ -92,6 +93,7 @@ func (g *Resource) Create(
 
 		configAWS := &sdk.AmazonInstanceConfiguration2{
 			NoAgent:         *sdk.NewNullableBool(&noAgent),
+			CreateUser:      *sdk.NewNullableBool(&createUser),
 			ResourcePoolId:  &resourcePoolId,
 			IsEC2:           &isEC2,
 			KmsKeyId:        &kmsKeyId,
@@ -387,6 +389,13 @@ func (g *Resource) Create(
 	// task_set_id
 	if !plan.TaskSetId.IsNull() {
 		reqInstance.TaskSetId = plan.TaskSetId.ValueInt64Pointer()
+	}
+
+	// user_group
+	if !plan.UserGroup.IsNull() {
+		reqInstance.Instance.UserGroup = &sdk.AddInstanceRequestInstanceUserGroup{
+			Id: plan.UserGroup.ValueInt64Pointer(),
+		}
 	}
 
 	// volumes

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -533,7 +533,7 @@ func (g *Resource) Create(
 	}
 
 	// Read the instance state
-	state, found, d := getInstanceAsState(ctx, instanceId, client, plan)
+	state, found, d := getInstanceAsState(ctx, instanceId, client, plan, false)
 	if d.HasError() || !found {
 		resp.Diagnostics.Append(d...)
 		resp.Diagnostics.AddError(

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -392,7 +392,7 @@ func (g *Resource) Create(
 	}
 
 	// user_group
-	if !plan.UserGroup.IsNull() {
+	if !plan.UserGroup.IsNull() && !plan.UserGroup.IsUnknown() {
 		reqInstance.Instance.UserGroup = &sdk.AddInstanceRequestInstanceUserGroup{
 			Id: plan.UserGroup.ValueInt64Pointer(),
 		}

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -55,6 +55,17 @@ func (g *Resource) Create(
 		return
 	}
 
+	// config is the raw configuration (before schema defaults are applied). It
+	// lets us tell whether the user actually set create_user versus it falling
+	// back to its schema default: when the user did not set it we omit it from
+	// the request so the API applies its own per-cloud default instead of an
+	// explicit value.
+	var config InstanceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Get timeout from HCL if set, the default is 45 minutes
 	createTimeout, diags := plan.Timeouts.Create(ctx, 45*time.Minute)
 	resp.Diagnostics.Append(diags...)
@@ -83,7 +94,6 @@ func (g *Resource) Create(
 	// AWS config
 	case !plan.ConfigAws.IsNull() && !plan.ConfigAws.IsUnknown():
 		noAgent := plan.ConfigAws.NoAgent.ValueBool()
-		createUser := plan.ConfigAws.CreateUser.ValueBool()
 		isEC2 := convert.BoolToStringTrueFalse(plan.ConfigAws.IsEc2.ValueBool()).ValueString()
 		kmsKeyId := plan.ConfigAws.KmsKeyId.ValueString()
 		instanceProfile := plan.ConfigAws.InstanceProfile.ValueString()
@@ -93,13 +103,17 @@ func (g *Resource) Create(
 
 		configAWS := &sdk.AmazonInstanceConfiguration2{
 			NoAgent:         *sdk.NewNullableBool(&noAgent),
-			CreateUser:      *sdk.NewNullableBool(&createUser),
 			ResourcePoolId:  &resourcePoolId,
 			IsEC2:           &isEC2,
 			KmsKeyId:        &kmsKeyId,
 			InstanceProfile: &instanceProfile,
 			PublicIpType:    &publicIpType,
 			AvailabilityId:  &availabilityId,
+		}
+
+		if !config.ConfigAws.CreateUser.IsNull() && !config.ConfigAws.CreateUser.IsUnknown() {
+			createUser := plan.ConfigAws.CreateUser.ValueBool()
+			configAWS.CreateUser = *sdk.NewNullableBool(&createUser)
 		}
 
 		// Security Groups
@@ -131,16 +145,19 @@ func (g *Resource) Create(
 	// HVM config
 	case !plan.ConfigHvm.IsNull() && !plan.ConfigHvm.IsUnknown():
 		// The provisionTypeCode default is "mvm" which is the code for the HVM provisioning type.
-		createUser := plan.ConfigHvm.CreateUser.ValueBool()
 		nestedVirtualization := plan.ConfigHvm.NestedVirtualization.ValueString()
 		noAgent := plan.ConfigHvm.NoAgent.ValueBool()
 		resourcePoolId := plan.ConfigHvm.ResourcePoolId.ValueString()
 
 		configHvm := &sdk.HVMInstanceConfiguration{
-			CreateUser:           *sdk.NewNullableBool(&createUser),
 			NestedVirtualization: &nestedVirtualization,
 			NoAgent:              *sdk.NewNullableBool(&noAgent),
 			ResourcePoolId:       &resourcePoolId,
+		}
+
+		if !config.ConfigHvm.CreateUser.IsNull() && !config.ConfigHvm.CreateUser.IsUnknown() {
+			createUser := plan.ConfigHvm.CreateUser.ValueBool()
+			configHvm.CreateUser = *sdk.NewNullableBool(&createUser)
 		}
 
 		if !plan.ConfigHvm.KvmHostId.IsNull() {
@@ -154,17 +171,20 @@ func (g *Resource) Create(
 	// VMware config
 	case !plan.ConfigVmware.IsNull() && !plan.ConfigVmware.IsUnknown():
 		nestedVirtualization := plan.ConfigVmware.NestedVirtualization.ValueString()
-		createUser := plan.ConfigVmware.CreateUser.ValueBool()
 		noAgent := plan.ConfigVmware.NoAgent.ValueBool()
 		resourcePoolId := plan.ConfigVmware.ResourcePoolId.ValueString()
 		vmwareFolderId := plan.ConfigVmware.VmwareFolderId.ValueString()
 
 		configVMware := &sdk.VMWareInstanceConfiguration2{
 			NestedVirtualization: &nestedVirtualization,
-			CreateUser:           *sdk.NewNullableBool(&createUser),
 			NoAgent:              *sdk.NewNullableBool(&noAgent),
 			ResourcePoolId:       &resourcePoolId,
 			VmwareFolderId:       &vmwareFolderId,
+		}
+
+		if !config.ConfigVmware.CreateUser.IsNull() && !config.ConfigVmware.CreateUser.IsUnknown() {
+			createUser := plan.ConfigVmware.CreateUser.ValueBool()
+			configVMware.CreateUser = *sdk.NewNullableBool(&createUser)
 		}
 
 		reqInstance.Config = sdk.AddInstanceRequestConfig{
@@ -173,12 +193,15 @@ func (g *Resource) Create(
 
 	// Azure config
 	case !plan.ConfigAzure.IsNull() && !plan.ConfigAzure.IsUnknown():
-		createUser := plan.ConfigAzure.CreateUser.ValueBool()
 		resourcePoolId := plan.ConfigAzure.ResourcePoolId.ValueString()
 
 		configAzure := &sdk.AzureInstanceConfiguration2{
-			CreateUser:     &createUser,
 			ResourcePoolId: &resourcePoolId,
+		}
+
+		if !config.ConfigAzure.CreateUser.IsNull() && !config.ConfigAzure.CreateUser.IsUnknown() {
+			createUser := plan.ConfigAzure.CreateUser.ValueBool()
+			configAzure.CreateUser = &createUser
 		}
 
 		if !plan.ConfigAzure.AzureRegion.IsNull() && !plan.ConfigAzure.AzureRegion.IsUnknown() {

--- a/morpheus/framework/resources/instance/instance_example.go
+++ b/morpheus/framework/resources/instance/instance_example.go
@@ -34,6 +34,8 @@ func RenderInstanceConfig(t *testing.T, overrides map[string]string) (string, er
 		"DatastoreId":     "1",
 		"InstanceContext": "dev",
 		"MultipleTags":    "",
+		"UserGroup":       "",
+		"StorageProfile":  "",
 	}
 
 	for key, value := range overrides {

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -315,6 +315,14 @@ func getInstanceAsState(
 	}
 	state.NetworkDomainId = networkDomainId
 
+	// user_group
+	userGroupId, ugDiags := getInstanceUserGroupId(instance, plan)
+	diags = append(diags, ugDiags...)
+	if diags.HasError() {
+		return state, false, diags
+	}
+	state.UserGroup = userGroupId
+
 	// plan_id
 	state.PlanId = convert.Int64ToType(instance.Plan.Id)
 
@@ -401,6 +409,29 @@ func getInstanceNetworkDomainId(
 	}
 
 	return convert.Int64ToType(apiConfig.NetworkDomain.Id), diags
+}
+
+// getInstanceUserGroupId returns the user_group id. On a normal read the plan
+// value is preserved (user_group is provision-time only, so it never changes
+// after create); on import it is read from the API config.
+func getInstanceUserGroupId(
+	instance sdk.GetInstance200ResponseInstance,
+	plan InstanceModel,
+) (types.Int64, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// if this isn't an import, return the plan value
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		return plan.UserGroup, diags
+	}
+
+	// on import, get the user group id from the config in the API response
+	apiConfig := instance.Config
+	if apiConfig == nil || apiConfig.UserGroup == nil {
+		return types.Int64Null(), diags
+	}
+
+	return convert.Int64ToType(apiConfig.UserGroup.Id), diags
 }
 
 func getInstanceAzureConfig(
@@ -1023,6 +1054,11 @@ func setDatastoreAutoSelectionAndSize(
 			apiVol.MaxStorage = planVol.Size.ValueInt64Pointer()
 			// We set this flag to indicate that Terraform set the MaxStorage value
 			apiVol.AdditionalProperties["TerraformSetMaxStorage"] = true
+
+			// storage_profile is a write-mostly field: preserve the plan value so
+			// that an API-returned default does not produce a spurious diff (or an
+			// inconsistent-result-after-apply error) on a normal read.
+			apiVol.StorageProfile = planVol.StorageProfile.ValueStringPointer()
 		}
 		// If i >= maxIndex, just append the apiVol as-is (unmatched volumes)
 
@@ -1201,6 +1237,7 @@ func convertAPIVolumesToStateVolumes(
 			v.StorageTypeId = convert.Int64ToType(in.TypeId)
 			v.DatastoreId = convert.Int64ToType(in.DatastoreId)
 			v.ControllerMountPoint = convert.StrToType(in.ControllerMountPoint)
+			v.StorageProfile = convert.StrToType(in.StorageProfile)
 
 			// Handle DatastoreAutoSelection and TerraformSetMaxStorage from AdditionalProperties
 			// TerraformSetMaxStorage flag indicates that MaxStorage was set from plan (already in GB)

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -74,7 +74,7 @@ func (g *Resource) Read(
 	// servicePlanOptions is not returned by the API
 	servicePlanOptions := data.ServicePlanOptions
 
-	state, found, diag := getInstanceAsState(ctx, data.Id.ValueInt64(), client, data)
+	state, found, diag := getInstanceAsState(ctx, data.Id.ValueInt64(), client, data, true)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
 		return
 	}
@@ -104,6 +104,11 @@ func getInstanceAsState(
 	id int64,
 	client *sdk.APIClient,
 	plan InstanceModel,
+	// refresh is true for a plain Read (drift detection): API-backed fields like
+	// volume storage_profile are taken from the API. It is false for create/update
+	// post-apply reads, where the configured value is preferred so the final state
+	// matches the plan.
+	refresh bool,
 ) (InstanceModel, bool, diag.Diagnostics) {
 	var state InstanceModel
 	var diags diag.Diagnostics
@@ -375,7 +380,7 @@ func getInstanceAsState(
 	state.TaskSetId = plan.TaskSetId
 
 	// volumes
-	volumes, d := getVolumes(ctx, instance, plan)
+	volumes, d := getVolumes(ctx, instance, plan, refresh)
 	diags.Append(d...)
 	state.Volumes = volumes
 
@@ -945,6 +950,7 @@ func getVolumes(
 	ctx context.Context,
 	instance sdk.GetInstance200ResponseInstance,
 	plan InstanceModel,
+	refresh bool,
 ) (basetypes.ListValue, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
@@ -1005,7 +1011,7 @@ func getVolumes(
 
 	// If the number of volumes is the same as the plan, we can do a direct conversion
 	if len(apiVolumes) == len(plan.Volumes.Elements()) {
-		autoselectVolumes := setDatastoreAutoSelectionAndSize(apiVolumes, plan)
+		autoselectVolumes := setDatastoreAutoSelectionAndSize(apiVolumes, plan, refresh)
 
 		return convertAPIVolumesToStateVolumes(ctx, autoselectVolumes)
 	}
@@ -1014,7 +1020,7 @@ func getVolumes(
 	nonRaidVolumes := removeRaidDisks(apiVolumes)
 	reorderedVolumes := reorderVolumes(nonRaidVolumes, plan)
 	filledVolumes := fillVolumeFieldsFromPlan(reorderedVolumes, plan)
-	autoselectVolumes := setDatastoreAutoSelectionAndSize(filledVolumes, plan)
+	autoselectVolumes := setDatastoreAutoSelectionAndSize(filledVolumes, plan, refresh)
 
 	return convertAPIVolumesToStateVolumes(ctx, autoselectVolumes)
 }
@@ -1026,6 +1032,7 @@ func getVolumes(
 func setDatastoreAutoSelectionAndSize(
 	apiVolumes []sdk.InstanceContainerServerVolume1,
 	plan InstanceModel,
+	refresh bool,
 ) []sdk.InstanceContainerServerVolume1 {
 	autoSelection := make([]sdk.InstanceContainerServerVolume1, 0, len(apiVolumes))
 	planVolumes := plan.Volumes.Elements()
@@ -1055,10 +1062,14 @@ func setDatastoreAutoSelectionAndSize(
 			// We set this flag to indicate that Terraform set the MaxStorage value
 			apiVol.AdditionalProperties["TerraformSetMaxStorage"] = true
 
-			// storage_profile is a write-mostly field: preserve the plan value so
-			// that an API-returned default does not produce a spurious diff (or an
-			// inconsistent-result-after-apply error) on a normal read.
-			apiVol.StorageProfile = planVol.StorageProfile.ValueStringPointer()
+			// storage_profile: on a post-apply read (create/update) prefer the
+			// configured value so the final state matches the plan, and an
+			// API-side default for an unset volume is absorbed by the computed
+			// attribute. On a plain refresh, leave the API value so a server-side
+			// change is detected as drift.
+			if !refresh && !planVol.StorageProfile.IsNull() && !planVol.StorageProfile.IsUnknown() {
+				apiVol.StorageProfile = planVol.StorageProfile.ValueStringPointer()
+			}
 		}
 		// If i >= maxIndex, just append the apiVol as-is (unmatched volumes)
 

--- a/morpheus/framework/resources/instance/instance_update.go
+++ b/morpheus/framework/resources/instance/instance_update.go
@@ -81,7 +81,7 @@ func (g *Resource) Update(
 	tflog.Info(ctx, fmt.Sprintf("Instance update state: %v", state.Volumes.Elements()))
 	tflog.Info(ctx, fmt.Sprintf("Instance update plan: %v", plan.Volumes.Elements()))
 
-	newState, found, diag := getInstanceAsState(ctx, state.Id.ValueInt64(), client, plan)
+	newState, found, diag := getInstanceAsState(ctx, state.Id.ValueInt64(), client, plan, false)
 	if resp.Diagnostics.Append(diag...); resp.Diagnostics.HasError() {
 		return
 	}

--- a/morpheus/framework/resources/instance/mappings.go
+++ b/morpheus/framework/resources/instance/mappings.go
@@ -54,6 +54,10 @@ func createVolumeMapper(
 		volume.DatastoreId.String = vol.DatastoreAutoSelection.ValueStringPointer()
 	}
 
+	if !vol.StorageProfile.IsNull() && !vol.StorageProfile.IsUnknown() {
+		volume.StorageProfile.Set(vol.StorageProfile.ValueStringPointer())
+	}
+
 	return volume
 }
 
@@ -96,6 +100,10 @@ func updateVolumeMapper(
 		volume.DatastoreId = &sdk.
 			CloneInstanceRequestVolumesInnerDatastoreId{}
 		volume.DatastoreId.String = vol.DatastoreAutoSelection.ValueStringPointer()
+	}
+
+	if !vol.StorageProfile.IsNull() && !vol.StorageProfile.IsUnknown() {
+		volume.StorageProfile.Set(vol.StorageProfile.ValueStringPointer())
 	}
 
 	return volume

--- a/morpheus/framework/resources/instance/mappings_internal_test.go
+++ b/morpheus/framework/resources/instance/mappings_internal_test.go
@@ -104,6 +104,78 @@ func TestNetworkInterfaceMapperNetworkID(t *testing.T) {
 	}
 }
 
+// TestVolumeMapperStorageProfile verifies that storage_profile is forwarded to
+// the create (AddInstanceRequestVolumesInner) and update
+// (ResizeInstanceRequestVolumesInner) volume requests only when the user set it,
+// and is left unset (so the omitempty NullableString is omitted) when the plan
+// value is null or unknown.
+func TestVolumeMapperStorageProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		storageProfile types.String
+		wantSet        bool
+		want           string
+	}{
+		{
+			name:           "storage_profile set",
+			storageProfile: types.StringValue("kvm-cache-none"),
+			wantSet:        true,
+			want:           "kvm-cache-none",
+		},
+		{
+			name:           "storage_profile null",
+			storageProfile: types.StringNull(),
+			wantSet:        false,
+		},
+		{
+			name:           "storage_profile unknown",
+			storageProfile: types.StringUnknown(),
+			wantSet:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			in := VolumesValue{
+				Id:                     types.Int64Null(),
+				Name:                   types.StringNull(),
+				RootVolume:             types.BoolNull(),
+				Size:                   types.Int64Null(),
+				StorageTypeId:          types.Int64Null(),
+				DatastoreId:            types.Int64Null(),
+				DatastoreAutoSelection: types.StringNull(),
+				StorageProfile:         tt.storageProfile,
+			}
+
+			create := createVolumeMapper(in)
+			if create.StorageProfile.IsSet() != tt.wantSet {
+				t.Errorf("create mapper StorageProfile.IsSet() = %v, want %v",
+					create.StorageProfile.IsSet(), tt.wantSet)
+			}
+			if tt.wantSet {
+				if got := create.StorageProfile.Get(); got == nil || *got != tt.want {
+					t.Errorf("create mapper StorageProfile = %v, want %q", got, tt.want)
+				}
+			}
+
+			update := updateVolumeMapper(in)
+			if update.StorageProfile.IsSet() != tt.wantSet {
+				t.Errorf("update mapper StorageProfile.IsSet() = %v, want %v",
+					update.StorageProfile.IsSet(), tt.wantSet)
+			}
+			if tt.wantSet {
+				if got := update.StorageProfile.Get(); got == nil || *got != tt.want {
+					t.Errorf("update mapper StorageProfile = %v, want %q", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
 // TestChildNetworkInterfaceMapperNetworkID verifies the network.id string sent to
 // the API for child virtual networks is built with the correct prefix for each of
 // network_id, network_group_id and subnet_id.

--- a/morpheus/framework/resources/instance/resource_test.go
+++ b/morpheus/framework/resources/instance/resource_test.go
@@ -89,6 +89,76 @@ func TestAccMorpheusInstanceResourceExampleOk(t *testing.T) {
 	})
 }
 
+// TestAccMorpheusInstanceResourceUserGroupStorageProfile provisions an HVM/KVM
+// instance with a user_group and a volume storage_profile and asserts both
+// round-trip into state. user_group is a provision-time, RequiresReplace input
+// read back from the instance config; storage_profile is a write-mostly volume
+// input preserved from the plan on read.
+func TestAccMorpheusInstanceResourceUserGroupStorageProfile(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	if capabilities.Missing(t, capabilities.All) {
+		t.Log("Skipping test due to missing capabilities")
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	name := acctest.RandomWithPrefix(t.Name())
+	// user_group and storage_profile use hard-coded values that exist in the
+	// reference test environment, consistent with the other instance tests
+	// (resource pool, layout, network, datastore). kvm-cache-none is a standard
+	// KVM/HVM storage profile code.
+	userGroup := "1"
+	storageProfile := "kvm-cache-none"
+
+	resourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name":           name,
+		"UserGroup":      userGroup,
+		"StorageProfile": storageProfile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_instance.example",
+			"name",
+			name,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_instance.example",
+			"user_group",
+			userGroup,
+		),
+		resource.TestCheckResourceAttr(
+			"hpe_morpheus_instance.example",
+			"volumes.0.storage_profile",
+			storageProfile,
+		),
+	}
+
+	checkFn := resource.ComposeAggregateTestCheckFunc(checks...)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           false,
+				Check:              checkFn,
+			},
+		},
+	})
+}
+
 func TestAccMorpheusInstanceResourceAzureExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -767,6 +767,7 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"storage_profile": schema.StringAttribute{
 							Optional:            true,
+							Computed:            true,
 							Description:         "Storage profile code for the volume. The available codes depend on the\nprovision type; query `/api/provision-types` to list the `storageProfiles`\nfor a type. For example, KVM/HVM volumes use cache-mode profiles such as\n`\"kvm-cache-none\"` or `\"kvm-cache-directsync\"` (`/api/provision-types?code=kvm`).",
 							MarkdownDescription: "Storage profile code for the volume. The available codes depend on the\nprovision type; query `/api/provision-types` to list the `storageProfiles`\nfor a type. For example, KVM/HVM volumes use cache-mode profiles such as\n`\"kvm-cache-none\"` or `\"kvm-cache-directsync\"` (`/api/provision-types?code=kvm`).",
 						},

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -767,8 +767,8 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"storage_profile": schema.StringAttribute{
 							Optional:            true,
-							Description:         "Storage Profile Code for the volume storage profile assignment. eg. `\"kvm-cache-none\"` or `\"kvm-cache-directsync\"`.\nUse `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.",
-							MarkdownDescription: "Storage Profile Code for the volume storage profile assignment. eg. `\"kvm-cache-none\"` or `\"kvm-cache-directsync\"`.\nUse `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.",
+							Description:         "Storage profile code for the volume. The available codes depend on the\nprovision type; query `/api/provision-types` to list the `storageProfiles`\nfor a type. For example, KVM/HVM volumes use cache-mode profiles such as\n`\"kvm-cache-none\"` or `\"kvm-cache-directsync\"` (`/api/provision-types?code=kvm`).",
+							MarkdownDescription: "Storage profile code for the volume. The available codes depend on the\nprovision type; query `/api/provision-types` to list the `storageProfiles`\nfor a type. For example, KVM/HVM volumes use cache-mode profiles such as\n`\"kvm-cache-none\"` or `\"kvm-cache-directsync\"` (`/api/provision-types?code=kvm`).",
 						},
 						"storage_type_id": schema.Int64Attribute{
 							Optional:            true,

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -5,6 +5,8 @@ package instance
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/HPE/terraform-provider-hpe/utils/validators"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator"
@@ -26,7 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -703,6 +704,14 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "The Workflow ID to execute.",
 			},
 			"timeouts": timeouts.AttributesAll(ctx),
+			"user_group": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "The id of the user group to associate with the instance. When create_user is enabled on\nthe relevant config_* block, the user group's members can be created as users on the\nprovisioned instance. The user group can only be set at provision time; changing it forces\nreplacement of the instance.\n",
+				MarkdownDescription: "The id of the user group to associate with the instance. When create_user is enabled on\nthe relevant config_* block, the user group's members can be created as users on the\nprovisioned instance. The user group can only be set at provision time; changing it forces\nreplacement of the instance.\n",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
 			"volumes": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -808,6 +817,7 @@ type InstanceModel struct {
 	Tags               types.Set               `tfsdk:"tags"`
 	TaskSetId          types.Int64             `tfsdk:"task_set_id"`
 	Timeouts           timeouts.Value          `tfsdk:"timeouts"`
+	UserGroup          types.Int64             `tfsdk:"user_group"`
 	Volumes            types.List              `tfsdk:"volumes"`
 }
 
@@ -1310,14 +1320,12 @@ func (t ConfigAwsType) ValueFromTerraform(ctx context.Context, in tftypes.Value)
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -1372,7 +1380,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals := make(map[string]tftypes.Value, 9)
 
 		val, err = v.AvailabilityZoneId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1380,7 +1387,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["availability_zone_id"] = val
 
 		val, err = v.CreateUser.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1388,7 +1394,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["create_user"] = val
 
 		val, err = v.InstanceProfile.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1396,7 +1401,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["instance_profile"] = val
 
 		val, err = v.IsEc2.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1404,7 +1408,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["is_ec2"] = val
 
 		val, err = v.KmsKeyId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1412,7 +1415,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["kms_key_id"] = val
 
 		val, err = v.NoAgent.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1420,7 +1422,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["no_agent"] = val
 
 		val, err = v.PublicIpType.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1428,7 +1429,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["public_ip_type"] = val
 
 		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1436,7 +1436,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["resource_pool_id"] = val
 
 		val, err = v.SecurityGroups.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1813,14 +1812,12 @@ func (t SecurityGroupsType) ValueFromTerraform(ctx context.Context, in tftypes.V
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -1857,7 +1854,6 @@ func (v SecurityGroupsValue) ToTerraformValue(ctx context.Context) (tftypes.Valu
 		vals := make(map[string]tftypes.Value, 1)
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2525,14 +2521,12 @@ func (t ConfigAzureType) ValueFromTerraform(ctx context.Context, in tftypes.Valu
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -2589,7 +2583,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals := make(map[string]tftypes.Value, 11)
 
 		val, err = v.AvailabilityOptions.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2597,7 +2590,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["availability_options"] = val
 
 		val, err = v.AvailabilitySet.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2605,7 +2597,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["availability_set"] = val
 
 		val, err = v.AvailabilityZone.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2613,7 +2604,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["availability_zone"] = val
 
 		val, err = v.AzureRegion.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2621,7 +2611,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["azure_region"] = val
 
 		val, err = v.AzurefloatingIp.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2629,7 +2618,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["azurefloating_ip"] = val
 
 		val, err = v.AzuresecurityGroupId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2637,7 +2625,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["azuresecurity_group_id"] = val
 
 		val, err = v.BootDiagnostics.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2645,7 +2632,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["boot_diagnostics"] = val
 
 		val, err = v.CreateUser.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2653,7 +2639,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["create_user"] = val
 
 		val, err = v.DiagnosticsStorageAccount.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2661,7 +2646,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["diagnostics_storage_account"] = val
 
 		val, err = v.OsGuestDiagnostics.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2669,7 +2653,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["os_guest_diagnostics"] = val
 
 		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3179,14 +3162,12 @@ func (t ConfigHvmType) ValueFromTerraform(ctx context.Context, in tftypes.Value)
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -3231,7 +3212,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals := make(map[string]tftypes.Value, 5)
 
 		val, err = v.CreateUser.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3239,7 +3219,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["create_user"] = val
 
 		val, err = v.KvmHostId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3247,7 +3226,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["kvm_host_id"] = val
 
 		val, err = v.NestedVirtualization.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3255,7 +3233,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["nested_virtualization"] = val
 
 		val, err = v.NoAgent.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3263,7 +3240,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["no_agent"] = val
 
 		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3731,14 +3707,12 @@ func (t ConfigVmwareType) ValueFromTerraform(ctx context.Context, in tftypes.Val
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -3783,7 +3757,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals := make(map[string]tftypes.Value, 5)
 
 		val, err = v.CreateUser.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3791,7 +3764,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals["create_user"] = val
 
 		val, err = v.NestedVirtualization.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3799,7 +3771,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals["nested_virtualization"] = val
 
 		val, err = v.NoAgent.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3807,7 +3778,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals["no_agent"] = val
 
 		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3815,7 +3785,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals["resource_pool_id"] = val
 
 		val, err = v.VmwareFolderId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4169,14 +4138,12 @@ func (t EvarsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (at
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -4215,7 +4182,6 @@ func (v EvarsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals := make(map[string]tftypes.Value, 2)
 
 		val, err = v.Name.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4223,7 +4189,6 @@ func (v EvarsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals["name"] = val
 
 		val, err = v.Value.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4898,14 +4863,12 @@ func (t NetworkInterfacesType) ValueFromTerraform(ctx context.Context, in tftype
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -4964,7 +4927,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals := make(map[string]tftypes.Value, 11)
 
 		val, err = v.ChildVirtualNetworks.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4972,7 +4934,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["child_virtual_networks"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4980,7 +4941,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["id"] = val
 
 		val, err = v.IpAddress.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4988,7 +4948,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["ip_address"] = val
 
 		val, err = v.IpMode.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4996,7 +4955,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["ip_mode"] = val
 
 		val, err = v.IpPool.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5004,7 +4962,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["ip_pool"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5012,7 +4969,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["name"] = val
 
 		val, err = v.NetworkGroupId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5020,7 +4976,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["network_group_id"] = val
 
 		val, err = v.NetworkId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5028,7 +4983,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["network_id"] = val
 
 		val, err = v.NetworkTypeId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5036,7 +4990,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["network_type_id"] = val
 
 		val, err = v.PrimaryInterface.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5044,7 +4997,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["primary_interface"] = val
 
 		val, err = v.SubnetId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5777,14 +5729,12 @@ func (t ChildVirtualNetworksType) ValueFromTerraform(ctx context.Context, in tft
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -5839,7 +5789,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals := make(map[string]tftypes.Value, 10)
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5847,7 +5796,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["id"] = val
 
 		val, err = v.IpAddress.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5855,7 +5803,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["ip_address"] = val
 
 		val, err = v.IpMode.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5863,7 +5810,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["ip_mode"] = val
 
 		val, err = v.IpPool.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5871,7 +5817,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["ip_pool"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5879,7 +5824,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["name"] = val
 
 		val, err = v.NetworkGroupId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5887,7 +5831,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["network_group_id"] = val
 
 		val, err = v.NetworkId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5895,7 +5838,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["network_id"] = val
 
 		val, err = v.NetworkTypeId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5903,7 +5845,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["network_type_id"] = val
 
 		val, err = v.PrimaryInterface.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5911,7 +5852,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["primary_interface"] = val
 
 		val, err = v.SubnetId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -6338,14 +6278,12 @@ func (t PortsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (at
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -6386,7 +6324,6 @@ func (v PortsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals := make(map[string]tftypes.Value, 3)
 
 		val, err = v.LoadBalancerProtocol.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -6394,7 +6331,6 @@ func (v PortsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals["load_balancer_protocol"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -6402,7 +6338,6 @@ func (v PortsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		vals["name"] = val
 
 		val, err = v.Port.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -6780,14 +6715,12 @@ func (t ServicePlanOptionsType) ValueFromTerraform(ctx context.Context, in tftyp
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -6828,7 +6761,6 @@ func (v ServicePlanOptionsValue) ToTerraformValue(ctx context.Context) (tftypes.
 		vals := make(map[string]tftypes.Value, 3)
 
 		val, err = v.CoresPerSocket.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -6836,7 +6768,6 @@ func (v ServicePlanOptionsValue) ToTerraformValue(ctx context.Context) (tftypes.
 		vals["cores_per_socket"] = val
 
 		val, err = v.MaxCores.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -6844,7 +6775,6 @@ func (v ServicePlanOptionsValue) ToTerraformValue(ctx context.Context) (tftypes.
 		vals["max_cores"] = val
 
 		val, err = v.MaxMemory.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7184,14 +7114,12 @@ func (t TagsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (att
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -7230,7 +7158,6 @@ func (v TagsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) 
 		vals := make(map[string]tftypes.Value, 2)
 
 		val, err = v.Name.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7238,7 +7165,6 @@ func (v TagsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) 
 		vals["name"] = val
 
 		val, err = v.Value.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7875,14 +7801,12 @@ func (t VolumesType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -7937,7 +7861,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals := make(map[string]tftypes.Value, 10)
 
 		val, err = v.ControllerMountPoint.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7945,7 +7868,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["controller_mount_point"] = val
 
 		val, err = v.DatastoreAutoSelection.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7953,7 +7875,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["datastore_auto_selection"] = val
 
 		val, err = v.DatastoreId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7961,7 +7882,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["datastore_id"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7969,7 +7889,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["id"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7977,7 +7896,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["name"] = val
 
 		val, err = v.RootVolume.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7985,7 +7903,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["root_volume"] = val
 
 		val, err = v.Size.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -7993,7 +7910,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["size"] = val
 
 		val, err = v.SizeId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -8001,7 +7917,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["size_id"] = val
 
 		val, err = v.StorageProfile.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -8009,7 +7924,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["storage_profile"] = val
 
 		val, err = v.StorageTypeId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}

--- a/morpheus/framework/resources/instanceclone/create.go
+++ b/morpheus/framework/resources/instanceclone/create.go
@@ -74,6 +74,11 @@ func (r *Resource) Create(
 		cloneReq.Plan = &sdk.CloneInstanceRequestPlan{Id: &pid}
 	}
 
+	if !plan.UserGroup.IsNull() && !plan.UserGroup.IsUnknown() {
+		ugid := plan.UserGroup.ValueInt64()
+		cloneReq.UserGroup = &sdk.CloneInstanceRequestUserGroup{Id: &ugid}
+	}
+
 	cloneConfig, cfgDiags := buildCloneConfig(ctx, plan)
 	resp.Diagnostics.Append(cfgDiags...)
 	if resp.Diagnostics.HasError() {
@@ -324,12 +329,14 @@ func buildCloneConfig(
 	// AWS config
 	case !plan.ConfigAws.IsNull() && !plan.ConfigAws.IsUnknown():
 		noAgent := plan.ConfigAws.NoAgent.ValueBool()
+		createUser := plan.ConfigAws.CreateUser.ValueBool()
 		isEC2 := convert.BoolToStringTrueFalse(plan.ConfigAws.IsEc2.ValueBool()).ValueString()
 		publicIpType := plan.ConfigAws.PublicIpType.ValueString()
 		resourcePoolId := plan.ConfigAws.ResourcePoolId.ValueString()
 
 		configAWS := &sdk.AmazonInstanceConfiguration3{
 			NoAgent:         *sdk.NewNullableBool(&noAgent),
+			CreateUser:      *sdk.NewNullableBool(&createUser),
 			ResourcePoolId:  &resourcePoolId,
 			IsEC2:           &isEC2,
 			KmsKeyId:        plan.ConfigAws.KmsKeyId.ValueStringPointer(),
@@ -509,6 +516,11 @@ func buildCloneVolumes(
 		if !v.SizeId.IsNull() && !v.SizeId.IsUnknown() {
 			siVal := v.SizeId.ValueInt64()
 			vol.SizeId = *sdk.NewNullableInt64(&siVal)
+		}
+
+		if !v.StorageProfile.IsNull() && !v.StorageProfile.IsUnknown() {
+			spVal := v.StorageProfile.ValueString()
+			vol.StorageProfile = *sdk.NewNullableString(&spVal)
 		}
 
 		if !v.ControllerMountPoint.IsNull() && !v.ControllerMountPoint.IsUnknown() {

--- a/morpheus/framework/resources/instanceclone/create.go
+++ b/morpheus/framework/resources/instanceclone/create.go
@@ -32,6 +32,16 @@ func (r *Resource) Create(
 		return
 	}
 
+	// config is the raw configuration (before schema defaults are applied), used
+	// to tell whether the user actually set create_user versus it falling back to
+	// its schema default; when unset we omit it so the API applies its own
+	// per-cloud default.
+	var config InstanceCloneModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	createTimeout, diags := plan.Timeouts.Create(ctx, 15*time.Minute)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -79,7 +89,7 @@ func (r *Resource) Create(
 		cloneReq.UserGroup = &sdk.CloneInstanceRequestUserGroup{Id: &ugid}
 	}
 
-	cloneConfig, cfgDiags := buildCloneConfig(ctx, plan)
+	cloneConfig, cfgDiags := buildCloneConfig(ctx, plan, config)
 	resp.Diagnostics.Append(cfgDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -321,7 +331,7 @@ func (r *Resource) Create(
 // order as the instance resource. The variants are mutually exclusive at plan
 // time (the dynamic config conflicts with the typed blocks).
 func buildCloneConfig(
-	ctx context.Context, plan InstanceCloneModel,
+	ctx context.Context, plan, config InstanceCloneModel,
 ) (*sdk.CloneInstanceRequestConfig, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -329,20 +339,23 @@ func buildCloneConfig(
 	// AWS config
 	case !plan.ConfigAws.IsNull() && !plan.ConfigAws.IsUnknown():
 		noAgent := plan.ConfigAws.NoAgent.ValueBool()
-		createUser := plan.ConfigAws.CreateUser.ValueBool()
 		isEC2 := convert.BoolToStringTrueFalse(plan.ConfigAws.IsEc2.ValueBool()).ValueString()
 		publicIpType := plan.ConfigAws.PublicIpType.ValueString()
 		resourcePoolId := plan.ConfigAws.ResourcePoolId.ValueString()
 
 		configAWS := &sdk.AmazonInstanceConfiguration3{
 			NoAgent:         *sdk.NewNullableBool(&noAgent),
-			CreateUser:      *sdk.NewNullableBool(&createUser),
 			ResourcePoolId:  &resourcePoolId,
 			IsEC2:           &isEC2,
 			KmsKeyId:        plan.ConfigAws.KmsKeyId.ValueStringPointer(),
 			InstanceProfile: plan.ConfigAws.InstanceProfile.ValueStringPointer(),
 			PublicIpType:    &publicIpType,
 			AvailabilityId:  plan.ConfigAws.AvailabilityZoneId.ValueStringPointer(),
+		}
+
+		if !config.ConfigAws.CreateUser.IsNull() && !config.ConfigAws.CreateUser.IsUnknown() {
+			createUser := plan.ConfigAws.CreateUser.ValueBool()
+			configAWS.CreateUser = *sdk.NewNullableBool(&createUser)
 		}
 
 		// The clone request has no top-level security groups field (unlike
@@ -367,16 +380,19 @@ func buildCloneConfig(
 
 	// HVM config
 	case !plan.ConfigHvm.IsNull() && !plan.ConfigHvm.IsUnknown():
-		createUser := plan.ConfigHvm.CreateUser.ValueBool()
 		nestedVirtualization := plan.ConfigHvm.NestedVirtualization.ValueString()
 		noAgent := plan.ConfigHvm.NoAgent.ValueBool()
 		resourcePoolId := plan.ConfigHvm.ResourcePoolId.ValueString()
 
 		configHvm := &sdk.HVMInstanceConfiguration1{
-			CreateUser:           *sdk.NewNullableBool(&createUser),
 			NestedVirtualization: &nestedVirtualization,
 			NoAgent:              *sdk.NewNullableBool(&noAgent),
 			ResourcePoolId:       &resourcePoolId,
+		}
+
+		if !config.ConfigHvm.CreateUser.IsNull() && !config.ConfigHvm.CreateUser.IsUnknown() {
+			createUser := plan.ConfigHvm.CreateUser.ValueBool()
+			configHvm.CreateUser = *sdk.NewNullableBool(&createUser)
 		}
 
 		if !plan.ConfigHvm.KvmHostId.IsNull() {
@@ -388,28 +404,34 @@ func buildCloneConfig(
 	// VMware config
 	case !plan.ConfigVmware.IsNull() && !plan.ConfigVmware.IsUnknown():
 		nestedVirtualization := plan.ConfigVmware.NestedVirtualization.ValueString()
-		createUser := plan.ConfigVmware.CreateUser.ValueBool()
 		noAgent := plan.ConfigVmware.NoAgent.ValueBool()
 		resourcePoolId := plan.ConfigVmware.ResourcePoolId.ValueString()
 
 		configVMware := &sdk.VMWareInstanceConfiguration3{
 			NestedVirtualization: &nestedVirtualization,
-			CreateUser:           *sdk.NewNullableBool(&createUser),
 			NoAgent:              *sdk.NewNullableBool(&noAgent),
 			ResourcePoolId:       &resourcePoolId,
 			VmwareFolderId:       plan.ConfigVmware.VmwareFolderId.ValueStringPointer(),
+		}
+
+		if !config.ConfigVmware.CreateUser.IsNull() && !config.ConfigVmware.CreateUser.IsUnknown() {
+			createUser := plan.ConfigVmware.CreateUser.ValueBool()
+			configVMware.CreateUser = *sdk.NewNullableBool(&createUser)
 		}
 
 		return &sdk.CloneInstanceRequestConfig{VMWareInstanceConfiguration3: configVMware}, diags
 
 	// Azure config
 	case !plan.ConfigAzure.IsNull() && !plan.ConfigAzure.IsUnknown():
-		createUser := plan.ConfigAzure.CreateUser.ValueBool()
 		resourcePoolId := plan.ConfigAzure.ResourcePoolId.ValueString()
 
 		configAzure := &sdk.AzureInstanceConfiguration3{
-			CreateUser:     &createUser,
 			ResourcePoolId: &resourcePoolId,
+		}
+
+		if !config.ConfigAzure.CreateUser.IsNull() && !config.ConfigAzure.CreateUser.IsUnknown() {
+			createUser := plan.ConfigAzure.CreateUser.ValueBool()
+			configAzure.CreateUser = &createUser
 		}
 
 		if !plan.ConfigAzure.AzureRegion.IsNull() && !plan.ConfigAzure.AzureRegion.IsUnknown() {

--- a/morpheus/framework/resources/instanceclone/example.tf.tmpl
+++ b/morpheus/framework/resources/instanceclone/example.tf.tmpl
@@ -1,11 +1,17 @@
 resource "hpe_morpheus_instance_clone" "example" {
   source_instance_id = {{.SourceInstanceId}}
   name               = "{{.Name}}"
+{{- if .UserGroup}}
+  user_group = {{.UserGroup}}
+{{- end}}
 
   volumes {
     name        = "root"
     size        = 20
     root_volume = true
+{{- if .StorageProfile}}
+    storage_profile = "{{.StorageProfile}}"
+{{- end}}
   }
 
   network_interfaces {

--- a/morpheus/framework/resources/instanceclone/instance_clone_example.go
+++ b/morpheus/framework/resources/instanceclone/instance_clone_example.go
@@ -20,6 +20,8 @@ func RenderInstanceCloneConfig(t *testing.T, overrides map[string]string) (strin
 		"SourceInstanceId": "1",
 		"Name":             "my-clone",
 		"NetworkId":        "1",
+		"UserGroup":        "",
+		"StorageProfile":   "",
 	}
 
 	for key, value := range overrides {

--- a/morpheus/framework/resources/instanceclone/read.go
+++ b/morpheus/framework/resources/instanceclone/read.go
@@ -83,6 +83,16 @@ func (r *Resource) Read(
 		}
 	}
 
+	// user_group is provision-time only (RequiresReplace) and the clone API does
+	// not return it as a first-class field; Morpheus stamps it onto the config.
+	// On import recover it from config.userGroup.id; on a normal refresh the
+	// value is already set and is left untouched so it is never clobbered.
+	if state.UserGroup.IsNull() || state.UserGroup.IsUnknown() {
+		if inst.Config != nil && inst.Config.UserGroup != nil {
+			state.UserGroup = convert.Int64ToType(inst.Config.UserGroup.Id)
+		}
+	}
+
 	// Update computed fields
 	state.Status = convert.StrToType(inst.Status)
 	state.Name = convert.StrToType(inst.Name)
@@ -177,6 +187,7 @@ func volumeValueFromAPI(
 	}
 
 	vol.ControllerMountPoint = convert.StrToType(v.ControllerMountPoint)
+	vol.StorageProfile = convert.StrToType(v.StorageProfile)
 	// size_id is a write-only input and is not returned by the read API.
 	vol.SizeId = types.Int64Null()
 
@@ -219,6 +230,7 @@ func mergeVolumesFromAPI(
 			StorageType:          types.Int64Null(),
 			ControllerMountPoint: types.StringNull(),
 			SizeId:               types.Int64Null(),
+			StorageProfile:       types.StringNull(),
 		}
 		if i < len(apiVolumes) {
 			api = volumeValueFromAPI(apiVolumes[i])
@@ -231,6 +243,9 @@ func mergeVolumesFromAPI(
 			Size: pv[i].Size,
 			// size_id is a write-only input; keep the plan value.
 			SizeId: pv[i].SizeId,
+			// storage_profile is an optional write field; keep the plan value so
+			// the post-apply state matches the configuration.
+			StorageProfile: pv[i].StorageProfile,
 			// Computed id always comes from the API.
 			Id: api.Id,
 			// Computed-optional fields keep the user's value when set.
@@ -291,6 +306,9 @@ func mergeVolumesForRead(
 		vol := volumeValueFromAPI(v)
 		if i < len(prior) {
 			vol.SizeId = prior[i].SizeId
+			// storage_profile is an optional write field; keep the prior value so
+			// an API-returned default does not produce a spurious diff on read.
+			vol.StorageProfile = prior[i].StorageProfile
 		}
 
 		objVal, d := vol.ToObjectValue(ctx)

--- a/morpheus/framework/resources/instanceclone/read.go
+++ b/morpheus/framework/resources/instanceclone/read.go
@@ -243,9 +243,6 @@ func mergeVolumesFromAPI(
 			Size: pv[i].Size,
 			// size_id is a write-only input; keep the plan value.
 			SizeId: pv[i].SizeId,
-			// storage_profile is an optional write field; keep the plan value so
-			// the post-apply state matches the configuration.
-			StorageProfile: pv[i].StorageProfile,
 			// Computed id always comes from the API.
 			Id: api.Id,
 			// Computed-optional fields keep the user's value when set.
@@ -253,6 +250,7 @@ func mergeVolumesFromAPI(
 			DatastoreId:          preferKnownInt64(pv[i].DatastoreId, api.DatastoreId),
 			StorageType:          preferKnownInt64(pv[i].StorageType, api.StorageType),
 			ControllerMountPoint: preferKnownString(pv[i].ControllerMountPoint, api.ControllerMountPoint),
+			StorageProfile:       preferKnownString(pv[i].StorageProfile, api.StorageProfile),
 		}
 
 		objVal, d := vol.ToObjectValue(ctx)
@@ -306,9 +304,6 @@ func mergeVolumesForRead(
 		vol := volumeValueFromAPI(v)
 		if i < len(prior) {
 			vol.SizeId = prior[i].SizeId
-			// storage_profile is an optional write field; keep the prior value so
-			// an API-returned default does not produce a spurious diff on read.
-			vol.StorageProfile = prior[i].StorageProfile
 		}
 
 		objVal, d := vol.ToObjectValue(ctx)

--- a/morpheus/framework/resources/instanceclone/resource_test.go
+++ b/morpheus/framework/resources/instanceclone/resource_test.go
@@ -92,3 +92,87 @@ func TestAccMorpheusInstanceCloneResource(t *testing.T) {
 		},
 	})
 }
+
+// TestAccMorpheusInstanceCloneResourceUserGroupStorageProfile clones an instance
+// with a user_group and a volume storage_profile and asserts both round-trip
+// into state, including recovering user_group from the clone config on import.
+func TestAccMorpheusInstanceCloneResourceUserGroupStorageProfile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping acceptance test in short mode")
+	}
+
+	if capabilities.Missing(t, capabilities.All) {
+		t.Log("Skipping test due to missing capabilities")
+
+		return
+	}
+
+	t.Parallel()
+	defer testhelpers.RecordResult(t)
+
+	cloneName := acctest.RandomWithPrefix(t.Name())
+	sourceInstanceID := os.Getenv("TF_ACC_INSTANCE_ID")
+	networkID := os.Getenv("TF_ACC_NETWORK_ID")
+
+	if sourceInstanceID == "" {
+		t.Skip("TF_ACC_INSTANCE_ID must be set for instance clone tests")
+	}
+
+	if networkID == "" {
+		networkID = "1"
+	}
+
+	// user_group and storage_profile use hard-coded values that exist in the
+	// reference test environment, consistent with the other clone inputs.
+	// kvm-cache-none is a standard KVM/HVM storage profile code.
+	userGroup := "1"
+	storageProfile := "kvm-cache-none"
+
+	config, err := instanceclone.RenderInstanceCloneConfig(t, map[string]string{
+		"Name":             cloneName,
+		"SourceInstanceId": sourceInstanceID,
+		"NetworkId":        networkID,
+		"UserGroup":        userGroup,
+		"StorageProfile":   storageProfile,
+	})
+	if err != nil {
+		t.Fatalf("failed to render config: %v", err)
+	}
+
+	resourceName := "hpe_morpheus_instance_clone.example"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, morpheus.New(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config: testhelpers.ProviderBlock() + config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", cloneName),
+					resource.TestCheckResourceAttr(resourceName, "user_group", userGroup),
+					resource.TestCheckResourceAttr(
+						resourceName, "volumes.0.storage_profile", storageProfile),
+				),
+			},
+			// Import: user_group is recovered from the clone config and verified.
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", resourceName)
+					}
+
+					return rs.Primary.Attributes["id"], nil
+				},
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"source_instance_id", "timeouts",
+					// storage_profile is a write-mostly volume input recovered
+					// best-effort from the API on import.
+					"volumes.0.storage_profile",
+				},
+			},
+		},
+	})
+}

--- a/morpheus/framework/resources/instanceclone/schema_gen.go
+++ b/morpheus/framework/resources/instanceclone/schema_gen.go
@@ -5,6 +5,8 @@ package instanceclone
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/HPE/terraform-provider-hpe/utils/validators"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator"
@@ -22,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -467,6 +468,14 @@ func InstanceCloneResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"timeouts": timeouts.AttributesAll(ctx),
+			"user_group": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "The id of the user group to associate with the clone. Can only be set at clone time; changing it forces replacement.",
+				MarkdownDescription: "The id of the user group to associate with the clone. Can only be set at clone time; changing it forces replacement.",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
 			"volumes": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -508,6 +517,11 @@ func InstanceCloneResourceSchema(ctx context.Context) schema.Schema {
 							Description:         "Selects a pre-existing logical volume size choice from Morpheus. Not returned by the API.",
 							MarkdownDescription: "Selects a pre-existing logical volume size choice from Morpheus. Not returned by the API.",
 						},
+						"storage_profile": schema.StringAttribute{
+							Optional:            true,
+							Description:         "Storage Profile Code for the volume storage profile assignment. eg. `\"kvm-cache-none\"` or `\"kvm-cache-directsync\"`.\nUse `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.",
+							MarkdownDescription: "Storage Profile Code for the volume storage profile assignment. eg. `\"kvm-cache-none\"` or `\"kvm-cache-directsync\"`.\nUse `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.",
+						},
 						"storage_type": schema.Int64Attribute{
 							Optional:            true,
 							Computed:            true,
@@ -546,6 +560,7 @@ type InstanceCloneModel struct {
 	SourceInstanceId  types.Int64       `tfsdk:"source_instance_id"`
 	Status            types.String      `tfsdk:"status"`
 	Timeouts          timeouts.Value    `tfsdk:"timeouts"`
+	UserGroup         types.Int64       `tfsdk:"user_group"`
 	Volumes           types.List        `tfsdk:"volumes"`
 }
 
@@ -1048,14 +1063,12 @@ func (t ConfigAwsType) ValueFromTerraform(ctx context.Context, in tftypes.Value)
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -1110,7 +1123,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals := make(map[string]tftypes.Value, 9)
 
 		val, err = v.AvailabilityZoneId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1118,7 +1130,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["availability_zone_id"] = val
 
 		val, err = v.CreateUser.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1126,7 +1137,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["create_user"] = val
 
 		val, err = v.InstanceProfile.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1134,7 +1144,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["instance_profile"] = val
 
 		val, err = v.IsEc2.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1142,7 +1151,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["is_ec2"] = val
 
 		val, err = v.KmsKeyId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1150,7 +1158,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["kms_key_id"] = val
 
 		val, err = v.NoAgent.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1158,7 +1165,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["no_agent"] = val
 
 		val, err = v.PublicIpType.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1166,7 +1172,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["public_ip_type"] = val
 
 		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1174,7 +1179,6 @@ func (v ConfigAwsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["resource_pool_id"] = val
 
 		val, err = v.SecurityGroups.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -1551,14 +1555,12 @@ func (t SecurityGroupsType) ValueFromTerraform(ctx context.Context, in tftypes.V
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -1595,7 +1597,6 @@ func (v SecurityGroupsValue) ToTerraformValue(ctx context.Context) (tftypes.Valu
 		vals := make(map[string]tftypes.Value, 1)
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2263,14 +2264,12 @@ func (t ConfigAzureType) ValueFromTerraform(ctx context.Context, in tftypes.Valu
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -2327,7 +2326,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals := make(map[string]tftypes.Value, 11)
 
 		val, err = v.AvailabilityOptions.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2335,7 +2333,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["availability_options"] = val
 
 		val, err = v.AvailabilitySet.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2343,7 +2340,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["availability_set"] = val
 
 		val, err = v.AvailabilityZone.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2351,7 +2347,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["availability_zone"] = val
 
 		val, err = v.AzureRegion.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2359,7 +2354,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["azure_region"] = val
 
 		val, err = v.AzurefloatingIp.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2367,7 +2361,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["azurefloating_ip"] = val
 
 		val, err = v.AzuresecurityGroupId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2375,7 +2368,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["azuresecurity_group_id"] = val
 
 		val, err = v.BootDiagnostics.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2383,7 +2375,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["boot_diagnostics"] = val
 
 		val, err = v.CreateUser.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2391,7 +2382,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["create_user"] = val
 
 		val, err = v.DiagnosticsStorageAccount.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2399,7 +2389,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["diagnostics_storage_account"] = val
 
 		val, err = v.OsGuestDiagnostics.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2407,7 +2396,6 @@ func (v ConfigAzureValue) ToTerraformValue(ctx context.Context) (tftypes.Value, 
 		vals["os_guest_diagnostics"] = val
 
 		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2917,14 +2905,12 @@ func (t ConfigHvmType) ValueFromTerraform(ctx context.Context, in tftypes.Value)
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -2969,7 +2955,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals := make(map[string]tftypes.Value, 5)
 
 		val, err = v.CreateUser.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2977,7 +2962,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["create_user"] = val
 
 		val, err = v.KvmHostId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2985,7 +2969,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["kvm_host_id"] = val
 
 		val, err = v.NestedVirtualization.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -2993,7 +2976,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["nested_virtualization"] = val
 
 		val, err = v.NoAgent.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3001,7 +2983,6 @@ func (v ConfigHvmValue) ToTerraformValue(ctx context.Context) (tftypes.Value, er
 		vals["no_agent"] = val
 
 		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3469,14 +3450,12 @@ func (t ConfigVmwareType) ValueFromTerraform(ctx context.Context, in tftypes.Val
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -3521,7 +3500,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals := make(map[string]tftypes.Value, 5)
 
 		val, err = v.CreateUser.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3529,7 +3507,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals["create_user"] = val
 
 		val, err = v.NestedVirtualization.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3537,7 +3514,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals["nested_virtualization"] = val
 
 		val, err = v.NoAgent.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3545,7 +3521,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals["no_agent"] = val
 
 		val, err = v.ResourcePoolId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -3553,7 +3528,6 @@ func (v ConfigVmwareValue) ToTerraformValue(ctx context.Context) (tftypes.Value,
 		vals["resource_pool_id"] = val
 
 		val, err = v.VmwareFolderId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4097,14 +4071,12 @@ func (t NetworkInterfacesType) ValueFromTerraform(ctx context.Context, in tftype
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -4155,7 +4127,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals := make(map[string]tftypes.Value, 7)
 
 		val, err = v.ChildVirtualNetworks.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4163,7 +4134,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["child_virtual_networks"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4171,7 +4141,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["id"] = val
 
 		val, err = v.IpAddress.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4179,7 +4148,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["ip_address"] = val
 
 		val, err = v.IpMode.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4187,7 +4155,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["ip_mode"] = val
 
 		val, err = v.MacAddress.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4195,7 +4162,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["mac_address"] = val
 
 		val, err = v.NetworkId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4203,7 +4169,6 @@ func (v NetworkInterfacesValue) ToTerraformValue(ctx context.Context) (tftypes.V
 		vals["network_id"] = val
 
 		val, err = v.NetworkInterfaceTypeId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4756,14 +4721,12 @@ func (t ChildVirtualNetworksType) ValueFromTerraform(ctx context.Context, in tft
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -4810,7 +4773,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals := make(map[string]tftypes.Value, 6)
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4818,7 +4780,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["id"] = val
 
 		val, err = v.IpAddress.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4826,7 +4787,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["ip_address"] = val
 
 		val, err = v.IpMode.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4834,7 +4794,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["ip_mode"] = val
 
 		val, err = v.MacAddress.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4842,7 +4801,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["mac_address"] = val
 
 		val, err = v.NetworkId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -4850,7 +4808,6 @@ func (v ChildVirtualNetworksValue) ToTerraformValue(ctx context.Context) (tftype
 		vals["network_id"] = val
 
 		val, err = v.NetworkInterfaceTypeId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5137,6 +5094,24 @@ func (t VolumesType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 			fmt.Sprintf(`size_id expected to be basetypes.Int64Value, was: %T`, sizeIdAttribute))
 	}
 
+	storageProfileAttribute, ok := attributes["storage_profile"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`storage_profile is missing from object`)
+
+		return nil, diags
+	}
+
+	storageProfileVal, ok := storageProfileAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`storage_profile expected to be basetypes.StringValue, was: %T`, storageProfileAttribute))
+	}
+
 	storageTypeAttribute, ok := attributes["storage_type"]
 
 	if !ok {
@@ -5167,6 +5142,7 @@ func (t VolumesType) ValueFromObject(ctx context.Context, in basetypes.ObjectVal
 		RootVolume:           rootVolumeVal,
 		Size:                 sizeVal,
 		SizeId:               sizeIdVal,
+		StorageProfile:       storageProfileVal,
 		StorageType:          storageTypeVal,
 		state:                attr.ValueStateKnown,
 	}, diags
@@ -5361,6 +5337,24 @@ func NewVolumesValue(attributeTypes map[string]attr.Type, attributes map[string]
 			fmt.Sprintf(`size_id expected to be basetypes.Int64Value, was: %T`, sizeIdAttribute))
 	}
 
+	storageProfileAttribute, ok := attributes["storage_profile"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`storage_profile is missing from object`)
+
+		return NewVolumesValueUnknown(), diags
+	}
+
+	storageProfileVal, ok := storageProfileAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`storage_profile expected to be basetypes.StringValue, was: %T`, storageProfileAttribute))
+	}
+
 	storageTypeAttribute, ok := attributes["storage_type"]
 
 	if !ok {
@@ -5391,6 +5385,7 @@ func NewVolumesValue(attributeTypes map[string]attr.Type, attributes map[string]
 		RootVolume:           rootVolumeVal,
 		Size:                 sizeVal,
 		SizeId:               sizeIdVal,
+		StorageProfile:       storageProfileVal,
 		StorageType:          storageTypeVal,
 		state:                attr.ValueStateKnown,
 	}, diags
@@ -5439,14 +5434,12 @@ func (t VolumesType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (
 	val := map[string]tftypes.Value{}
 
 	err := in.As(&val)
-
 	if err != nil {
 		return nil, err
 	}
 
 	for k, v := range val {
 		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
-
 		if err != nil {
 			return nil, err
 		}
@@ -5471,12 +5464,13 @@ type VolumesValue struct {
 	RootVolume           basetypes.BoolValue   `tfsdk:"root_volume"`
 	Size                 basetypes.Int64Value  `tfsdk:"size"`
 	SizeId               basetypes.Int64Value  `tfsdk:"size_id"`
+	StorageProfile       basetypes.StringValue `tfsdk:"storage_profile"`
 	StorageType          basetypes.Int64Value  `tfsdk:"storage_type"`
 	state                attr.ValueState
 }
 
 func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
-	attrTypes := make(map[string]tftypes.Type, 8)
+	attrTypes := make(map[string]tftypes.Type, 9)
 
 	var val tftypes.Value
 	var err error
@@ -5488,16 +5482,16 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 	attrTypes["root_volume"] = basetypes.BoolType{}.TerraformType(ctx)
 	attrTypes["size"] = basetypes.Int64Type{}.TerraformType(ctx)
 	attrTypes["size_id"] = basetypes.Int64Type{}.TerraformType(ctx)
+	attrTypes["storage_profile"] = basetypes.StringType{}.TerraformType(ctx)
 	attrTypes["storage_type"] = basetypes.Int64Type{}.TerraformType(ctx)
 
 	objectType := tftypes.Object{AttributeTypes: attrTypes}
 
 	switch v.state {
 	case attr.ValueStateKnown:
-		vals := make(map[string]tftypes.Value, 8)
+		vals := make(map[string]tftypes.Value, 9)
 
 		val, err = v.ControllerMountPoint.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5505,7 +5499,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["controller_mount_point"] = val
 
 		val, err = v.DatastoreId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5513,7 +5506,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["datastore_id"] = val
 
 		val, err = v.Id.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5521,7 +5513,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["id"] = val
 
 		val, err = v.Name.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5529,7 +5520,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["name"] = val
 
 		val, err = v.RootVolume.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5537,7 +5527,6 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["root_volume"] = val
 
 		val, err = v.Size.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5545,15 +5534,20 @@ func (v VolumesValue) ToTerraformValue(ctx context.Context) (tftypes.Value, erro
 		vals["size"] = val
 
 		val, err = v.SizeId.ToTerraformValue(ctx)
-
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
 
 		vals["size_id"] = val
 
-		val, err = v.StorageType.ToTerraformValue(ctx)
+		val, err = v.StorageProfile.ToTerraformValue(ctx)
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
 
+		vals["storage_profile"] = val
+
+		val, err = v.StorageType.ToTerraformValue(ctx)
 		if err != nil {
 			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
 		}
@@ -5597,6 +5591,7 @@ func (v VolumesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 		"root_volume":            basetypes.BoolType{},
 		"size":                   basetypes.Int64Type{},
 		"size_id":                basetypes.Int64Type{},
+		"storage_profile":        basetypes.StringType{},
 		"storage_type":           basetypes.Int64Type{},
 	}
 
@@ -5618,6 +5613,7 @@ func (v VolumesValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue,
 			"root_volume":            v.RootVolume,
 			"size":                   v.Size,
 			"size_id":                v.SizeId,
+			"storage_profile":        v.StorageProfile,
 			"storage_type":           v.StorageType,
 		})
 
@@ -5667,6 +5663,10 @@ func (v VolumesValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	if !v.StorageProfile.Equal(other.StorageProfile) {
+		return false
+	}
+
 	if !v.StorageType.Equal(other.StorageType) {
 		return false
 	}
@@ -5691,6 +5691,7 @@ func (v VolumesValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
 		"root_volume":            basetypes.BoolType{},
 		"size":                   basetypes.Int64Type{},
 		"size_id":                basetypes.Int64Type{},
+		"storage_profile":        basetypes.StringType{},
 		"storage_type":           basetypes.Int64Type{},
 	}
 }

--- a/morpheus/framework/resources/instanceclone/schema_gen.go
+++ b/morpheus/framework/resources/instanceclone/schema_gen.go
@@ -519,8 +519,8 @@ func InstanceCloneResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"storage_profile": schema.StringAttribute{
 							Optional:            true,
-							Description:         "Storage Profile Code for the volume storage profile assignment. eg. `\"kvm-cache-none\"` or `\"kvm-cache-directsync\"`.\nUse `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.",
-							MarkdownDescription: "Storage Profile Code for the volume storage profile assignment. eg. `\"kvm-cache-none\"` or `\"kvm-cache-directsync\"`.\nUse `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.",
+							Description:         "Storage profile code for the volume. The available codes depend on the\nprovision type; query `/api/provision-types` to list the `storageProfiles`\nfor a type. For example, KVM/HVM volumes use cache-mode profiles such as\n`\"kvm-cache-none\"` or `\"kvm-cache-directsync\"` (`/api/provision-types?code=kvm`).",
+							MarkdownDescription: "Storage profile code for the volume. The available codes depend on the\nprovision type; query `/api/provision-types` to list the `storageProfiles`\nfor a type. For example, KVM/HVM volumes use cache-mode profiles such as\n`\"kvm-cache-none\"` or `\"kvm-cache-directsync\"` (`/api/provision-types?code=kvm`).",
 						},
 						"storage_type": schema.Int64Attribute{
 							Optional:            true,

--- a/morpheus/framework/resources/instanceclone/schema_gen.go
+++ b/morpheus/framework/resources/instanceclone/schema_gen.go
@@ -519,6 +519,7 @@ func InstanceCloneResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"storage_profile": schema.StringAttribute{
 							Optional:            true,
+							Computed:            true,
 							Description:         "Storage profile code for the volume. The available codes depend on the\nprovision type; query `/api/provision-types` to list the `storageProfiles`\nfor a type. For example, KVM/HVM volumes use cache-mode profiles such as\n`\"kvm-cache-none\"` or `\"kvm-cache-directsync\"` (`/api/provision-types?code=kvm`).",
 							MarkdownDescription: "Storage profile code for the volume. The available codes depend on the\nprovision type; query `/api/provision-types` to list the `storageProfiles`\nfor a type. For example, KVM/HVM volumes use cache-mode profiles such as\n`\"kvm-cache-none\"` or `\"kvm-cache-directsync\"` (`/api/provision-types?code=kvm`).",
 						},

--- a/morpheus/framework/resources/instanceclone/update.go
+++ b/morpheus/framework/resources/instanceclone/update.go
@@ -220,6 +220,11 @@ func buildResizeVolumes(
 			vol.SizeId = *sdk.NewNullableInt64(&siVal)
 		}
 
+		if !v.StorageProfile.IsNull() && !v.StorageProfile.IsUnknown() {
+			spVal := v.StorageProfile.ValueString()
+			vol.StorageProfile = *sdk.NewNullableString(&spVal)
+		}
+
 		if !v.ControllerMountPoint.IsNull() && !v.ControllerMountPoint.IsUnknown() {
 			vol.ControllerMountPoint = v.ControllerMountPoint.ValueStringPointer()
 		}


### PR DESCRIPTION
## Summary

Adds two provision-time inputs to the typed config of the `hpe_morpheus_instance` and `hpe_morpheus_instance_clone` resources, and fixes an AWS `create_user` omission (MORPH-13001).

### `user_group`
A top-level, cloud-agnostic `user_group` id that associates the instance (or clone) with a Morpheus user group. It is provision-time only:
- `RequiresReplace` — changing it forces replacement. The API applies the user group only at create/clone time; instance update and resize do not reassign it.
- Read back from the instance config, and recovered on import.

### `storage_profile`
A per-volume `storage_profile` code (e.g. `kvm-cache-none` for KVM/HVM volumes). Sent on create and resize, and preserved across reads so an API-returned default does not produce a spurious diff.

### AWS `create_user` fix
`create_user` is now sent for the Amazon configuration at provision time; it was previously omitted from the AWS request build (the other clouds already sent it).

## SDK

Bumps `hpe-morpheus-go-sdk/oapigen` to `v0.75.0`, which models the new `userGroup` and `storageProfile` fields.

## Testing

- `go build`, `go vet`, and `golangci-lint` (0 issues in the changed packages)
- New unit test for the `storage_profile` volume mapper
- Acceptance tests (using the existing render-template helpers) covering `user_group` and `storage_profile` round-trip on both resources, plus the clone import path
- `make docs` regenerated
