### PR TITLE
Move Terraform schema-generation configs into the provider (specs/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,12 @@ AGENTS.md
 .gitattributes
 tools/.hero-satellite
 tools/.opencode/
+
+# Schema generation: the per-resource config.yaml files under specs/ (and
+# specs/config-provider.yaml) are the source of truth. The split/merge
+# intermediates and any bundled OpenAPI spec are regenerated, not stored.
+specs/**/spec.yaml
+specs/provider.yaml
+specs/provider_code_spec.json
+specs/**/bundled.json
+specs/**/bundled.yaml

--- a/morpheus/framework/resources/settingwhitelabel/resource.go
+++ b/morpheus/framework/resources/settingwhitelabel/resource.go
@@ -39,7 +39,7 @@ func (r *settingWhitelabelResource) Schema(
 	_ resource.SchemaRequest,
 	resp *resource.SchemaResponse,
 ) {
-	resp.Schema = WhitelabelSettingsResourceSchema(ctx)
+	resp.Schema = SettingWhitelabelResourceSchema(ctx)
 }
 
 func (r *settingWhitelabelResource) Create(
@@ -55,7 +55,7 @@ func (r *settingWhitelabelResource) Create(
 		return
 	}
 
-	var plan WhitelabelSettingsModel
+	var plan SettingWhitelabelModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -90,7 +90,7 @@ func (r *settingWhitelabelResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	var state WhitelabelSettingsModel
+	var state SettingWhitelabelModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -126,7 +126,7 @@ func (r *settingWhitelabelResource) Update(
 		return
 	}
 
-	var plan WhitelabelSettingsModel
+	var plan SettingWhitelabelModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -193,7 +193,7 @@ func (r *settingWhitelabelResource) Delete(
 
 func (r *settingWhitelabelResource) readIntoModel(
 	ctx context.Context,
-	model *WhitelabelSettingsModel,
+	model *SettingWhitelabelModel,
 	diagnostics *diag.Diagnostics,
 ) {
 	client, err := r.NewClient(ctx)
@@ -219,7 +219,7 @@ func (r *settingWhitelabelResource) readIntoModel(
 	mapResponseToModel(model, settings)
 }
 
-func buildUpdateRequest(plan *WhitelabelSettingsModel) sdk.UpdateWhitelabelSettingsRequest {
+func buildUpdateRequest(plan *SettingWhitelabelModel) sdk.UpdateWhitelabelSettingsRequest {
 	settings := sdk.UpdateWhitelabelSettingsRequestWhitelabelSettings{}
 	if !plan.Enabled.IsNull() {
 		settings.Enabled = plan.Enabled.ValueBoolPointer()
@@ -240,7 +240,7 @@ func buildUpdateRequest(plan *WhitelabelSettingsModel) sdk.UpdateWhitelabelSetti
 }
 
 func mapResponseToModel(
-	model *WhitelabelSettingsModel,
+	model *SettingWhitelabelModel,
 	settings *sdk.ListWhitelabelSettings200ResponseWhitelabelSettings,
 ) {
 	model.Id = types.StringValue("settings")

--- a/morpheus/framework/resources/settingwhitelabel/schema_gen.go
+++ b/morpheus/framework/resources/settingwhitelabel/schema_gen.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
-func WhitelabelSettingsResourceSchema(ctx context.Context) schema.Schema {
+func SettingWhitelabelResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"appliance_name": schema.StringAttribute{
@@ -74,7 +74,7 @@ func WhitelabelSettingsResourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
-type WhitelabelSettingsModel struct {
+type SettingWhitelabelModel struct {
 	ApplianceName    types.String `tfsdk:"appliance_name"`
 	Enabled          types.Bool   `tfsdk:"enabled"`
 	Favicon          types.String `tfsdk:"favicon"`

--- a/specs/config-provider.yaml
+++ b/specs/config-provider.yaml
@@ -1,0 +1,1505 @@
+provider:
+  name: morpheus
+resources:
+  active_directory_identity_source:
+    create:
+      path: /api/user-sources
+      method: POST
+    read:
+      path: /api/user-sources/{id}
+      method: GET
+    update:
+      path: /api/user-sources/{id}
+      method: PUT
+    delete:
+      path: /api/user-sources/{id}
+      method: DELETE
+  backup_setting:
+    create:
+      path: /api/backup-settings
+      method: PUT
+    read:
+      path: /api/backup-settings
+      method: GET
+    update:
+      path: /api/backup-settings
+      method: PUT
+  blueprint:
+    create:
+      path: /api/blueprints
+      method: POST
+    read:
+      path: /api/blueprints/{id}
+      method: GET
+    update:
+      path: /api/blueprints/{id}
+      method: PUT
+    delete:
+      path: /api/blueprints/{id}
+      method: DELETE
+  boot_script:
+    create:
+      path: /api/boot-scripts
+      method: POST
+    read:
+      path: /api/boot-scripts/{id}
+      method: GET
+    update:
+      path: /api/boot-scripts/{id}
+      method: PUT
+    delete:
+      path: /api/boot-scripts/{id}
+      method: DELETE
+  catalog_item_type:
+    create:
+      path: /api/catalog-item-types
+      method: POST
+    read:
+      path: /api/catalog-item-types/{id}
+      method: GET
+    update:
+      path: /api/catalog-item-types/{id}
+      method: PUT
+    delete:
+      path: /api/catalog-item-types/{id}
+      method: DELETE
+  cloud:
+    create:
+      path: /api/zones
+      method: POST
+    read:
+      path: /api/zones/{id}
+      method: GET
+    update:
+      path: /api/zones/{id}
+      method: PUT
+    delete:
+      path: /api/zones/{id}
+      method: DELETE
+    schema:
+      templates:
+        bool:
+          bool:
+            description: CHANGE ME
+            computed_optional_required: optional
+        azure-region:
+          string:
+            description: The Azure region associated with the cloud integration
+            computed_optional_required: required
+      moves:
+        - zone: "" # unnest zone
+        - account_id: tenant_id
+        - agent_mode: agent_install_mode
+        - timezone: time_zone
+        - config.appliance_url: appliance_url
+        - config.datacenter_name: data_center_name
+        - config.external_id: external_id
+        - config.inventory_level: import_existing_vms
+        - config.console_keymap: keyboard_layout
+        - config.anyof0.oneof2: config_hvm
+        - config_aws.endpoint: config_aws.region
+        - config_aws.sts_assume_role: config_aws.role_arn
+        - config_azure.rpc_mode.oneof0: config_azure.rpc_mode
+        - config_vsphere.rpc_mode.oneof0: config_vsphere.rpc_mode
+        - network_server.id: network_server_id
+      removes:
+        - account
+        - api_proxy
+        - config
+        - config_aws.use_host_credentials
+        - console_keymap # added from GET examples?
+        - container_mode
+        - cost_last_sync
+        - cost_last_sync_duration
+        - cost_status
+        - cost_status_date
+        - cost_status_message
+        - credential
+        - credential_type
+        - dark_image_path
+        - date_created
+        - default_datastore_sync_active
+        - default_folder_sync_active
+        - default_network_sync_active
+        - default_plan_sync_active
+        - default_pool_sync_active
+        - default_security_group_sync_active
+        - description
+        - domain_name
+        - groups
+        - image_path
+        - inventory_level # added from GET examples?
+        - last_sync
+        - last_sync_duration
+        - last_updated
+        - linked_account_id
+        - network_domain
+        - network_server
+        - network_server_id
+        - next_run_date
+        - owner
+        - provisioning_proxy
+        - region_code
+        - scale_priority
+        - security_server
+        - server_count
+        - service_version
+        - stats
+        - status
+        - status_date
+        - status_message
+        - storage_mode
+        - success
+        - user_data_linux
+        - user_data_windows
+        - uuid
+        - zone_type
+        - zone_type_id
+        - time_zone # Bug
+      overrides:
+        agent_install_mode:
+          description: The method used to install the Morpheus agent on virtual machines
+            provisioned in the cloud (ssh, cloudInit)
+          computed_optional_required: computed_optional
+        appliance_url:
+          computed_optional_required: optional
+        config_hvm:
+          computed_optional_required: optional
+        config_hvm.enable_network_type_selection:
+          description: Whether to enable the user to select the network interface type
+            during provisioning
+          computed_optional_required: optional
+        costing_mode:
+          description: Whether to enable costing on the cloud (off, costing, reservations,
+            full)
+          one_of: [off, costing, reservations, full]
+          default: off
+          computed_optional_required: computed_optional
+        data_center_name:
+          computed_optional_required: optional
+        external_id:
+          computed_optional_required: optional
+        group_id:
+          computed_optional_required: required
+          requires_replace: true
+        guidance_mode:
+          description: Whether to enable guidance recommendations on the cloud (manual, off)
+          computed_optional_required: computed_optional
+          one_of: [off, manual]
+          default: off
+        id:
+          description: The ID of the cloud
+          state_for_unknown: true
+        import_existing_vms:
+          description: Whether to import existing virtual machines (off, basic, full)
+          computed_optional_required: optional
+          one_of: [off, basic, full]
+        keyboard_layout:
+          computed_optional_required: optional
+        location:
+          computed_optional_required: optional
+        name:
+          computed_optional_required: required
+        tenant_id:
+          computed_optional_required: required
+          requires_replace: true
+  cluster:
+    create:
+      path: /api/clusters
+      method: POST
+    read:
+      path: /api/clusters/{clusterId}
+      method: GET
+    update:
+      path: /api/clusters/{clusterId}
+      method: PUT
+    delete:
+      path: /api/clusters/{clusterId}
+      method: DELETE
+  cluster_layout:
+    create:
+      path: /api/library/cluster-layouts
+      method: POST
+    read:
+      path: /api/library/cluster-layouts/{id}
+      method: GET
+    update:
+      path: /api/library/cluster-layouts/{id}
+      method: PUT
+    delete:
+      path: /api/library/cluster-layouts/{id}
+      method: DELETE
+  cluster_affinity_group:
+    create:
+      path: /api/clusters/{clusterId}/affinity-groups
+      method: POST
+    read:
+      path: /api/clusters/{clusterId}/affinity-groups/{id}
+      method: GET
+    update:
+      path: /api/clusters/{clusterId}/affinity-groups/{id}
+      method: PUT
+    delete:
+      path: /api/clusters/{clusterId}/affinity-groups/{id}
+      method: DELETE
+  cluster_namespace:
+    create:
+      path: /api/clusters/{clusterId}/namespaces
+      method: POST
+    read:
+      path: /api/clusters/{clusterId}/namespaces/{id}
+      method: GET
+    update:
+      path: /api/clusters/{clusterId}/namespaces/{id}
+      method: PUT
+    delete:
+      path: /api/clusters/{clusterId}/namespaces/{id}
+      method: DELETE
+  contact:
+    create:
+      path: /api/monitoring/contacts
+      method: POST
+    read:
+      path: /api/monitoring/contacts/{id}
+      method: GET
+    update:
+      path: /api/monitoring/contacts/{id}
+      method: PUT
+    delete:
+      path: /api/monitoring/contacts/{id}
+      method: DELETE
+  datastore:
+    create:
+      path: /api/data-stores
+      method: POST
+    read:
+      path: /api/data-stores/{id}
+      method: GET
+    update:
+      path: /api/data-stores/{id}
+      method: PUT
+    delete:
+      path: /api/data-stores/{id}
+      method: DELETE
+  file_template:
+    create:
+      path: /api/library/container-templates
+      method: POST
+    read:
+      path: /api/library/container-templates/{id}
+      method: GET
+    update:
+      path: /api/library/container-templates/{id}
+      method: PUT
+    delete:
+      path: /api/library/container-templates/{id}
+      method: DELETE
+  group:
+    create:
+      path: /api/groups
+      method: POST
+    read:
+      path: /api/groups/{id}
+      method: GET
+    update:
+      path: /api/groups/{id}
+      method: PUT
+    delete:
+      path: /api/groups/{id}
+      method: DELETE
+  guidance_setting:
+    create:
+      path: /api/guidance-settings
+      method: PUT
+    read:
+      path: /api/guidance-settings
+      method: GET
+    update:
+      path: /api/guidance-settings
+      method: PUT
+  image:
+    create:
+      path: /api/virtual-images
+      method: POST
+    read:
+      path: /api/virtual-images/{virtualImageId}
+      method: GET
+    update:
+      path: /api/virtual-images/{virtualImageId}
+      method: PUT
+  load_balancer:
+    create:
+      path: /api/load-balancers
+      method: POST
+    read:
+      path: /api/load-balancers/{loadBalancerId}
+      method: GET
+    update:
+      path: /api/load-balancers/{loadBalancerId}
+      method: PUT
+    delete:
+      path: /api/load-balancers/{loadBalancerId}
+      method: DELETE
+  load_balancer_monitor:
+    create:
+      path: /api/load-balancers/{loadBalancerId}/monitors
+      method: POST
+    read:
+      path: /api/load-balancers/{loadBalancerId}/monitors/{id}
+      method: GET
+    update:
+      path: /api/load-balancers/{loadBalancerId}/monitors/{id}
+      method: PUT
+    delete:
+      path: /api/load-balancers/{loadBalancerId}/monitors/{id}
+      method: DELETE
+  instance:
+    create:
+      path: /api/instances
+      method: POST
+    read:
+      path: /api/instances/{id}
+      method: GET
+    update:
+      path: /api/instances/{id}
+      method: PUT
+    delete:
+      path: /api/instances/{id}
+      method: DELETE
+  instance_snapshot:
+    create:
+      path: /api/instances/{id}/snapshot
+      method: PUT
+    read:
+      path: /api/snapshots/{id}
+      method: GET
+    delete:
+      path: /api/snapshots/{id}
+      method: DELETE
+  instance_clone:
+    create:
+      path: /api/instances/{id}/clone
+      method: PUT
+    read:
+      path: /api/instances/{id}
+      method: GET
+  instance_type_layout:
+    create:
+      path: /api/library/instance-types/{instanceTypeId}/layouts
+      method: POST
+    read:
+      path: /api/library/layouts/{id}
+      method: GET
+    update:
+      path: /api/library/layouts/{id}
+      method: PUT
+    delete:
+      path: /api/library/layouts/{id}
+      method: DELETE
+  instance_type:
+    create:
+      path: /api/library/instance-types
+      method: POST
+    read:
+      path: /api/library/instance-types/{instanceTypeId}
+      method: GET
+    update:
+      path: /api/library/instance-types/{instanceTypeId}
+      method: PUT
+    delete:
+      path: /api/library/instance-types/{instanceTypeId}
+      method: DELETE
+  load_balancer_pool:
+    create:
+      path: /api/load-balancers/{loadBalancerId}/pools
+      method: POST
+    read:
+      path: /api/load-balancers/{loadBalancerId}/pools/{id}
+      method: GET
+    update:
+      path: /api/load-balancers/{loadBalancerId}/pools/{id}
+      method: PUT
+    delete:
+      path: /api/load-balancers/{loadBalancerId}/pools/{id}
+      method: DELETE
+  load_balancer_profile:
+    create:
+      path: /api/load-balancers/{loadBalancerId}/profiles
+      method: POST
+    read:
+      path: /api/load-balancers/{loadBalancerId}/profiles/{id}
+      method: GET
+    update:
+      path: /api/load-balancers/{loadBalancerId}/profiles/{id}
+      method: PUT
+    delete:
+      path: /api/load-balancers/{loadBalancerId}/profiles/{id}
+      method: DELETE
+  load_balancer_virtual_server:
+    create:
+      path: /api/load-balancers/{loadBalancerId}/virtual-servers
+      method: POST
+    read:
+      path: /api/load-balancers/{loadBalancerId}/virtual-servers/{id}
+      method: GET
+    update:
+      path: /api/load-balancers/{loadBalancerId}/virtual-servers/{id}
+      method: PUT
+    delete:
+      path: /api/load-balancers/{loadBalancerId}/virtual-servers/{id}
+      method: DELETE
+  monitoring_setting:
+    create:
+      path: /api/monitoring-settings
+      method: PUT
+    read:
+      path: /api/monitoring-settings
+      method: GET
+    update:
+      path: /api/monitoring-settings
+      method: PUT
+  # network resource
+  network:
+    create:
+      path: /api/networks
+      method: POST
+    read:
+      path: /api/networks/{id}
+      method: GET
+    update:
+      path: /api/networks/{id}
+      method: PUT
+    delete:
+      path: /api/networks/{id}
+      method: DELETE
+  network_dhcp_server:
+    create:
+      path: /api/networks/servers/{serverId}/dhcp-servers
+      method: POST
+    read:
+      path: /api/networks/servers/{serverId}/dhcp-servers/{id}
+      method: GET
+    update:
+      path: /api/networks/servers/{serverId}/dhcp-servers/{id}
+      method: PUT
+    delete:
+      path: /api/networks/servers/{serverId}/dhcp-servers/{id}
+      method: DELETE
+  network_firewall_rule:
+    create:
+      path: /api/networks/servers/{serverId}/firewall-rules
+      method: POST
+    read:
+      path: /api/networks/servers/{serverId}/firewall-rules/{id}
+      method: GET
+    update:
+      path: /api/networks/servers/{serverId}/firewall-rules/{id}
+      method: PUT
+    delete:
+      path: /api/networks/servers/{serverId}/firewall-rules/{id}
+      method: DELETE
+  network_firewall_rule_group:
+    create:
+      path: /api/networks/servers/{serverId}/firewall-rule-groups
+      method: POST
+    read:
+      path: /api/networks/servers/{serverId}/firewall-rule-groups/{id}
+      method: GET
+    update:
+      path: /api/networks/servers/{serverId}/firewall-rule-groups/{id}
+      method: PUT
+    delete:
+      path: /api/networks/servers/{serverId}/firewall-rule-groups/{id}
+      method: DELETE
+  network_router_bgp_neighbor:
+    create:
+      path: /api/networks/routers/{routerId}/bgp-neighbors
+      method: POST
+    read:
+      path: /api/networks/routers/{routerId}/bgp-neighbors/{id}
+      method: GET
+    update:
+      path: /api/networks/routers/{routerId}/bgp-neighbors/{id}
+      method: PUT
+    delete:
+      path: /api/networks/routers/{routerId}/bgp-neighbors/{id}
+      method: DELETE
+  network_router:
+    create:
+      path: /api/networks/routers
+      method: POST
+    read:
+      path: /api/networks/routers/{id}
+      method: GET
+    update:
+      path: /api/networks/routers/{id}
+      method: PUT
+    delete:
+      path: /api/networks/routers/{id}
+      method: DELETE
+  node_type:
+    create:
+      path: /api/library/container-types
+      method: POST
+    read:
+      path: /api/library/container-types/{id}
+      method: GET
+    update:
+      path: /api/library/container-types/{id}
+      method: PUT
+    delete:
+      path: /api/library/container-types/{id}
+      method: DELETE
+  network_router_route:
+    create:
+      path: /api/networks/routers/{routerId}/routes
+      method: POST
+    read:
+      path: /api/networks/routers/{routerId}/routes/{id}
+      method: GET
+    update:
+      path: /api/networks/routers/{routerId}/routes/{id}
+      method: PUT
+    delete:
+      path: /api/networks/routers/{routerId}/routes/{id}
+      method: DELETE
+  os_type_image:
+    create:
+      path: /api/library/operating-systems/os-types/create-image
+      method: POST
+    read:
+      path: /api/library/operating-systems/os-types/images/{id}
+      method: GET
+    delete:
+      path: /api/library/operating-systems/os-types/images/{id}
+      method: DELETE
+  option_list:
+    create:
+      path: /api/library/option-type-lists
+      method: POST
+    read:
+      path: /api/library/option-type-lists/{id}
+      method: GET
+    update:
+      path: /api/library/option-type-lists/{id}
+      method: PUT
+    delete:
+      path: /api/library/option-type-lists/{id}
+      method: DELETE
+  option_type_list:
+    create:
+      path: /api/library/option-type-lists
+      method: POST
+    read:
+      path: /api/library/option-type-lists/{id}
+      method: GET
+    update:
+      path: /api/library/option-type-lists/{id}
+      method: PUT
+    delete:
+      path: /api/library/option-type-lists/{id}
+      method: DELETE
+  os_type:
+    create:
+      path: /api/library/operating-systems/os-types
+      method: POST
+    read:
+      path: /api/library/operating-systems/os-types/{id}
+      method: GET
+    update:
+      path: /api/library/operating-systems/os-types/{id}
+      method: PUT
+    delete:
+      path: /api/library/operating-systems/os-types/{id}
+      method: DELETE
+  policy:
+    create:
+      path: /api/policies
+      method: POST
+    read:
+      path: /api/policies/{id}
+      method: GET
+    update:
+      path: /api/policies/{id}
+      method: PUT
+    delete:
+      path: /api/policies/{id}
+      method: DELETE
+  preseed_script:
+    create:
+      path: /api/preseed-scripts
+      method: POST
+    read:
+      path: /api/preseed-scripts/{id}
+      method: GET
+    update:
+      path: /api/preseed-scripts/{id}
+      method: PUT
+    delete:
+      path: /api/preseed-scripts/{id}
+      method: DELETE
+  provisioning_setting:
+    create:
+      path: /api/provisioning-settings
+      method: PUT
+    read:
+      path: /api/provisioning-settings
+      method: GET
+    update:
+      path: /api/provisioning-settings
+      method: PUT
+  resource_pool_group:
+    create:
+      path: /api/resource-pools/groups
+      method: POST
+    read:
+      path: /api/resource-pools/groups/{id}
+      method: GET
+    update:
+      path: /api/resource-pools/groups/{id}
+      method: PUT
+    delete:
+      path: /api/resource-pools/groups/{id}
+      method: DELETE
+  container_script:
+    create:
+      path: /api/library/container-scripts
+      method: POST
+    read:
+      path: /api/library/container-scripts/{id}
+      method: GET
+    update:
+      path: /api/library/container-scripts/{id}
+      method: PUT
+    delete:
+      path: /api/library/container-scripts/{id}
+      method: DELETE
+  script_template:
+    create:
+      path: /api/library/container-scripts
+      method: POST
+    read:
+      path: /api/library/container-scripts/{id}
+      method: GET
+    update:
+      path: /api/library/container-scripts/{id}
+      method: PUT
+    delete:
+      path: /api/library/container-scripts/{id}
+      method: DELETE
+  service_plan:
+    create:
+      path: /api/service-plans
+      method: POST
+    read:
+      path: /api/service-plans/{id}
+      method: GET
+    update:
+      path: /api/service-plans/{id}
+      method: PUT
+    delete:
+      path: /api/service-plans/{id}
+      method: DELETE
+  spec_template:
+    create:
+      path: /api/library/spec-templates
+      method: POST
+    read:
+      path: /api/library/spec-templates/{id}
+      method: GET
+    update:
+      path: /api/library/spec-templates/{id}
+      method: PUT
+    delete:
+      path: /api/library/spec-templates/{id}
+      method: DELETE
+  task:
+    create:
+      path: /api/tasks
+      method: POST
+    read:
+      path: /api/tasks/{id}
+      method: GET
+    update:
+      path: /api/tasks/{id}
+      method: PUT
+    delete:
+      path: /api/tasks/{id}
+      method: DELETE
+  tenant:
+    create:
+      path: /api/accounts
+      method: POST
+    read:
+      path: /api/accounts/{id}
+      method: GET
+    update:
+      path: /api/accounts/{id}
+      method: PUT
+    delete:
+      path: /api/accounts/{id}
+      method: DELETE
+  # user resource
+  user:
+    create:
+      path: /api/users
+      method: POST
+    read:
+      path: /api/users/{id}
+      method: GET
+    update:
+      path: /api/users/{id}
+      method: PUT
+    delete:
+      path: /api/users/{id}
+      method: DELETE
+  role:
+    create:
+      path: /api/roles
+      method: POST
+    read:
+      path: /api/roles/{id}
+      method: GET
+    update:
+      path: /api/roles/{id}
+      method: PUT
+    delete:
+      path: /api/roles/{id}
+      method: DELETE
+  wiki_page:
+    create:
+      path: /api/wiki/pages
+      method: POST
+    read:
+      path: /api/wiki/pages/{id}
+      method: GET
+    update:
+      path: /api/wiki/pages/{id}
+      method: PUT
+    delete:
+      path: /api/wiki/pages/{id}
+      method: DELETE
+  backup_host:
+    create:
+      path: /api/backups
+      method: POST
+    read:
+      path: /api/backups/{id}
+      method: GET
+    update:
+      path: /api/backups/{id}
+      method: PUT
+    delete:
+      path: /api/backups/{id}
+      method: DELETE
+  backup_instance:
+    create:
+      path: /api/backups
+      method: POST
+    read:
+      path: /api/backups/{id}
+      method: GET
+    update:
+      path: /api/backups/{id}
+      method: PUT
+    delete:
+      path: /api/backups/{id}
+      method: DELETE
+  backup_job:
+    create:
+      path: /api/backups/jobs
+      method: POST
+    read:
+      path: /api/backups/jobs/{id}
+      method: GET
+    update:
+      path: /api/backups/jobs/{id}
+      method: PUT
+    delete:
+      path: /api/backups/jobs/{id}
+      method: DELETE
+  budget:
+    create:
+      path: /api/budgets
+      method: POST
+    read:
+      path: /api/budgets/{id}
+      method: GET
+    update:
+      path: /api/budgets/{id}
+      method: PUT
+    delete:
+      path: /api/budgets/{id}
+      method: DELETE
+  certificate:
+    create:
+      path: /api/certificates
+      method: POST
+    read:
+      path: /api/certificates/{id}
+      method: GET
+    update:
+      path: /api/certificates/{id}
+      method: PUT
+    delete:
+      path: /api/certificates/{id}
+      method: DELETE
+  cypher:
+    create:
+      path: /api/cypher/{cypherPath}
+      method: POST
+    read:
+      path: /api/cypher/{cypherPath}
+      method: GET
+    delete:
+      path: /api/cypher/{cypherPath}
+      method: DELETE
+  deployment:
+    create:
+      path: /api/deployments
+      method: POST
+    read:
+      path: /api/deployments/{deploymentId}
+      method: GET
+    update:
+      path: /api/deployments/{deploymentId}
+      method: PUT
+    delete:
+      path: /api/deployments/{deploymentId}
+      method: DELETE
+  library_container_script:
+    create:
+      path: /api/library/container-scripts
+      method: POST
+    read:
+      path: /api/library/container-scripts/{id}
+      method: GET
+    update:
+      path: /api/library/container-scripts/{id}
+      method: PUT
+    delete:
+      path: /api/library/container-scripts/{id}
+      method: DELETE
+  library_file_template:
+    create:
+      path: /api/library/container-templates
+      method: POST
+    read:
+      path: /api/library/container-templates/{id}
+      method: GET
+    update:
+      path: /api/library/container-templates/{id}
+      method: PUT
+    delete:
+      path: /api/library/container-templates/{id}
+      method: DELETE
+  library_instance_type:
+    create:
+      path: /api/library/instance-types
+      method: POST
+    read:
+      path: /api/library/instance-types/{instanceTypeId}
+      method: GET
+    update:
+      path: /api/library/instance-types/{instanceTypeId}
+      method: PUT
+    delete:
+      path: /api/library/instance-types/{instanceTypeId}
+      method: DELETE
+  library_option_type_list:
+    create:
+      path: /api/library/option-type-lists
+      method: POST
+    read:
+      path: /api/library/option-type-lists/{id}
+      method: GET
+    update:
+      path: /api/library/option-type-lists/{id}
+      method: PUT
+    delete:
+      path: /api/library/option-type-lists/{id}
+      method: DELETE
+  library_spec_template:
+    create:
+      path: /api/library/spec-templates
+      method: POST
+    read:
+      path: /api/library/spec-templates/{id}
+      method: GET
+    update:
+      path: /api/library/spec-templates/{id}
+      method: PUT
+    delete:
+      path: /api/library/spec-templates/{id}
+      method: DELETE
+  monitoring_alert:
+    create:
+      path: /api/monitoring/alerts
+      method: POST
+    read:
+      path: /api/monitoring/alerts/{id}
+      method: GET
+    update:
+      path: /api/monitoring/alerts/{id}
+      method: PUT
+    delete:
+      path: /api/monitoring/alerts/{id}
+      method: DELETE
+  monitoring_check:
+    create:
+      path: /api/monitoring/checks
+      method: POST
+    read:
+      path: /api/monitoring/checks/{id}
+      method: GET
+    update:
+      path: /api/monitoring/checks/{id}
+      method: PUT
+    delete:
+      path: /api/monitoring/checks/{id}
+      method: DELETE
+  monitoring_group:
+    create:
+      path: /api/monitoring/groups
+      method: POST
+    read:
+      path: /api/monitoring/groups/{id}
+      method: GET
+    update:
+      path: /api/monitoring/groups/{id}
+      method: PUT
+    delete:
+      path: /api/monitoring/groups/{id}
+      method: DELETE
+  network_group:
+    create:
+      path: /api/networks/groups
+      method: POST
+    read:
+      path: /api/networks/groups/{id}
+      method: GET
+    update:
+      path: /api/networks/groups/{id}
+      method: PUT
+    delete:
+      path: /api/networks/groups/{id}
+      method: DELETE
+  network_pool:
+    create:
+      path: /api/networks/pools
+      method: POST
+    read:
+      path: /api/networks/pools/{id}
+      method: GET
+    update:
+      path: /api/networks/pools/{id}
+      method: PUT
+    delete:
+      path: /api/networks/pools/{id}
+      method: DELETE
+  network_pool_server:
+    create:
+      path: /api/networks/pool-servers
+      method: POST
+    read:
+      path: /api/networks/pool-servers/{id}
+      method: GET
+    update:
+      path: /api/networks/pool-servers/{id}
+      method: PUT
+    delete:
+      path: /api/networks/pool-servers/{id}
+      method: DELETE
+  network_router_firewall_rule:
+    create:
+      path: /api/networks/routers/{routerId}/firewall-rules
+      method: POST
+    read:
+      path: /api/networks/routers/{routerId}/firewall-rules/{id}
+      method: GET
+    update:
+      path: /api/networks/routers/{routerId}/firewall-rules/{id}
+      method: PUT
+    delete:
+      path: /api/networks/routers/{routerId}/firewall-rules/{id}
+      method: DELETE
+  network_router_nat:
+    create:
+      path: /api/networks/routers/{routerId}/nats
+      method: POST
+    read:
+      path: /api/networks/routers/{routerId}/nats/{id}
+      method: GET
+    update:
+      path: /api/networks/routers/{routerId}/nats/{id}
+      method: PUT
+    delete:
+      path: /api/networks/routers/{routerId}/nats/{id}
+      method: DELETE
+  power_schedule:
+    create:
+      path: /api/power-schedules
+      method: POST
+    read:
+      path: /api/power-schedules/{id}
+      method: GET
+    update:
+      path: /api/power-schedules/{id}
+      method: PUT
+    delete:
+      path: /api/power-schedules/{id}
+      method: DELETE
+  provisioning_license:
+    create:
+      path: /api/provisioning-licenses
+      method: POST
+    read:
+      path: /api/provisioning-licenses/{id}
+      method: GET
+    update:
+      path: /api/provisioning-licenses/{id}
+      method: PUT
+    delete:
+      path: /api/provisioning-licenses/{id}
+      method: DELETE
+  security_group:
+    create:
+      path: /api/security-groups
+      method: POST
+    read:
+      path: /api/security-groups/{id}
+      method: GET
+    update:
+      path: /api/security-groups/{id}
+      method: PUT
+    delete:
+      path: /api/security-groups/{id}
+      method: DELETE
+  security_group_rule:
+    create:
+      path: /api/security-groups/{id}/rules
+      method: POST
+    read:
+      path: /api/security-groups/{id}/rules/{sgId}
+      method: GET
+    update:
+      path: /api/security-groups/{id}/rules/{sgId}
+      method: PUT
+    delete:
+      path: /api/security-groups/{id}/rules/{sgId}
+      method: DELETE
+  storage_bucket:
+    create:
+      path: /api/storage-buckets
+      method: POST
+    read:
+      path: /api/storage-buckets/{id}
+      method: GET
+    update:
+      path: /api/storage-buckets/{id}
+      method: PUT
+    delete:
+      path: /api/storage-buckets/{id}
+      method: DELETE
+  storage_server:
+    create:
+      path: /api/storage-servers
+      method: POST
+    read:
+      path: /api/storage-servers/{id}
+      method: GET
+    update:
+      path: /api/storage-servers/{id}
+      method: PUT
+    delete:
+      path: /api/storage-servers/{id}
+      method: DELETE
+  storage_volume:
+    create:
+      path: /api/storage-volumes
+      method: POST
+    read:
+      path: /api/storage-volumes/{id}
+      method: GET
+    update:
+      path: /api/storage-volumes/{id}
+      method: PUT
+    delete:
+      path: /api/storage-volumes/{id}
+      method: DELETE
+  subnet:
+    create:
+      path: /api/subnets
+      method: POST
+    read:
+      path: /api/subnets/{id}
+      method: GET
+    update:
+      path: /api/subnets/{id}
+      method: PUT
+    delete:
+      path: /api/subnets/{id}
+      method: DELETE
+  vdi_app:
+    create:
+      path: /api/vdi-apps
+      method: POST
+    read:
+      path: /api/vdi-apps/{id}
+      method: GET
+    update:
+      path: /api/vdi-apps/{id}
+      method: PUT
+    delete:
+      path: /api/vdi-apps/{id}
+      method: DELETE
+  vdi_gateway:
+    create:
+      path: /api/vdi-gateways
+      method: POST
+    read:
+      path: /api/vdi-gateways/{id}
+      method: GET
+    update:
+      path: /api/vdi-gateways/{id}
+      method: PUT
+    delete:
+      path: /api/vdi-gateways/{id}
+      method: DELETE
+  vdi_pool:
+    create:
+      path: /api/vdi-pools
+      method: POST
+    read:
+      path: /api/vdi-pools/{id}
+      method: GET
+    update:
+      path: /api/vdi-pools/{id}
+      method: PUT
+    delete:
+      path: /api/vdi-pools/{id}
+      method: DELETE
+  whitelabel_settings:
+    create:
+      path: /api/whitelabel-settings
+      method: PUT
+    read:
+      path: /api/whitelabel-settings
+      method: GET
+    update:
+      path: /api/whitelabel-settings
+      method: PUT
+data_sources:
+  ansible_tower_inventory:
+    read:
+      path: /api/options/ansibleTowerInventory
+      method: GET
+  ansible_tower_job_template:
+    read:
+      path: /api/options/ansibleTowerJobTemplate
+      method: GET
+  backup:
+    read:
+      path: /api/backups/{id}
+      method: GET
+  backup_type:
+    read:
+      path: /api/backups/types/{id}
+      method: GET
+  blueprint:
+    read:
+      path: /api/blueprints/{id}
+      method: GET
+  budget:
+    read:
+      path: /api/budgets/{id}
+      method: GET
+  catalog_item_type:
+    read:
+      path: /api/catalog/types/{id}
+      method: GET
+  chef_server:
+    read:
+      path: /api/options/chefServer
+      method: GET
+  cloud:
+    read:
+      path: /api/zones/{id}
+      method: GET
+  cloud_datastore:
+    read:
+      path: /api/zones/{zoneId}/data-stores/{id}
+      method: GET
+  cloud_type:
+    read:
+      path: /api/options/zoneTypes
+      method: GET
+  cluster:
+    read:
+      path: /api/clusters/{clusterId}
+      method: GET
+  contact:
+    read:
+      path: /api/monitoring/contacts/{id}
+      method: GET
+  credential:
+    read:
+      path: /api/credentials/{id}
+      method: GET
+  cypher_secret:
+    read:
+      path: /api/cypher/{cypherPath}
+      method: GET
+  datastore:
+    read:
+      path: /api/data-stores/{id}
+      method: GET
+  environment:
+    read:
+      path: /api/environments/{id}
+      method: GET
+  execute_schedule:
+    read:
+      path: /api/execute-schedules/{id}
+      method: GET
+  file_template:
+    read:
+      path: /api/library/container-templates/{id}
+      method: GET
+  git_integration:
+    read:
+      path: /api/integrations/{id}
+      method: GET
+  group:
+    read:
+      path: /api/groups/{id}
+      method: GET
+  instance_snapshot:
+    read:
+      path: /api/snapshots/{id}
+      method: GET
+  instance_type_layout:
+    read:
+      path: /api/library/layouts/{id}
+      method: GET
+  instance_type:
+    read:
+      path: /api/library/instance-types/{instanceTypeId}
+      method: GET
+  integration:
+    read:
+      path: /api/integrations/{id}
+      method: GET
+  job:
+    read:
+      path: /api/jobs/{id}
+      method: GET
+  key_pair:
+    read:
+      path: /api/key-pairs/{id}
+      method: GET
+  load_balancer:
+    read:
+      path: /api/load-balancers/{loadBalancerId}
+      method: GET
+  load_balancer_monitor:
+    read:
+      path: /api/load-balancers/{loadBalancerId}/monitors/{id}
+      method: GET
+  load_balancer_pool:
+    read:
+      path: /api/load-balancers/{loadBalancerId}/pools/{id}
+      method: GET
+  load_balancer_profile:
+    read:
+      path: /api/load-balancers/{loadBalancerId}/profiles/{id}
+      method: GET
+  load_balancer_virtual_server:
+    read:
+      path: /api/load-balancers/{loadBalancerId}/virtual-servers/{id}
+      method: GET
+  network_router_bgp_neighbor:
+    read:
+      path: /api/networks/routers/{routerId}/bgp-neighbors/{id}
+      method: GET
+  # network datasource
+  network:
+    read:
+      path: /api/networks/{id}
+      method: GET
+  network_firewall_rule:
+    read:
+      path: /api/networks/servers/{serverId}/firewall-rules/{id}
+      method: GET
+  network_firewall_rule_group:
+    read:
+      path: /api/networks/servers/{serverId}/firewall-rule-groups/{id}
+      method: GET
+  network_dhcp_server:
+    read:
+      path: /api/networks/servers/{serverId}/dhcp-servers/{id}
+      method: GET
+  network_domain:
+    read:
+      path: /api/networks/domains/{id}
+      method: GET
+  network_group:
+    read:
+      path: /api/networks/groups/{id}
+      method: GET
+  network_edge_cluster:
+    read:
+      path: /api/networks/servers/{serverId}/edge-clusters/{id}
+      method: GET
+  network_pool:
+    read:
+      path: /api/networks/pools/{id}
+      method: GET
+  network_server:
+    read:
+      path: /api/networks/servers/{id}
+      method: GET
+  network_transport_zone:
+    read:
+      path: /api/networks/servers/{serverId}/scopes/{id}
+      method: GET
+  network_type:
+    read:
+      path: /api/network-types/{id}
+      method: GET
+  network_router:
+    read:
+      path: /api/networks/routers/{id}
+      method: GET
+  network_router_route:
+    read:
+      path: /api/networks/routers/{routerId}/routes/{id}
+      method: GET
+  network_subnet:
+    read:
+      path: /api/subnets/{id}
+      method: GET
+  node_type:
+    read:
+      path: /api/library/container-types/{id}
+      method: GET
+  option_list:
+    read:
+      path: /api/library/option-type-lists/{id}
+      method: GET
+  option_type:
+    read:
+      path: /api/library/option-types/{id}
+      method: GET
+  os_type:
+    read:
+      path: /api/library/operating-systems/os-types/{id}
+      method: GET
+  os_type_image:
+    read:
+      path: /api/library/operating-systems/os-types/images/{id}
+      method: GET
+  service_plan:
+    read:
+      path: /api/service-plans/{id}
+      method: GET
+  policy:
+    read:
+      path: /api/policies/{id}
+      method: GET
+  power_schedule:
+    read:
+      path: /api/power-schedules/{id}
+      method: GET
+  price:
+    read:
+      path: /api/prices/{id}
+      method: GET
+  price_set:
+    read:
+      path: /api/price-sets/{id}
+      method: GET
+  provision_type:
+    read:
+      path: /api/provision-types/{id}
+      method: GET
+  resource_pool:
+    read:
+      path: /api/zones/{zoneId}/resource-pools/{id}
+      method: GET
+  script_template:
+    read:
+      path: /api/library/container-scripts/{id}
+      method: GET
+  security_group:
+    read:
+      path: /api/security-groups/{id}
+      method: GET
+  security_package:
+    read:
+      path: /api/security-packages/{id}
+      method: GET
+  servicenow_workflow:
+    read:
+      path: /api/options/serviceNowWorkflows
+      method: GET
+  spec_template:
+    read:
+      path: /api/library/spec-templates/{id}
+      method: GET
+  storage_bucket:
+    read:
+      path: /api/storage-buckets/{id}
+      method: GET
+  storage_server:
+    read:
+      path: /api/storage-servers/{id}
+      method: GET
+  storage_servers:
+    read:
+      path: /api/storage-servers
+      method: GET
+  storage_volume:
+    read:
+      path: /api/storage-volumes/{id}
+      method: GET
+  storage_volume_type:
+    read:
+      path: /api/storage-volume-types/{id}
+      method: GET
+  task:
+    read:
+      path: /api/tasks/{id}
+      method: GET
+  tenant:
+    read:
+      path: /api/accounts/{id}
+      method: GET
+  user:
+    read:
+      path: /api/users/{id}
+      method: GET
+  user_group:
+    read:
+      path: /api/user-groups/{id}
+      method: GET
+  role:
+    read:
+      path: /api/roles/{id}
+      method: GET
+  vdi_pool:
+    read:
+      path: /api/vdi-pools/{id}
+      method: GET
+  image:
+    read:
+      path: /api/virtual-images/{virtualImageId}
+      method: GET
+  instance:
+    read:
+      path: /api/instances/{id}
+      method: GET
+  workflow:
+    read:
+      path: /api/task-sets/{id}
+      method: GET

--- a/specs/config-provider.yaml
+++ b/specs/config-provider.yaml
@@ -1179,7 +1179,7 @@ resources:
     delete:
       path: /api/vdi-pools/{id}
       method: DELETE
-  whitelabel_settings:
+  setting_whitelabel:
     create:
       path: /api/whitelabel-settings
       method: PUT

--- a/specs/datasources/backup/config.yaml
+++ b/specs/datasources/backup/config.yaml
@@ -1,0 +1,17 @@
+backup:
+  moves:
+    - backup: ""
+    - server: host
+  overrides:
+    id:
+      description: ID of the Backup
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: Name of the Backup
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    host.id:
+      description: Host (server) ID
+    host.name:
+      description: Host (server) name

--- a/specs/datasources/backup_type/config.yaml
+++ b/specs/datasources/backup_type/config.yaml
@@ -1,0 +1,10 @@
+backup_type:
+  moves:
+    - backup_type: ""
+  overrides:
+    id:
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional

--- a/specs/datasources/cloud/config.yaml
+++ b/specs/datasources/cloud/config.yaml
@@ -1,0 +1,48 @@
+cloud:
+  templates:
+    group_ids:
+      set:
+        computed_optional_required: computed
+        description: The ids of the groups granted access to the cloud
+        element_type:
+          int64: {}
+  includes:
+    - zone.id
+    - zone.name
+    - zone.code
+    - zone.costing_mode
+    - zone.external_id
+    - zone.inventory_level
+    - zone.guidance_mode
+    - zone.labels
+    - zone.location
+    - zone.timezone
+  moves:
+    - zone: "" # unnest zone to root
+    - timezone: time_zone
+    - template-group_ids: group_ids
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: Morpheus ID of the Object being referenced
+      conflicts_with: [name]
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the Morpheus cloud
+      conflicts_with: [id]
+    code:
+      description: Optional code for use with policies
+    costing_mode:
+      description: The costing mode of the cloud
+    external_id:
+      description: The external id of the cloud
+    inventory_level:
+      description: The inventory level of the cloud
+    guidance_mode:
+      description: The guidance mode of the cloud
+    labels:
+      description: The organization labels associated with the cloud
+    location:
+      description: Optional location for your cloud
+    time_zone:
+      description: The time zone of the cloud

--- a/specs/datasources/cluster/config.yaml
+++ b/specs/datasources/cluster/config.yaml
@@ -1,0 +1,31 @@
+cluster:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: computed
+  moves:
+    - cluster: "" # unnest cluster
+    - cluster_id: id
+    - accounts: tenants
+    - zone: cloud
+    - site: group
+    - cloud.zone_type: cloud.cloud_type
+    - permissions.resource_permissions.account: permissions.resource_permissions.tenant
+    - permissions.resource_permissions.sites: permissions.resource_permissions.groups
+    - template-config: config
+  removes:
+    # Clusters don't use code.
+    - code
+    # stats is a query parameter used enable getting a detailed `stats` object in the response.
+    # We won't suppport it for now - OpenAPI spec needs to be updated with the stats object.
+    - stats
+    # cpu_placement_mode is not yet exposed by the provider schema.
+    - cpu_placement_mode
+  overrides:
+    id:
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      conflicts_with: ["id"]
+      description: The name of the cluster.
+      computed_optional_required: computed_optional

--- a/specs/datasources/datastore/config.yaml
+++ b/specs/datasources/datastore/config.yaml
@@ -1,0 +1,155 @@
+datastore:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: computed
+        description: Generic configuration options for the datastore, varies based on the type of datastore.
+    configFromAPI:
+      dynamic:
+        computed_optional_required: computed
+        description: Configuration options for the datastore as returned from the API.
+    configNfsSourceHostname:
+      string:
+        computed_optional_required: computed
+        description: Host name or IP address for target NFS instance
+    configNfsSourceDirPath:
+      string:
+        computed_optional_required: computed
+        description: Path to the target NFS export directory
+    configNfsParent:
+      single_nested:
+        computed_optional_required: computed
+        description: NFS datastore config
+    configAlletraMPHVMEnableRansomware:
+      bool:
+        computed_optional_required: computed
+        description: Enable ransomware protection for this datastore
+    configAlletraMPHVMProtocolType:
+      string:
+        computed_optional_required: computed
+        description: Storage protocol type, either iSCSI or FC (Fibre Channel)
+    configAlletraMPHVMParent:
+      single_nested:
+        computed_optional_required: computed
+        description: Alletra MP HVM configuration
+    configGFS2BlockDevice:
+      string:
+        computed_optional_required: computed
+        description: Block device for target GFS2
+    configGFS2Parent:
+      single_nested:
+        computed_optional_required: computed
+        description: GFS2 configuration
+    datastoreTypeParent:
+      single_nested:
+        computed_optional_required: computed
+        description: The type of datastore.
+    datastoreTypeId:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the datastore type.
+    datastoreTypeCode:
+      string:
+        computed_optional_required: required
+        description: The code of the datastore type.
+    tenantId:
+      int64:
+        computed_optional_required: computed
+        description: The tenant ID
+    tenantDefaultStore:
+      bool:
+        computed_optional_required: computed
+        description: If the datastore is the default store
+    tenantDefaultTarget:
+      bool:
+        computed_optional_required: computed
+        description: If the datastore is the default target
+    tenantParent:
+      set_nested:
+        computed_optional_required: computed
+    groupsId:
+      int64:
+        computed_optional_required: computed
+        description: The group id
+    groupsName:
+      string:
+        computed_optional_required: computed
+        description: The group name
+    groupsDefault:
+      bool:
+        computed_optional_required: computed
+        description: Is the datastore the group default
+    groupsParent:
+      set_nested:
+        computed_optional_required: computed
+    resourcePermissions:
+      single_nested:
+        computed_optional_required: computed
+  moves:
+    - datastore: "" # unnest datastore
+    - account_id: tenant_id
+    - template-configNfsParent: config_nfs
+    - template-configNfsSourceHostname: config_nfs.source_hostname
+    - template-configNfsSourceDirPath: config_nfs.source_dir_path
+    - template-configAlletraMPHVMParent: config_alletramp_hvm
+    - template-configAlletraMPHVMEnableRansomware: config_alletramp_hvm.enable_ransomware
+    - template-configAlletraMPHVMProtocolType: config_alletramp_hvm.protocol_type
+    - template-configGFS2Parent: config_gfs2
+    - template-configGFS2BlockDevice: config_gfs2.block_device
+    - template-config: config
+    - template-configFromAPI: config_from_api
+    - template-datastoreTypeParent: datastore_type
+    - template-datastoreTypeId: datastore_type.id
+    - template-datastoreTypeCode: datastore_type.code
+    - template-tenantParent: tenants
+    - template-tenantId: tenants.id
+    - template-tenantDefaultTarget: tenants.default_target
+    - template-tenantDefaultStore: tenants.default_store
+    - template-groupsParent: groups
+    - template-groupsDefault: groups.default
+    - template-groupsId: groups.id
+    - template-groupsName: groups.name
+    - template-resourcePermissions: resource_permissions
+    - groups: resource_permissions.groups
+    - ref_id: associated_resource_id
+    - ref_type: associated_resource_type
+    - zone: cloud
+    - zone_pool: resource_pool
+    - ComputeZone: Cloud
+    - ComputeServerGroup: Cluster
+  removes:
+    # - success
+    # - tenant_permissions
+    # Removing this for now since I can't successfully test it
+    # - config_nfs.source_version.default
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: The ID of the datastore
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the datastore
+    associated_resource_type:
+      description: Type of the resource this datastore is associated with, can be 'Cloud' or 'Cluster'
+      computed_optional_required: computed
+    associated_resource_id:
+      description: The ID of the resource this datastore is associated with, e.g. Cloud, Cluster
+      computed_optional_required: computed
+    cloud:
+      description: The Cloud this datastore is associated with
+      computed_optional_required: computed
+    resource_pool:
+      description: The resource pool this datastore is associated with (for some Cloud datastores)
+      computed_optional_required: computed
+    resource_pool.id:
+      computed_optional_required: computed
+    #  conflicts_with: [config_nfs, config]
+    #  computed_optional_required: optional
+    #  requires_replace: true
+    #  at_least_one_of: [config_nfs, config_gfs2, config]
+    # TODO we need to add support for dynamic attributes in data-sources
+    #config:
+    #  conflicts_with: [config_nfs, config_alletramp_hvm]
+    #  computed_optional_required: optional
+    #  requires_replace: true
+    #  at_least_one_of: [config_nfs, config, config_alletramp_hvm]

--- a/specs/datasources/environment/config.yaml
+++ b/specs/datasources/environment/config.yaml
@@ -1,0 +1,27 @@
+environment:
+  includes:
+    - environment.id
+    - environment.name
+    - environment.code
+    - environment.active
+    - environment.description
+    - environment.visibility
+  moves:
+    - environment: "" # unnest environment to root
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: Morpheus ID of the Object being referenced
+      conflicts_with: [name]
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the Morpheus environment
+      conflicts_with: [id]
+    code:
+      description: Optional code for use with policies
+    active:
+      description: Whether the environment is active
+    description:
+      description: The description of the Morpheus environment
+    visibility:
+      description: Whether the environment is visible in sub-tenants or not

--- a/specs/datasources/group/config.yaml
+++ b/specs/datasources/group/config.yaml
@@ -1,0 +1,28 @@
+group:
+  moves:
+    - group: "" # unnest group
+  removes:
+    - account # drop the residual account object (only name remained)
+    - account_id
+    - active
+    - config
+    - date_created
+    - labels
+    - last_updated
+    - server_count
+    - stats
+    - uuid
+    - zones
+  overrides:
+    id:
+      description: Morpheus ID of the Object being referenced
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the Morpheus group
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    code:
+      description: Optional code for use with policies
+    location:
+      description: Optional location argument for your group

--- a/specs/datasources/image/config.yaml
+++ b/specs/datasources/image/config.yaml
@@ -1,0 +1,45 @@
+image:
+  moves:
+  - virtual_image: ""
+  - accounts: tenants
+  - config.azure_reference_virtual_image_configuration: config_azure
+  - os_type.id: os_type_id
+  - storage_provider.id: storage_provider_id
+  - is_auto_join_domain: auto_join_domain
+  - is_cloud_init: cloud_init
+  - is_force_customization: force_customization
+  - is_sysprep: sysprep
+  removes:
+    - config
+    - tenant
+    - config.oneof1
+    - min_disk_gb
+    - min_ram_gb
+    - storage_provider
+    - ssh_password
+    - ssh_password_hash
+    - os_type
+    - virtual_image_id
+    - date_created
+    - last_updated
+    - locations
+    - network_interfaces
+    - raw_size_gb
+    - storage_controllers
+    - volumes
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      conflicts_with: 
+        - name
+        - image_type
+    name:
+      computed_optional_required: computed_optional
+    image_type:
+      computed_optional_required: computed_optional
+      also_requires: 
+        - name
+    os_type_id:
+      description: ID of the OS Type
+    storage_provider_id:
+      description: ID of the storage provider where the image will be uploaded

--- a/specs/datasources/instance/config.yaml
+++ b/specs/datasources/instance/config.yaml
@@ -1,0 +1,66 @@
+instance:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: computed
+        description: Configuration object. Settings vary by type.
+        validators:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/validators"
+            schema_definition: validators.ValidObjectMap()
+  moves:
+    - instance: ""
+    - account_id: tenant_id
+    - interfaces.id.oneof0: interfaces.id
+    - container_details.server.interfaces: container_details.server.container_interfaces
+    - container_details.server.container_interfaces.interfaces: container_details.server.container_interfaces.child_interfaces
+    - container_details.server.container_interfaces.network: container_details.server.container_interfaces.child_network
+    - container_details.server.owner: container_details.server.container_owner
+    - container_details.server.plan: container_details.server.container_plan
+    - container_details.server.volumes: container_details.server.child_volumes
+    - controllers.type: controllers.controllers_type
+    - cluster.type: cluster.cluster_type
+    - evars.value.oneof0: evars.value # converts the value attr into a string
+    - container_details.server.child_volumes.zone: container_details.server.child_volumes.volume_zone
+    - interfaces.network_interfaces.id.oneof0: interfaces.network_interfaces.id
+    - interfaces.network_interfaces.network: interfaces.network_interfaces.interface_network
+    - interfaces.network.pool: interfaces.network.interface_network_pool
+    - template-config: config
+  removes:
+    - details
+    - apps
+    - interfaces.id.oneof1
+    - interfaces.network_interfaces.id.oneof1
+    - stats
+    - container_details.cloud
+    - container_details.plan
+    - container_details.volumes
+    - evars.value.oneof1
+    - instance_threshold
+    - custom_options
+    - data_created
+    - expire_date
+    - expire_warning_date
+    - last_updated
+    - removal_date
+    - shutdown_date
+    - shutdown_warning_date
+    - status_date
+    - container_details.last_updated
+    - container_details.date_created
+    - container_details.server.last_agent_update
+    - container_details.server.power_state
+    - container_details.server.status_date
+    - current_load_balancer_containers_in
+    - current_load_balancer_containers_out
+    - current_load_balancer_instances
+    - last_deploy
+  overrides:
+    id:
+      at_least_one_of: [id, name]
+      conflicts_with: [name]
+      computed_optional_required: computed_optional
+    name:
+      conflicts_with: [id]
+      computed_optional_required: computed_optional

--- a/specs/datasources/instance_snapshot/config.yaml
+++ b/specs/datasources/instance_snapshot/config.yaml
@@ -1,0 +1,63 @@
+instance_snapshot:
+  templates:
+    cloud_id:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the cloud (zone) the snapshot belongs to.
+  moves:
+    - snapshot: ""                          # unnest read wrapper (components/schemas/snapshot.yaml)
+    - template-cloud_id: cloud_id
+  removes:
+    - zone                                  # (components/schemas/snapshot.yaml) - exposed as cloud_id
+  overrides:
+    id:
+      computed_optional_required: required
+      description: The ID of the snapshot to look up.
+    name:
+      computed_optional_required: computed
+      description: The name of the snapshot.
+    description:
+      computed_optional_required: computed
+      description: A description of the snapshot.
+    status:
+      computed_optional_required: computed
+      description: The status of the snapshot.
+    external_id:
+      computed_optional_required: computed
+      description: The external (cloud-provider) identifier of the snapshot.
+    state:
+      computed_optional_required: computed
+      description: The lifecycle state of the snapshot.
+    snapshot_type:
+      computed_optional_required: computed
+      description: The type of the snapshot (cloud/provider specific).
+    snapshot_created:
+      computed_optional_required: computed
+      description: When the snapshot was taken on the underlying platform.
+    datastore:
+      computed_optional_required: computed
+      description: The datastore the snapshot resides on, if reported by the platform.
+    parent_snapshot:
+      computed_optional_required: computed
+      description: The ID of the parent snapshot in the snapshot lineage, if any.
+    currently_active:
+      computed_optional_required: computed
+      description: Whether this snapshot is the currently active snapshot for the instance.
+    memory_snapshot:
+      computed_optional_required: computed
+      description: Whether the snapshot includes the instance's memory.
+    for_export:
+      computed_optional_required: computed
+      description: Whether the snapshot was created in an exportable form (a full, standalone disk image).
+    for_backup:
+      computed_optional_required: computed
+      description: Whether the snapshot was created as part of a backup operation.
+    date_created:
+      computed_optional_required: computed
+      description: When the snapshot was created.
+    cloud_id:
+      computed_optional_required: computed
+      description: The ID of the cloud (zone) the snapshot belongs to.
+    snapshot_files:
+      computed_optional_required: computed
+      description: The files that make up the snapshot, as reported by the platform.

--- a/specs/datasources/instance_type_layout/config.yaml
+++ b/specs/datasources/instance_type_layout/config.yaml
@@ -1,0 +1,38 @@
+instance_type_layout:
+  templates:
+    version:
+      string:
+        computed_optional_required: computed_optional
+        description: The version of the instance layout
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+            - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: |-
+              stringvalidator.ConflictsWith(path.Expressions{
+                path.MatchRoot("id"),
+              }...)
+  includes:
+    - instance_type_layout.id
+    - instance_type_layout.name
+    - instance_type_layout.code
+    - instance_type_layout.description
+    - instance_type_layout.sort_order
+  moves:
+    - instance_type_layout: "" # unnest to root
+    - template-version: version
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: Morpheus ID of the instance layout
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the Morpheus instance layout
+      conflicts_with: [id]
+    code:
+      description: Optional code for use with policies
+    description:
+      description: The description of the instance layout
+    sort_order:
+      description: Display order of the layout higher to lower

--- a/specs/datasources/load_balancer/config.yaml
+++ b/specs/datasources/load_balancer/config.yaml
@@ -1,0 +1,86 @@
+load_balancer:
+  moves:
+    - load_balancer: ""          # unnest wrapper (components/schemas/loadBalancer.yaml)
+    - account_id: tenant_id      # (components/schemas/loadBalancer.yaml)
+    - resource_permission: permissions                               # (components/schemas/loadBalancer.yaml)
+    - permissions.account.id: permissions.tenant_id                    # (components/schemas/loadBalancer.yaml)
+    - permissions.sites: permissions.groups                            # (components/schemas/loadBalancer.yaml)
+  removes:
+    - load_balancer_id             # path parameter - redundant with id
+    - permissions.account  # (components/schemas/loadBalancer.yaml) empty after flattening to tenant_id
+  overrides:
+    id:
+      description: The ID of the load balancer
+      state_for_unknown: true
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the load balancer
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    tenant_id:
+      description: The ID of the tenant the load balancer belongs to
+    description:
+      description: The description of the load balancer
+    type:
+      description: The type of load balancer
+    cloud:
+      description: The cloud associated with the load balancer
+    owner:
+      description: The owner of the load balancer
+    visibility:
+      description: The visibility of the load balancer
+    enabled:
+      description: Whether the load balancer is enabled
+    host:
+      description: The hostname of the load balancer
+    port:
+      description: The port of the load balancer
+    username:
+      description: The username for the load balancer
+    password:
+      description: The password for the load balancer
+    password_hash:
+      description: The hashed password for the load balancer
+    ip:
+      description: The IP address of the load balancer
+    internal_ip:
+      description: The internal IP address of the load balancer
+    external_ip:
+      description: The external IP address of the load balancer
+    external_id:
+      description: The external ID of the load balancer
+    api_port:
+      description: The API port of the load balancer
+    admin_port:
+      description: The admin port of the load balancer
+    ssl_enabled:
+      description: Whether SSL is enabled on the load balancer
+    ssl_cert:
+      description: The SSL certificate of the load balancer
+    allow_vip_entry:
+      description: Whether VIP entry is allowed
+    vip_pools:
+      description: The VIP pools associated with the load balancer
+    virtual_service_name:
+      description: The virtual service name of the load balancer
+    pool_name:
+      description: The pool name of the load balancer
+    server_name:
+      description: The server name of the load balancer
+    config:
+      description: The configuration of the load balancer
+    date_created:
+      description: The date the load balancer was created
+    last_updated:
+      description: The date the load balancer was last updated
+    credential:
+      description: The credential associated with the load balancer
+    tenants:
+      description: The tenants associated with the load balancer
+    permissions:
+      description: The resource permissions of the load balancer
+    instance_price:
+      description: The instance price of the load balancer
+    uuid:
+      description: The UUID of the load balancer

--- a/specs/datasources/load_balancer_monitor/config.yaml
+++ b/specs/datasources/load_balancer_monitor/config.yaml
@@ -1,0 +1,120 @@
+load_balancer_monitor:
+  templates:
+    config:
+      single_nested: {}
+      computed_optional_required: computed
+    monitor:
+      single_nested: {}
+      computed_optional_required: computed
+    monitor_id:
+      int64: {}
+      computed_optional_required: computed
+    monitor_config:
+      dynamic: {}
+      computed_optional_required: computed
+
+  moves:
+    - load_balancer_monitor: "" # unnest wrapper (components/schemas/loadBalancerMonitor.yaml)
+    - template-config: config
+    - template-monitor: config.monitor
+    - template-monitor_id: config.monitor.id
+    - template-monitor_config: config.monitor_config
+
+  removes:
+    # API response fields (components/schemas/successMessage.yaml)
+    - success
+    # Fields not returned by GET API
+    - extra_config
+    - partition
+    # Fields not useful in a data source context
+    - alias_address
+    - created_by
+    - date_created
+    - disabled_data
+    - last_updated
+    - load_balancer
+    - monitor_adaptive
+    - monitor_password
+    - monitor_password_hash
+    - monitor_reverse
+    - monitor_source
+    - monitor_transparent
+
+  overrides:
+    id:
+      description: The ID of the load balancer monitor
+      computed_optional_required: computed_optional
+      conflicts_with: ["name"]
+      at_least_one_of: [id, name]
+    load_balancer_id:
+      description: The ID of the load balancer associated with the monitor
+      computed_optional_required: required
+    name:
+      description: The name of the load balancer monitor
+      computed_optional_required: computed_optional
+      conflicts_with: ["id"]
+    description:
+      description: A description of the load balancer monitor
+    monitor_type:
+      description: >-
+        The monitor protocol type. NSX-T values: http, https, icmp, passive,
+        tcp, udp (returned as profile names, e.g. LBHttpMonitorProfile).
+        NSX-V values: dns, http, https, ldap, mssql, tcp, udp.
+    code:
+      description: The internal code identifier for the monitor
+    category:
+      description: The category of the monitor
+    visibility:
+      description: The visibility of the monitor (e.g. public, private)
+    enabled:
+      description: Whether the monitor is enabled
+    status:
+      description: The current status of the monitor
+    status_message:
+      description: A message providing additional status details
+    status_date:
+      description: The date of the last status change
+    external_id:
+      description: The external identifier of the monitor in the load balancer provider
+    internal_id:
+      description: The internal identifier of the monitor
+    monitor_interval:
+      description: The interval in seconds at which the monitor checks target health
+    monitor_timeout:
+      description: The maximum time in seconds to wait for a health check response before marking as failed
+    send_data:
+      description: The request body sent to the target during health checks
+    send_version:
+      description: The HTTP protocol version used in health check requests (e.g. HTTP/1.0, HTTP/1.1)
+    send_type:
+      description: The HTTP method for the health check request (e.g. GET, POST, HEAD)
+    receive_data:
+      description: The expected response body string to validate in the health check response
+    receive_code:
+      description: The expected HTTP response status codes for a successful health check (e.g. 200,201,204)
+    monitor_username:
+      description: The username for authenticated health checks
+    monitor_destination:
+      description: The target path or URL for the health check (e.g. /health)
+    fall_count:
+      description: The number of consecutive failed health checks before marking the target as down
+    rise_count:
+      description: The number of consecutive successful health checks before marking the target as up
+    alias_port:
+      description: An alternative port used for health checks if different from the target port
+    data_length:
+      description: The length in bytes of the data payload for ICMP echo requests
+    max_retry:
+      description: The number of retries before the health check is considered failed
+    config:
+      description: Configuration object with parameters that vary by monitor type
+      computed_optional_required: computed
+    config.monitor:
+      description: Parent monitor reference
+      computed_optional_required: computed
+    config.monitor.id:
+      description: The ID of the parent monitor
+      computed_optional_required: computed
+    config.monitor_config:
+      description: Free-form monitor configuration content
+      computed_optional_required: computed

--- a/specs/datasources/load_balancer_pool/config.yaml
+++ b/specs/datasources/load_balancer_pool/config.yaml
@@ -1,0 +1,168 @@
+load_balancer_pool:
+  templates:
+    config:
+      dynamic:
+        description: Generic pool configuration object. Settings vary by load balancer type.
+        computed_optional_required: computed
+    config_nsxt:
+      single_nested:
+        computed_optional_required: computed
+        description: NSX-T load balancer pool configuration
+    config_nsxt_active_monitor_paths:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the active health monitor
+    config_nsxt_passive_monitor_path:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the passive health monitor
+    config_nsxt_snat_translation_type:
+      string:
+        computed_optional_required: computed
+        description: SNAT translation type
+    config_nsxt_snat_ip_addresses:
+      list:
+        computed_optional_required: computed
+        description: List of SNAT IP addresses
+        element_type:
+          string: {}
+    config_nsxt_tcp_multiplexing:
+      bool:
+        computed_optional_required: computed
+        description: Whether TCP multiplexing is enabled
+    config_nsxt_tcp_multiplexing_number:
+      int64:
+        computed_optional_required: computed
+        description: Maximum number of TCP multiplexing connections
+    config_nsxt_member_group:
+      single_nested:
+        computed_optional_required: computed
+        description: NSX-T member group configuration
+    config_nsxt_member_group_path:
+      string:
+        computed_optional_required: computed
+        description: NSX-T member group path
+    config_nsxt_member_group_ip_revision_filter:
+      string:
+        computed_optional_required: computed
+        description: IP revision filter for member group
+    config_nsxt_member_group_max_ip_list_size:
+      int64:
+        computed_optional_required: computed
+        description: Maximum IP list size for member group
+    config_nsxt_member_group_port:
+      int64:
+        computed_optional_required: computed
+        description: Port for member group
+
+  moves:
+    - load_balancer_pool: ""                             # unnest wrapper
+    - template-config_nsxt: config_nsxt                  # inject NSX-T config block
+    - template-config_nsxt_active_monitor_paths: config_nsxt.active_monitor_paths
+    - template-config_nsxt_passive_monitor_path: config_nsxt.passive_monitor_path
+    - template-config_nsxt_snat_translation_type: config_nsxt.snat_translation_type
+    - template-config_nsxt_snat_ip_addresses: config_nsxt.snat_ip_addresses
+    - template-config_nsxt_tcp_multiplexing: config_nsxt.tcp_multiplexing
+    - template-config_nsxt_tcp_multiplexing_number: config_nsxt.tcp_multiplexing_number
+    - template-config_nsxt_member_group: config_nsxt.member_group
+    - template-config_nsxt_member_group_path: config_nsxt.member_group.path
+    - template-config_nsxt_member_group_ip_revision_filter: config_nsxt.member_group.ip_revision_filter
+    - template-config_nsxt_member_group_max_ip_list_size: config_nsxt.member_group.max_ip_list_size
+    - template-config_nsxt_member_group_port: config_nsxt.member_group.port
+    - template-config: config                            # replace config with dynamic fallback (must be last)
+
+  removes:
+    # API response envelope fields
+    - success                                            # (components/schemas/successMessage.yaml)
+    - msg                                                # (components/schemas/successMessage.yaml)
+    # Read-only metadata (createdBy is an object the provider does not surface)
+    - created_by                                         # (components/schemas/loadBalancerPool.yaml)
+
+  overrides:
+    id:
+      description: The ID of the load balancer pool
+      computed_optional_required: computed_optional
+      conflicts_with: ["name"]
+      at_least_one_of: [id, name]
+    load_balancer_id:
+      description: The ID of the load balancer this pool belongs to
+      computed_optional_required: required
+    name:
+      description: The name of the load balancer pool
+      computed_optional_required: computed_optional
+      conflicts_with: ["id"]
+    description:
+      description: A description of the load balancer pool
+    vip_balance:
+      description: The balance algorithm for the pool
+    vip_sticky:
+      description: Session persistence mode for the pool
+    vip_client_ip_mode:
+      description: VIP client IP mode
+    min_active:
+      description: Minimum number of active pool members
+    port:
+      description: The port number for the pool
+    partition:
+      description: Partition identifier
+    monitors:
+      description: The monitors associated with the pool
+    nodes:
+      description: The nodes associated with the pool
+    members:
+      description: The members of the pool
+    # Read-only computed fields (virtual server pattern — keep all API response fields)
+    allow_nat:
+      computed_optional_required: computed
+    allow_snat:
+      computed_optional_required: computed
+    category:
+      computed_optional_required: computed
+    date_created:
+      computed_optional_required: computed
+    down_action:
+      computed_optional_required: computed
+    enabled:
+      computed_optional_required: computed
+    error_penalty:
+      computed_optional_required: computed
+    external_id:
+      computed_optional_required: computed
+    health_penalty:
+      computed_optional_required: computed
+    health_score:
+      computed_optional_required: computed
+    internal_id:
+      computed_optional_required: computed
+    last_updated:
+      computed_optional_required: computed
+    load_balancer:
+      computed_optional_required: computed
+    max_queue_depth:
+      computed_optional_required: computed
+    max_queue_time:
+      computed_optional_required: computed
+    min_in_service:
+      computed_optional_required: computed
+    min_up_action:
+      computed_optional_required: computed
+    min_up_monitor:
+      computed_optional_required: computed
+    number_active:
+      computed_optional_required: computed
+    number_in_service:
+      computed_optional_required: computed
+    performance_score:
+      computed_optional_required: computed
+    port_type:
+      computed_optional_required: computed
+    ramp_time:
+      computed_optional_required: computed
+    security_penalty:
+      computed_optional_required: computed
+    status:
+      computed_optional_required: computed
+    vip_server_ip_mode:
+      computed_optional_required: computed
+    visibility:
+      computed_optional_required: computed

--- a/specs/datasources/load_balancer_profile/config.yaml
+++ b/specs/datasources/load_balancer_profile/config.yaml
@@ -1,0 +1,74 @@
+load_balancer_profile:
+  templates:
+    config_http_https_redirect:
+      bool:
+        computed_optional_required: computed
+        description: >-
+          Whether HTTP traffic is redirected to HTTPS. Reflects the API
+          "on"/"off" value.
+    tags:
+      set_nested:
+        computed_optional_required: computed
+        description: NSX-T tags applied to the profile.
+        nested_object:
+          attributes:
+            - name: name
+              string:
+                computed_optional_required: computed
+                description: Tag name.
+            - name: value
+              string:
+                computed_optional_required: computed
+                description: Tag scope/value.
+
+  moves:
+    - load_balancer_profile: ""                                          # unnest envelope wrapper
+    - config.httpload_balancer_profile_config: config_http
+    - config.fast_tcpload_balancer_profile_config: config_fast_tcp
+    - config.fast_udpload_balancer_profile_config: config_fast_udp
+    - config.cookie_persistence_load_balancer_profile_config: config_cookie_persistence
+    - config.source_ippersistence_load_balancer_profile_config: config_source_ip_persistence
+    - config.generic_persistence_load_balancer_profile_config: config_generic_persistence
+    - config.client_sslload_balancer_profile_config: config_client_ssl
+    - config.server_sslload_balancer_profile_config: config_server_ssl
+    - template-config_http_https_redirect: config_http.https_redirect
+    - template-tags: tags
+
+  removes:
+    - config
+    - success
+    - msg
+    - created_by
+    - config_http.profile_type
+    - config_fast_tcp.profile_type
+    - config_fast_udp.profile_type
+    - config_cookie_persistence.profile_type
+    - config_source_ip_persistence.profile_type
+    - config_generic_persistence.profile_type
+    - config_client_ssl.profile_type
+    - config_server_ssl.profile_type
+    - config_http.tags
+    - config_fast_tcp.tags
+    - config_fast_udp.tags
+    - config_cookie_persistence.tags
+    - config_source_ip_persistence.tags
+    - config_generic_persistence.tags
+    - config_client_ssl.tags
+    - config_server_ssl.tags
+
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: The ID of the load balancer profile. One of id or name is required.
+      conflicts_with: [name]
+      at_least_one_of: [id, name]
+    load_balancer_id:
+      computed_optional_required: required
+      description: The ID of the load balancer this profile belongs to.
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the load balancer profile. One of id or name is required.
+      conflicts_with: [id]
+    tags:
+      computed_optional_required: computed
+      description: NSX-T tags applied to the profile.

--- a/specs/datasources/load_balancer_virtual_server/config.yaml
+++ b/specs/datasources/load_balancer_virtual_server/config.yaml
@@ -1,0 +1,56 @@
+load_balancer_virtual_server:
+  templates:
+    pool_id:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the load balancer pool assigned to this virtual server.
+    config:
+      dynamic:
+        description: Generic virtual server configuration object. Settings vary by load balancer type.
+        computed_optional_required: computed
+    config_nsxt:
+      single_nested:
+        computed_optional_required: computed
+        description: NSX-T virtual server configuration
+    config_nsxt_application_profile:
+      int64:
+        computed_optional_required: computed
+        description: The Load Balancer Application Profile ID (`NetworkLoadBalancerProfile`). Use `/api/options/nsxt/nsxtLBVirtualServerApplicationProfile?loadBalancerId={id}&loadBalancerInstance.vipProtocol={protocol}` to list available options.
+    config_nsxt_persistence:
+      string:
+        computed_optional_required: computed
+        description: "Session persistence mode. Available values depend on protocol. For HTTP: `SOURCE_IP`, `COOKIE`, or empty string (disabled). For TCP/UDP: `SOURCE_IP` or empty string (disabled)."
+    config_nsxt_persistence_profile:
+      int64:
+        computed_optional_required: computed
+        description: The persistence profile ID (`NetworkLoadBalancerProfile`).
+    config_nsxt_ssl_client_profile:
+      int64:
+        computed_optional_required: computed
+        description: The SSL client profile ID (`NetworkLoadBalancerProfile`).
+    config_nsxt_ssl_server_profile:
+      int64:
+        computed_optional_required: computed
+        description: The SSL server profile ID (`NetworkLoadBalancerProfile`).
+  moves:
+    - load_balancer_instance: "" # unnest wrapper
+    - template-config: config
+    - template-pool_id: pool_id
+    - template-config_nsxt: config_nsxt
+    - template-config_nsxt_application_profile: config_nsxt.application_profile
+    - template-config_nsxt_persistence: config_nsxt.persistence
+    - template-config_nsxt_persistence_profile: config_nsxt.persistence_profile
+    - template-config_nsxt_ssl_client_profile: config_nsxt.ssl_client_profile
+    - template-config_nsxt_ssl_server_profile: config_nsxt.ssl_server_profile
+  removes:
+    - success                    # API response wrapper
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: The ID of the load balancer virtual server
+    load_balancer_id:
+      computed_optional_required: required
+      description: The ID of the load balancer this virtual server belongs to
+    vip_name:
+      computed_optional_required: computed_optional
+      description: VIP Name

--- a/specs/datasources/network/config.yaml
+++ b/specs/datasources/network/config.yaml
@@ -1,0 +1,21 @@
+network:
+  includes:
+    - network.id
+    - network.name
+    - network.active
+    - network.cidr
+    - network.description
+    - network.display_name
+    - network.labels
+    - network.visibility
+  moves:
+    - network: "" # unnest network to root
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: Morpheus ID of the network being referenced
+      conflicts_with: [name]
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the Morpheus network
+      conflicts_with: [id]

--- a/specs/datasources/network_dhcp_server/config.yaml
+++ b/specs/datasources/network_dhcp_server/config.yaml
@@ -1,0 +1,55 @@
+network_dhcp_server:
+  templates:
+    config:
+      dynamic:
+        description: Generic DHCP Server Configuration
+        computed_optional_required: computed
+
+  moves:
+    - network_dhcp_server: ""                    # unnest wrapper (components/schemas/networkDhcpServer.yaml)
+    - server_id: network_integration_id
+    - config.nsxdhcpserver_configuration: config_nsxt
+    - config_nsxt.preferred_edge_node1: config_nsxt.active_edge_node
+    - config_nsxt.preferred_edge_node2: config_nsxt.standby_edge_node
+    - template-config: config
+
+  removes:
+    - date_created                               # (components/schemas/networkDhcpServer.yaml)
+    - last_updated                               # (components/schemas/networkDhcpServer.yaml)
+    - owner                                      # (components/schemas/networkDhcpServer.yaml)
+    - network_server                             # (components/schemas/networkDhcpServer.yaml)
+    - external_id                                # (components/schemas/networkDhcpServer.yaml)
+    - provider_id                                # (components/schemas/networkDhcpServer.yaml)
+    - success                                    
+    - server_id                                  # duplicate of network_server_id template
+
+  overrides:
+    id:
+      description: Morpheus ID of the network DHCP server
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network DHCP server
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    server_ip_address:
+      description: Server address for the DHCP server
+      computed_optional_required: computed
+    lease_time:
+      description: Lease time in seconds for the DHCP server
+      computed_optional_required: computed
+    config_nsxt:
+      description: Configuration object with parameters that vary by type
+      computed_optional_required: computed
+    config_nsxt.edge_cluster:
+      description: Edge Cluster
+      computed_optional_required: computed
+    config_nsxt.active_edge_node:
+      description: Active Edge Node
+      computed_optional_required: computed
+    config_nsxt.standby_edge_node:
+      description: Standby Edge Node
+      computed_optional_required: computed
+    network_integration_id:
+      description: The ID of the network integration this DHCP server belongs to
+      computed_optional_required: required

--- a/specs/datasources/network_domain/config.yaml
+++ b/specs/datasources/network_domain/config.yaml
@@ -1,0 +1,14 @@
+network_domain:
+  moves:
+    - network_domain: ""       # unnest wrapper (components/schemas/networkDomain.yaml)
+    - zone_type: cloud_type    # (components/schemas/networkDomain.yaml)
+    - template-description: description # (components/schemas/networkDomain.yaml)
+  overrides:
+    id:
+      description: Morpheus ID of the network domain
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network domain
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional

--- a/specs/datasources/network_edge_cluster/config.yaml
+++ b/specs/datasources/network_edge_cluster/config.yaml
@@ -1,0 +1,57 @@
+network_edge_cluster:
+  templates:
+    config:
+      dynamic:
+        description: Edge cluster configuration object.
+        computed_optional_required: computed
+    network_server_id:
+      int64:
+        description: The ID of the network server (integration) this edge cluster belongs to.
+        computed_optional_required: required
+
+  moves:
+    - network_edge_cluster: ""              # unnest wrapper (components/schemas/networkEdgeCluster.yaml)
+    - template-config: config
+    - template-network_server_id: network_server_id
+
+  removes:
+    - date_created                          # (components/schemas/networkEdgeCluster.yaml) - read-only
+    - last_updated                          # (components/schemas/networkEdgeCluster.yaml) - read-only
+    - network_server                        # (components/schemas/networkEdgeCluster.yaml) - nested object
+    - owner                                 # (components/schemas/networkEdgeCluster.yaml) - internal ref
+    - server_id                             # path param duplicate of network_server_id
+    - success                               # API response wrapper
+    - tenants                               # (components/schemas/networkEdgeCluster.yaml) - nested array
+    - zone                                  # (components/schemas/networkEdgeCluster.yaml) - nested object
+
+  overrides:
+    id:
+      description: The ID of the network edge cluster
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network edge cluster
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    network_server_id:
+      description: The ID of the network server (integration) this edge cluster belongs to
+      computed_optional_required: required
+    config:
+      description: Edge cluster configuration object
+      computed_optional_required: computed
+    description:
+      description: The description of the edge cluster
+    display_name:
+      description: The display name of the edge cluster
+    external_id:
+      description: The external identifier of the edge cluster in the network provider
+    internal_id:
+      description: The internal identifier of the edge cluster
+    provider_id:
+      description: The provider-assigned identifier for the edge cluster
+    enabled:
+      description: Whether the edge cluster is enabled
+    active:
+      description: Whether the edge cluster is active
+    visibility:
+      description: The visibility of the edge cluster (e.g. public, private)

--- a/specs/datasources/network_firewall_rule/config.yaml
+++ b/specs/datasources/network_firewall_rule/config.yaml
@@ -1,0 +1,58 @@
+network_firewall_rule:
+  templates:
+    config:
+      dynamic:
+        description: Additional configuration for the firewall rule
+        computed_optional_required: computed
+    applied_targets:
+      dynamic:
+        description: The applied targets of the firewall rule
+        computed_optional_required: computed
+  moves:
+    - rule: ""                     # unnest wrapper (components/schemas/networkFirewallRule.yaml)
+    - server_id: network_integration_id
+    - template-config: config
+    - template-applied_targets: applied_targets
+  removes:
+    - success                      # (API response wrapper)
+    - description                   # not exposed by the provider schema
+  overrides:
+    id:
+      description: The ID of the network firewall rule
+      conflicts_with: ["name"]
+      at_least_one_of: ["id", "name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network firewall rule
+      conflicts_with: ["id"]
+      at_least_one_of: ["id", "name"]
+      computed_optional_required: computed_optional
+    network_integration_id:
+      description: The ID of the network integration that the firewall rule belongs to
+      computed_optional_required: required
+    enabled:
+      description: Whether the firewall rule is enabled
+    direction:
+      description: The direction of the firewall rule (e.g. ingress, egress)
+    policy:
+      description: The policy action of the firewall rule (e.g. accept, deny)
+    priority:
+      description: The priority of the firewall rule
+    source_type:
+      description: The source type of the firewall rule
+    destination_type:
+      description: The destination type of the firewall rule
+    group_name:
+      description: The name of the firewall rule group
+    rule_group:
+      description: The rule group associated with the firewall rule
+    sources:
+      description: The source objects of the firewall rule
+    destinations:
+      description: The destination objects of the firewall rule
+    applications:
+      description: The applications associated with the firewall rule
+    scopes:
+      description: The scopes associated with the firewall rule
+    profiles:
+      description: The profiles associated with the firewall rule

--- a/specs/datasources/network_firewall_rule_group/config.yaml
+++ b/specs/datasources/network_firewall_rule_group/config.yaml
@@ -1,0 +1,24 @@
+network_firewall_rule_group:
+  moves:
+    - rule_group: "" # unnest wrapper (components/schemas/networkFirewallRuleGroup.yaml)
+    - server_id: network_integration_id # (components/schemas/networkFirewallRuleGroup.yaml)
+  removes:
+    - success        # (components/schemas/networkFirewallRuleGroup.yaml)
+  overrides:
+    id:
+      description: Morpheus ID of the network firewall rule group
+      at_least_one_of: [id, name]
+      conflicts_with: [name]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network firewall rule group
+      conflicts_with: [id]
+      computed_optional_required: computed_optional
+    description:
+      description: Network firewall rule group description
+    priority:
+      description: Network firewall rule group priority
+    group_layer:
+      description: The group layer of the firewall rule group
+    network_integration_id:
+      description: The ID of the network integration

--- a/specs/datasources/network_pool/config.yaml
+++ b/specs/datasources/network_pool/config.yaml
@@ -1,0 +1,56 @@
+network_pool:
+  moves:
+    - network_pool: ""                      # unnest wrapper (components/schemas/networkPool.yaml)
+
+  removes:
+    - account                               # (components/schemas/networkPool.yaml) - internal ref
+    - boot_file                             # (components/schemas/networkPool.yaml) - not needed
+    - config                                # (components/schemas/networkPool.yaml) - not needed
+    - display_name                          # (components/schemas/networkPool.yaml) - duplicate of name
+    - dns_search_path                       # (components/schemas/networkPool.yaml) - not needed
+    - dns_servers                           # (components/schemas/networkPool.yaml) - not needed
+    - dns_suffix_list                       # (components/schemas/networkPool.yaml) - not needed
+    - host_prefix                           # (components/schemas/networkPool.yaml) - not needed
+    - http_proxy                            # (components/schemas/networkPool.yaml) - not needed
+    - internal_id                           # (components/schemas/networkPool.yaml) - not needed
+    - ip_ranges                             # (components/schemas/networkPool.yaml) - nested array
+    - parent_id                             # (components/schemas/networkPool.yaml) - internal
+    - parent_type                           # (components/schemas/networkPool.yaml) - internal
+    - pool_group                            # (components/schemas/networkPool.yaml) - nested object
+    - ref_id                                # (components/schemas/networkPool.yaml) - internal
+    - ref_type                              # (components/schemas/networkPool.yaml) - internal
+    - success                               # API response wrapper
+    - tftp_server                           # (components/schemas/networkPool.yaml) - not needed
+    - type                                  # (components/schemas/networkPool.yaml) - nested object
+
+  overrides:
+    id:
+      description: The ID of the network pool
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network pool
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    category:
+      description: The category of the network pool
+    code:
+      description: The code of the network pool
+    dhcp_server:
+      description: Whether DHCP server is enabled for this pool
+    dns_domain:
+      description: The DNS domain for the network pool
+    external_id:
+      description: The external identifier of the network pool
+    free_count:
+      description: The number of free IPs in the pool
+    gateway:
+      description: The gateway address for the network pool
+    ip_count:
+      description: The total number of IPs in the pool
+    netmask:
+      description: The netmask for the network pool
+    pool_enabled:
+      description: Whether the pool is enabled
+    subnet_address:
+      description: The subnet address for the network pool

--- a/specs/datasources/network_router/config.yaml
+++ b/specs/datasources/network_router/config.yaml
@@ -1,0 +1,51 @@
+network_router:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: computed
+  moves:
+    # unnest
+    - network_router: ""
+    - zone: cloud
+    - site: group
+    - network_server: network_integration
+    - firewall.rule_groups.zone: firewall.rule_groups.cloud
+    - firewall.rule_groups.zone_pool: firewall.rule_groups.cloud_pool
+    - template-config: config
+  removes:
+    - category
+    - date_created
+    - description
+    - external_id
+    - external_ip
+    - external_network
+    - firewall
+    - instance
+    - last_updated
+    - nats
+    - network_server
+    - router_type
+    - routes
+    - status
+    - type
+    # having id and name of network integration is probably enough.
+    - network_integration.integration
+    # Exclude these (not in HPE-GL)
+    - interfaces.code
+    - interfaces.enabled
+    - interfaces.external_link
+    - interfaces.interface_type
+    - interfaces.name
+    - interfaces.network
+    - interfaces.network_position
+  overrides:
+    id:
+      description: The ID of the network router.
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      conflicts_with: ["id"]
+      description: The name of the network router.
+      computed_optional_required: computed_optional
+    interfaces.ip_address:
+      description: Equivalent to interfaces.source_addresses in the HPE-GL Provider.

--- a/specs/datasources/network_router_bgp_neighbor/config.yaml
+++ b/specs/datasources/network_router_bgp_neighbor/config.yaml
@@ -1,0 +1,27 @@
+network_router_bgp_neighbor:
+  templates:
+    router_id:
+      int64:
+        computed_optional_required: required
+        description: The ID of the network router this BGP neighbor belongs to
+    config:
+      dynamic:
+        description: Generic BGP neighbor configuration object. Settings vary by router type.
+        computed_optional_required: computed
+  moves:
+    - network_router_bgp_neighbor: ""   # unnest wrapper
+    - template-router_id: router_id
+    - config.nsxtbgpneighbor_config: config_nsxt
+    - config.nsxvbgpneighbor_config: config_nsxv
+    - template-config: config
+  removes:
+    - password          # sensitive - don't expose in datasource
+    - password_hash     # sensitive
+    - config.generic_bgpneighbor_config  # covered by dynamic config
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: The ID of the BGP neighbor
+    ip_address:
+      computed_optional_required: computed_optional
+      description: The IP address of the BGP neighbor. Used to look up the neighbor if ID is not provided.

--- a/specs/datasources/network_router_route/config.yaml
+++ b/specs/datasources/network_router_route/config.yaml
@@ -1,0 +1,29 @@
+network_router_route:
+  templates:
+    mtu:
+      int64:
+        computed_optional_required: computed
+        description: Maximum Transmission Unit (MTU).
+  moves:
+    - network_route: ""
+    - template-mtu: mtu
+  removes:
+    - network_mtu        # provider exposes mtu as an Int64 (via template) instead of the API number
+    - destination        # (components/schemas/networkRouterRoute.yaml)
+    - destination_type   # (components/schemas/networkRouterRoute.yaml)
+    - external_interface # (components/schemas/networkRouterRoute.yaml)
+    - external_type      # (components/schemas/networkRouterRoute.yaml)
+    - internal_id        # (components/schemas/networkRouterRoute.yaml)
+    - priority           # (components/schemas/networkRouterRoute.yaml)
+    - source             # (components/schemas/networkRouterRoute.yaml)
+    - unique_id          # (components/schemas/networkRouterRoute.yaml)
+    - visible            # (components/schemas/networkRouterRoute.yaml)
+  overrides:
+    id:
+      description: The ID of the Network router route.
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the Network router route.
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional

--- a/specs/datasources/network_server/config.yaml
+++ b/specs/datasources/network_server/config.yaml
@@ -1,0 +1,47 @@
+network_server:
+  templates:
+    config:
+      dynamic:
+        description: Network server configuration object. Settings vary by integration type.
+        computed_optional_required: computed
+
+  moves:
+    - network_server: ""                    # unnest wrapper (components/schemas/networkServer.yaml)
+    - template-config: config
+
+  removes:
+    - account                               # (components/schemas/networkServer.yaml) - internal ref
+    - credential                            # (components/schemas/networkServer.yaml) - nested object
+    - date_created                          # (components/schemas/networkServer.yaml) - read-only
+    - integration                           # (components/schemas/networkServer.yaml) - nested object
+    - last_sync                             # (components/schemas/networkServer.yaml) - read-only
+    - last_sync_duration                    # (components/schemas/networkServer.yaml) - read-only
+    - last_updated                          # (components/schemas/networkServer.yaml) - read-only
+    - next_run_date                         # (components/schemas/networkServer.yaml) - read-only
+    - service_password_hash                 # (components/schemas/networkServer.yaml) - sensitive hash
+    - service_token_hash                    # (components/schemas/networkServer.yaml) - sensitive hash
+    - status                                # (components/schemas/networkServer.yaml) - read-only
+    - status_date                           # (components/schemas/networkServer.yaml) - read-only
+    - status_message                        # (components/schemas/networkServer.yaml) - read-only
+    - success                               # API response wrapper
+    - tenants                               # (components/schemas/networkServer.yaml) - nested array
+    - type                                  # (components/schemas/networkServer.yaml) - nested object
+
+  overrides:
+    id:
+      description: The ID of the network server (integration)
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network server (integration)
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    service_password:
+      description: The service password for the network server integration
+      sensitive: true
+    service_token:
+      description: The service token for the network server integration
+      sensitive: true
+    config:
+      description: Network server configuration object. Settings vary by integration type.
+      computed_optional_required: computed

--- a/specs/datasources/network_transport_zone/config.yaml
+++ b/specs/datasources/network_transport_zone/config.yaml
@@ -1,0 +1,61 @@
+network_transport_zone:
+  templates:
+    config:
+      dynamic:
+        description: Transport zone configuration object.
+        computed_optional_required: computed
+    network_server_id:
+      int64:
+        description: The ID of the network server (integration) this transport zone belongs to.
+        computed_optional_required: required
+
+  moves:
+    - network_scope: ""                     # unnest wrapper (response wraps in networkScope)
+    - template-config: config
+    - template-network_server_id: network_server_id
+
+  removes:
+    - date_created                          # (components/schemas/networkTransportZone.yaml) - read-only
+    - last_updated                          # (components/schemas/networkTransportZone.yaml) - read-only
+    - network_server                        # (components/schemas/networkTransportZone.yaml) - nested object
+    - owner                                 # (components/schemas/networkTransportZone.yaml) - internal ref
+    - server_id                             # path param duplicate of network_server_id
+    - success                               # API response wrapper
+    - tenants                               # (components/schemas/networkTransportZone.yaml) - nested array
+    - zone                                  # (components/schemas/networkTransportZone.yaml) - nested object
+
+  overrides:
+    id:
+      description: The ID of the network transport zone
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network transport zone
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    network_server_id:
+      description: The ID of the network server (integration) this transport zone belongs to
+      computed_optional_required: required
+    config:
+      description: Transport zone configuration object
+      computed_optional_required: computed
+    description:
+      description: The description of the transport zone
+    display_name:
+      description: The display name of the transport zone
+    external_id:
+      description: The external identifier of the transport zone in the network provider
+    internal_id:
+      description: The internal identifier of the transport zone
+    provider_id:
+      description: The provider-assigned identifier for the transport zone
+    enabled:
+      description: Whether the transport zone is enabled
+    active:
+      description: Whether the transport zone is active
+    status:
+      description: The current status of the transport zone
+    stream_type:
+      description: The stream type of the transport zone (e.g. OVERLAY, VLAN)
+    visibility:
+      description: The visibility of the transport zone (e.g. public, private)

--- a/specs/datasources/network_type/config.yaml
+++ b/specs/datasources/network_type/config.yaml
@@ -1,0 +1,60 @@
+network_type:
+  moves:
+    - network_type: ""                      # unnest wrapper (components/schemas/networkType.yaml)
+
+  removes:
+    - option_types                          # (components/schemas/networkType.yaml) - nested array of objects
+    - route_option_types                    # (components/schemas/networkType.yaml) - nested array of objects
+    - success                               # API response wrapper
+
+  overrides:
+    id:
+      description: The ID of the network type
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the network type
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    code:
+      description: The code identifier of the network type
+    category:
+      description: The category of the network type
+    description:
+      description: A description of the network type
+    external_type:
+      description: The external type identifier
+    creatable:
+      description: Whether networks of this type can be created
+    deletable:
+      description: Whether networks of this type can be deleted
+    has_cidr:
+      description: Whether the network type supports CIDR notation
+    cidr_editable:
+      description: Whether the CIDR field is editable
+    cidr_required:
+      description: Whether the CIDR field is required
+    can_assign_pool:
+      description: Whether a network pool can be assigned to this network type
+    dns_editable:
+      description: Whether DNS settings are editable
+    gateway_editable:
+      description: Whether the gateway field is editable
+    dhcp_server_editable:
+      description: Whether the DHCP server setting is editable
+    has_floating_ips:
+      description: Whether the network type supports floating IPs
+    has_network_server:
+      description: Whether the network type has an associated network server
+    has_static_routes:
+      description: Whether the network type supports static routes
+    name_editable:
+      description: Whether the network name is editable
+    network_domain_editable:
+      description: Whether the network domain is editable
+    overlay:
+      description: Whether this is an overlay network type
+    static_override_editable:
+      description: Whether the static override setting is editable
+    vlan_id_editable:
+      description: Whether the VLAN ID is editable

--- a/specs/datasources/os_type/config.yaml
+++ b/specs/datasources/os_type/config.yaml
@@ -1,0 +1,49 @@
+os_type:
+  moves:
+    - os_type: ""              # (components/schemas/osType.yaml)
+    - images.zone: images.cloud_id
+    - images.compute_zone_type: images.cloud_type_id
+    - images.account: images.tenant_id
+    - images.provision_type: images.provision_type_id
+    # owner became oneOf(string, {id,name}) in the spec; keep the string form
+    # the data source has always exposed (no functional drift).
+    - owner: owner_poly
+    - owner_poly.oneof0: owner
+  removes:
+    - success                  # (components/schemas/osType.yaml)
+    - owner_poly               # drop the unused object variant of owner
+  overrides:
+    id:
+      description: Morpheus ID of the OS type
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      description: The name of the OS type
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+    bit_count:
+      description: The architecture bit count (e.g. 32 or 64)
+    code:
+      description: The code Morpheus uses as an internal identifier
+    platform:
+      description: The platform of the OS type (e.g. linux, windows)
+    cloud_init_version:
+      description: The version of CloudInit being used
+    install_agent:
+      description: Whether to install the Morpheus agent on provisioned instances
+    category:
+      description: The category of the OS type
+    description:
+      description: The description of the OS type
+    os_codename:
+      description: The codename of the OS type
+    os_family:
+      description: The family of the OS type
+    os_name:
+      description: The OS name of the OS type
+    os_version:
+      description: The OS version of the OS type
+    vendor:
+      description: The vendor of the OS type
+    owner:
+      description: The owner of the OS type

--- a/specs/datasources/os_type_image/config.yaml
+++ b/specs/datasources/os_type_image/config.yaml
@@ -1,0 +1,31 @@
+os_type_image:
+  templates:
+    int64:
+      int64: {}
+  moves:
+    - os_type_image: "" # unnest wrapper (components/schemas/osTypeImage.yaml)
+    - zone: cloud_id # (components/schemas/osTypeImage.yaml)
+    - compute_zone_type: cloud_type_id # (components/schemas/osTypeImage.yaml)
+    - account: tenant_id # (components/schemas/osTypeImage.yaml)
+    - provision_type: provision_type_id # (components/schemas/osTypeImage.yaml)
+    - template-int64: os_type_id
+  overrides:
+    os_type_id:
+      description: The ID of the os type to search for the image
+      computed_optional_required: required
+    tenant_id:
+      description: The tenant associated with the os type image
+    id:
+      description: Morpheus ID of the os type image
+      computed_optional_required: computed
+    cloud_id:
+      description: The cloud that is attached to the os type image
+    cloud_type_id:
+      description: The cloud type of the os type image
+    provision_type_id:
+      description: The Provision Type of the os type image
+    virtual_image_id:
+      description: The id of the virtual image
+    virtual_image_name:
+      description: The name of the virtual image
+      computed_optional_required: required

--- a/specs/datasources/policy/config.yaml
+++ b/specs/datasources/policy/config.yaml
@@ -1,0 +1,501 @@
+policy:
+  templates:
+    config:
+      dynamic:
+        description: Generic Policy Configuration
+        computed_optional_required: computed
+   
+    config_lifecycle.lifecycle_auto_renew:
+      bool:
+        computed_optional_required: computed
+
+    config_lifecycle.lifecycle_allow_extend:
+      bool:
+        computed_optional_required: computed
+    
+    config_max_cores.exclude_containers:
+      bool:
+        computed_optional_required: computed
+
+    config_max_memory.exclude_containers:
+      bool:
+        computed_optional_required: computed
+ 
+    config_max_storage.exclude_containers:
+      bool:
+        computed_optional_required: computed
+
+    config_motd.fullpage.exclude_containers:
+      bool:
+        computed_optional_required: computed
+
+    config_shutdown.shutdown_auto_renew:
+      bool:
+        computed_optional_required: computed
+
+    config_shutdown.shutdown_allow_extend:
+      bool:
+        computed_optional_required: computed
+
+  moves:
+    - policy: "" # unnest policy
+    - ref_type: associated_resource_type
+    - ref_id: associated_resource_id
+    - site: "group"
+    - zone: "cloud"
+    - accounts: "tenants"
+
+    # rename config elements to relevant policy type
+    - config.approve_policy_type_configuration: config_approval
+    - config.backup_creation_policy_type_configuration: config_create_backup
+    - config.backup_targets_policy_type_configuration: config_backup_storage
+    - config.budget_policy_type_configuration: config_max_price
+    - config.cluster_resource_name_policy_type_configuration: config_server_naming
+    - config.cypher_access_policy_type_configuration: config_cypher
+    - config.delayed_delete_policy_type_configuration: config_delayed_removal
+    - config.expiration_policy_type_configuration: config_lifecycle
+    - config.hostname_policy_type_configuration: config_host_naming
+    - config.instance_name_policy_type_configuration: config_naming
+    - config.max_containers_policy_type_configuration: config_max_containers
+    - config.max_cores_policy_type_configuration: config_max_cores
+    - config.max_hosts_policy_type_configuration: config_max_hosts
+    - config.max_load_balancer_pools_policy_type_configuration: config_max_pools
+    - config.max_memory_policy_type_configuration: config_max_memory
+    - config.max_pool_members_policy_type_configuration: config_max_pool_members
+    - config.max_snapshots_policy_type_configuration: config_max_snapshots
+    - config.max_storageand_object_storage_quota_policy_type_configuration: config_max_storage
+    - config.max_virtual_servers_policy_type_configuration: config_max_virtual_servers
+    - config.max_vms_policy_type_configuration: config_max_vms
+    - config.messageofthe_day_policy_type_configuration: config_motd
+    - config.network_quota_policy_type_configuration: config_max_networks
+    - config.power_schedule_policy_type_configuration: config_power_schedule
+    - config.required_network_policy_type_configuration: config_required_network
+    - config.router_quota_policy_type_configuration: config_max_routers
+    - config.shutdown_policy_type_configuration: config_shutdown
+    - config.storage_server_storage_quota_policy_type_configuration: config_storage_server_quota
+    - config.tags_policy_type_configuration: config_tags
+    - config.user_creation_policy_type_configuration: config_create_user
+    - config.user_group_creation_policy_type_configuration: config_create_user_group
+    - config.workflow_policy_type_configuration: config_workflow
+
+    # Moving motdfull_page.oneof0 to motd_fullpage for simplicity
+    # note: moving to motdfull_page directly keeps motdfull_page as single-nested instead of string type
+    # therefore, slightly altering the name and removing it later.
+    - config_motd.motdfull_page.oneof0: config_motd.motd_fullpage
+
+    # Have a dynamic config as well as static schemas
+    - template-config: config
+
+    # Swap on/off fields with boolean templates
+    - template-config_lifecycle.lifecycle_auto_renew: config_lifecycle.lifecycle_auto_renew
+    - template-config_lifecycle.lifecycle_allow_extend: config_lifecycle.lifecycle_allow_extend
+    - template-config_max_cores.exclude_containers: config_max_cores.exclude_containers
+    - template-config_max_memory.exclude_containers: config_max_memory.exclude_containers
+    - template-config_max_storage.exclude_containers: config_max_storage.exclude_containers
+    - template-config_motd_fullpage.exclude_containers: config_motd_fullpage.exclude_containers
+    - template-config_shutdown.shutdown_auto_renew: config_shutdown.shutdown_auto_renew
+    - template-config_shutdown.shutdown_allow_extend: config_shutdown.shutdown_allow_extend
+  removes:
+    # Removing unneccessary inner motd and motdfull_page
+    - config_motd.motd
+    - config_motd.motdfull_page
+
+  overrides:
+    id:
+      description: Morpheus ID of the Object being referenced
+      conflicts_with: ["name"]
+      computed_optional_required: computed_optional
+    name:
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional
+
+    config_approval:
+      description: |
+        Configuration for the following policy types:
+        	- Approve Delete (deleteApproval)
+        	- Approve Provision (provisionApproval)
+        	- Approve Reconfigure (reconfigureApproval)
+        	- Approve Workflow Execute (workflowApproval)
+    
+    config_approval.account_integration_id:
+      description: ID of your ServiceNow or approval integration
+    
+    config_approval.flow_id:
+      description: ID of ServiceNow Flow (set if workflowType is 'flow')
+    
+    config_approval.workflow_id:
+      description: ID of legacy ServiceNow workflow (set if workflowType is 'workflow')
+    
+    config_approval.workflow_type:
+      description: "Options: \"workflow\" (legacy workflow), \"flow\" (ServiceNow Flow)"
+    
+    config_create_backup:
+      description: |
+        Configuration for the following policy type:
+        	- Backup Creation (createBackup)
+    
+    config_create_backup.create_backup:
+      description: Enforce backup creation
+    
+    config_create_backup.create_backup_type:
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict pattern)"
+    
+    config_backup_storage:
+      description: |
+        Configuration for the following policy type:
+        	- Backup Targets (backupStorage)
+    
+    config_backup_storage.backup_storage_ids:
+      description: Array of backup storage IDs to restrict available backup targets
+    
+    config_max_price:
+      description: |
+        Configuration for the following policy type:
+        	- Budget (maxPrice)
+    
+    config_max_price.max_price:
+      description: Maximum price limit
+    
+    config_max_price.max_price_currency:
+      description: Currency code (e.g., USD)
+    
+    config_max_price.max_price_unit:
+      description: "Options: \"hour\", \"month\""
+    
+    config_server_naming:
+      description: |
+        Configuration for the following policy type:
+        	- Cluster Resource Name (serverNaming)
+    
+    config_server_naming.server_naming_conflict:
+      description: Auto-resolve conflicts
+    
+    config_server_naming.server_naming_pattern:
+      description: Name pattern uses ${variable} string interpolation.  Available variables are:<br>groupName, groupCode, cloudName, cloudCode, type, accountId, account, accountType, platform, username, userId, userInitials, provisionType
+    
+    config_server_naming.server_naming_type:
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict pattern)"
+    
+    config_cypher:
+      description: |
+        Configuration for the following policy type:
+        	- Cypher Access (cypher)
+    
+    config_cypher.delete:
+      description: Allow delete access
+    
+    config_cypher.key_pattern:
+      description: Pattern to match Cypher keys (e.g., "secret/*", "password/*")
+    
+    config_cypher.list:
+      description: Allow list access
+    
+    config_cypher.read:
+      description: Allow read access
+    
+    config_cypher.update:
+      description: Allow update access
+    
+    config_cypher.write:
+      description: Allow write access
+    
+    config_delayed_removal:
+      description: |
+        Configuration for the following policy type:
+        	- Delayed Delete (delayedRemoval)
+    
+    config_delayed_removal.removal_age:
+      description: Number of days to delay deletion
+    
+    config_lifecycle:
+      description: |
+        Configuration for the following policy type:
+        	- Expiration (lifecycle)
+    
+    config_lifecycle.account_integration_id:
+      description: ID of your ServiceNow or approval integration
+    
+    config_lifecycle.flow_id:
+      description: ID of ServiceNow Flow (set if workflowType is 'flow')
+    
+    config_lifecycle.lifecycle_age:
+      description: Days until expiration
+    
+    config_lifecycle.lifecycle_extensions_before_approval:
+      description: Number of extensions before requiring approval
+    
+    config_lifecycle.lifecycle_hide_fixed:
+      description: Hide fixed expiration from users
+    
+    config_lifecycle.lifecycle_message:
+      description: Notification message
+    
+    config_lifecycle.lifecycle_notify:
+      description: Days before expiration to notify
+    
+    config_lifecycle.lifecycle_renewal:
+      description: Days for renewal window
+    
+    config_lifecycle.lifecycle_type:
+      description: "Options: \"user\" (user configurable), \"fixed\" (fixed expiration)"
+    
+    config_lifecycle.lifecycle_workflow_id:
+      description: ID of legacy ServiceNow workflow (set if workflowType is 'workflow')
+    
+    config_lifecycle.workflow_type:
+      description: "Options: \"workflow\" (legacy workflow), \"flow\" (ServiceNow Flow)"
+    
+    config_host_naming:
+      description: |
+        Configuration for the following policy type:
+        	- Hostname (hostNaming)
+    
+    config_host_naming.host_naming_pattern:
+      description: Name pattern uses ${variable} string interpolation.  Available variables are:<br>groupName, groupCode, cloudName, cloudCode, type, accountId, account, accountType, platform, username, userId, userInitials, provisionType
+    
+    config_host_naming.host_naming_type:
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict pattern)"
+    
+    config_naming:
+      description: |
+        Configuration for the following policy type:
+        	- Instance Name (naming)
+    
+    config_naming.naming_conflict:
+      description: Auto-resolve conflicts
+    
+    config_naming.naming_pattern:
+      description: Name pattern uses ${variable} string interpolation.  Available variables are:<br>groupName, groupCode, cloudName, cloudCode, type, accountId, account, accountType, platform, username, userId, userInitials, provisionType
+    
+    config_naming.naming_type:
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict pattern)"
+    
+    config_max_containers:
+      description: |
+        Configuration for the following policy type:
+        	- Max Containers (maxContainers)
+    
+    config_max_containers.max_containers:
+      description: Max Containers
+    
+    config_max_cores:
+      description: |
+        Configuration for the following policy type:
+        	- Max Cores (maxCores)
+    
+    config_max_cores.max_cores:
+      description: Max Cores
+    
+    config_max_hosts:
+      description: |
+        Configuration for the following policy type:
+        	- Max Hosts (maxHosts)
+    
+    config_max_hosts.max_hosts:
+      description: Max Hosts
+    
+    config_max_pools:
+      description: |
+        Configuration for the following policy type:
+        	- Max Load Balancer Pools (maxPools)
+    
+    config_max_pools.max_pools:
+      description: Max Pools
+    
+    config_max_memory:
+      description: |
+        Configuration for the following policy type:
+        	- Max Memory (maxMemory)
+    
+    config_max_memory.max_memory:
+      description: Max Memory (GB)
+    
+    config_max_pool_members:
+      description: |
+        Configuration for the following policy type:
+        	- Max Pool Members (maxPoolMembers)
+    
+    config_max_pool_members.max_pool_members:
+      description: Max Pool Members
+    
+    config_max_snapshots:
+      description: |
+        Configuration for the following policy type:
+        	- Max Snapshots (maxSnapshots)
+    
+    config_max_snapshots.max_snapshots:
+      description: Max Snapshots
+
+    config_max_storage:
+      description: |
+        Configuration for the following policy types:
+        	- Max Storage (maxStorage)
+        	- Object Storage Quota (storageBucketQuota)
+        	- File Share Storage Quota (storageShareQuota)
+    
+    config_max_storage.max_storage:
+      description: Max Storage (GB)
+    
+    config_max_virtual_servers:
+      description: |
+        Configuration for the following policy type:
+        	- Max Virtual Servers (maxVirtualServers)
+    
+    config_max_virtual_servers.max_virtual_servers:
+      description: Max Virtual Servers
+    
+    config_max_vms:
+      description: |
+        Configuration for the following policy type:
+        	- Max VMs (maxVms)
+    
+    config_max_vms.max_vms:
+      description: Max VMs
+    
+    config_motd:
+      description: |
+        Configuration for the following policy type:
+        	- Message of the Day (motd)
+    
+    config_motd.motddate:
+      description: Display date for message
+    
+    config_motd.motdmessage:
+      description: Message content
+    
+    config_motd.motdtitle:
+      description: Message title
+    
+    config_motd.motdtype:
+      description: "Options: \"info\", \"warning\", \"critical\""
+    
+    config_max_networks:
+      description: |
+        Configuration for the following policy type:
+        	- Network Quota (maxNetworks)
+    
+    config_max_networks.max_networks:
+      description: Max Networks
+    
+    config_power_schedule:
+      description: |
+        Configuration for the following policy type:
+        	- Power Scheduling (powerSchedule)
+    
+    config_power_schedule.power_schedule:
+      description: ID of the power schedule
+    
+    config_power_schedule.power_schedule_hide_fixed:
+      description: Hide fixed schedule from users
+    
+    config_power_schedule.power_schedule_type:
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict schedule)"
+    
+    config_required_network:
+      description: |
+        Configuration for the following policy type:
+        	- Instance Networks (requiredNetwork)
+    
+    config_required_network.required_networks:
+      description: Array of required network IDs
+    
+    config_max_routers:
+      description: |
+        Configuration for the following policy type:
+        	- Router Quota (maxRouters)
+    
+    config_max_routers.max_routers:
+      description: Max Routers
+    
+    config_shutdown:
+      description: |
+        Configuration for the following policy type:
+        	- Shutdown (shutdown)
+    
+    config_shutdown.account_integration_id:
+      description: ID of your ServiceNow or approval integration
+    
+    config_shutdown.flow_id:
+      description: ID of ServiceNow Flow (set if workflowType is 'flow')
+    
+    config_shutdown.shutdown_age:
+      description: Days instance is allowed to run before shutdown
+    
+    config_shutdown.shutdown_extensions_before_approval:
+      description: Number of extensions before requiring approval
+    
+    config_shutdown.shutdown_hide_fixed:
+      description: Hide fixed shutdown from users
+    
+    config_shutdown.shutdown_message:
+      description: Notification message
+    
+    config_shutdown.shutdown_notify:
+      description: Days before shutdown to notify via email
+    
+    config_shutdown.shutdown_renewal:
+      description: If the instance is renewed, this is the number of day increments the shutdown date is increased by
+    
+    config_shutdown.shutdown_type:
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict shutdown)"
+    
+    config_shutdown.shutdown_workflow_id:
+      description: ID of legacy ServiceNow workflow (set if workflowType is 'workflow')
+    
+    config_shutdown.workflow_type:
+      description: "Options: \"workflow\" (legacy workflow), \"flow\" (ServiceNow Flow)"
+    
+    config_storage_server_quota:
+      description: |
+        Configuration for the following policy type:
+        	- Storage Server Storage Quota (storageServerQuota)
+    
+    config_storage_server_quota.max_storage:
+      description: Max Storage (GB)
+    
+    config_storage_server_quota.storage_server_id:
+      description: ID of the storage server
+    
+    config_tags:
+      description: |
+        Configuration for the following policy type:
+        	- Tags (tags)
+    
+    config_tags.key:
+      description: Tag key to enforce
+    
+    config_tags.strict:
+      description: Strict enforcement
+    
+    config_tags.value:
+      description: Tag value (optional, can be left empty for any value)
+    
+    config_tags.value_list_id:
+      description: ID of value from value list (optional)
+    
+    config_create_user:
+      description: |
+        Configuration for the following policy type:
+        	- User Creation (createUser)
+    
+    config_create_user.create_user:
+      description: Enforce user creation
+    
+    config_create_user.create_user_type:
+      description: "Options: \"user\" (user configurable), \"fixed\""
+    
+    config_create_user_group:
+      description: |
+        Configuration for the following policy type:
+        	- User Group Creation (createUserGroup)
+    
+    config_create_user_group.user_group:
+      description: ID of the user group to assign
+    
+    config_workflow:
+      description: |
+        Configuration for the following policy type:
+        	- Workflow (workflow)
+    
+    config_workflow.workflow_id:
+      description: ID of the workflow to execute

--- a/specs/datasources/role/config.yaml
+++ b/specs/datasources/role/config.yaml
@@ -1,0 +1,517 @@
+role:
+  templates:
+    default_persona:
+      single_nested:
+        computed_optional_required: computed
+        attributes:
+        - name: code
+          string:
+            computed_optional_required: computed
+        - name: id
+          int64:
+            computed_optional_required: computed
+        - name: name
+          string:
+            computed_optional_required: computed
+        description: The default Persona assigned to the Role.
+    permissions:
+      single_nested:
+        computed_optional_required: computed
+        attributes:
+        - name: blueprint_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: computed
+                  description: "`id` of the blueprint (appTemplate)"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified blueprints (appTemplates)
+        - name: catalog_item_type_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: computed
+                  description: "`id` of the catalog item type"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified catalog item types
+        - name: cloud_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "read",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: computed
+                  description: "`id` of the cloud (zone)"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified clouds (zones). Only applies to base account (tenant) roles.
+        - name: default_blueprint_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for blueprints
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_catalog_item_type_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for catalog item types
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_cloud_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for for clouds (zones). Only applies to base account (tenant) roles.
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "read",
+                  "none",
+                  )
+        - name: default_group_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for for groups (sites). Only applies to user roles.
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "read",
+                  "none",
+                  )
+        - name: default_instance_type_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for for instance types
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_persona_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for personas
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_report_type_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for report types
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_task_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for tasks
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_vdi_pool_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for VDI pools
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_workflow_access
+          string:
+            computed_optional_required: computed
+            description: Set the default access level for workflows (taskSets)
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: feature_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "full",
+                        "full_decrypted",
+                        "group",
+                        "listfiles",
+                        "managerules",
+                        "no",
+                        "none",
+                        "provision",
+                        "read",
+                        "rolemappings",
+                        "user",
+                        "view",
+                        "yes",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: computed
+                  description: "`code` of the feature permission"
+              - name: id
+                int64:
+                  computed_optional_required: computed
+              - name: name
+                string:
+                  computed_optional_required: computed
+              - name: sub_category
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified permissions.
+        - name: group_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "read",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: computed
+                  description: "`id` of the group (site)"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified groups (sites). Only applies to user roles.
+        - name: instance_type_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: computed
+              - name: id
+                int64:
+                  computed_optional_required: computed
+                  description: "`id` of the instance type"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified instance types
+        - name: persona_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: computed
+                  description: "`code` of the persona"
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "standard",
+                        "serviceCatalog",
+                        "vdi",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: computed
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified personas
+        - name: report_type_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: computed
+                  description: "`code` of the report type"
+              - name: id
+                int64:
+                  computed_optional_required: computed
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified report types
+        - name: task_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: computed
+              - name: id
+                int64:
+                  computed_optional_required: computed
+                  description: "`id` of the task"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified tasks
+        - name: vdi_pool_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: computed
+                  description: "`id` of the VDI pool"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified VDI pools
+        - name: workflow_permissions
+          set_nested:
+            computed_optional_required: computed
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: computed
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: computed
+                  description: "`id` of the workflow (taskSet)"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified workflows (taskSets)
+        description: The set of permissions to assign to the role
+  includes:
+    - role.id
+    - role.name
+    - role.description
+    - role.landing_url
+    - role.multitenant
+    - role.multitenant_locked
+    - role.role_type
+  moves:
+    - role: "" # unnest role wrapper to root
+    - template-default_persona: default_persona
+    - template-permissions: permissions
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: Morpheus ID of the Object being referenced
+      conflicts_with: [name]
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the Morpheus role
+      conflicts_with: [id]
+    multitenant:
+      description: Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant*
+    multitenant_locked:
+      description: Multitenant Locked prevents sub-tenant users from modifying their copy of multitenant roles. *Only available to master tenant*
+    role_type:
+      description: Role type

--- a/specs/datasources/security_group/config.yaml
+++ b/specs/datasources/security_group/config.yaml
@@ -1,0 +1,64 @@
+security_group:
+  templates:
+    cloud_id:
+      int64:
+        computed_optional_required: computed
+        description: The cloud (zone) ID for the security group.
+    tenant_ids:
+      set:
+        computed_optional_required: computed
+        element_type:
+          int64: {}
+        description: Set of tenant IDs that are allowed access to the security group.
+    resource_permission_groups_all:
+      bool:
+        computed_optional_required: computed
+        description: Whether all groups have access to the security group.
+    resource_permission_group_ids:
+      set:
+        computed_optional_required: computed
+        element_type:
+          int64: {}
+        description: Set of group IDs that have access to the security group.
+  moves:
+    - security_group: "" # unnest GET envelope
+    - template-cloud_id: cloud_id
+    - template-tenant_ids: tenant_ids
+    - template-resource_permission_groups_all: resource_permission_groups_all
+    - template-resource_permission_group_ids: resource_permission_group_ids
+  removes:
+    - custom_options
+    - locations
+    - resource_permission
+    - resource_permissions
+    - rules
+    - success
+    - tenant_permissions
+    - tenants
+    - zone
+    - zone_id
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      conflicts_with: ["name"]
+      description: The ID of the security group. Conflicts with name.
+    name:
+      computed_optional_required: computed_optional
+      conflicts_with: ["id"]
+      description: The name of the security group. Conflicts with id.
+    description:
+      description: The description of the security group.
+    active:
+      description: Whether the security group is active.
+    visibility:
+      description: The visibility of the security group.
+    account_id:
+      description: The tenant (account) ID that owns the security group.
+    external_id:
+      description: The external ID of the security group.
+    group_source:
+      description: The source of the security group.
+    sync_source:
+      description: The sync source of the security group.
+    enabled:
+      description: Whether the security group is enabled (on/off).

--- a/specs/datasources/service_plan/config.yaml
+++ b/specs/datasources/service_plan/config.yaml
@@ -1,0 +1,118 @@
+service_plan:
+  templates:
+    provision_type_code:
+      string:
+        computed_optional_required: computed_optional
+        description: The provision type code of the Morpheus service plan
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+            - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: |-
+              stringvalidator.AlsoRequires(path.Expressions{
+                path.MatchRoot("name"),
+              }...)
+    cloud_id:
+      int64:
+        computed_optional_required: optional
+        description: ID of the cloud the service plan must be available in. Disambiguates plans that share a name across clouds/regions (e.g. Azure). Requires name and provision_type_code.
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+            - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: |-
+              int64validator.AlsoRequires(path.Expressions{
+                path.MatchRoot("name"),
+                path.MatchRoot("provision_type_code"),
+              }...)
+    price_set_ids:
+      set:
+        computed_optional_required: computed
+        element_type:
+          int64: {}
+    config_ranges:
+      single_nested:
+        computed_optional_required: computed
+        description: The min and max ranges that instances using this service plan must conform to.
+        attributes:
+          - name: min_storage
+            int64: {computed_optional_required: computed, description: Custom min storage in GB}
+          - name: max_storage
+            int64: {computed_optional_required: computed, description: Custom max storage in GB}
+          - name: min_per_disk_size
+            int64: {computed_optional_required: computed, description: Custom min per disk size in GB}
+          - name: max_per_disk_size
+            int64: {computed_optional_required: computed, description: Custom max per disk size in GB}
+          - name: min_memory
+            int64: {computed_optional_required: computed, description: Custom min memory in bytes}
+          - name: max_memory
+            int64: {computed_optional_required: computed, description: Custom max memory in bytes}
+          - name: min_cores
+            int64: {computed_optional_required: computed, description: Custom min cores}
+          - name: max_cores
+            int64: {computed_optional_required: computed, description: Custom max cores}
+          - name: min_sockets
+            int64: {computed_optional_required: computed, description: Custom min sockets}
+          - name: max_sockets
+            int64: {computed_optional_required: computed, description: Custom max sockets}
+          - name: min_cores_per_socket
+            int64: {computed_optional_required: computed, description: Custom min cores allowed per socket}
+          - name: max_cores_per_socket
+            int64: {computed_optional_required: computed, description: Custom max cores allowed per socket}
+  includes:
+    - service_plan.id
+    - service_plan.name
+    - service_plan.code
+    - service_plan.description
+    - service_plan.max_memory
+    - service_plan.max_storage
+    - service_plan.config.storage_size_type
+    - service_plan.config.memory_size_type
+    - service_plan.custom_cores
+    - service_plan.custom_max_storage
+    - service_plan.custom_max_memory
+    - service_plan.add_volumes
+    - service_plan.cores_per_socket
+    - service_plan.max_disks
+    - service_plan.max_cpu
+    - service_plan.max_cores
+    - service_plan.sort_order
+    - service_plan.custom_cpu
+  moves:
+    - service_plan: "" # unnest servicePlan wrapper to root
+    - config: "" # unnest config to root
+    - template-provision_type_code: provision_type_code
+    - template-price_set_ids: price_set_ids
+    - template-config_ranges: config_ranges
+    - template-cloud_id: cloud_id
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: Morpheus ID of the Object being referenced
+      conflicts_with: [name, provision_type_code]
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the Morpheus service plan
+      also_requires: [provision_type_code]
+    code:
+      description: The code of the Morpheus service plan
+    description:
+      description: The description of the Morpheus service plan
+    max_memory:
+      description: Max memory size in bytes
+    max_storage:
+      description: Max storage size in bytes
+    cores_per_socket:
+      description: Number of cores per CPU
+    max_disks:
+      description: Max disks allowed
+    max_cpu:
+      description: Max CPUs
+    max_cores:
+      description: Max number of total cores
+    sort_order:
+      description: Sort order
+    custom_cpu:
+      description: Can be used to enable / disable customizable cpu

--- a/specs/datasources/storage_server/config.yaml
+++ b/specs/datasources/storage_server/config.yaml
@@ -1,0 +1,64 @@
+storage_server:
+  templates:
+    type_id:
+      int64:
+        computed_optional_required: computed
+        description: The storage server type ID.
+    type_code:
+      string:
+        computed_optional_required: computed
+        description: The storage server type code (for example, 3par, netapp).
+    type_name:
+      string:
+        computed_optional_required: computed
+        description: The storage server type name.
+    cloud_id:
+      int64:
+        computed_optional_required: computed
+        description: The cloud (zone) ID the storage server is scoped to, when ref_type is ComputeZone.
+    cloud_name:
+      string:
+        computed_optional_required: computed
+        description: The cloud (zone) name the storage server is scoped to, when ref_type is ComputeZone.
+  moves:
+    - storage_server: "" # unnest GET envelope
+    - template-type_id: type_id
+    - template-type_code: type_code
+    - template-type_name: type_name
+    - template-cloud_id: cloud_id
+    - template-cloud_name: cloud_name
+  removes:
+    - type
+    - config
+    - chassis
+    - credential
+    - groups
+    - host_groups
+    - hosts
+    - owner
+    - tenants
+    - service_password
+    - service_password_hash
+    - service_token
+    - service_token_hash
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      conflicts_with: ["name"]
+      description: The ID of the storage server. Conflicts with name.
+    name:
+      computed_optional_required: computed_optional
+      conflicts_with: ["id"]
+      description: The name of the storage server. Conflicts with id.
+    description:
+      description: The description of the storage server.
+    visibility:
+      description: The visibility of the storage server (public or private).
+    enabled:
+      description: Whether the storage server is enabled.
+    status:
+      description: The status of the storage server.
+    ref_type:
+      description: The reference type the storage server is scoped to (for example, ComputeZone).
+    ref_id:
+      description: The reference ID the storage server is scoped to.

--- a/specs/datasources/storage_servers/config.yaml
+++ b/specs/datasources/storage_servers/config.yaml
@@ -1,0 +1,86 @@
+storage_servers:
+  templates:
+    type_id:
+      int64:
+        computed_optional_required: computed
+        description: The storage server type ID.
+    type_code:
+      string:
+        computed_optional_required: computed
+        description: The storage server type code (for example, 3par, netapp).
+    type_name:
+      string:
+        computed_optional_required: computed
+        description: The storage server type name.
+    cloud_id:
+      int64:
+        computed_optional_required: computed
+        description: The cloud (zone) ID the storage server is scoped to, when ref_type is ComputeZone.
+    cloud_name:
+      string:
+        computed_optional_required: computed
+        description: The cloud (zone) name the storage server is scoped to, when ref_type is ComputeZone.
+  moves:
+    - template-type_id: storage_servers.type_id
+    - template-type_code: storage_servers.type_code
+    - template-type_name: storage_servers.type_name
+    - template-cloud_id: storage_servers.cloud_id
+    - template-cloud_name: storage_servers.cloud_name
+  removes:
+    - max
+    - offset
+    - sort
+    - direction
+    - phrase
+    - name
+    - meta
+    - storage_servers.type
+    - storage_servers.config
+    - storage_servers.chassis
+    - storage_servers.credential
+    - storage_servers.groups
+    - storage_servers.host_groups
+    - storage_servers.hosts
+    - storage_servers.owner
+    - storage_servers.tenants
+    - storage_servers.service_password
+    - storage_servers.service_password_hash
+    - storage_servers.service_token
+    - storage_servers.service_token_hash
+  blocks:
+    filter:
+      set_nested:
+        description: >-
+          Filter block. Repeat to apply multiple filters (all ANDed together).
+          Filter values are case-sensitive and support Go regular expressions
+          (https://regex101.com/).
+        nested_object:
+          attributes:
+            - name: name
+              string:
+                computed_optional_required: required
+                description: >-
+                  The field to filter on. Valid names are: name, type_id,
+                  type_code, cloud_id, cloud_name, visibility, enabled, status.
+                validators:
+                  - custom:
+                      imports:
+                        - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: stringvalidator.OneOf("name", "type_id", "type_code", "cloud_id", "cloud_name", "visibility", "enabled", "status")
+            - name: values
+              set:
+                element_type:
+                  string: {}
+                computed_optional_required: required
+                description: >-
+                  The filter values. A storage server matches the block if the
+                  chosen field matches ANY value (Go regular expression).
+                validators:
+                  - custom:
+                      imports:
+                        - path: github.com/hashicorp/terraform-plugin-framework-validators/setvalidator
+                      schema_definition: setvalidator.SizeAtLeast(1)
+  overrides:
+    storage_servers:
+      computed_optional_required: computed
+      description: The list of storage servers matching the supplied filters.

--- a/specs/datasources/user/config.yaml
+++ b/specs/datasources/user/config.yaml
@@ -1,0 +1,27 @@
+user:
+  moves:
+    - user: "" # unnest user
+    - account: "tenant"
+    - access.app_templates: "access.blueprints"
+    - access.task_sets: "access.workflows"
+    - access.zones: "access.clouds"
+    - access.sites: "access.groups"
+  removes:
+    - include_access
+    - linux_password
+    - windows_password
+    - login_count
+    - login_attempts
+    - last_updated
+    - last_login_date
+    - date_created
+    - account_id
+  overrides:
+    id:
+      description: Morpheus ID of the Object being referenced
+      conflicts_with: ["username"]
+      computed_optional_required: computed_optional
+    username:
+      description: The username of the user
+      conflicts_with: ["id"]
+      computed_optional_required: computed_optional

--- a/specs/resources/backup_host/config.yaml
+++ b/specs/resources/backup_host/config.yaml
@@ -1,0 +1,117 @@
+backup_host:
+  description: "Manages a Morpheus Backup resource for Hosts."
+  templates:
+    backup_type_str:
+      string:
+        computed_optional_required: required
+        description: The backup type code. For Host backups, this is either fileBackup or directoryBackup.
+        validators:
+          - custom:
+              imports:
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              schema_definition: |-
+                stringvalidator.OneOf(
+                "fileBackup",
+                "directoryBackup",
+                )
+    path_str:
+      string:
+        computed_optional_required: optional
+        description: The file or directory path on the target host to back up.
+    ssh_username:
+      string:
+        computed_optional_required: optional
+        description: SSH username. Required if the Host was provisioned without providing SSH username/password at creation via Morpheus.
+        # We won't use an AlsoRequires on ssh_username for ssh_password_wo as ssh_password_wo should be set in the config only on create and update time.
+        # We don't want to require the config to always have it as it's WriteOnly.
+    ssh_password_wo:
+      string:
+        computed_optional_required: optional
+        description: SSH password (Write Only). Required if the Host was provisioned without providing SSH username/password at creation via Morpheus. Also requires ssh_username to be set.
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.AlsoRequires(path.Expressions{
+                  path.MatchRoot("ssh_username"),
+                }...)
+    ssh_password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: SSH password version. Used to determine if ssh_password_wo has been updated.
+  moves:
+    - backup: ""
+    - backup_server_host.server_id: host_id
+    - storage_provider.id: storage_provider_id
+    - job.id: job_id
+    - template-backup_type_str: backup_type_code
+    - template-path_str: path
+    - template-ssh_username: ssh_username
+    - template-ssh_password_wo: ssh_password_wo
+    - template-ssh_password_wo_version: ssh_password_wo_version
+  removes:
+    - backup_type
+    - container_id
+    - backup_instance
+    - backup_provider
+    - backup_repository
+    - backup_server_host
+    - backup_storage_provider
+    - retention_count
+    - cron_expression
+    - date_created
+    - instance
+    - job
+    - last_result
+    - last_status
+    - last_updated
+    - location_type
+    - next_fire
+    - schedule
+    - stats
+    - storage_provider
+    - success
+    - location
+    - server
+    - target_all
+    - target_host
+    - target_name
+    - target_password
+    - target_password_hash
+    - target_path
+    - target_port
+    - target_username
+    - volume_path
+  overrides:
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the backup is enabled.
+      default: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the backup.
+      state_for_unknown: true
+    host_id:
+      computed_optional_required: required
+      description: The ID of the host (server) to backup.
+      requires_replace: true
+    name:
+      computed_optional_required: required
+      description: The name of the backup.
+    job_id:
+      computed_optional_required: required
+      description: The Backup Job that this Backup will use. If this is the only Backup referencing the Backup Job, deleting the Backup resource will also delete the Backup Job referenced by job_id.
+    storage_provider_id:
+      computed_optional_required: computed_optional
+      description: The ID of the storage provider (Bucket or File Share) to save backups to. If omitted, uses the system default.
+      state_for_unknown: true

--- a/specs/resources/backup_instance/config.yaml
+++ b/specs/resources/backup_instance/config.yaml
@@ -1,0 +1,77 @@
+backup_instance:
+  description: "Manages a Morpheus Backup resource for Instances."
+  templates:
+    backup_type_str:
+      string:
+        computed_optional_required: computed_optional
+        description: The backup type code. Computed from the Instance if not provided.
+  moves:
+    - backup: ""
+    - instance.id: instance_id
+    - job.id: job_id
+    - storage_provider.id: storage_provider_id
+    - template-backup_type_str: backup_type_code
+    - template-storage_bucket_id: storage_bucket_id
+  removes:
+    - backup_type
+    - backup_instance
+    - backup_provider
+    - backup_repository
+    - backup_server_host
+    - backup_storage_provider
+    - retention_count
+    - cron_expression
+    - date_created
+    - instance
+    - job
+    - last_result
+    - last_status
+    - last_updated
+    - location_type
+    - next_fire
+    - schedule
+    - stats
+    - storage_provider
+    - success
+    - location
+    - server
+    - target_all
+    - target_host
+    - target_name
+    - target_password
+    - target_password_hash
+    - target_path
+    - target_port
+    - target_username
+    - volume_path
+  overrides:
+    backup_type_code:
+      state_for_unknown: true
+      requires_replace: true
+    container_id:
+      computed_optional_required: computed_optional
+      description: The ID of the container to backup. Computed from the Instance if not provided.
+      state_for_unknown: true
+      requires_replace: true
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the backup is enabled.
+      default: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the backup.
+      state_for_unknown: true
+    instance_id:
+      computed_optional_required: required
+      description: The ID of the instance to backup.
+      requires_replace: true
+    name:
+      computed_optional_required: required
+      description: The name of the backup.
+    job_id:
+      computed_optional_required: required
+      description: The Backup Job that this Backup will use. If this is the only Backup referencing the Backup Job, deleting the Backup resource will also delete the Backup Job referenced by job_id.
+    storage_provider_id:
+      computed_optional_required: computed_optional
+      description: The ID of the storage provider (Bucket or File Share) to save backups to. If omitted, uses the system default.
+      state_for_unknown: true

--- a/specs/resources/backup_job/config.yaml
+++ b/specs/resources/backup_job/config.yaml
@@ -1,0 +1,41 @@
+backup_job:
+  description: "Manages a Morpheus Backup Job resource."
+  moves:
+    - job: ""
+    - schedule.id: schedule_id
+  removes:
+    - account
+    - backup_provider
+    - backup_respository
+    - backups
+    - cron_expression
+    - date_created
+    - external_id
+    - last_updated
+    - next_fire
+    - schedule
+    - source
+    - success
+    - visibility
+  overrides:
+    code:
+      computed_optional_required: optional
+      description: The code of the backup job.
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the backup job is enabled.
+      default: true
+      state_for_unknown: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the backup job.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the backup job.
+    retention_count:
+      computed_optional_required: optional
+      description: The retention count.
+    schedule_id:
+      computed_optional_required: optional
+      description: The execute schedule ID.

--- a/specs/resources/budget/config.yaml
+++ b/specs/resources/budget/config.yaml
@@ -1,0 +1,68 @@
+budget:
+  description: "Manages a Morpheus Budget resource."
+  moves:
+    - budget: ""
+  removes:
+    - account
+    - average_cost
+    - costs
+    - created_by_id
+    - created_by_name
+    - currency
+    - date_created
+    - external_id
+    - forecast_type
+    - internal_id
+    - is_fiscal
+    - last_updated
+    - over_limit
+    - period
+    - ref_id
+    - ref_name
+    - ref_scope
+    - ref_type
+    - resource_type
+    - rollover
+    - scope_cloud_id
+    - scope_group_id
+    - scope_tenant_id
+    - scope_user_id
+    - stats
+    - success
+    - timezone
+    - total_cost
+    - updated_by_id
+    - updated_by_name
+    - warning_limit
+  overrides:
+    description:
+      computed_optional_required: optional
+      description: The description of the budget.
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the budget is enabled.
+      default: true
+    end_date:
+      computed_optional_required: optional
+      description: The end date of the budget.
+    id:
+      computed_optional_required: computed
+      description: The ID of the budget.
+      state_for_unknown: true
+    interval:
+      computed_optional_required: computed_optional
+      description: The budget interval (year, quarter, month).
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the budget.
+    scope:
+      computed_optional_required: computed_optional
+      description: The scope of the budget.
+      state_for_unknown: true
+    start_date:
+      computed_optional_required: optional
+      description: The start date of the budget.
+    year:
+      computed_optional_required: optional
+      description: The year of the budget.

--- a/specs/resources/certificate/config.yaml
+++ b/specs/resources/certificate/config.yaml
@@ -1,0 +1,46 @@
+certificate:
+  description: "Manages a Morpheus Certificate resource."
+  moves:
+    - certificate: ""
+  removes:
+    - account_id
+    - category
+    - cert_type
+    - chain_file
+    - common_name
+    - generated
+    - integration_id
+    - key_file_md5
+    - self_signed
+    - success
+    - type
+    - wildcard
+  overrides:
+    cert_file:
+      computed_optional_required: required
+      description: The contents of the certificate file.
+      sensitive: true
+      state_for_unknown: true
+    description:
+      computed_optional_required: optional
+      description: A description of the certificate.
+    domain_name:
+      computed_optional_required: computed_optional
+      description: The domain name this certificate is tied to.
+      state_for_unknown: true
+    enabled:
+      computed_optional_required: computed
+      description: Whether the certificate is enabled.
+      state_for_unknown: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the certificate.
+      state_for_unknown: true
+    key_file:
+      computed_optional_required: required
+      description: The contents of the key file.
+      sensitive: true
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the certificate.

--- a/specs/resources/cloud/config.yaml
+++ b/specs/resources/cloud/config.yaml
@@ -1,0 +1,375 @@
+cloud:
+  templates:
+    config:
+      dynamic:
+        description: Generic Cloud Configuration
+        computed_optional_required: optional
+    bool:
+      bool:
+        description: CHANGE ME
+        computed_optional_required: optional
+    azure-region:
+      string:
+        description: The Azure region associated with the cloud integration
+        computed_optional_required: required
+    string:
+      string:
+        description: CHANGE ME
+        computed_optional_required: optional
+    vmware_password_version:
+      int64:
+        computed_optional_required: optional
+        description: Password version. Used to determine if password has been updated.
+    azure_client_secret_version:
+      int64:
+        computed_optional_required: optional
+        description: Client secret version. Used to determine if client secret has been updated.
+  moves:
+    - zone: "" # unnest zone
+    - account_id: tenant_id
+    - agent_mode: agent_install_mode
+    - timezone: time_zone
+    - config.appliance_url: appliance_url
+    - config.datacenter_name: data_center_name
+    - config.external_id: external_id
+    - config.inventory_level: import_existing_vms
+    - config.console_keymap: keyboard_layout
+    - network_server.id: network_server_id
+    - zone_type.anyof1.code: cloud_type_code
+    # AWS static config
+    - config.anyof0: config_aws
+    - template-bool: config_aws.use_host_credentials
+    - template-bool: config_aws.bypass_proxy
+    - template-bool: config_aws.cmdb_discovery
+    - template-string: config_aws.credentials
+    - config_aws.sts_assume_role: config_aws.role_arn
+    - config_aws.backup_mode: config_aws.backup_provider
+    - config_aws.replication_mode: config_aws.replication_provider
+    - config_aws.user_data_linux: config_aws.user_data
+    # HVM static config
+    - config.anyof2: config_hvm
+    - template-bool: config_hvm.enable_network_type_selection
+    # VMware static config
+    - config.anyof3: config_vmware
+    - template-bool: config_vmware.enable_disk_type_selection
+    - template-bool: config_vmware.enable_network_type_selection
+    - template-bool: config_vmware.enable_storage_type_selection
+    - template-bool: config_vmware.enable_vnc
+    - template-bool: config_vmware.hide_host_selection
+    - template-vmware_password_version: config_vmware.password_version
+    - config_vmware.rpc_mode.oneof0: config_vmware.rpc_mode
+    # Azure static config
+    - config.anyof4: config_azure
+    - template-bool: config_azure.cmdb_discovery
+    - template-azure-region: config_azure.azure_region
+    - template-azure_client_secret_version: config_azure.client_secret_version
+    - config_azure.rpc_mode.oneof0: config_azure.rpc_mode
+    # Generic config
+    - template-config: config
+    # Move common items to top level
+    - config_hvm.appliance_url: appliance_url
+    - config_hvm.datacenter_name: data_center_name
+    - config_hvm.external_id: external_id
+    - config_hvm.inventory_level: import_existing_vms
+    - config_hvm.console_keymap: keyboard_layout
+  removes:
+    # Remove top level items from indented config
+    - config_aws.appliance_url
+    - config_aws.datacenter_name
+    - config_aws.external_id
+    - config_aws.inventory_level
+    - config_aws.console_keymap
+    - config_vmware.appliance_url
+    - config_vmware.datacenter_name
+    - config_vmware.external_id
+    - config_vmware.inventory_level
+    - config_vmware.console_keymap
+    - config_azure.appliance_url
+    - config_azure.datacenter_name
+    - config_azure.external_id
+    - config_azure.inventory_level
+    - config_azure.console_keymap
+    # More unwanted items
+    - config_aws.bypass_proxy_for_cloud
+    - config_aws.certificate_provider
+    - config_aws.config_cmdb_discovery
+    - config_aws.enable_network_type_selection
+    - config_aws.kube_url
+    - config_aws.network_server
+    - config_aws.network_serverid
+    - config_aws.replication_mode
+    - config_aws.security_server
+    - config_vmware.access_key
+    - config_vmware.backup_mode
+    - config_vmware.config_cmdb_discovery
+    - config_vmware.costing_access_key
+    - config_vmware.costing_bucket
+    - config_vmware.costing_bucket_name
+    - config_vmware.costing_folder
+    - config_vmware.costing_region
+    - config_vmware.costing_report
+    - config_vmware.costing_report_name
+    - config_vmware.costing_secret_key
+    - config_vmware.costing_secret_key_hash
+    - config_vmware.dns_integration_id
+    - config_vmware.ebs_encryption
+    - config_vmware.endpoint
+    - config_vmware.image_store_id
+    - config_vmware.is_vpc
+    - config_vmware.network_server
+    - config_vmware.network_serverid
+    - config_vmware.replication_mode
+    - config_vmware.secret_key
+    - config_vmware.secret_key_hash
+    - config_vmware.security_server
+    - config_vmware.service_registry_id
+    - config_vmware.sts_assume_role
+    - config_vmware.storage_type
+    - config_vmware.use_host_credentials
+    - config_vmware.vpc
+    # Azure internal/system fields
+    - config_azure.network_server
+    - config_azure.network_serverid
+    - config_azure.security_mode
+    - config_azure.certificate_provider
+    - config_azure.backup_mode
+    - config_azure.replication_mode
+    - config_azure.dns_integration_id
+    - config_azure.config_management_id
+    - config_azure.config_cmdb_id
+    - config_azure.security_server
+    - config_azure.account_type
+    - config_azure.service_registry_id
+    - config_azure.disk_encryption
+    - config_azure.encryption_set
+    - config_azure.csp_tenant_id
+    - config_azure.csp_client_id
+    - config_azure.csp_client_secret
+    - config_azure.csp_customer
+    - config_azure.config_cmdb_discovery
+    - config_azure.azure_costing_mode
+    - config_azure.client_secret_hash
+    - config_azure.csp_client_secret_hash
+    - account
+    - api_proxy
+    - config_aws.use_host_credentials
+    - console_keymap # added from GET examples?
+    - container_mode
+    - cost_last_sync
+    - cost_last_sync_duration
+    - cost_status
+    - cost_status_date
+    - cost_status_message
+    - credential
+    - credential_type
+    - dark_image_path
+    - date_created
+
+    - description
+    - domain_name
+    - groups
+    - image_path
+    - inventory_level # added from GET examples?
+    - last_sync
+    - last_sync_duration
+    - last_updated
+    - linked_account_id
+    - network_domain
+    - network_server
+    - network_server_id
+    - next_run_date
+    - owner
+    - provisioning_proxy
+    - region_code
+    - scale_priority
+    - security_server
+    - server_count
+    - service_version
+    - stats
+    - status
+    - status_date
+    - status_message
+    - storage_mode
+    - success
+    - user_data_linux
+    - user_data_windows
+    - uuid
+    - zone_type
+    - zone_type_id
+    - time_zone # Bug
+  overrides:
+    agent_install_mode:
+      description: The method used to install the Morpheus agent on virtual machines provisioned in the cloud (ssh, cloudInit)
+      computed_optional_required: computed_optional
+    appliance_url:
+      computed_optional_required: optional
+    cloud_type_code:
+      description: Cloud (zone) type code
+      computed_optional_required: computed_optional
+    config:
+      at_least_one_of: [config, config_aws, config_azure, config_hvm, config_vmware]
+      conflicts_with: [config_aws, config_azure, config_hvm, config_vmware]
+    config_aws:
+      computed_optional_required: optional 
+    config_aws.backup_mode:
+      description: The backup mode for the cloud
+      computed_optional_required: computed_optional
+    config_aws.bypass_proxy:
+      description: Whether to bypass the proxy for cloud API calls
+      computed_optional_required: computed_optional
+    config_aws.cmdb_discovery:
+      description: Whether to enable CMDB discovery on the cloud
+      computed_optional_required: computed_optional
+    config_aws.credentials:
+      description: Stored AWS credentials
+      computed_optional_required: computed_optional
+      # conflicts_with: [config_aws.access_key, config_aws.secret_key]
+    config_aws.replication_provider:
+      description: The replication provider for the cloud
+      computed_optional_required: computed_optional
+    config_aws.backup_provider:
+      description: The backup provider for the cloud
+      computed_optional_required: computed_optional
+    config_hvm:
+      computed_optional_required: optional
+    config_hvm.enable_network_type_selection:
+      description: Whether to enable the user to select the network interface type during provisioning
+      computed_optional_required: computed_optional
+    config_azure:
+      computed_optional_required: optional
+    config_azure.azure_region:
+      description: The Azure region associated with the cloud integration
+      computed_optional_required: required
+    config_azure.subscriber_id:
+      description: The Azure subscription ID
+      computed_optional_required: required
+    config_azure.tenant_id:
+      description: The Azure Active Directory tenant ID
+      computed_optional_required: required
+    config_azure.client_id:
+      description: The Azure client (application) ID
+      computed_optional_required: required
+    config_azure.client_secret:
+      description: The Azure client secret
+      computed_optional_required: required
+      sensitive: true
+      write_only: true
+      plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    config_azure.client_secret_version:
+      computed_optional_required: optional
+      description: Client secret version. Used to determine if client secret has been updated.
+    config_azure.resource_group:
+      description: The Azure resource group
+      computed_optional_required: required
+    config_azure.cloud_type:
+      description: The Azure cloud type (global, usgov, german, china)
+      computed_optional_required: computed_optional
+      one_of: [global, usgov, german, china]
+      default: global
+    config_azure.import_existing:
+      description: Whether to import existing resources from the cloud (on, off)
+      computed_optional_required: computed_optional
+      one_of: ["on", "off"]
+    config_azure.storage_account:
+      description: The Azure storage account to use
+      computed_optional_required: computed_optional
+    config_azure.rpc_mode:
+      description: The method for interacting with cloud workloads (guestexec (VMware Tools) or rpc (SSH/WinRM))
+      computed_optional_required: computed_optional
+    config_azure.cmdb_discovery:
+      description: Whether to enable CMDB discovery on the cloud
+      computed_optional_required: computed_optional
+    config_vmware:
+      computed_optional_required: optional
+    config_vmware.password:
+      computed_optional_required: optional
+      sensitive: true
+      write_only: true
+      plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    config_vmware.password_version:
+      computed_optional_required: optional
+      description: Password version. Used to determine if password has been updated.
+    costing_mode:
+      description: Whether to enable costing on the cloud (off, costing, reservations, full)
+      one_of: [off, costing, reservations, full]
+      default: off
+      computed_optional_required: computed_optional
+    data_center_name:
+      computed_optional_required: optional
+    external_id:
+      computed_optional_required: optional
+    group_id:
+      computed_optional_required: optional
+    guidance_mode:
+      description: Whether to enable guidance recommendations on the cloud (manual, off)
+      computed_optional_required: computed_optional
+      one_of: [off, manual]
+      default: off
+    id:
+      description: The ID of the cloud
+      state_for_unknown: true
+    import_existing_vms:
+      description: Whether to import existing virtual machines (off, basic, full)
+      computed_optional_required: optional
+      one_of: [off, basic, full]
+    keyboard_layout:
+      computed_optional_required: optional
+    location:
+      computed_optional_required: optional
+    name:
+      computed_optional_required: required
+    tenant_id:
+      computed_optional_required: required
+      requires_replace: true
+    config_vmware.enable_disk_type_selection:
+      description: Whether to enable the user to select the disk type during provisioning.
+      computed_optional_required: computed_optional
+    config_vmware.enable_network_type_selection:
+      description: Whether to enable the user to select the network type during provisioning.
+      computed_optional_required: computed_optional
+    config_vmware.enable_storage_type_selection:
+      description: Whether to enable the user to select the storage type during provisioning.
+      computed_optional_required: computed_optional
+    config_vmware.enable_vnc:
+      description: Enable VNC access to the console.
+      computed_optional_required: computed_optional
+    config_vmware.hide_host_selection:
+      description: Whether to hide the ability to select the vSphere host from the user during provisioning.
+      computed_optional_required: computed_optional
+    config_vmware.rpc_mode:
+      description: The method for interacting with cloud workloads (guestexec (VMware Tools) or rpc (SSH/WinRM))
+      computed_optional_required: computed_optional
+    default_datastore_sync_active:
+      description: Sets the default active state during discovery of new datastores.
+      computed_optional_required: computed_optional
+      default: true
+    default_folder_sync_active:
+      description: Sets the default active state during discovery of new folders.
+      computed_optional_required: computed_optional
+      default: true
+    default_network_sync_active:
+      description: Sets the default active state during discovery of new networks.
+      computed_optional_required: computed_optional
+      default: true
+    default_plan_sync_active:
+      description: Sets the default active state during discovery of new plans.
+      computed_optional_required: computed_optional
+      default: true
+    default_pool_sync_active:
+      description: Sets the default active state during discovery of new resource pools.
+      computed_optional_required: computed_optional
+      default: true
+    default_security_group_sync_active:
+      description: Sets the default active state during discovery of new security groups.
+      computed_optional_required: computed_optional
+      default: true

--- a/specs/resources/cluster/config.yaml
+++ b/specs/resources/cluster/config.yaml
@@ -1,0 +1,394 @@
+cluster:
+  enable_timeouts: true
+  templates:
+    config:
+      dynamic:
+        description: Generic Cluster Configuration
+        computed_optional_required: optional
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator
+            - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: dynamicvalidator.ConflictsWith(path.Expressions{path.MatchRoot("config_hvm")}...)
+    create_user:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether to create a user on the cluster's workers. The default is 'false'.
+        default:
+          static: false
+        requires_replace: true
+    cluster_type_code:
+      string:
+        computed_optional_required: computed_optional
+        description: Code of type of cluster to be created. Automatically set to the appropriate code by the provider when using a static config.
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator
+            - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: |-
+              stringvalidator.AlsoRequires(path.Expressions{path.MatchRoot("config")}...)
+    network_id:
+      int64:
+        description: The ID of the network.
+        # required IF we specify a network_interface
+        computed_optional_required: required
+    service_plan_id:
+      int64:
+        description: ID of the cluster server service plan.
+        computed_optional_required: optional
+    user_group_id:
+      int64:
+        description: User Group ID for server host
+        computed_optional_required: optional
+    auto_datastore:
+      bool:
+        description: Whether to automatically select a data store.
+        computed_optional_required: optional
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator
+            - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: boolvalidator.ConflictsWith(path.Expressions{path.MatchRoot("datastore_id")}...)
+    ssh_key_pair_id:
+      int64:
+        description: SSH Key Pair ID.
+        computed_optional_required: optional
+    ssh_master_hosts:
+      set:
+        element_type:
+          string: {}
+        computed_optional_required: optional
+        description: IP addresses of the master hosts.
+    ssh_worker_hosts:
+      set:
+        element_type:
+          string: {}
+        computed_optional_required: optional
+        description: IP addresses of the worker hosts.
+    datastore_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: The ID of the specific datastore.
+    datastore_auto_selection:
+      string:
+        computed_optional_required: optional
+        description: Auto selection can be specified as auto or autoCluster (for clusters).
+        validators:
+          - custom:
+              imports:
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              schema_definition: |-
+                stringvalidator.OneOf(
+                "auto",
+                "autoCluster",
+                )
+          - custom:
+              imports:
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.ConflictsWith(path.Expressions{path.MatchRelative().AtParent().AtName("datastore_id")}...)
+    node_count:
+      int64:
+        description: The number of worker nodes to be provisioned. Can be updated to resize the cluster.
+        computed_optional_required: required
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+            schema_definition: int64validator.AtLeast(3)
+    management_net_interface:
+      string:
+        description: The primary management interface name to establish a management bridge (i.e. eth0,ens192,bond0,etc)
+        computed_optional_required: optional
+    ssh_password_wo:
+      string:
+        computed_optional_required: optional
+        description: SSH password (Write Only)
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    ssh_password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: SSH password version. Used to determine if ssh_password_wo has been updated.
+    dynamic_placement:
+      bool:
+        computed_optional_required: optional
+        description: When enabled, Dynamic Placement will automatically balance VMs across cluster hosts based on resource utilization. When disabled, VMs will only migrate to a new host if they are pinned to a specific host or failed over and not running on the preferred host.
+  moves:
+    - cluster: "" # unnest cluster
+    - cluster_id: id
+    - workers_count: workers
+    - cloud.id: cloud_id
+    - group.id: group_id
+    - layout.id: layout_id
+    - task_set_id: workflow_id
+    - server.config.anyof0.oneof0: config_aks
+    - server.config.anyof0.oneof1: config_docker
+    - server.config.anyof0.oneof2: config_eks
+    - server.config.anyof0.oneof3: config_gke
+    - server.config.anyof0.oneof4: config_hks
+    - server.config.anyof0.oneof5: config_hks_hvm
+    - server.config.anyof0.oneof6: config_hvm
+    - server.config.anyof0.oneof7: config_vsphere
+    - server.config.default_repo_account: server.default_repo_account
+    - server.config.image_server: server.image_server
+    - server.volumes.storage_type: server.volumes.storage_type_id
+    - config.template_parameter: config_aks.template_parameters
+    # template stuff
+    - template-config: config
+    - template-create_user: config_hvm.create_user
+    - template-cluster_type_code: cluster_type_code
+    - template-service_plan_id: server.service_plan_id
+    - template-network_id: server.network_interfaces.network_id
+    - template-user_group_id: server.user_group_id
+    - template-ssh_key_pair_id: server.ssh_key_pair_id
+    - template-ssh_master_hosts: server.ssh_master_hosts
+    - template-ssh_worker_hosts: server.ssh_worker_hosts
+    - template-datastore_id: server.volumes.datastore_id
+    - template-datastore_auto_selection: server.volumes.datastore_auto_selection
+    - template-management_net_interface: server.management_net_interface
+    - template-ssh_password_wo: server.ssh_password_wo
+    - template-ssh_password_wo_version: server.ssh_password_wo_version
+    # HKS on HVM
+    - template-node_count: config_hks_hvm.node_count
+    # HVM
+    - template-dynamic_placement: config_hvm.dynamic_placement
+  removes:
+    - stats
+    - code # not used for cluster
+    - accounts
+    - auto_recover_power_state
+    - permissions
+    - category
+    - cloud
+    - containers_count
+    - created_by
+    - datacenter_id
+    - date_created
+    - deployments_count
+    - enable_internal_dns
+    - enabled
+    - external_id
+    - group
+    - integrations
+    - internal_id
+    - inventory_level
+    - jobs_count
+    - last_sync
+    - last_sync_duration
+    - last_updated
+    - layout
+    - location
+    - managed
+    - namespaces_count
+    - next_run_date
+    - owner
+    - pods_count
+    - provision_complete
+    - search_domains
+    - server.labels
+    - servers
+    - service_access
+    - service_access_hash
+    - service_cert
+    - service_cert_hash
+    - service_entry
+    - service_host
+    - service_hostname
+    - service_password
+    - service_password_hash
+    - service_path
+    - service_port
+    - service_token
+    - service_token_hash
+    - service_username
+    - service_version
+    - services_count
+    - site
+    - status
+    - status_date
+    - status_message
+    - success
+    - type
+    - use_agent
+    - user_group
+    - volumes_count
+    - worker_stats
+    - zone
+    - workers
+    - visibility
+    - server.config.anyof0
+    - server.node_count
+    - server.config # its properties were unnested
+    - server.config.generic_cluster_server_configuration # We're using a custom Dynamic config attribute for generic config
+    # Don't include these for now - until we decide to support these cluster types
+    - config_aks
+    - config_docker
+    - config_eks
+    - config_gke
+    - config_hks
+    - config_hks_hvm
+    - config_vsphere
+    # dont need most of these for create
+    - server.network # replaced with management_net_interface
+    - server.network_interfaces.network
+    - server.network_interfaces.ip_address
+    - server.network_interfaces.network_interface_type_id
+    - server.plan
+    - server.server_type
+    - server.user_group
+    - server.ssh_password # we have a write-only template
+    - server.ssh_key_pair
+    - server.ssh_master_hosts # server.ssh_hosts should take care of this for now
+    - server.ssh_worker_hosts # server.ssh_hosts should take care of this for now
+    - server.service_plan_options # don't support setting service plan options for now.
+    - config_hvm.dynamic_placement_mode # replaced with template dynamic_placement (bool)
+  overrides:
+    id:
+      computed_optional_required: computed
+      state_for_unknown: true
+    uuid:
+      state_for_unknown: true
+    service_url:
+      state_for_unknown: true
+    cluster_type_code:
+      state_for_unknown: true
+    cloud_id:
+      computed_optional_required: required
+      requires_replace: true
+    description:
+      computed_optional_required: optional
+    group_id:
+      computed_optional_required: required
+      requires_replace: true
+    layout_id:
+      computed_optional_required: required
+      requires_replace: true
+    labels:
+      description: Array of strings (keywords).
+      computed_optional_required: optional
+    visibility:
+      computed_optional_required: computed_optional
+    workflow_id:
+      computed_optional_required: optional
+      requires_replace: true
+
+    # Server config blocks
+    server:
+      description: Configuration options for the cluster's workers.
+      requires_replace: true
+    server.name:
+      computed_optional_required: optional
+      requires_replace: true
+    server.ssh_port:
+      computed_optional_required: optional
+      requires_replace: true
+    server.ssh_hosts:
+      computed_optional_required: optional
+      requires_replace: true
+    server.ssh_hosts.ip:
+      computed_optional_required: required
+    server.ssh_hosts.name:
+      computed_optional_required: required
+    server.hostname:
+      computed_optional_required: optional
+      requires_replace: true
+    server.network_domain:
+      computed_optional_required: optional
+      requires_replace: true
+    server.ssh_username:
+      computed_optional_required: optional
+      requires_replace: true
+    server.volumes:
+      state_for_unknown: true
+      computed_optional_required: optional
+    server.volumes.id:
+      state_for_unknown: true
+      computed_optional_required: computed
+    server.volumes.size_id:
+      computed_optional_required: optional
+    server.volumes.storage_type_id:
+      computed_optional_required: optional
+    server.network_interfaces:
+      computed_optional_required: optional
+    server.lvm_enabled:
+      computed_optional_required: optional
+      requires_replace: true
+    server.data_device:
+      computed_optional_required: optional
+      requires_replace: true
+    server.security_groups:
+      computed_optional_required: optional
+      requires_replace: true
+    server.tags:
+      computed_optional_required: optional
+      requires_replace: true
+
+    ### HVM
+    config_hvm:
+      computed_optional_required: optional
+    # optional
+    config_hvm.create_user:
+      requires_replace: true
+    config_hvm.default_repo_account:
+      computed_optional_required: optional
+    config_hvm.dynamic_placement_mode:
+      computed_optional_required: optional
+    config_hvm.image_server:
+      computed_optional_required: optional
+    config_hvm.compute_interface_name:
+      computed_optional_required: optional
+    config_hvm.compute_vlans:
+      computed_optional_required: optional
+      requires_replace: true
+    config_hvm.overlay_interface_name:
+      computed_optional_required: optional
+    config_hvm.storage_interface_name:
+      computed_optional_required: optional
+    config_hvm.vcpu_placement_mode:
+      computed_optional_required: optional
+    # required
+    config_hvm.cpu_arch:
+      computed_optional_required: required
+    config_hvm.cpu_model:
+      computed_optional_required: required
+    config_hvm.power_policy:
+      computed_optional_required: required
+
+
+    # TODO: Come back to this when we support hks_hvm
+    ### HKS_HVM
+    # config_hks_hvm:
+    #   computed_optional_required: optional
+    #   requires_replace: true
+    # config_hks_hvm.create_user:
+    #   computed_optional_required: computed_optional
+    #   requires_replace: true
+    #   default: false
+    # config_hks_hvm.node_count:
+    #   write_only: true
+    # config_hks_hvm.pod_cidr:
+    #   computed_optional_required: computed_optional
+    #   default: ""
+    # config_hks_hvm.service_cidr:
+    #   computed_optional_required: computed_optional
+    #   default: ""
+    # config_hks_hvm.resource_pool_id:
+    #   computed_optional_required: required
+    #   requires_replace: true
+    # config_hks_hvm.image_server:
+    #   computed_optional_required: optional
+    #   requires_replace: true
+    # config_hks_hvm.default_repo_account:
+    #   computed_optional_required: optional
+    #   requires_replace: true

--- a/specs/resources/cluster_affinity_group/config.yaml
+++ b/specs/resources/cluster_affinity_group/config.yaml
@@ -1,0 +1,41 @@
+cluster_affinity_group:
+  description: "Manages a Morpheus Cluster Affinity Group resource."
+  templates:
+    description:
+      string:
+        computed_optional_required: optional
+        description: Description of the affinity group.
+  moves:
+    - affinity_group: ""
+    - template-description: description
+  removes:
+    - affinity_type
+    - enabled
+    - pool
+    - ref_id
+    - ref_type
+    - resource_permissions
+    - servers
+    - source
+    - success
+    - tenants
+    - visibility
+  overrides:
+    active:
+      computed_optional_required: computed_optional
+      description: Whether the affinity group is active.
+      default: true
+    cluster_id:
+      computed_optional_required: required
+      description: The ID of the cluster.
+      requires_replace: true
+    description:
+      computed_optional_required: optional
+      description: The description of the affinity group.
+    id:
+      computed_optional_required: computed
+      description: The ID of the cluster affinity group.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the affinity group.

--- a/specs/resources/cluster_namespace/config.yaml
+++ b/specs/resources/cluster_namespace/config.yaml
@@ -1,0 +1,39 @@
+cluster_namespace:
+  description: "Manages a Morpheus Cluster Namespace resource."
+  moves:
+    - namespace: ""
+  removes:
+    - external_id
+    - permissions
+    - region_code
+    - resource_permissions
+    - status
+    - success
+    - visibility
+  overrides:
+    active:
+      computed_optional_required: computed_optional
+      description: Whether the namespace is active.
+      default: true
+      state_for_unknown: true
+    cluster_id:
+      computed_optional_required: required
+      description: The ID of the cluster.
+      requires_replace: true
+    description:
+      computed_optional_required: optional
+      description: The description of the namespace.
+    id:
+      computed_optional_required: computed
+      description: The ID of the cluster namespace.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the namespace. Must be 63 characters or less. Must be lower case.
+      string_length_at_most: 63
+      requires_replace: true
+      validators:
+        - custom:
+            imports:
+              - path: github.com/HPE/terraform-provider-hpe/utils/validators
+            schema_definition: validators.Lowercase()

--- a/specs/resources/container_script/config.yaml
+++ b/specs/resources/container_script/config.yaml
@@ -1,0 +1,60 @@
+container_script:
+  description: "Manages a Morpheus Library Container Script resource."
+  templates:
+    labelsList:
+      list:
+        computed_optional_required: computed_optional
+        element_type:
+          string: {}
+        description: The labels of the library container script.
+  moves:
+    - container_script: ""           # unnest wrapper (components/schemas/scriptCreate.yaml)
+    - template-labelsList: labels
+  removes:
+    - account                        # (components/schemas/script.yaml) read-only
+    - code                           # (components/schemas/script.yaml) read-only
+    - run_as_password                # (components/schemas/scriptCreate.yaml) sensitive
+    - script_method                  # (components/schemas/script.yaml) read-only
+    - script_service                 # (components/schemas/script.yaml) read-only
+    - sort_order                     # (components/schemas/script.yaml) read-only
+    - success                        # (components/schemas/successId.yaml)
+  overrides:
+    category:
+      computed_optional_required: optional
+      description: The category of the library container script.
+    fail_on_error:
+      computed_optional_required: computed_optional
+      description: Whether the script fails on error.
+      state_for_unknown: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the library container script.
+      state_for_unknown: true
+    labels:
+      computed_optional_required: computed_optional
+      description: The labels of the library container script.
+    name:
+      computed_optional_required: required
+      description: The name of the library container script.
+    run_as_user:
+      computed_optional_required: optional
+      description: The user to run the script as.
+    script:
+      computed_optional_required: optional
+      description: The script content.
+    script_phase:
+      computed_optional_required: computed_optional
+      description: The phase of the script.
+      default: "provision"
+    script_type:
+      computed_optional_required: computed_optional
+      description: The type of the script.
+      default: "bash"
+    script_version:
+      computed_optional_required: computed_optional
+      description: The version of the script.
+      default: 1
+    sudo_user:
+      computed_optional_required: computed_optional
+      description: Whether to run the script as sudo.
+      default: false

--- a/specs/resources/datastore/config.yaml
+++ b/specs/resources/datastore/config.yaml
@@ -1,0 +1,152 @@
+datastore:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: optional
+        description: Generic configuration options for the datastore, varies based on the type of datastore.
+    configFromAPI:
+      dynamic:
+        computed_optional_required: computed
+        description: Configuration options for the datastore as returned from the API.
+    configAlletraRansomware:
+      bool:
+        computed_optional_required: computed_optional
+        description: Enable ransomware protection for this datastore.
+    datastoreTypeParent:
+      single_nested:
+        computed_optional_required: required
+        description: The type of datastore.
+    datastoreTypeId:
+      int64:
+        computed_optional_required: required
+        description: The ID of the datastore type.
+    datastoreTypeCode:
+      string:
+        computed_optional_required: required
+        description: The code of the datastore type.
+  moves:
+    - datastore: "" # unnest datastore
+    - account_id: tenant_id
+    - config.nfsdatastore_configuration: config_nfs
+    - config.gfs2datastore_configuration: config_gfs2
+    - config.generic_datastore_configuration: config
+    - config.alletra_mphvmdatastore_configuration: config_alletramp_hvm
+    - template-configAlletraRansomware: config_alletramp_hvm.enable_ransomware
+    - template-datastoreTypeParent: datastore_type
+    - template-datastoreTypeId: datastore_type.id
+    - template-datastoreTypeCode: datastore_type.code
+    - template-configFromAPI: config_from_api
+    - template-config: config
+    - ref_id: associated_resource_id
+    - ref_type: associated_resource_type
+    - zone: cloud
+    - zone_pool: resource_pool
+    - resource_permissions.sites: resource_permissions.groups
+    - resource_permissions.account: resource_permissions.tenant
+    - tenant_permissions.accounts: tenants
+    - ComputeZone: Cloud
+    - ComputeServerGroup: Cluster
+  removes:
+    - success
+    - tenant_permissions
+    - heartbeat_target
+    # Removing this for now since I can't successfully test it
+    - config_gfs2
+    - config_nfs.source_version.default
+    - resource_permissions.morpheus_resource_type
+    - resource_permissions.morpheus_resource_id
+    - resource_permissions.tenant
+    - config_alletramp_hvm.enableransomware
+  overrides:
+    # config_generic:
+    #   description: Generic configuration options for the datastore, varies based on the type of datastore.
+    # conflicts_with: [config_nfs, config_gfs2]
+    associated_resource_type:
+      one_of: [Cloud, Cluster]
+      description: Type of the resource this datastore is associated with, can be 'Cloud' or 'Cluster'
+      computed_optional_required: required
+      requires_replace: true
+    associated_resource_id:
+      description: The ID of the resource this datastore is associated with, e.g. Cloud, Cluster
+      computed_optional_required: required
+      requires_replace: true
+    cloud:
+      description: The Cloud this datastore is associated with
+      computed_optional_required: computed
+    resource_pool:
+      description: The resource pool this datastore is associated with (for some Cloud datastores)
+      computed_optional_required: computed
+    resource_pool.id:
+      computed_optional_required: computed
+    resource_permissions:
+      computed_optional_required: optional
+    resource_permissions.groups:
+      computed_optional_required: optional
+    resource_permissions.groups.id:
+      computed_optional_required: optional
+    resource_permissions.groups.name:
+      computed_optional_required: optional
+    resource_permissions.groups.code:
+      computed_optional_required: optional
+    resource_permissions.all:
+      computed_optional_required: optional
+    resource_permissions.default_target:
+      computed_optional_required: optional
+    resource_permissions.default_store:
+      computed_optional_required: optional
+    resource_permissions.all_groups:
+      computed_optional_required: optional
+    resource_permissions.can_manage:
+      computed_optional_required: optional
+    resource_permissions.plans:
+      computed_optional_required: optional
+    resource_permissions.plans.id:
+      computed_optional_required: optional
+    resource_permissions.plans.name:
+      computed_optional_required: optional
+    resource_permissions.plans.code:
+      computed_optional_required: optional
+    resource_permissions.all_plans:
+      computed_optional_required: optional
+    config_nfs:
+      conflicts_with: [config, config_alletramp_hvm]
+      computed_optional_required: optional
+      requires_replace: true
+    #config_gfs2:
+    #  conflicts_with: [config_nfs, config]
+    #  computed_optional_required: optional
+    #  requires_replace: true
+    #  at_least_one_of: [config_nfs, config_gfs2, config]
+    config_nfs.source_version:
+      one_of: [3, 4]
+      description: NFS version to use when mounting the export, either 3 or 4
+      computed_optional_required: optional
+    config:
+      conflicts_with: [config_nfs, config_alletramp_hvm]
+      computed_optional_required: optional
+      requires_replace: true
+      at_least_one_of: [config_nfs, config, config_alletramp_hvm]
+    config_alletramp_hvm:
+      description: Alletra MP HVM Datastore Configuration
+      conflicts_with: [config_nfs, config]
+      computed_optional_required: optional
+      requires_replace: true
+    config_alletramp_hvm.protocol_type:
+      one_of: [iSCSI, FC]
+      description: Storage protocol type, either iSCSI or FC (Fibre Channel)
+    locations:
+      computed_optional_required: computed
+    visibility:
+      computed_optional_required: computed_optional
+    default_store:
+      computed_optional_required: computed_optional
+    tenants:
+      computed_optional_required: optional
+    tenants.id:
+      computed_optional_required: optional
+    tenants.name:
+      computed_optional_required: optional
+    tenants.default_store:
+      computed_optional_required: optional
+    tenants.default_target:
+      computed_optional_required: optional

--- a/specs/resources/deployment/config.yaml
+++ b/specs/resources/deployment/config.yaml
@@ -1,0 +1,25 @@
+deployment:
+  description: "Manages a Morpheus Deployment resource."
+  moves:
+    - deployment: ""
+  removes:
+    - account_id
+    - date_created
+    - deployment_id
+    - external_id
+    - last_updated
+    - max_versions
+    - success
+    - version_count
+    - versions
+  overrides:
+    description:
+      computed_optional_required: optional
+      description: The description of the deployment.
+    id:
+      computed_optional_required: computed
+      description: The ID of the deployment.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the deployment.

--- a/specs/resources/group/config.yaml
+++ b/specs/resources/group/config.yaml
@@ -1,0 +1,34 @@
+group:
+  templates:
+    cloud_ids:
+      list:
+        computed_optional_required: computed_optional
+        element_type:
+          int64: {}
+        description: List of cloud ids to add to the group
+  includes:
+    - group.id
+    - group.name
+    - group.code
+    - group.labels
+    - group.location
+  moves:
+    - group: "" # unnest group to root
+    - template-cloud_ids: cloud_ids
+  overrides:
+    id:
+      computed_optional_required: computed
+      description: The ID of the group
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: A unique name for the group
+    code:
+      computed_optional_required: optional
+      description: Optional code for use with policies
+    labels:
+      computed_optional_required: computed_optional
+      description: The organization labels associated with the group
+    location:
+      computed_optional_required: optional
+      description: Optional location for the group

--- a/specs/resources/image/config.yaml
+++ b/specs/resources/image/config.yaml
@@ -1,0 +1,98 @@
+image:
+  templates:
+  #   file:
+  #     string:
+  #       computed_optional_required: optional
+  #       description:
+  #         "Path to a local image file to upload"
+    ssh_password_wo:
+      string:
+        computed_optional_required: optional
+        description: SSH password (Write Only)
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+        - custom:
+            imports: 
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    ssh_password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: SSH password version. Used to determine if ssh_password_wo has been updated.
+  removes:
+    - console_keymap
+    - success
+    - date_created
+    - network_interfaces
+    - storage_controllers
+    - volumes
+    - config
+    - locations
+    - storage_provider
+    - user_defined
+    - user_uploaded
+    - last_updated
+    - status
+    - tenant
+    - ssh_password_hash
+    - ssh_password
+    - ssh_key
+    - min_disk_gb
+    - min_ram_gb
+    - raw_size_gb
+    - virtual_image_id
+  moves:
+    - virtual_image: ""
+    - accounts: tenant_ids
+    # - template-file: file
+    - config.azure_reference_virtual_image_configuration: config_azure
+    - os_type: os_type_id
+    - storage_provider.id: storage_provider_id
+    - is_auto_join_domain: auto_join_domain
+    - is_cloud_init: cloud_init
+    - is_force_customization: force_customization
+    - is_sysprep: sysprep
+    - template-ssh_password_wo: ssh_password_wo
+    - template-ssh_password_wo_version: ssh_password_wo_version
+  overrides:
+    description:
+      requires_replace: true
+    tenant_id:
+      computed_optional_required: computed_optional
+    os_type_id:
+      description: ID of the OS Type
+    name:
+      computed_optional_required: required
+    image_type:
+      requires_replace: true
+      computed_optional_required: required
+    storage_provider_id:
+      requires_replace: true
+      description: ID of the storage provider where the image will be uploaded
+    tenant_ids:
+      description: List of tenant IDs
+    config_azure.offer:
+      requires_replace: true
+    config_azure.publisher:
+      requires_replace: true
+    config_azure.sku:
+      requires_replace: true
+    config_azure.version:
+      requires_replace: true
+    url:
+      computed_optional_required: optional
+      requires_replace: true
+      # conflicts_with:
+      #   - "file"
+    owner_id:
+      description: ID of the user which created this image
+    raw_size:
+      description: Size of image in bytes
+    min_ram:
+      computed_optional_required: computed_optional
+      description: Minimal required amount of RAM for provisioning in GB
+    min_disk:
+      computed_optional_required: computed_optional
+      description: Minimal required amount of disk space for provisioning in GB

--- a/specs/resources/instance/config.yaml
+++ b/specs/resources/instance/config.yaml
@@ -1,0 +1,584 @@
+instance:
+  enable_timeouts: true
+  includes:
+    - evars
+    - instance.name
+    - instance.status
+    - instance.instance_context
+    - layout_size
+    - ports
+    - tags
+    - task_set_id
+    - zone_id
+    - instance.site.id
+  templates:
+    id:
+      int64:
+        computed_optional_required: computed
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
+            schema_definition: int64planmodifier.UseStateForUnknown()
+    instance_type_id:
+      int64:
+        computed_optional_required: required
+        description: The type of instance by id we want to fetch.
+    layout_id:
+      int64:
+        computed_optional_required: required
+        description: The layout id for the instance type that you want to provision. i.e. single process or cluster
+    plan_id:
+      int64:
+        computed_optional_required: required
+        description: The id for the memory and storage option pre-configured within Morpheus.
+    volumes:
+      list_nested:
+        computed_optional_required: computed_optional
+        nested_object:
+          attributes:
+          - name: controller_mount_point
+            string:
+              computed_optional_required: computed_optional
+              description: "The controller mount point specification for this volume in the format:\n  \"id:busNumber:typeId:unitNumber\"\nFor new storage controllers the id is passed as -1, so an example value would be:\n  \"-1:1:6:0\"\nwhich translates to id: -1 (new), busNumber: 1, storage controller type id: 6 (SCSI VMware Paravirtual), unit number: 0.\nThe current list of storage controllers is returned for instances and servers for determining existing id values.\nUse /api/provision-types?code=vmware to see the available controllerTypes for vmware.\"\n"
+          - name: datastore_auto_selection
+            string:
+              computed_optional_required: optional
+              description: Auto selection can be specified as auto or autoCluster (for clusters).
+              validators:
+              - custom:
+                  imports:
+                  - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                  schema_definition: |-
+                    stringvalidator.OneOf(
+                    "auto",
+                    "autoCluster",
+                    )
+          - name: datastore_id
+            int64:
+              computed_optional_required: computed_optional
+              description: The ID of the specific datastore.
+          - name: id
+            int64:
+              computed_optional_required: computed
+              description: The id for the LV configuration being created.
+          - name: name
+            string:
+              computed_optional_required: computed_optional
+              description: Name/type of the LV being created.
+          - name: root_volume
+            bool:
+              computed_optional_required: computed_optional
+              description: If set to false then a non-root LV will be created.
+          - name: size
+            int64:
+              computed_optional_required: optional
+              description: Size of the LV to be created in GBs.  Uses default from service plan.
+          - name: size_id
+            int64:
+              computed_optional_required: optional
+              description: Can be used to select pre-existing LV choices from Morpheus.
+          - name: storage_profile
+            string:
+              computed_optional_required: computed_optional
+              description: |-
+                Storage profile code for the volume. The available codes depend on the
+                provision type; query `/api/provision-types` to list the `storageProfiles`
+                for a type. For example, KVM/HVM volumes use cache-mode profiles such as
+                `"kvm-cache-none"` or `"kvm-cache-directsync"` (`/api/provision-types?code=kvm`).
+          - name: storage_type_id
+            int64:
+              computed_optional_required: optional
+              description: Identifier for LV type
+        description: Logical Volume configuration to create additional LVs at provision time
+    availabilityId:
+      string:
+        computed_optional_required: optional
+        description: The id of the AWS zone to provision the instance in.
+    config:
+      dynamic:
+        computed_optional_required: computed_optional
+        description: Configuration object. Settings vary by type.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: validators.ValidObjectMap()
+    configAWS:
+      single_nested:
+        computed_optional_required: optional
+        description: Configuration options for AWS instances.
+    configAzure:
+      single_nested:
+        computed_optional_required: optional
+        description: Configuration options for Azure instances.
+    azureRegion:
+      string:
+        computed_optional_required: optional
+        description: The Azure region to provision the instance in.
+    azuresecurityGroupId:
+      string:
+        computed_optional_required: optional
+        description: The id of the Azure security group to assign the instance to.
+    availabilityOptions:
+      string:
+        computed_optional_required: optional
+        description: The availability option for the instance (zone, set).
+    availabilitySet:
+      string:
+        computed_optional_required: optional
+        description: The availability set to use when availability_options is 'set'.
+    availabilityZone:
+      string:
+        computed_optional_required: optional
+        description: The availability zone to use when availability_options is 'zone'.
+    azurefloatingIp:
+      string:
+        computed_optional_required: optional
+        description: Whether to assign a public IP to the instance (on, off).
+    bootDiagnostics:
+      string:
+        computed_optional_required: optional
+        description: Boot diagnostics setting (enable, enable_custom_storage).
+    diagnosticsStorageAccount:
+      string:
+        computed_optional_required: optional
+        description: The diagnostics storage account to use when boot_diagnostics is 'enable_custom_storage'.
+    osGuestDiagnostics:
+      string:
+        computed_optional_required: optional
+        description: OS guest diagnostics setting (on, off).
+    configHVM:
+      single_nested:
+        computed_optional_required: optional
+        description: Configuration options for HVM instances.
+    configVMware:
+      single_nested:
+        computed_optional_required: optional
+        description: Configuration options for VMware instances.
+    connectionInfo:
+      list:
+        computed_optional_required: computed
+        element_type:
+          string: {}
+        description: List of IP addresses to use when connecting to instance
+    coresPerSocket:
+      int64:
+        computed_optional_required: computed_optional
+        description: The number of cores per socket to use for the instance.  This is only applicable for certain service plans.
+        default:
+          static: 1
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+              schema_definition: |-
+                int64validator.AtLeast(1)
+    createUser:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether to create a user when provisioning the instance.  The default is 'false'
+        default:
+          static: false
+    description:
+      string:
+        computed_optional_required: optional
+        description: A description of the instance.
+    instanceProfile:
+      string:
+        computed_optional_required: optional
+        description: The AWS IAM Profile to use for provisioning.
+    ipPool:
+      int64:
+        computed_optional_required: computed_optional
+        description: id of the ip pool to be used with this network
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("ip_address"),
+                }...)
+    ipAddress:
+      string:
+        computed_optional_required: computed_optional
+        description: The ip address. Not applicable when using DHCP or IP Pools.
+    ipMode:
+      string:
+        computed_optional_required: computed_optional
+        description: The mode for determining ip address. Can be 'static', 'dhcp' or ''.  The default is ''.
+    isEC2:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether this instance is an EC2 instance.  The default is 'false'.
+        default:
+          static: false
+    kmsKeyId:
+      string:
+        computed_optional_required: optional
+        description: The AWS KMS Key ID to use for provisioning.
+    kvmHostId:
+      int64:
+        computed_optional_required: optional
+        description: The id of the KVM host to use for provisioning.
+    layoutSize:
+      int64:
+        computed_optional_required: computed_optional
+        default:
+          static: 1
+        description: Apply a multiply factor of containers/vms within the instance.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+              schema_definition: |-
+                int64validator.OneOf(1)
+    maxCores:
+      int64:
+        computed_optional_required: optional
+        description: The maximum number of cores to use for the instance.  This is only applicable for certain service plans.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+              schema_definition: |-
+                int64validator.AtLeast(1)
+    maxMemory:
+      int64:
+        computed_optional_required: optional
+        description: The maximum amount of memory (in MB) to use for the instance.  This is only applicable for certain service plans.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+              schema_definition: |-
+                int64validator.AtLeast(1)
+    nestedVirtualization:
+      string:
+        computed_optional_required: computed_optional
+        default:
+          static: "off"
+        description: |
+          Enable nested virtualization on the instance. Can be a number of valid string values:
+             "on", "off", "0", "1", "true", "false", "yes", "no", "".  The default is "off".
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              schema_definition: |-
+                stringvalidator.OneOf("on", "off", "0", "1", "true", "false", "yes", "no", "")
+    networkDomainId:
+      int64:
+        computed_optional_required: optional
+        description: The Network Domain ID to provision the instance into.
+    userGroupId:
+      int64:
+        computed_optional_required: optional
+        description: |
+          The id of the user group to associate with the instance. When create_user is enabled on
+          the relevant config_* block, the user group's members can be created as users on the
+          provisioned instance. The user group can only be set at provision time; changing it forces
+          replacement of the instance.
+    networkGroupId:
+      int64:
+        computed_optional_required: computed_optional
+        description: |
+          id of the network group to be used. Cannot be used with 'network_id', will be used instead of 'network_id'
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("network_id"),
+                  path.MatchRelative().AtParent().AtName("subnet_id"),
+                }...)
+    networkId:
+      int64:
+        computed_optional_required: computed_optional
+        description: id of the network to be used.  This cannot be used with 'network_group_id'
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("network_group_id"),
+                  path.MatchRelative().AtParent().AtName("subnet_id"),
+                }...)
+    subnetId:
+      int64:
+        computed_optional_required: computed_optional
+        description: id of the subnet to be used (required by some clouds, e.g. Azure). Cannot be used with 'network_id' or 'network_group_id'.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("network_id"),
+                  path.MatchRelative().AtParent().AtName("network_group_id"),
+                }...)
+    networkInterfaceId:
+      int64:
+        computed_optional_required: computed
+        description: The id of the network interface
+    networkInterfaceTypeId:
+      int64:
+        computed_optional_required: computed_optional
+        description: The id of the type of network interface
+    networkInterfacesOuter:
+      list_nested:
+        computed_optional_required: required
+        description: |
+          The networkInterfaces parameter is for network configuration.
+
+          The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" can be used to see which options are available.
+    networkInterfacesInner:
+      list_nested:
+        computed_optional_required: optional
+        description: |
+          The child_virtual_networks parameter is for network configuration of child virtual networks.  Note that this list
+          cannot be empty, it can either not be specified in HCL or if specified must contain at least one element.
+
+          The Options API "/api/options/zoneNetworkOptions?zoneId=5&provisionTypeId=10" can be used to see which options are available.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/listvalidator
+              schema_definition: |-
+                listvalidator.SizeAtLeast(1)
+    noAgent:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether to skip installing the Morpheus agent on the instance.  The default is 'true'
+        default:
+          static: true
+    primaryInterface:
+      bool:
+        computed_optional_required: computed
+        description: Is this interface the 'primary interface'?
+    publicIpType:
+      string:
+        computed_optional_required: computed_optional
+        description: The type of public IP to associate with the instance.
+        default:
+          static: "subnet"
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              schema_definition: |-
+                stringvalidator.OneOf("subnet", "elasticIp")
+    resourcePoolId:
+      string:
+        computed_optional_required: required
+        description: The id of the resource group to be used, can be prefixed with 'pool-'.  A resource pool group can be specified instead by prefixing its ID wih 'poolGroup-'.
+    securityGroups:
+      list_nested:
+        computed_optional_required: required
+        description: a list of objects containing the ids of the AWS security groups to assign the instance to.
+    securityGroupId:
+      string:
+        computed_optional_required: required
+        description: id of the AWS security group to assign the instance to.
+    servicePlanOptions:
+      single_nested:
+        computed_optional_required: optional
+        description: Custom options for selected service plan - the supported options depend on the service plan selected
+    vmwareFolderID:
+      string:
+        computed_optional_required: optional
+        description: VMware folder external ID.
+    interfaceName:
+      string:
+        computed_optional_required: computed
+        description: The name of the interface, e.g. 'eth0', 'eth1'
+    status:
+      string:
+        computed_optional_required: computed
+        description: |
+          The status of the instance (e.g. running, stopped, failed, unknown). The provider
+          refreshes this on read, so an out-of-band deletion of the underlying VM - which Morpheus
+          reports as "unknown" while retaining the instance record - surfaces as a change on the next plan.
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier
+            schema_definition: stringplanmodifier.UseStateForUnknown()
+  moves:
+    - instance: "" # unnest instance wrapper to root
+    - template-id: id
+    - template-status: status
+    - template-instance_type_id: instance_type_id
+    - template-layout_id: layout_id
+    - template-plan_id: plan_id
+    - template-volumes: volumes
+    - site.id: group_id
+    - zone_id: cloud_id
+    - ports.lb: ports.load_balancer_protocol
+    - template-config: config
+    - template-configHVM: config_hvm
+    - template-createUser: config_hvm.create_user
+    - template-description: description
+    - template-noAgent: config_hvm.no_agent
+    - template-nestedVirtualization: config_hvm.nested_virtualization
+    - template-resourcePoolId: config_hvm.resource_pool_id
+    - template-kvmHostId: config_hvm.kvm_host_id
+    - template-configVMware: config_vmware
+    - template-createUser: config_vmware.create_user
+    - template-noAgent: config_vmware.no_agent
+    - template-nestedVirtualization: config_vmware.nested_virtualization
+    - template-resourcePoolId: config_vmware.resource_pool_id
+    - template-vmwareFolderID: config_vmware.vmware_folder_id
+    - template-configAWS: config_aws
+    - template-availabilityId: config_aws.availability_zone_id
+    - template-instanceProfile: config_aws.instance_profile
+    - template-kmsKeyId: config_aws.kms_key_id
+    - template-publicIpType: config_aws.public_ip_type
+    - template-isEC2: config_aws.is_ec2
+    - template-noAgent: config_aws.no_agent
+    - template-createUser: config_aws.create_user
+    - template-resourcePoolId: config_aws.resource_pool_id
+    - template-securityGroups: security_groups
+    - template-securityGroupId: security_groups.id
+    - security_groups: config_aws.security_groups
+    # Azure static config
+    - template-configAzure: config_azure
+    - template-azureRegion: config_azure.azure_region
+    - template-azuresecurityGroupId: config_azure.azuresecurity_group_id
+    - template-availabilityOptions: config_azure.availability_options
+    - template-availabilitySet: config_azure.availability_set
+    - template-availabilityZone: config_azure.availability_zone
+    - template-azurefloatingIp: config_azure.azurefloating_ip
+    - template-bootDiagnostics: config_azure.boot_diagnostics
+    - template-createUser: config_azure.create_user
+    - template-diagnosticsStorageAccount: config_azure.diagnostics_storage_account
+    - template-osGuestDiagnostics: config_azure.os_guest_diagnostics
+    - template-resourcePoolId: config_azure.resource_pool_id
+    - template-networkDomainId: network_domain_id
+    - template-userGroupId: user_group
+    - template-connectionInfo: connection_info
+    - template-networkInterfacesOuter: network_interfaces
+    - template-ipAddress: network_interfaces.ip_address
+    - template-ipMode: network_interfaces.ip_mode
+    - template-ipPool: network_interfaces.ip_pool
+    - template-layoutSize: layout_size
+    - template-networkGroupId: network_interfaces.network_group_id
+    - template-networkId: network_interfaces.network_id
+    - template-subnetId: network_interfaces.subnet_id
+    - template-networkInterfaceId: network_interfaces.id
+    - template-networkInterfaceTypeId: network_interfaces.network_type_id
+    - template-primaryInterface: network_interfaces.primary_interface
+    - template-interfaceName: network_interfaces.name
+    - template-networkInterfacesInner: network_interfaces_inner
+    - template-ipAddress: network_interfaces_inner.ip_address
+    - template-ipMode: network_interfaces_inner.ip_mode
+    - template-ipPool: network_interfaces_inner.ip_pool
+    - template-networkGroupId: network_interfaces_inner.network_group_id
+    - template-networkId: network_interfaces_inner.network_id
+    - template-subnetId: network_interfaces_inner.subnet_id
+    - template-networkInterfaceId: network_interfaces_inner.id
+    - template-networkInterfaceTypeId: network_interfaces_inner.network_type_id
+    - template-primaryInterface: network_interfaces_inner.primary_interface
+    - template-servicePlanOptions: service_plan_options
+    - template-maxCores: service_plan_options.max_cores
+    - template-coresPerSocket: service_plan_options.cores_per_socket
+    - template-maxMemory: service_plan_options.max_memory
+    - template-interfaceName: network_interfaces_inner.name
+    - network_interfaces_inner: network_interfaces.child_virtual_networks
+  removes:
+    - site
+  overrides:
+    status:
+      computed_optional_required: computed
+      description: |
+        The status of the instance (e.g. running, stopped, failed, unknown). The provider
+        refreshes this on read, so an out-of-band deletion of the underlying VM - which Morpheus
+        reports as "unknown" while retaining the instance record - surfaces as a change on the next plan.
+      state_for_unknown: true
+    config:
+      conflicts_with: [config_hvm, config_vmware, config_aws, config_azure]
+      at_least_one_of: [config, config_hvm, config_vmware, config_aws, config_azure]
+    config_hvm:
+      computed_optional_required: optional
+    config_vmware:
+      computed_optional_required: optional
+    config_aws:
+      computed_optional_required: optional
+      requires_replace: true
+    config_azure:
+      computed_optional_required: optional
+      requires_replace: true
+    config_azure.resource_pool_id:
+      description: The id of the Azure resource group to provision the instance in, can be prefixed with 'pool-'. A resource pool group can be specified instead by prefixing its ID with 'poolGroup-'.
+      computed_optional_required: required
+    config_azure.azure_region:
+      description: The Azure region to provision the instance in.
+      computed_optional_required: optional
+    config_azure.azuresecurity_group_id:
+      description: The id of the Azure security group to assign the instance to.
+      computed_optional_required: optional
+    config_azure.availability_options:
+      description: The availability option for the instance (zone, set).
+      computed_optional_required: optional
+      one_of: ["zone", "set"]
+    config_azure.availability_set:
+      description: The availability set to use when availability_options is 'set'.
+      computed_optional_required: optional
+    config_azure.availability_zone:
+      description: The availability zone to use when availability_options is 'zone'.
+      computed_optional_required: optional
+    config_azure.azurefloating_ip:
+      description: Whether to assign a public IP to the instance (on, off).
+      computed_optional_required: optional
+      one_of: ["on", "off"]
+    config_azure.boot_diagnostics:
+      description: Boot diagnostics setting (enable, enable_custom_storage).
+      computed_optional_required: optional
+      one_of: ["enable", "enable_custom_storage"]
+    config_azure.os_guest_diagnostics:
+      description: OS guest diagnostics setting (on, off).
+      computed_optional_required: optional
+      one_of: ["on", "off"]
+    config_azure.diagnostics_storage_account:
+      description: The diagnostics storage account to use when boot_diagnostics is 'enable_custom_storage'.
+      computed_optional_required: optional
+    config_azure.create_user:
+      description: Whether to create a user when provisioning the instance.
+      computed_optional_required: computed_optional
+      default: true
+    evars:
+      state_for_unknown: true
+    network_domain_id:
+      requires_replace: true
+    user_group:
+      requires_replace: true
+    task_set_id:
+      computed_optional_required: optional
+    ports:
+      computed_optional_required: optional
+    evars.name:
+      computed_optional_required: required
+    evars.value:
+      computed_optional_required: required
+    tags:
+      computed_optional_required: optional
+    tags.name:
+      computed_optional_required: required
+    tags.value:
+      computed_optional_required: required
+    ports.load_balancer_protocol:
+      description: Enable a load balancer and set load balancer protocol. HTTP, HTTPS, or TCP.
+      computed_optional_required: optional
+    network_interfaces.ip_mode:
+      one_of: ["static", "dhcp", ""]
+      default: ""
+    network_interfaces.child_virtual_networks.ip_mode:
+      one_of: ["static", "dhcp", ""]
+      default: ""

--- a/specs/resources/instance_clone/config.yaml
+++ b/specs/resources/instance_clone/config.yaml
@@ -1,0 +1,408 @@
+instance_clone:
+  description: "Clones an instance in HPE Morpheus from a source instance, copying its disk contents."
+  enable_timeouts: true
+  includes:
+    - name
+    - group.id
+    - cloud.id
+    - plan.id
+    - instance.id
+    - instance.status
+  templates:
+    source_instance_id:
+      int64:
+        computed_optional_required: required
+        description: The ID of the source instance to clone.
+    volumesOuter:
+      list_nested:
+        computed_optional_required: required
+        description: |
+          The complete set of volumes for the clone. Replaces the source instance's volumes.
+          Volume specifications define infrastructure parameters only - disk contents are copied from the source.
+    volumeId:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the volume after creation.
+    volumeName:
+      string:
+        computed_optional_required: required
+        description: Name of the volume. Should match the source volume name so content is cloned (KVM matches by name).
+    rootVolume:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether this is the root volume. Exactly one volume must be the root volume.
+    volumeSize:
+      int64:
+        computed_optional_required: required
+        description: Size of the volume in GB. Must be greater than or equal to the source volume size (shrink is silently ignored).
+    datastoreId:
+      int64:
+        computed_optional_required: computed_optional
+        description: The ID of the datastore to place the volume on.
+    storageType:
+      int64:
+        computed_optional_required: computed_optional
+        description: The storage volume type ID.
+    sizeId:
+      int64:
+        computed_optional_required: optional
+        description: Selects a pre-existing logical volume size choice from Morpheus. Not returned by the API.
+    controllerMountPoint:
+      string:
+        computed_optional_required: computed_optional
+        description: |
+          The storage controller mount point for this volume, in the format "id:busNumber:typeId:unitNumber".
+          For a new controller the id is -1, e.g. "-1:1:6:0". Use /api/provision-types?code=vmware for controller types.
+    networkInterfacesOuter:
+      list_nested:
+        computed_optional_required: required
+        description: |
+          The complete set of network interfaces for the clone. Replaces the source instance's network interfaces.
+          Use an ip_mode of pool or dhcp to avoid IP conflicts with the source.
+    networkInterfaceId:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the network interface after creation.
+    networkId:
+      int64:
+        computed_optional_required: required
+        description: The ID of the network to attach the interface to.
+    ipMode:
+      string:
+        computed_optional_required: computed_optional
+        description: The mode for determining the IP address. One of static, dhcp or an empty string (IP pool).
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              schema_definition: |-
+                stringvalidator.OneOf(
+                "",
+                "static",
+                "dhcp",
+                )
+    ipAddress:
+      string:
+        computed_optional_required: computed_optional
+        description: The static IP address. Only applicable when ip_mode is static.
+    networkInterfaceTypeId:
+      int64:
+        computed_optional_required: computed_optional
+        description: The ID of the network interface type.
+    macAddress:
+      string:
+        computed_optional_required: optional
+        description: A specific MAC address to assign to the interface. Not returned by the API.
+    childVirtualNetworksOuter:
+      list_nested:
+        computed_optional_required: computed_optional
+        description: |
+          Child virtual network interfaces for this interface. Only applies to provision types that
+          support virtual interfaces (the VMware family). The Options API
+          /api/options/zoneNetworkOptions can be used to see which types support this.
+    config:
+      dynamic:
+        computed_optional_required: computed_optional
+        description: |
+          Generic configuration overrides as a free-form object, merged key-by-key over the source
+          instance's configuration at clone time. Use this for clouds or keys not covered by the typed
+          config_* blocks (for example custom_options or Google Cloud keys). Cannot be
+          combined with a typed config_* block.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: validators.ValidObjectMap()
+    configAWS:
+      single_nested:
+        computed_optional_required: optional
+        description: Configuration overrides for AWS clones, merged over the source instance's configuration.
+    configAzure:
+      single_nested:
+        computed_optional_required: optional
+        description: Configuration overrides for Azure clones, merged over the source instance's configuration.
+    configHVM:
+      single_nested:
+        computed_optional_required: optional
+        description: Configuration overrides for HVM (Morpheus VM) clones, merged over the source instance's configuration.
+    configVMware:
+      single_nested:
+        computed_optional_required: optional
+        description: Configuration overrides for VMware clones, merged over the source instance's configuration.
+    createUser:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether to create a user when provisioning the clone.  The default is 'false'
+        default:
+          static: false
+    noAgent:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether to skip installing the Morpheus agent on the clone.  The default is 'true'
+        default:
+          static: true
+    nestedVirtualization:
+      string:
+        computed_optional_required: computed_optional
+        default:
+          static: "off"
+        description: |
+          Enable nested virtualization on the clone. Can be a number of valid string values:
+             "on", "off", "0", "1", "true", "false", "yes", "no", "".  The default is "off".
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              schema_definition: |-
+                stringvalidator.OneOf("on", "off", "0", "1", "true", "false", "yes", "no", "")
+    resourcePoolId:
+      string:
+        computed_optional_required: required
+        description: The id of the resource group to be used, can be prefixed with 'pool-'.  A resource pool group can be specified instead by prefixing its ID wih 'poolGroup-'.
+    kvmHostId:
+      int64:
+        computed_optional_required: optional
+        description: The id of the KVM host to use for provisioning.
+    vmwareFolderID:
+      string:
+        computed_optional_required: optional
+        description: VMware folder external ID.
+    availabilityId:
+      string:
+        computed_optional_required: optional
+        description: The id of the AWS zone to provision the clone in.
+    instanceProfile:
+      string:
+        computed_optional_required: optional
+        description: The AWS IAM Profile to use for provisioning.
+    kmsKeyId:
+      string:
+        computed_optional_required: optional
+        description: The AWS KMS Key ID to use for provisioning.
+    publicIpType:
+      string:
+        computed_optional_required: computed_optional
+        description: The type of public IP to associate with the clone.
+        default:
+          static: "subnet"
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              schema_definition: |-
+                stringvalidator.OneOf("subnet", "elasticIp")
+    isEC2:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether this clone is an EC2 instance.  The default is 'false'.
+        default:
+          static: false
+    securityGroups:
+      list_nested:
+        computed_optional_required: required
+        description: a list of objects containing the ids of the AWS security groups to assign the clone to.
+    securityGroupId:
+      string:
+        computed_optional_required: required
+        description: id of the AWS security group to assign the clone to.
+    azureRegion:
+      string:
+        computed_optional_required: optional
+        description: The Azure region to provision the clone in.
+    azuresecurityGroupId:
+      string:
+        computed_optional_required: optional
+        description: The id of the Azure security group to assign the clone to.
+    availabilityOptions:
+      string:
+        computed_optional_required: optional
+        description: The availability option for the clone (zone, set).
+    availabilitySet:
+      string:
+        computed_optional_required: optional
+        description: The availability set to use when availability_options is 'set'.
+    availabilityZone:
+      string:
+        computed_optional_required: optional
+        description: The availability zone to use when availability_options is 'zone'.
+    azurefloatingIp:
+      string:
+        computed_optional_required: optional
+        description: Whether to assign a public IP to the clone (on, off).
+    bootDiagnostics:
+      string:
+        computed_optional_required: optional
+        description: Boot diagnostics setting (enable, enable_custom_storage).
+    diagnosticsStorageAccount:
+      string:
+        computed_optional_required: optional
+        description: The diagnostics storage account to use when boot_diagnostics is 'enable_custom_storage'.
+    osGuestDiagnostics:
+      string:
+        computed_optional_required: optional
+        description: OS guest diagnostics setting (on, off).
+    userGroupId:
+      int64:
+        computed_optional_required: optional
+        description: The id of the user group to associate with the clone. Can only be set at clone time; changing it forces replacement.
+    storageProfile:
+      string:
+        computed_optional_required: computed_optional
+        description: |-
+          Storage profile code for the volume. The available codes depend on the
+          provision type; query `/api/provision-types` to list the `storageProfiles`
+          for a type. For example, KVM/HVM volumes use cache-mode profiles such as
+          `"kvm-cache-none"` or `"kvm-cache-directsync"` (`/api/provision-types?code=kvm`).
+  moves:
+    - instance: ""                              # unnest the instance read wrapper to root
+    - template-source_instance_id: source_instance_id
+    - group.id: group_id
+    - cloud.id: cloud_id
+    - plan.id: plan_id
+    - template-userGroupId: user_group
+    - template-config: config
+    - template-configHVM: config_hvm
+    - template-createUser: config_hvm.create_user
+    - template-noAgent: config_hvm.no_agent
+    - template-nestedVirtualization: config_hvm.nested_virtualization
+    - template-resourcePoolId: config_hvm.resource_pool_id
+    - template-kvmHostId: config_hvm.kvm_host_id
+    - template-configVMware: config_vmware
+    - template-createUser: config_vmware.create_user
+    - template-noAgent: config_vmware.no_agent
+    - template-nestedVirtualization: config_vmware.nested_virtualization
+    - template-resourcePoolId: config_vmware.resource_pool_id
+    - template-vmwareFolderID: config_vmware.vmware_folder_id
+    - template-configAWS: config_aws
+    - template-availabilityId: config_aws.availability_zone_id
+    - template-instanceProfile: config_aws.instance_profile
+    - template-kmsKeyId: config_aws.kms_key_id
+    - template-publicIpType: config_aws.public_ip_type
+    - template-isEC2: config_aws.is_ec2
+    - template-noAgent: config_aws.no_agent
+    - template-createUser: config_aws.create_user
+    - template-resourcePoolId: config_aws.resource_pool_id
+    - template-securityGroups: security_groups
+    - template-securityGroupId: security_groups.id
+    - security_groups: config_aws.security_groups
+    - template-configAzure: config_azure
+    - template-azureRegion: config_azure.azure_region
+    - template-azuresecurityGroupId: config_azure.azuresecurity_group_id
+    - template-availabilityOptions: config_azure.availability_options
+    - template-availabilitySet: config_azure.availability_set
+    - template-availabilityZone: config_azure.availability_zone
+    - template-azurefloatingIp: config_azure.azurefloating_ip
+    - template-bootDiagnostics: config_azure.boot_diagnostics
+    - template-createUser: config_azure.create_user
+    - template-diagnosticsStorageAccount: config_azure.diagnostics_storage_account
+    - template-osGuestDiagnostics: config_azure.os_guest_diagnostics
+    - template-resourcePoolId: config_azure.resource_pool_id
+    - template-volumesOuter: volumes
+    - template-volumeId: volumes.id
+    - template-volumeName: volumes.name
+    - template-rootVolume: volumes.root_volume
+    - template-volumeSize: volumes.size
+    - template-datastoreId: volumes.datastore_id
+    - template-storageType: volumes.storage_type
+    - template-sizeId: volumes.size_id
+    - template-controllerMountPoint: volumes.controller_mount_point
+    - template-storageProfile: volumes.storage_profile
+    - template-networkInterfacesOuter: network_interfaces
+    - template-networkInterfaceId: network_interfaces.id
+    - template-networkId: network_interfaces.network_id
+    - template-ipMode: network_interfaces.ip_mode
+    - template-ipAddress: network_interfaces.ip_address
+    - template-networkInterfaceTypeId: network_interfaces.network_interface_type_id
+    - template-macAddress: network_interfaces.mac_address
+    - template-childVirtualNetworksOuter: network_interfaces.child_virtual_networks
+    - template-networkInterfaceId: network_interfaces.child_virtual_networks.id
+    - template-networkId: network_interfaces.child_virtual_networks.network_id
+    - template-ipMode: network_interfaces.child_virtual_networks.ip_mode
+    - template-ipAddress: network_interfaces.child_virtual_networks.ip_address
+    - template-networkInterfaceTypeId: network_interfaces.child_virtual_networks.network_interface_type_id
+    - template-macAddress: network_interfaces.child_virtual_networks.mac_address
+  removes:
+    - group                                 # flattened to group_id
+    - cloud                                 # flattened to cloud_id
+    - plan                                  # flattened to plan_id
+  overrides:
+    source_instance_id:
+      computed_optional_required: required
+      description: The ID of the source instance to clone.
+      requires_replace: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the cloned instance.
+      state_for_unknown: true
+    status:
+      computed_optional_required: computed
+      description: The status of the cloned instance.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: A unique name for the new cloned instance. Used to retrieve the clone after the asynchronous clone operation.
+    group_id:
+      computed_optional_required: optional
+      description: The ID of the group to clone into. Defaults to the source instance's group.
+      requires_replace: true
+    cloud_id:
+      computed_optional_required: optional
+      description: The ID of the cloud to clone into. Defaults to the source instance's cloud.
+      requires_replace: true
+    plan_id:
+      computed_optional_required: optional
+      description: The ID of the service plan override for the clone. Defaults to the source instance's service plan.
+    user_group:
+      requires_replace: true
+    config:
+      conflicts_with: [config_hvm, config_vmware, config_aws, config_azure]
+    config_hvm:
+      computed_optional_required: optional
+      requires_replace: true
+    config_vmware:
+      computed_optional_required: optional
+      requires_replace: true
+    config_aws:
+      computed_optional_required: optional
+      requires_replace: true
+    config_azure:
+      computed_optional_required: optional
+      requires_replace: true
+    config_azure.resource_pool_id:
+      description: The id of the Azure resource group to provision the clone in, can be prefixed with 'pool-'. A resource pool group can be specified instead by prefixing its ID with 'poolGroup-'.
+      computed_optional_required: required
+    config_azure.azure_region:
+      description: The Azure region to provision the clone in.
+      computed_optional_required: optional
+    config_azure.azuresecurity_group_id:
+      description: The id of the Azure security group to assign the clone to.
+      computed_optional_required: optional
+    config_azure.availability_options:
+      description: The availability option for the clone (zone, set).
+      computed_optional_required: optional
+      one_of: ["zone", "set"]
+    config_azure.availability_set:
+      description: The availability set to use when availability_options is 'set'.
+      computed_optional_required: optional
+    config_azure.availability_zone:
+      description: The availability zone to use when availability_options is 'zone'.
+      computed_optional_required: optional
+    config_azure.azurefloating_ip:
+      description: Whether to assign a public IP to the clone (on, off).
+      computed_optional_required: optional
+      one_of: ["on", "off"]
+    config_azure.boot_diagnostics:
+      description: Boot diagnostics setting (enable, enable_custom_storage).
+      computed_optional_required: optional
+      one_of: ["enable", "enable_custom_storage"]
+    config_azure.os_guest_diagnostics:
+      description: OS guest diagnostics setting (on, off).
+      computed_optional_required: optional
+      one_of: ["on", "off"]
+    config_azure.diagnostics_storage_account:
+      description: The diagnostics storage account to use when boot_diagnostics is 'enable_custom_storage'.
+      computed_optional_required: optional
+    config_azure.create_user:
+      description: Whether to create a user when provisioning the clone.
+      computed_optional_required: computed_optional
+      default: true

--- a/specs/resources/instance_snapshot/config.yaml
+++ b/specs/resources/instance_snapshot/config.yaml
@@ -1,0 +1,98 @@
+instance_snapshot:
+  description: "Manages an instance snapshot in HPE Morpheus."
+  enable_timeouts: true
+  templates:
+    instance_id:
+      int64:
+        computed_optional_required: required
+        description: The ID of the instance to snapshot.
+    retain_on_delete:
+      bool:
+        computed_optional_required: optional
+        description: When true, the snapshot is left in Morpheus when the resource is destroyed (removed from Terraform state only). Defaults to false.
+    cloud_id:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the cloud (zone) the snapshot belongs to.
+  moves:
+    - snapshot: ""                          # unnest read wrapper (response wraps in 'snapshot')
+    - template-instance_id: instance_id
+    - template-retain_on_delete: retain_on_delete
+    - template-cloud_id: cloud_id
+  removes:
+    - zone                                  # (components/schemas/snapshot.yaml) - nested object; exposed as cloud_id
+    - snapshot_files                        # (components/schemas/snapshot.yaml) - nested array; exposed on the data source
+    - process_ids                           # (snapshotInstance 200 response) - async tracking, not resource state
+    - success                               # API response wrapper
+  overrides:
+    id:
+      computed_optional_required: computed
+      description: The ID of the snapshot.
+      state_for_unknown: true
+    instance_id:
+      computed_optional_required: required
+      description: The ID of the instance to snapshot.
+      requires_replace: true
+    name:
+      computed_optional_required: required
+      description: The name of the snapshot.
+      requires_replace: true
+    description:
+      computed_optional_required: optional
+      description: A description of the snapshot.
+      requires_replace: true
+    memory_snapshot:
+      computed_optional_required: computed_optional
+      description: Whether to include the instance's memory in the snapshot.
+      requires_replace: true
+    for_export:
+      computed_optional_required: computed_optional
+      description: When true, the snapshot is created in an exportable form (a full, standalone disk image) rather than a lightweight in-place snapshot. Supported on MVM/KVM and VMware. Defaults to false.
+      requires_replace: true
+    retain_on_delete:
+      computed_optional_required: optional
+      description: When true, the snapshot is left in Morpheus when the resource is destroyed (removed from Terraform state only). Defaults to false.
+    status:
+      computed_optional_required: computed
+      description: The status of the snapshot.
+      state_for_unknown: true
+    external_id:
+      computed_optional_required: computed
+      description: The external (cloud-provider) identifier of the snapshot.
+      state_for_unknown: true
+    date_created:
+      computed_optional_required: computed
+      description: When the snapshot was created.
+      state_for_unknown: true
+    cloud_id:
+      computed_optional_required: computed
+      description: The ID of the cloud (zone) the snapshot belongs to.
+      state_for_unknown: true
+    state:
+      computed_optional_required: computed
+      description: The lifecycle state of the snapshot.
+      state_for_unknown: true
+    snapshot_type:
+      computed_optional_required: computed
+      description: The type of the snapshot (cloud/provider specific).
+      state_for_unknown: true
+    snapshot_created:
+      computed_optional_required: computed
+      description: When the snapshot was taken on the underlying platform.
+      state_for_unknown: true
+    datastore:
+      computed_optional_required: computed
+      description: The datastore the snapshot resides on, if reported by the platform.
+      state_for_unknown: true
+    parent_snapshot:
+      computed_optional_required: computed
+      description: The ID of the parent snapshot in the snapshot lineage, if any.
+      state_for_unknown: true
+    currently_active:
+      computed_optional_required: computed
+      description: Whether this snapshot is the currently active snapshot for the instance.
+      state_for_unknown: true
+    for_backup:
+      computed_optional_required: computed
+      description: Whether the snapshot was created as part of a backup operation.
+      state_for_unknown: true

--- a/specs/resources/load_balancer/config.yaml
+++ b/specs/resources/load_balancer/config.yaml
@@ -1,0 +1,190 @@
+load_balancer:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: computed_optional
+        description: Configuration object with parameters that vary by load balancer type.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: validators.ValidObjectMap()
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                dynamicvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRoot("config_haproxy"),
+                  path.MatchRoot("config_nsxt"),
+                }...)
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                dynamicvalidator.ExactlyOneOf(path.Expressions{
+                  path.MatchRoot("config"),
+                  path.MatchRoot("config_haproxy"),
+                  path.MatchRoot("config_nsxt"),
+                }...)
+    config_haproxy:
+      single_nested: {}
+    config_nsxt:
+      single_nested: {}
+    admin_state:
+      bool: {}
+    size:
+      string: {}
+    tier1_gateway:
+      string: {}
+    log_level:
+      string: {}
+    plan_id:
+      int64: {}
+    pool:
+      string: {}
+    type_code:
+      string: {}
+    group_id:
+      int64: {}
+    permissions_all:
+      bool:
+        computed_optional_required: computed_optional
+        description: Pass true to allow access to all groups
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                boolvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("groups"),
+                }...)
+    permissions_groups:
+      list:
+        computed_optional_required: computed_optional
+        description: Array of group IDs that are allowed access
+        element_type:
+          int64: {}
+
+  moves:
+    - load_balancer: "" # unnest wrapper (components/schemas/loadBalancerCreate.yaml)
+    - template-type_code: type_code # replace read-only type object with string for type code
+    - template-group_id: group_id # site.id from create payload (not in OpenAPI spec)
+    - zone.id: cloud_id # (components/schemas/loadBalancer.yaml)
+    - template-config_haproxy: config_haproxy
+    - template-config_nsxt: config_nsxt
+    - template-admin_state: config_nsxt.admin_state
+    - template-size: config_nsxt.size
+    - template-tier1_gateway: config_nsxt.tier1_gateway
+    - template-log_level: config_nsxt.log_level
+    - template-plan_id: config_haproxy.plan_id
+    - template-pool: config_haproxy.pool
+    - resource_permissions: permissions # (components/schemas/loadBalancerCreate.yaml)
+    - template-permissions_all: permissions.all
+    - template-permissions_groups: permissions.groups
+    - template-config: config
+
+  removes:
+    - account_id # (components/schemas/loadBalancer.yaml)
+    - admin_port # (components/schemas/loadBalancer.yaml)
+    - allow_vip_entry # (components/schemas/loadBalancer.yaml)
+    - api_port # (components/schemas/loadBalancer.yaml)
+    - cloud # (components/schemas/loadBalancer.yaml)
+    - zone # (components/schemas/loadBalancer.yaml)
+    - credential # (components/schemas/loadBalancer.yaml)
+    - date_created # (components/schemas/loadBalancer.yaml)
+    - enabled # (components/schemas/loadBalancer.yaml)
+    - external_id # (components/schemas/loadBalancer.yaml)
+    - external_ip # (components/schemas/loadBalancer.yaml)
+    - host # (components/schemas/loadBalancer.yaml)
+    - instance_price # (components/schemas/loadBalancer.yaml)
+    - internal_ip # (components/schemas/loadBalancer.yaml)
+    - ip # (components/schemas/loadBalancer.yaml)
+    - load_balancer_id # path parameter, redundant with id
+    - last_updated # (components/schemas/loadBalancer.yaml)
+    - owner # (components/schemas/loadBalancer.yaml)
+    - password # (components/schemas/loadBalancer.yaml)
+    - password_hash # (components/schemas/loadBalancer.yaml)
+    - pool_name # (components/schemas/loadBalancer.yaml)
+    - port # (components/schemas/loadBalancer.yaml)
+    - resource_permission # (components/schemas/loadBalancer.yaml)
+    - server_name # (components/schemas/loadBalancer.yaml)
+    - site # (components/schemas/loadBalancerCreate.yaml)
+    - ssl_cert # (components/schemas/loadBalancer.yaml)
+    - ssl_enabled # (components/schemas/loadBalancer.yaml)
+    - type # (components/schemas/loadBalancer.yaml)
+    - username # (components/schemas/loadBalancer.yaml)
+    - uuid # (components/schemas/loadBalancer.yaml)
+    - vip_pools # (components/schemas/loadBalancer.yaml)
+    - virtual_service_name # (components/schemas/loadBalancer.yaml)
+    - permissions.all_plans # (components/schemas/resourcePermissions.yaml)
+    - permissions.plans # (components/schemas/resourcePermissions.yaml)
+    - permissions.sites # replaced by template (components/schemas/resourcePermissions.yaml)
+
+  overrides:
+    id:
+      state_for_unknown: true
+    cloud_id:
+      description: The ID of the cloud associated with the load balancer
+      computed_optional_required: optional
+      requires_replace: true # REVIEW: likely immutable after creation
+    config_haproxy:
+      description: Configuration for HAProxy container load balancer type
+      computed_optional_required: optional
+      conflicts_with: [type_code]
+    config_nsxt:
+      description: Configuration for NSX-T load balancer type
+      computed_optional_required: optional
+      conflicts_with: [config, config_haproxy]
+      requires_replace: true
+    config_nsxt.admin_state:
+      description: If true then Admin State will be active/enabled.
+      computed_optional_required: optional
+      requires_replace: true
+    config_nsxt.size:
+      description: Supported Values are "SMALL", "MEDIUM", "LARGE"
+      computed_optional_required: optional
+      one_of: [SMALL, MEDIUM, LARGE]
+      requires_replace: true
+    config_nsxt.tier1_gateway:
+      description: Provider ID of the Tier-1 Gateway. provider_id can be found in the hpe_morpheus_network_router datasource.
+      computed_optional_required: required
+      requires_replace: true
+    config_nsxt.log_level:
+      description: Supported Values are "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "ALERT", "EMERGENCY"
+      computed_optional_required: optional
+      one_of: [DEBUG, INFO, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY]
+      requires_replace: true
+    config_haproxy.plan_id:
+      description: The ID of the service plan for the HAProxy load balancer
+      computed_optional_required: required
+    config_haproxy.pool:
+      description: The ID of the network pool for the HAProxy load balancer
+      computed_optional_required: required
+    description:
+      computed_optional_required: computed_optional
+    group_id:
+      description: The ID of the group associated with the load balancer
+      computed_optional_required: optional
+      requires_replace: true # REVIEW: likely immutable after creation
+      write_only: true # not returned in GET response
+    name:
+      computed_optional_required: required
+      string_length_at_most: 32
+    network_server_id:
+      computed_optional_required: optional
+      requires_replace: true # REVIEW: not in update schema, cannot be changed after creation
+      write_only: true # not returned in GET response
+    permissions:
+      description: Resource permissions for the load balancer
+      computed_optional_required: computed_optional
+    type_code:
+      description: The type code of the load balancer (e.g. haproxyContainer)
+      computed_optional_required: optional
+      requires_replace: true
+    visibility:
+      computed_optional_required: computed_optional
+      one_of: [public, private]
+      default: public

--- a/specs/resources/load_balancer_monitor/config.yaml
+++ b/specs/resources/load_balancer_monitor/config.yaml
@@ -1,0 +1,143 @@
+load_balancer_monitor:
+  templates:
+    config:
+      single_nested: {}
+    monitor:
+      single_nested: {}
+    monitor_id:
+      int64: {}
+    monitor_config:
+      dynamic: {}
+    monitor_password_wo:
+      string:
+        computed_optional_required: optional
+        description: The password for authenticated health checks (Write Only)
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    monitor_password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: Monitor password version. Used to determine if monitor_password_wo has been updated.
+        requires_replace: true
+
+  moves:
+    - load_balancer_monitor: "" # unnest wrapper (components/schemas/loadBalancerMonitorCreate.yaml)
+    - template-config: config
+    - template-monitor: config.monitor
+    - template-monitor_id: config.monitor.id
+    - template-monitor_config: config.monitor_config
+    - template-monitor_password_wo: monitor_password_wo
+    - template-monitor_password_wo_version: monitor_password_wo_version
+
+  removes:
+    # API response fields (components/schemas/successMessage.yaml)
+    - msg
+    - success
+    # Read-only fields (components/schemas/loadBalancerMonitor.yaml)
+    - alias_address
+    - category
+    - code
+    - created_by
+    - date_created
+    - disabled_data
+    - enabled
+    - external_id
+    - internal_id
+    - last_updated
+    - load_balancer
+    - monitor_adaptive
+    - monitor_password_hash
+    - monitor_reverse
+    - monitor_source
+    - monitor_transparent
+    - monitor_password
+    - partition
+    - status
+    - status_date
+    - status_message
+    - visibility
+
+  overrides:
+    id:
+      state_for_unknown: true
+    load_balancer_id:
+      description: The ID of the load balancer associated with the monitor
+      computed_optional_required: required
+      requires_replace: true
+    name:
+      description: The name of the load balancer monitor
+      computed_optional_required: required
+    description:
+      description: A description of the load balancer monitor
+      computed_optional_required: computed_optional
+    monitor_type:
+      description: >-
+        The monitor protocol type. Valid values are: dns, http, https, icmp,
+        ldap, mssql, passive, tcp, udp. The provider maps these to the
+        appropriate load-balancer-specific value based on the load balancer
+        type (e.g. http becomes LBHttpMonitorProfile for NSX-T).
+      computed_optional_required: computed_optional
+    monitor_interval:
+      description: The interval in seconds at which the monitor checks target health
+      computed_optional_required: computed_optional
+    monitor_timeout:
+      description: The maximum time in seconds to wait for a health check response before marking as failed
+      computed_optional_required: computed_optional
+    send_data:
+      description: The request body to send to the target during health checks
+      computed_optional_required: computed_optional
+    send_version:
+      description: The HTTP protocol version to use in health check requests (e.g. HTTP/1.0, HTTP/1.1)
+      computed_optional_required: computed_optional
+    send_type:
+      description: The HTTP method for the health check request (e.g. GET, POST, HEAD)
+      computed_optional_required: computed_optional
+    receive_data:
+      description: The expected response body string to validate in the health check response
+      computed_optional_required: computed_optional
+    receive_code:
+      description: A comma-separated list of HTTP status codes expected for a successful health check (e.g. "200" or "200,201")
+      computed_optional_required: computed_optional
+    monitor_username:
+      description: The username for authenticated health checks
+      computed_optional_required: computed_optional
+      requires_replace: true
+    monitor_destination:
+      description: The target path or URL for the health check (e.g. /health)
+      computed_optional_required: computed_optional
+    fall_count:
+      description: The number of consecutive failed health checks before marking the target as down
+      computed_optional_required: computed_optional
+    rise_count:
+      description: The number of consecutive successful health checks before marking the target as up
+      computed_optional_required: computed_optional
+    alias_port:
+      description: An alternative port to use for health checks if different from the target port
+      computed_optional_required: computed_optional
+    data_length:
+      description: The length in bytes of the data payload for ICMP echo requests
+      computed_optional_required: computed_optional
+    max_retry:
+      description: The number of retries before the health check is considered failed
+      computed_optional_required: computed_optional
+    extra_config:
+      description: Additional monitor extension configuration. Used with NSX-V load balancer monitors to provide extension parameters for specific monitor types (e.g. http, https, tcp, udp, dns, mssql, ldap). This field is write-only and not returned by the API.
+      computed_optional_required: optional
+    config:
+      description: Configuration object with parameters that vary by monitor type
+      computed_optional_required: computed_optional
+    config.monitor:
+      description: Parent monitor reference. Allows this monitor to inherit from an existing monitor.
+      computed_optional_required: computed_optional
+    config.monitor.id:
+      description: The ID of the parent monitor. If set, the monitorType of the new monitor will be inherited from the parent monitor.
+      computed_optional_required: computed_optional
+    config.monitor_config:
+      description: Free-form monitor configuration content.
+      computed_optional_required: computed_optional

--- a/specs/resources/load_balancer_pool/config.yaml
+++ b/specs/resources/load_balancer_pool/config.yaml
@@ -1,0 +1,120 @@
+load_balancer_pool:
+  templates:
+    config:
+      dynamic:
+        description: Generic pool configuration object. Settings vary by load balancer type.
+        computed_optional_required: optional
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: validators.ValidObjectMap()
+    partition:
+      string:
+        computed_optional_required: optional
+        description: Partition identifier
+        write_only: true
+
+  moves:
+    - load_balancer_pool: ""                             # unnest wrapper
+    - config.nsxtload_balancer_pool_config_object: config_nsxt  # extract NSX-T config from anyOf
+    - template-partition: partition                              # inject write-only partition field
+    - template-config: config                            # replace anyOf shell with dynamic fallback (must be last)
+
+  removes:
+    # API response envelope fields
+    - success                                            # (components/schemas/successMessage.yaml)
+    - msg                                                # (components/schemas/successMessage.yaml)
+    # Sub-resource collections (managed via separate resources)
+    - nodes                                              # (components/schemas/loadBalancerPool.yaml)
+    - monitors                                           # (components/schemas/loadBalancerPool.yaml)
+    - members                                            # (components/schemas/loadBalancerPool.yaml)
+    # Read-only metadata
+    - created_by                                         # (components/schemas/loadBalancerPool.yaml)
+    - date_created                                       # (components/schemas/loadBalancerPool.yaml)
+
+  overrides:
+    id:
+      state_for_unknown: true
+    load_balancer_id:
+      description: The ID of the load balancer this pool belongs to
+      computed_optional_required: required
+      requires_replace: true
+    name:
+      description: The name of the load balancer pool
+      computed_optional_required: required
+    description:
+      description: A description of the load balancer pool
+      computed_optional_required: computed_optional
+    vip_balance:
+      description: The balance algorithm for the pool (e.g. ROUND_ROBIN, LEAST_CONNECTION, IP_HASH)
+      computed_optional_required: computed_optional
+    vip_sticky:
+      description: Session persistence mode for the pool
+      computed_optional_required: computed_optional
+    vip_client_ip_mode:
+      description: VIP client IP mode
+      computed_optional_required: computed_optional
+    min_active:
+      description: Minimum number of active pool members
+      computed_optional_required: computed_optional
+    port:
+      description: The port number for the pool
+      computed_optional_required: computed_optional
+    config:
+      conflicts_with: [config_nsxt]
+    config_nsxt:
+      conflicts_with: [config]
+    # Read-only computed fields (virtual server pattern — keep all API response fields)
+    allow_nat:
+      computed_optional_required: computed
+    allow_snat:
+      computed_optional_required: computed
+    category:
+      computed_optional_required: computed
+    down_action:
+      computed_optional_required: computed
+    enabled:
+      computed_optional_required: computed
+    error_penalty:
+      computed_optional_required: computed
+    external_id:
+      computed_optional_required: computed
+    health_penalty:
+      computed_optional_required: computed
+    health_score:
+      computed_optional_required: computed
+    internal_id:
+      computed_optional_required: computed
+    last_updated:
+      computed_optional_required: computed
+    load_balancer:
+      computed_optional_required: computed
+    max_queue_depth:
+      computed_optional_required: computed
+    max_queue_time:
+      computed_optional_required: computed
+    min_in_service:
+      computed_optional_required: computed
+    min_up_action:
+      computed_optional_required: computed
+    min_up_monitor:
+      computed_optional_required: computed
+    number_active:
+      computed_optional_required: computed
+    number_in_service:
+      computed_optional_required: computed
+    performance_score:
+      computed_optional_required: computed
+    port_type:
+      computed_optional_required: computed
+    ramp_time:
+      computed_optional_required: computed
+    security_penalty:
+      computed_optional_required: computed
+    status:
+      computed_optional_required: computed
+    vip_server_ip_mode:
+      computed_optional_required: computed
+    visibility:
+      computed_optional_required: computed

--- a/specs/resources/load_balancer_profile/config.yaml
+++ b/specs/resources/load_balancer_profile/config.yaml
@@ -1,0 +1,132 @@
+load_balancer_profile:
+  templates:
+    # https_redirect is modelled as a bool in Terraform; the provider converts
+    # it to the API "on"/"off" string. Replaces the auto-extracted string enum.
+    config_http_https_redirect:
+      bool:
+        computed_optional_required: computed_optional
+        description: >-
+          Whether to redirect HTTP traffic to HTTPS. Maps to the API "on"/"off"
+          value; leave unset for no redirection. When false ("off"), set
+          redirect_address.
+    # Single top-level tags set, shared across all service types (the provider
+    # injects it into the active config block). Replaces the per-block tags.
+    tags:
+      set_nested:
+        computed_optional_required: optional
+        description: NSX-T tags applied to the profile.
+        nested_object:
+          attributes:
+            - name: name
+              string:
+                computed_optional_required: required
+                description: Tag name.
+            - name: value
+              string:
+                computed_optional_required: optional
+                description: Tag scope/value.
+
+  moves:
+    - load_balancer_profile: ""                                          # unnest envelope wrapper
+    # Extract the 8 typed config variants from the anyOf shell to top level
+    - config.httpload_balancer_profile_config: config_http
+    - config.fast_tcpload_balancer_profile_config: config_fast_tcp
+    - config.fast_udpload_balancer_profile_config: config_fast_udp
+    - config.cookie_persistence_load_balancer_profile_config: config_cookie_persistence
+    - config.source_ippersistence_load_balancer_profile_config: config_source_ip_persistence
+    - config.generic_persistence_load_balancer_profile_config: config_generic_persistence
+    - config.client_sslload_balancer_profile_config: config_client_ssl
+    - config.server_sslload_balancer_profile_config: config_server_ssl
+    # Replace the string https_redirect with the bool template (must run after
+    # config_http is extracted above)
+    - template-config_http_https_redirect: config_http.https_redirect
+    # Inject the single top-level tags set
+    - template-tags: tags
+
+  removes:
+    - config                                                             # empty anyOf shell (no dynamic fallback)
+    - success                                                            # API response envelope
+    - msg                                                                # API response envelope
+    - created_by                                                         # object the provider does not surface
+    # profileType is auto-injected by the provider from service_type
+    - config_http.profile_type
+    - config_fast_tcp.profile_type
+    - config_fast_udp.profile_type
+    - config_cookie_persistence.profile_type
+    - config_source_ip_persistence.profile_type
+    - config_generic_persistence.profile_type
+    - config_client_ssl.profile_type
+    - config_server_ssl.profile_type
+    # Per-block tags replaced by the single top-level tags set
+    - config_http.tags
+    - config_fast_tcp.tags
+    - config_fast_udp.tags
+    - config_cookie_persistence.tags
+    - config_source_ip_persistence.tags
+    - config_generic_persistence.tags
+    - config_client_ssl.tags
+    - config_server_ssl.tags
+
+  overrides:
+    id:
+      state_for_unknown: true
+    load_balancer_id:
+      computed_optional_required: required
+      requires_replace: true
+      description: The ID of the load balancer this profile belongs to.
+    name:
+      computed_optional_required: required
+      description: The name of the load balancer profile.
+    description:
+      computed_optional_required: optional
+      description: A description of the load balancer profile.
+    service_type:
+      computed_optional_required: required
+      requires_replace: true
+      description: >-
+        The profile service type. Determines which config_* block applies.
+      one_of:
+        - LBHttpProfile
+        - LBFastTcpProfile
+        - LBFastUdpProfile
+        - LBCookiePersistenceProfile
+        - LBSourceIpPersistenceProfile
+        - LBGenericPersistenceProfile
+        - LBClientSslProfile
+        - LBServerSslProfile
+    tags:
+      computed_optional_required: optional
+      description: NSX-T tags applied to the profile.
+    # cookie_type is exposed with friendly values; the provider translates
+    # session<->LBSessionCookieTime and persistence<->LBPersistenceCookieTime.
+    config_cookie_persistence.cookie_type:
+      one_of: [session, persistence]
+      description: >-
+        Cookie time type: `session` (LBSessionCookieTime) or `persistence`
+        (LBPersistenceCookieTime). Required when cookie_mode is INSERT.
+    # The 8 config blocks are mutually exclusive (only the one matching
+    # service_type may be set).
+    config_http:
+      computed_optional_required: optional
+      conflicts_with: [config_fast_tcp, config_fast_udp, config_cookie_persistence, config_source_ip_persistence, config_generic_persistence, config_client_ssl, config_server_ssl]
+    config_fast_tcp:
+      computed_optional_required: optional
+      conflicts_with: [config_http, config_fast_udp, config_cookie_persistence, config_source_ip_persistence, config_generic_persistence, config_client_ssl, config_server_ssl]
+    config_fast_udp:
+      computed_optional_required: optional
+      conflicts_with: [config_http, config_fast_tcp, config_cookie_persistence, config_source_ip_persistence, config_generic_persistence, config_client_ssl, config_server_ssl]
+    config_cookie_persistence:
+      computed_optional_required: optional
+      conflicts_with: [config_http, config_fast_tcp, config_fast_udp, config_source_ip_persistence, config_generic_persistence, config_client_ssl, config_server_ssl]
+    config_source_ip_persistence:
+      computed_optional_required: optional
+      conflicts_with: [config_http, config_fast_tcp, config_fast_udp, config_cookie_persistence, config_generic_persistence, config_client_ssl, config_server_ssl]
+    config_generic_persistence:
+      computed_optional_required: optional
+      conflicts_with: [config_http, config_fast_tcp, config_fast_udp, config_cookie_persistence, config_source_ip_persistence, config_client_ssl, config_server_ssl]
+    config_client_ssl:
+      computed_optional_required: optional
+      conflicts_with: [config_http, config_fast_tcp, config_fast_udp, config_cookie_persistence, config_source_ip_persistence, config_generic_persistence, config_server_ssl]
+    config_server_ssl:
+      computed_optional_required: optional
+      conflicts_with: [config_http, config_fast_tcp, config_fast_udp, config_cookie_persistence, config_source_ip_persistence, config_generic_persistence, config_client_ssl]

--- a/specs/resources/load_balancer_virtual_server/config.yaml
+++ b/specs/resources/load_balancer_virtual_server/config.yaml
@@ -1,0 +1,203 @@
+load_balancer_virtual_server:
+  templates:
+    config:
+      dynamic:
+        description: Generic virtual server configuration object. Settings vary by load balancer type.
+        computed_optional_required: optional
+    int64_requires_replace:
+      int64:
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
+            schema_definition: |-
+                     int64planmodifier.RequiresReplace(), // force new
+    pool_id:
+      int64:
+        computed_optional_required: optional
+        description: The ID of the load balancer pool to assign to this virtual server.
+    config_nsxt:
+      single_nested:
+        computed_optional_required: optional
+        description: NSX-T virtual server configuration
+    config_nsxt_application_profile:
+      int64:
+        computed_optional_required: optional
+        description: The Load Balancer Application Profile ID (`NetworkLoadBalancerProfile`). Use `/api/options/nsxt/nsxtLBVirtualServerApplicationProfile?loadBalancerId={id}&loadBalancerInstance.vipProtocol={protocol}` to list available options.
+    config_nsxt_persistence:
+      string:
+        computed_optional_required: optional
+        description: "Session persistence mode. Available values depend on protocol. For HTTP: `SOURCE_IP`, `COOKIE`, or empty string (disabled). For TCP/UDP: `SOURCE_IP` or empty string (disabled). Use `/api/options/nsxt/nsxtLBPersistence?loadBalancerId={id}&loadBalancerInstance.vipProtocol={protocol}` to list available options."
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+              schema_definition: |-
+                stringvalidator.OneOf("SOURCE_IP", "COOKIE", "")
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: |-
+                validators.RequiresNonEmptyStringAlsoRequiresInt64At("persistence_profile")
+    config_nsxt_persistence_profile:
+      int64:
+        computed_optional_required: optional
+        description: The persistence profile ID (`NetworkLoadBalancerProfile`). Required when `persistence` is set to a non-empty value (`SOURCE_IP` or `COOKIE`). Use `/api/options/nsxt/nsxtLBPersistenceProfile?loadBalancerId={id}&config.persistence={value}` to list available options.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.AlsoRequires(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("persistence"),
+                }...)
+    config_nsxt_ssl_client_profile:
+      int64:
+        computed_optional_required: optional
+        description: The SSL client profile ID (`NetworkLoadBalancerProfile`). Only applicable when `ssl_cert` is set to a non-zero value. Use `/api/options/nsxt/nsxtLBClientSSlProfiles?loadBalancerId={id}` to list available options.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: |-
+                validators.RequiresNonZeroInt64At("ssl_cert")
+    config_nsxt_ssl_server_profile:
+      int64:
+        computed_optional_required: optional
+        description: The SSL server profile ID (`NetworkLoadBalancerProfile`). Only applicable when `ssl_server_cert` is set to a non-zero value. Use `/api/options/nsxt/nsxtLBServerSSlProfiles?loadBalancerId={id}` to list available options.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: |-
+                validators.RequiresNonZeroInt64At("ssl_server_cert")
+  moves:
+    - load_balancer_instance: "" # unnest wrapper (components/schemas/loadBalancerInstance.yaml)
+    - template-config: config         # replace generic oneOf shell with dynamic type
+    - template-int64_requires_replace: load_balancer_id  # replace Number with Int64 + RequiresReplace
+    - template-pool_id: pool_id      # flat pool ID replaces nested pool object
+    - template-config_nsxt: config_nsxt  # NSX-T config as explicit template (supports validators)
+    - template-config_nsxt_application_profile: config_nsxt.application_profile
+    - template-config_nsxt_persistence: config_nsxt.persistence
+    - template-config_nsxt_persistence_profile: config_nsxt.persistence_profile
+    - template-config_nsxt_ssl_client_profile: config_nsxt.ssl_client_profile
+    - template-config_nsxt_ssl_server_profile: config_nsxt.ssl_server_profile
+  removes:
+    - success                # API response wrapper
+    - pool                   # replaced by pool_id
+  overrides:
+    id:
+      state_for_unknown: true
+    load_balancer_id:
+      computed_optional_required: required
+      description: The ID of the load balancer this virtual server belongs to
+    vip_name:
+      computed_optional_required: computed_optional
+      description: VIP Name
+    description:
+      computed_optional_required: optional
+      description: Description
+    vip_address:
+      computed_optional_required: computed_optional
+      description: VIP Address. Required when `vip_pool` is not set.
+    vip_port:
+      computed_optional_required: computed_optional
+      description: VIP Port
+    vip_protocol:
+      computed_optional_required: computed_optional
+      description: "VIP Protocol. For NSX-T load balancers, this is the virtual server type. Allowed values: `http`, `tcp`, `udp`."
+      one_of: [http, tcp, udp]
+    vip_hostname:
+      computed_optional_required: optional
+      description: VIP Hostname
+    vip_pool:
+      computed_optional_required: optional
+      description: Network Pool ID for automatic VIP address allocation. When set, a VIP address will be leased from this pool and `vip_address` does not need to be specified.
+    ssl_cert:
+      computed_optional_required: optional
+      description: SSL Client Certificate ID. Use `0` for none.
+    ssl_server_cert:
+      computed_optional_required: optional
+      description: SSL Server Certificate ID. Use `0` for none.
+    config:
+      computed_optional_required: optional
+      description: Generic virtual server configuration object. Settings vary by load balancer type.
+      requires_replace: true
+      conflicts_with: [config_nsxt] # mutually exclusive with NSX-T config
+    config_nsxt:
+      requires_replace: true
+      conflicts_with: [config] # mutually exclusive with generic config
+    # Read-only computed attributes (components/schemas/loadBalancerInstance.yaml)
+    load_balancer:
+      computed_optional_required: computed
+      description: The parent load balancer
+    instance:
+      computed_optional_required: computed
+    internal_id:
+      computed_optional_required: computed
+    external_id:
+      computed_optional_required: computed
+    date_created:
+      computed_optional_required: computed
+    last_updated:
+      computed_optional_required: computed
+    active:
+      computed_optional_required: computed
+    sticky:
+      computed_optional_required: computed
+    ssl_enabled:
+      computed_optional_required: computed
+    external_address:
+      computed_optional_required: computed
+    backend_port:
+      computed_optional_required: computed
+    vip_type:
+      computed_optional_required: computed_optional
+      description: >-
+        The VIP type. This is primarily used by NSX Advanced Load Balancer (AVI)
+        to distinguish between normal, parent (shared), and child VIPs. It has
+        no effect for NSX-T load balancers and will be null.
+      requires_replace: true
+    vip_scheme:
+      computed_optional_required: computed
+    vip_mode:
+      computed_optional_required: computed
+    vip_sticky:
+      computed_optional_required: computed
+    vip_balance:
+      computed_optional_required: computed
+    service_port:
+      computed_optional_required: computed
+    source_address:
+      computed_optional_required: computed
+    ssl_mode:
+      computed_optional_required: computed
+    ssl_redirect_mode:
+      computed_optional_required: computed
+    vip_shared:
+      computed_optional_required: computed
+    vip_direct_address:
+      computed_optional_required: computed
+    server_name:
+      computed_optional_required: computed
+    pool_name:
+      computed_optional_required: computed
+    removing:
+      computed_optional_required: computed
+    vip_source:
+      computed_optional_required: computed
+    extra_config:
+      computed_optional_required: computed
+    service_access:
+      computed_optional_required: computed
+    network_id:
+      computed_optional_required: computed
+    subnet_id:
+      computed_optional_required: computed
+    external_port_id:
+      computed_optional_required: computed
+    status:
+      computed_optional_required: computed
+    vip_status:
+      computed_optional_required: computed

--- a/specs/resources/monitoring_alert/config.yaml
+++ b/specs/resources/monitoring_alert/config.yaml
@@ -1,0 +1,42 @@
+monitoring_alert:
+  description: "Manages a Morpheus Monitoring Alert resource."
+  moves:
+    - alert: ""
+  removes:
+    - all_apps
+    - apps
+    - check_groups
+    - checks
+    - contacts
+    - date_created
+    - groups
+    - last_updated
+    - success
+  overrides:
+    active:
+      computed_optional_required: computed_optional
+      description: Whether the alert is active.
+      default: true
+    all_checks:
+      computed_optional_required: computed_optional
+      description: Trigger for all checks.
+      default: false
+    all_groups:
+      computed_optional_required: computed_optional
+      description: Trigger for all check groups.
+      default: false
+    id:
+      computed_optional_required: computed
+      description: The ID of the monitoring alert.
+      state_for_unknown: true
+    min_duration:
+      computed_optional_required: computed_optional
+      description: Duration in minutes of the delay before sending notifications.
+      default: 0
+    min_severity:
+      computed_optional_required: computed_optional
+      description: Severity level threshold for sending notifications.
+      default: "critical"
+    name:
+      computed_optional_required: required
+      description: The name of the monitoring alert.

--- a/specs/resources/monitoring_check/config.yaml
+++ b/specs/resources/monitoring_check/config.yaml
@@ -1,0 +1,80 @@
+monitoring_check:
+  description: "Manages a Morpheus Monitoring Check resource."
+  templates:
+    check_type_id:
+      int64:
+        computed_optional_required: required
+        description: The check type ID.
+  moves:
+    - check: ""
+    - template-check_type_id: check_type_id
+  removes:
+    - account
+    - api_key
+    - availability
+    - check_agent
+    - check_socket
+    - check_spec
+    - check_type
+    - config
+    - container
+    - create_incident
+    - created_by
+    - date_created
+    - deleted
+    - elastic_check
+    - end_date
+    - health
+    - last_box_stats
+    - last_check_status
+    - last_error
+    - last_error_date
+    - last_message
+    - last_metric
+    - last_run_date
+    - last_stats
+    - last_success_date
+    - last_timer
+    - last_updated
+    - last_warning_date
+    - muted
+    - my_sql_check
+    - next_run_date
+    - outage_time
+    - postgres_check
+    - push_check
+    - snmpcheck
+    - sql_check
+    - start_date
+    - success
+    - web_check
+  overrides:
+    active:
+      computed_optional_required: computed_optional
+      description: Whether the check is active.
+      default: true
+    check_interval:
+      computed_optional_required: computed_optional
+      description: Check interval in seconds.
+      default: 300
+    check_type_id:
+      computed_optional_required: required
+      description: The check type ID.
+    description:
+      computed_optional_required: optional
+      description: The description of the monitoring check.
+    id:
+      computed_optional_required: computed
+      description: The ID of the monitoring check.
+      state_for_unknown: true
+    in_uptime:
+      computed_optional_required: computed_optional
+      description: Whether the check affects account-wide availability calculations.
+      default: true
+    name:
+      computed_optional_required: required
+      description: The name of the monitoring check.
+    severity:
+      computed_optional_required: computed_optional
+      description: Severity level threshold for sending notifications.
+      default: "critical"

--- a/specs/resources/monitoring_group/config.yaml
+++ b/specs/resources/monitoring_group/config.yaml
@@ -1,0 +1,51 @@
+monitoring_group:
+  description: "Manages a Morpheus Monitoring Group (Check Group) resource."
+  moves:
+    - check_group: ""
+  removes:
+    - account
+    - active
+    - availability
+    - check_type
+    - checks
+    - create_incident
+    - created_by
+    - date_created
+    - health
+    - history
+    - instance
+    - last_check_status
+    - last_error
+    - last_error_date
+    - last_metric
+    - last_run_date
+    - last_success_date
+    - last_timer
+    - last_updated
+    - last_warning_date
+    - muted
+    - outage_time
+    - success
+  overrides:
+    description:
+      computed_optional_required: optional
+      description: The description of the monitoring group.
+    id:
+      computed_optional_required: computed
+      description: The ID of the monitoring group.
+      state_for_unknown: true
+    in_uptime:
+      computed_optional_required: computed_optional
+      description: Whether the group affects account-wide availability calculations.
+      default: true
+    min_happy:
+      computed_optional_required: computed_optional
+      description: Minimum number of checks that must be happy to keep the group healthy.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the monitoring group.
+    severity:
+      computed_optional_required: computed_optional
+      description: Maximum severity level this group can incur on an incident when failing.
+      state_for_unknown: true

--- a/specs/resources/network/config.yaml
+++ b/specs/resources/network/config.yaml
@@ -1,0 +1,144 @@
+network:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: computed_optional
+        description: Configuration object. Settings vary by type.
+        validators:
+        - custom:
+            imports:
+            - path: github.com/HPE/terraform-provider-hpe/utils/validators
+            schema_definition: validators.ValidObjectMap()
+    name:
+      string:
+        computed_optional_required: required
+        description: Network name.
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier
+            schema_definition: stringplanmodifier.RequiresReplace(), // force new
+    cidr:
+      string:
+        computed_optional_required: optional
+        description: Network CIDR.
+        plan_modifiers:
+        - custom:
+            schema_definition: stringplanmodifier.RequiresReplace(), // force new
+    cidr_ipv6:
+      string:
+        computed_optional_required: optional
+        description: Network IPv6 CIDR.
+        plan_modifiers:
+        - custom:
+            schema_definition: stringplanmodifier.RequiresReplace(), // force new
+    id:
+      int64:
+        computed_optional_required: computed
+        description: Network id
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
+            schema_definition: int64planmodifier.UseStateForUnknown()
+    network_domain_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: Network domain id
+    zone_pool_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: Zone pool id
+    network_proxy_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: Network proxy id
+    type_id:
+      int64:
+        computed_optional_required: required
+        description: Network type id
+    pool_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: Network Pool ID
+    pool_ipv6_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: IPv6 Network Pool ID
+    group_id:
+      int64:
+        computed_optional_required: required
+        description: Group (site) id
+    cloud_id:
+      int64:
+        computed_optional_required: required
+        description: Cloud (zone) id
+        plan_modifiers:
+        - custom:
+            schema_definition: int64planmodifier.RequiresReplace(), // force new
+    tenant_ids:
+      set:
+        computed_optional_required: computed_optional
+        description: List of tenant account ids that are allowed access
+        element_type:
+          int64: {}
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier
+            schema_definition: setplanmodifier.RequiresReplace(), // force new
+    resource_permissions:
+      single_nested:
+        computed_optional_required: computed
+        attributes:
+          - name: all
+            bool:
+              computed_optional_required: computed
+              description: Pass true to allow access all groups
+          - name: group_ids
+            set:
+              computed_optional_required: computed
+              description: Array of group (site) IDs that are allowed access
+              element_type:
+                int64: {}
+  includes:
+    - network.active
+    - network.allow_static_override
+    - network.appliance_url_proxy_bypass
+    - network.assign_public_ip
+    - network.description
+    - network.dhcp_server
+    - network.dhcp_server_ipv6
+    - network.display_name
+    - network.dns_primary
+    - network.dns_primary_ipv6
+    - network.dns_secondary
+    - network.dns_secondary_ipv6
+    - network.gateway
+    - network.gateway_ipv6
+    - network.ipv4enabled
+    - network.ipv6enabled
+    - network.labels
+    - network.netmask_ipv6
+    - network.no_proxy
+    - network.search_domains
+    - network.switch_id
+    - network.vlan_id
+    - network.visibility
+  moves:
+    - network: "" # unnest network wrapper to root
+    - template-config: config
+    - template-name: name
+    - template-cidr: cidr
+    - template-cidr_ipv6: cidr_ipv6
+    - template-id: id
+    - template-network_domain_id: network_domain_id
+    - template-zone_pool_id: zone_pool_id
+    - template-network_proxy_id: network_proxy_id
+    - template-type_id: type_id
+    - template-pool_id: pool_id
+    - template-pool_ipv6_id: pool_ipv6_id
+    - template-group_id: group_id
+    - template-cloud_id: cloud_id
+    - template-tenant_ids: tenant_ids
+    - template-resource_permissions: resource_permissions

--- a/specs/resources/network_dhcp_server/config.yaml
+++ b/specs/resources/network_dhcp_server/config.yaml
@@ -1,0 +1,54 @@
+network_dhcp_server:
+  templates:
+    config:
+      dynamic:
+        description: Generic DHCP Server Configuration
+        computed_optional_required: optional
+
+  moves:
+    - network_dhcp_server: ""                    # unnest wrapper (components/schemas/networkDhcpServerCreate.yaml)
+    - server_id: network_integration_id               # (components/schemas/networkDhcpServerCreate.yaml)
+    - config.nsxdhcpserver_configuration: config_nsxt
+    - config_nsxt.preferred_edge_node1: config_nsxt.active_edge_node
+    - config_nsxt.preferred_edge_node2: config_nsxt.standby_edge_node
+    - template-config: config
+
+  removes:
+    - date_created                               # (components/schemas/networkDhcpServer.yaml)
+    - last_updated                               # (components/schemas/networkDhcpServer.yaml)
+    - provider_id                                # (components/schemas/networkDhcpServer.yaml)
+    - external_id                                # (components/schemas/networkDhcpServer.yaml)
+    - owner                                      # (components/schemas/networkDhcpServer.yaml)
+    - network_server                             # (components/schemas/networkDhcpServer.yaml)
+    - success
+
+  overrides:
+    id:
+      state_for_unknown: true
+    network_integration_id:
+      computed_optional_required: required
+      requires_replace: true
+      description: The ID of the network integration this DHCP server belongs to
+    name:
+      computed_optional_required: required
+    server_ip_address:
+      computed_optional_required: required
+      description: Server address for the DHCP server
+    lease_time:
+      computed_optional_required: computed_optional
+      default: 86400
+      description: Lease time in seconds for the DHCP server
+    config:
+      conflicts_with: [config_nsxt]
+    config_nsxt:
+      computed_optional_required: optional
+      description: Configuration object with parameters that vary by type
+    config_nsxt.edge_cluster:
+      computed_optional_required: computed_optional
+      description: Edge Cluster
+    config_nsxt.active_edge_node:
+      computed_optional_required: computed_optional
+      description: Active Edge Node
+    config_nsxt.standby_edge_node:
+      computed_optional_required: computed_optional
+      description: Standby Edge Node

--- a/specs/resources/network_firewall_rule/config.yaml
+++ b/specs/resources/network_firewall_rule/config.yaml
@@ -1,0 +1,62 @@
+network_firewall_rule:
+  templates:
+    priority:
+      int64:
+        computed_optional_required: computed_optional
+        description: The priority of the network firewall rule.
+  moves:
+    - rule: ""                       # unnest wrapper — MUST BE FIRST
+    - server_id: network_integration_id
+    - rule_group: rule_group_id      # (components/schemas/networkFirewallRuleCreate.yaml)
+    - config.application: application  # (components/schemas/networkFirewallRuleCreate.yaml)
+    - config.profile: profile          # (components/schemas/networkFirewallRuleCreate.yaml)
+    - template-priority: priority    # override String → Int64
+  removes:
+    - success                        # (components/schemas/successId.yaml)
+    - source_type                    # (components/schemas/networkFirewallRule.yaml) read-only
+    - destination_type               # (components/schemas/networkFirewallRule.yaml) read-only
+    - group_name                     # (components/schemas/networkFirewallRule.yaml) read-only
+    - applications                   # (components/schemas/networkFirewallRule.yaml) read-only
+    - profiles                       # (components/schemas/networkFirewallRule.yaml) read-only
+    - applied_targets                # (components/schemas/networkFirewallRule.yaml) read-only
+    - config                         # (components/schemas/networkFirewallRuleCreate.yaml) empty after promotion
+  overrides:
+    id:
+      state_for_unknown: true
+    network_integration_id:
+      computed_optional_required: required
+      requires_replace: true
+      description: The ID of the network integration
+    name:
+      computed_optional_required: required
+      description: The name of the network firewall rule.
+    description:
+      computed_optional_required: computed_optional
+      description: The description of the network firewall rule.
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the firewall rule is enabled.
+    direction:
+      computed_optional_required: computed_optional
+      description: The traffic direction for the firewall rule (e.g. ingress, egress).
+    policy:
+      computed_optional_required: computed_optional
+      description: The policy action for the firewall rule (e.g. accept, deny, drop).
+    rule_group_id:
+      computed_optional_required: computed_optional
+      description: The ID of the firewall rule group this rule belongs to.
+    sources:
+      computed_optional_required: computed_optional
+      description: Source addresses or groups for the firewall rule.
+    destinations:
+      computed_optional_required: computed_optional
+      description: Destination addresses or groups for the firewall rule.
+    scopes:
+      computed_optional_required: computed_optional
+      description: The scopes applied to the firewall rule.
+    application:
+      computed_optional_required: computed_optional
+      description: Application identifiers for the firewall rule.
+    profile:
+      computed_optional_required: computed_optional
+      description: Profile identifiers for the firewall rule.

--- a/specs/resources/network_firewall_rule_group/config.yaml
+++ b/specs/resources/network_firewall_rule_group/config.yaml
@@ -1,0 +1,33 @@
+network_firewall_rule_group:
+  description: "Manages a network firewall rule group resource in Morpheus."
+  moves:
+    - rule_group: "" # unnest wrapper (components/schemas/networkFirewallRuleGroupCreate.yaml)
+    - server_id: network_integration_id
+  removes:
+    - success # (POST response wrapper)
+    - rules # (components/schemas/networkFirewallRuleGroup.yaml)
+  overrides:
+    id:
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: Network firewall rule group name
+    description:
+      computed_optional_required: computed_optional
+      description: Network firewall rule group description
+    external_type:
+      computed_optional_required: required
+      requires_replace: true
+      description: The external type of the firewall rule group (e.g. SecurityPolicy)
+    priority:
+      computed_optional_required: computed_optional
+      description: Network firewall rule group priority
+    group_layer:
+      computed_optional_required: computed_optional
+      requires_replace: true
+      description: The group layer of the firewall rule group
+    network_integration_id:
+      computed_optional_required: required
+      requires_replace: true
+      description: The ID of the network integration
+

--- a/specs/resources/network_group/config.yaml
+++ b/specs/resources/network_group/config.yaml
@@ -1,0 +1,31 @@
+network_group:
+  description: "Manages a Morpheus Network Group resource."
+  moves:
+    - network_group: ""
+  removes:
+    - networks
+    - subnets
+    - success
+    - tenants
+  overrides:
+    active:
+      computed_optional_required: computed_optional
+      description: Whether the network group is active.
+      default: true
+      state_for_unknown: true
+    description:
+      computed_optional_required: optional
+      description: The description of the network group.
+    id:
+      computed_optional_required: computed
+      description: The ID of the network group.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the network group.
+    visibility:
+      computed_optional_required: computed_optional
+      description: The visibility of the network group.
+      default: "private"
+      one_of: [public, private]
+      state_for_unknown: true

--- a/specs/resources/network_pool/config.yaml
+++ b/specs/resources/network_pool/config.yaml
@@ -1,0 +1,93 @@
+network_pool:
+  description: "Manages a Morpheus Network Pool resource."
+  templates:
+    typeCode:
+      string:
+        computed_optional_required: required
+        description: The code of the network pool type. Default available codes are morpheus, morpheusipv6, vcd, and nsx-t. Plugins can add additional pool types.
+    ipRanges:
+      object:
+        computed_optional_required: required
+        description: The IPv4 IP address pool IP ranges.
+        attribute_types:
+          - name: starting_address
+            string: {}
+          - name: ending_address
+            string: {}
+  moves:
+    - network_pool: ""
+    - template-typeCode: type_code
+    - template-ipRanges: ip_ranges
+  removes:
+    - account
+    - boot_file
+    - category
+    - code
+    - config
+    - dhcp_ip
+    - display_name
+    - dns_search_path
+    - dns_servers
+    - dns_suffix_list
+    - external_id
+    - host_prefix
+    - http_proxy
+    - internal_id
+    - parent_id
+    - parent_type
+    - pool_group
+    - ref_id
+    - ref_type
+    - tftp_server
+    - type
+    - type_id
+  overrides:
+    dhcp_server:
+      computed_optional_required: computed_optional
+      description: Whether DHCP server is enabled.
+    dns_domain:
+      computed_optional_required: computed_optional
+      description: The DNS domain for the network pool.
+    free_count:
+      computed_optional_required: computed
+      description: The number of free IPs in the pool.
+      plan_modifiers:
+        - custom:
+            imports:
+              - path: github.com/HPE/terraform-provider-hpe/utils/modifiers
+              - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: |-
+              modifiers.Int64UseStateForUnknownUnless(path.Root("ip_ranges"))
+    gateway:
+      computed_optional_required: computed_optional
+      description: The gateway IP address.
+    id:
+      computed_optional_required: computed
+      description: The ID of the network pool.
+      state_for_unknown: true
+    ip_count:
+      computed_optional_required: computed
+      description: The total number of IPs in the pool.
+      plan_modifiers:
+        - custom:
+            imports:
+              - path: github.com/HPE/terraform-provider-hpe/utils/modifiers
+              - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: |-
+              modifiers.Int64UseStateForUnknownUnless(path.Root("ip_ranges"))
+    name:
+      computed_optional_required: required
+      description: The name of the network pool.
+    netmask:
+      computed_optional_required: computed_optional
+      description: The netmask.
+    pool_enabled:
+      computed_optional_required: computed
+      description: Whether the pool is enabled.
+      state_for_unknown: true
+    subnet_address:
+      computed_optional_required: computed_optional
+      description: The subnet IP address.
+    type_code:
+      computed_optional_required: required
+      requires_replace: true

--- a/specs/resources/network_pool_server/config.yaml
+++ b/specs/resources/network_pool_server/config.yaml
@@ -1,0 +1,134 @@
+network_pool_server:
+  description: "Manages a Morpheus Network Pool Server (IPAM integration) resource."
+  templates:
+    type_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: The pool server type ID.
+    type_code:
+      string:
+        computed_optional_required: computed_optional
+        description: The pool server type code.
+    inventory_existing:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether to inventory existing networks from the pool server.
+    credential_id:
+      int64:
+        computed_optional_required: optional
+        description: The ID of a stored credential to use for authentication.
+    service_password_wo:
+      string:
+        computed_optional_required: optional
+        description: The service password for authentication.
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    service_password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: Service password version. Used to determine if service_password_wo has been updated.
+  moves:
+    - network_pool_server: ""
+    - template-type_id: type_id
+    - template-type_code: type_code
+    - template-inventory_existing: inventory_existing
+    - template-credential_id: credential_id
+    - template-service_password_wo: service_password_wo
+    - template-service_password_wo_version: service_password_wo_version
+  removes:
+    - account
+    - bluecat_network_pool_server
+    - config
+    - credential
+    - date_created
+    - infoblox_network_pool_server
+    - integration
+    - last_updated
+    - php_ipamnetwork_pool_server
+    - pools
+    - service_host
+    - service_password
+    - service_password_hash
+    - service_port
+    - solar_winds_network_pool_server
+    - status_date
+    - status_message
+    - success
+    - type
+  overrides:
+    credential_id:
+      computed_optional_required: optional
+      description: The ID of a stored credential to use for authentication. Conflicts with service_username and service_password_wo.
+      conflicts_with: [service_username, service_password_wo]
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the network pool server is enabled.
+      default: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the network pool server.
+      state_for_unknown: true
+    ignore_ssl:
+      computed_optional_required: computed_optional
+      description: Whether to ignore SSL certificate errors.
+      default: false
+    name:
+      computed_optional_required: required
+      description: The name of the network pool server.
+    service_password_wo:
+      computed_optional_required: optional
+      description: The service password for authentication. Conflicts with credential_id.
+      conflicts_with: [credential_id]
+    service_password_wo_version:
+      computed_optional_required: optional
+      description: Service password version. Used to determine if service_password_wo has been updated.
+    service_url:
+      computed_optional_required: optional
+      description: The service URL for the IPAM integration.
+    service_username:
+      computed_optional_required: optional
+      description: The service username for authentication. Conflicts with credential_id.
+      conflicts_with: [credential_id]
+    status:
+      computed_optional_required: computed
+      description: The current status of the network pool server.
+      state_for_unknown: true
+    network_filter:
+      computed_optional_required: optional
+      description: Filter expression for which networks to sync from the pool server.
+    service_mode:
+      computed_optional_required: optional
+      description: The service mode (e.g. "static" or "dhcp"). Applies to Infoblox.
+    service_throttle_rate:
+      computed_optional_required: computed_optional
+      description: Rate limit (in milliseconds) for API requests to the pool server.
+      default: 0
+    tenant_match:
+      computed_optional_required: optional
+      description: Tenant matching expression for multi-tenancy (Infoblox only).
+    type_id:
+      computed_optional_required: computed_optional
+      description: The ID of the network pool server type. Mutually exclusive with type_code.
+      requires_replace: true
+      state_for_unknown: true
+      at_least_one_of: [type_id, type_code]
+      conflicts_with: [type_code]
+    type_code:
+      computed_optional_required: computed_optional
+      description: 'The network pool server type code (e.g. "infoblox", "bluecat", "phpipam", "solarwindsipam", "solidserver"). Mutually exclusive with type_id.'
+      requires_replace: true
+      state_for_unknown: true
+      conflicts_with: [type_id]
+    inventory_existing:
+      computed_optional_required: computed_optional
+      description: Whether to inventory existing networks from the pool server. Applies to all pool server types.
+      default: false
+    zone_filter:
+      computed_optional_required: optional
+      description: Filter expression for which DNS zones to sync (Infoblox only).

--- a/specs/resources/network_router/config.yaml
+++ b/specs/resources/network_router/config.yaml
@@ -1,0 +1,315 @@
+network_router:
+  templates:
+    bool:
+      bool:
+        computed_optional_required: computed_optional
+    config:
+      dynamic:
+        computed_optional_required: computed_optional
+        description: Generic configuration object for network routers.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: validators.ValidObjectMap()
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                dynamicvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRoot("config_nsxt_gateway_tier0"),
+                  path.MatchRoot("config_nsxt_gateway_tier1"),
+                }...)
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/dynamicvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                dynamicvalidator.ExactlyOneOf(path.Expressions{
+                  path.MatchRoot("config"),
+                  path.MatchRoot("config_nsxt_gateway_tier0"),
+                  path.MatchRoot("config_nsxt_gateway_tier1"),
+                }...)
+    group_id:
+      int64:
+        computed_optional_required: required
+        description: Group ID
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.ConflictsWith(path.Expressions{
+                  path.MatchRoot("group_id"),
+                }...)
+    shared_group_access:
+      bool:
+        computed_optional_required: optional
+        description: Used to enable shared group access. Conflicts with group_id.
+    network_integration_id:
+      int64:
+        computed_optional_required: optional
+        description: Required when router type supports a network integration
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.ConflictsWith(path.Expressions{
+                  path.MatchRoot("cloud_id"),
+                }...)
+    type_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: The network router type ID. Must be set if using generic config block. The provider will attempt to set this automatically if using a static config block.
+        validators:
+          - custom:
+              imports:
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+              - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.AlsoRequires(path.Expressions{path.MatchRoot("config")}...)
+    cloud_id:
+      int64:
+        computed_optional_required: optional
+        description: Required when router type does not support a network integration
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                int64validator.ConflictsWith(path.Expressions{
+                  path.MatchRoot("network_integration_id"),
+                }...)
+    edge_cluster:
+      string:
+        description: If set, also requires fail_over to be set.
+        computed_optional_required: optional
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.AlsoRequires(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("fail_over"),
+                }...)
+    fail_over:
+      string:
+        computed_optional_required: optional
+        description: Required with edge_cluster.
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.OneOf(
+                  "NON_PREEMPTIVE",
+                  "PREEMPTIVE",
+                )
+  moves:
+    - network_router: ""
+    - zone: cloud
+    - site: group
+    - template-group_id: group_id
+    - template-shared: group.shared
+    - template-cloud_id: cloud_id
+    - template-network_integration_id: network_integration_id
+    - template-type_id: type_id
+    - config.anyof0.oneof0: config_nsxt_gateway_tier0
+    - config.anyof0.oneof1: config_nsxt_gateway_tier1
+    - config_nsxt_gateway_tier1.tier0gateway: config_nsxt_gateway_tier1.tier0_gateway
+    - template-config: config
+    - template-fail_over: config_nsxt_gateway_tier0.fail_over
+    - template-fail_over: config_nsxt_gateway_tier1.fail_over
+    - template-edge_cluster: config_nsxt_gateway_tier0.edge_cluster
+
+    # NSX Tier 0 Gateway Bools
+    - template-bool: config_nsxt_gateway_tier0.ecmp
+    - template-bool: config_nsxt_gateway_tier0.multipath_relax
+    - template-bool: config_nsxt_gateway_tier0.tier0_dns_forwarder_ip
+    - template-bool: config_nsxt_gateway_tier0.tier0_external_interface
+    - template-bool: config_nsxt_gateway_tier0.tier0_ipsec_local_ip
+    - template-bool: config_nsxt_gateway_tier0.tier0_loopback_interface
+    - template-bool: config_nsxt_gateway_tier0.tier0_nat
+    - template-bool: config_nsxt_gateway_tier0.tier0_segment
+    - template-bool: config_nsxt_gateway_tier0.tier0_service_interface
+    - template-bool: config_nsxt_gateway_tier0.tier0_static
+    - template-bool: config_nsxt_gateway_tier0.tier1_dns_forwarder_ip
+    - template-bool: config_nsxt_gateway_tier0.tier1_ipsec_local_endpoint
+    - template-bool: config_nsxt_gateway_tier0.tier1_lb_snat
+    - template-bool: config_nsxt_gateway_tier0.tier1_lb_vip
+    - template-bool: config_nsxt_gateway_tier0.tier1_nat
+    - template-bool: config_nsxt_gateway_tier0.tier1_segment
+    - template-bool: config_nsxt_gateway_tier0.tier1_service_interface
+    - template-bool: config_nsxt_gateway_tier0.tier1_static
+    - template-bool: config_nsxt_gateway_tier0.inter_sr_ibgp
+    # NSX Tier 1 Gateway Bools
+    - template-bool: config_nsxt_gateway_tier1.tier1_connected
+    - template-bool: config_nsxt_gateway_tier1.tier1_dns_forwarder_ip
+    - template-bool: config_nsxt_gateway_tier1.tier1_ipsec_local_endpoint
+    - template-bool: config_nsxt_gateway_tier1.tier1_lb_snat
+    - template-bool: config_nsxt_gateway_tier1.tier1_lb_vip
+    - template-bool: config_nsxt_gateway_tier1.tier1_nat
+    - template-bool: config_nsxt_gateway_tier1.tier1_static_routes
+    - template-edge_cluster: config_nsxt_gateway_tier1.edge_cluster
+    - template-shared_group_access: shared_group_access
+  removes:
+    - description # unused it seems
+    # complex comptued attributes
+    # we can use the data source for reading all this
+    - cloud
+    - firewall
+    - group
+    - interfaces
+    - nats
+    - network_server
+    - permissions
+    - routes
+    - type
+    # simple computed attributes
+    - category
+    - date_created
+    - external_id
+    - external_ip
+    - external_network
+    - instance
+    - last_updated
+    - provider_id
+    - router_type
+    - status
+    - success
+  overrides:
+    id:
+      state_for_unknown: true
+    cloud_id:
+      requires_replace: true
+    group_id:
+      requires_replace: true
+    network_integration_id:
+      requires_replace: true
+    type_id:
+      requires_replace: true
+    enabled:
+      default: true
+    enable_bgp:
+      default: false
+      requires_replace: true
+
+    # config_nsxt_gateway_tier0
+    config_nsxt_gateway_tier0:
+      computed_optional_required: optional
+      requires_replace: true
+    config_nsxt_gateway_tier0.ha_mode:
+      computed_optional_required: required
+    config_nsxt_gateway_tier0.edge_cluster:
+      computed_optional_required: optional
+    config_nsxt_gateway_tier0.ip_management_type:
+      computed_optional_required: optional
+    config_nsxt_gateway_tier0.ip_server_id:
+      computed_optional_required: optional
+    config_nsxt_gateway_tier0.tier0_nat:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier0_ipsec_local_ip:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier0_dns_forwarder_ip:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier0_service_interface:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier0_external_interface:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier0_loopback_interface:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier0_segment:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier0_static:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier1_dns_forwarder_ip:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier1_static:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier1_lb_vip:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier1_nat:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier1_lb_snat:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier1_ipsec_local_endpoint:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier1_service_interface:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.tier1_segment:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.local_as_num:
+      computed_optional_required: computed_optional
+      default: "65000"
+    config_nsxt_gateway_tier0.ecmp:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.multipath_relax:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.inter_sr_ibgp:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier0.restart_mode:
+      computed_optional_required: required
+    config_nsxt_gateway_tier0.restart_time:
+      computed_optional_required: optional
+    config_nsxt_gateway_tier0.stale_route_time:
+      computed_optional_required: optional
+
+    # config_nsxt_gateway_tier1
+    config_nsxt_gateway_tier1:
+      computed_optional_required: optional
+      requires_replace: true
+    config_nsxt_gateway_tier1.tier0_gateway:
+      computed_optional_required: optional
+    config_nsxt_gateway_tier1.edge_cluster:
+      computed_optional_required: optional
+    config_nsxt_gateway_tier1.ip_management_type:
+      computed_optional_required: optional
+    config_nsxt_gateway_tier1.ip_server_id:
+      computed_optional_required: optional
+    config_nsxt_gateway_tier1.tier1_connected:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier1.tier1_nat:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier1.tier1_static_routes:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier1.tier1_lb_vip:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier1.tier1_lb_snat:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier1.tier1_dns_forwarder_ip:
+      computed_optional_required: computed_optional
+      default: false
+    config_nsxt_gateway_tier1.tier1_ipsec_local_endpoint:
+      computed_optional_required: computed_optional
+      default: false

--- a/specs/resources/network_router_bgp_neighbor/config.yaml
+++ b/specs/resources/network_router_bgp_neighbor/config.yaml
@@ -1,0 +1,91 @@
+network_router_bgp_neighbor:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: computed_optional
+        description: Dynamic configuration
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: validators.ValidObjectMap()
+    router_id:
+      int64:
+        computed_optional_required: required
+        description: The ID of the network router
+    bfd_enabled:
+      bool:
+        computed_optional_required: computed_optional
+        description: Enable BFD (Bidirectional Forwarding Detection)
+        default:
+          static: false
+    allow_as_in:
+      bool:
+        computed_optional_required: computed_optional
+        description: Allow AS-in
+        default:
+          static: false
+    password_wo:
+      string:
+        computed_optional_required: optional
+        description: Password (Write Only)
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+          - custom:
+              imports:
+                - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+              schema_definition: |-
+                modifiers.NullableStringUpdateModifier{}
+    password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: Password version. Used to determine if password_wo has been updated.
+  moves:
+    - network_router_bgp_neighbor: "" # unnest
+    # Static config blocks
+    - config.nsxtbgpneighbor_config: config_nsxt
+    - config.nsxvbgpneighbor_config: config_nsxv
+    # Generic config (dynamic fallback)
+    - template-config: config
+    - template-router_id: router_id
+    - template-bfd_enabled: bfd_enabled
+    - template-allow_as_in: allow_as_in
+    - template-password_wo: password_wo
+    - template-password_wo_version: password_wo_version
+  removes:
+    - date_created
+    - last_updated
+    - password_hash
+    - sync_source
+    - internal_id
+    - external_id
+    - ref_type
+    - ref_id
+    - provider_id
+    - password
+    - success
+  overrides:
+    id:
+      description: The ID of the BGP neighbor
+      state_for_unknown: true
+    router_id:
+      requires_replace: true
+    ip_address:
+      computed_optional_required: required
+    config:
+      conflicts_with: [config_nsxt, config_nsxv]
+    config_nsxt:
+      conflicts_with: [config_nsxv]
+    weight:
+      default: 60
+    keep_alive:
+      default: 60
+    hold_down:
+      default: 180
+    hop_limit:
+      default: 1
+    restart_mode:
+      one_of: [HELPER_ONLY, GRACEFUL_RESTART, DISABLE]
+    route_filtering_type:
+      one_of: [IPV4, IPV6]

--- a/specs/resources/network_router_firewall_rule/config.yaml
+++ b/specs/resources/network_router_firewall_rule/config.yaml
@@ -1,0 +1,52 @@
+network_router_firewall_rule:
+  moves:
+    - rule: ""
+  removes:
+    - application
+    - application_type
+    - applications
+    - code
+    - destination
+    - destination_port_range
+    - destination_type
+    - group_name
+    - profiles
+    - rule_type
+    - source
+    - source_group
+    - source_port_range
+    - source_tier
+    - source_type
+    - success
+  overrides:
+    direction:
+      computed_optional_required: computed_optional
+      description: Direction (ingress or egress)
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the firewall rule is enabled
+      default: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the firewall rule
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: Name of the firewall rule
+    policy:
+      computed_optional_required: computed_optional
+      description: Policy action (accept, deny, reject)
+      default: "accept"
+    port_range:
+      computed_optional_required: computed_optional
+      description: Port range
+    priority:
+      computed_optional_required: computed_optional
+      description: Priority of the firewall rule
+    protocol:
+      computed_optional_required: computed_optional
+      description: Protocol
+    router_id:
+      computed_optional_required: required
+      description: The ID of the parent network router
+      requires_replace: true

--- a/specs/resources/network_router_nat/config.yaml
+++ b/specs/resources/network_router_nat/config.yaml
@@ -1,0 +1,89 @@
+network_router_nat:
+  templates:
+    name:
+      string:
+        computed_optional_required: required
+        description: Name of the NAT rule.
+    action:
+      string:
+        computed_optional_required: required
+        description: The NAT action (e.g. SNAT, DNAT, REFLEXIVE).
+    description:
+      string:
+        computed_optional_required: optional
+        description: Description of the NAT rule.
+    enabled:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether the NAT rule is enabled.
+      default: true
+    priority:
+      int64:
+        computed_optional_required: optional
+        description: Priority of the NAT rule.
+    protocol:
+      string:
+        computed_optional_required: optional
+        description: Protocol for the NAT rule.
+    source_network:
+      string:
+        computed_optional_required: optional
+        description: Source network for the NAT rule.
+    destination_network:
+      string:
+        computed_optional_required: optional
+        description: Destination network for the NAT rule.
+    translated_network:
+      string:
+        computed_optional_required: optional
+        description: Translated network for the NAT rule.
+  moves:
+    - template-name: name
+    - template-action: action
+    - template-description: description
+    - template-enabled: enabled
+    - template-priority: priority
+    - template-protocol: protocol
+    - template-source_network: source_network
+    - template-destination_network: destination_network
+    - template-translated_network: translated_network
+  removes:
+    - network_router_nat
+    - success
+  overrides:
+    description:
+      computed_optional_required: computed_optional
+      description: Description of the NAT rule
+    action:
+      computed_optional_required: required
+      description: The NAT action (e.g. SNAT, DNAT, REFLEXIVE).
+    destination_network:
+      computed_optional_required: computed_optional
+      description: Destination network
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the NAT rule is enabled
+      default: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the NAT rule
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: Name of the NAT rule
+    priority:
+      computed_optional_required: computed_optional
+      description: Priority of the NAT rule
+    protocol:
+      computed_optional_required: computed_optional
+      description: Protocol
+    router_id:
+      computed_optional_required: required
+      description: The ID of the parent network router
+      requires_replace: true
+    source_network:
+      computed_optional_required: computed_optional
+      description: Source network
+    translated_network:
+      computed_optional_required: computed_optional
+      description: Translated network

--- a/specs/resources/network_router_route/config.yaml
+++ b/specs/resources/network_router_route/config.yaml
@@ -1,0 +1,58 @@
+network_router_route:
+  templates:
+    networkMtu:
+      float64:
+        computed_optional_required: optional
+        description: Network MTU
+  moves:
+    - network_route: ""
+    - network: source
+    - next_hop: destination
+    - template-networkMtu: network_mtu
+  removes:
+    - code
+    - external_id
+    - provider_id
+    - route_type
+    - source_type
+    - mtu
+    - destination_type
+    - external_interface
+    - external_type
+    - internal_id
+    - priority
+    - success
+    - unique_id
+    - visible
+  overrides:
+    id:
+      description: The ID of the route
+      state_for_unknown: true
+    router_id:
+      computed_optional_required: required
+      description: The ID of the parent network router
+      requires_replace: true
+    name:
+      computed_optional_required: computed_optional
+      description: Name of the route
+      requires_replace: true
+    description:
+      computed_optional_required: computed_optional
+      description: Description of the route
+      requires_replace: true
+    source:
+      computed_optional_required: required
+      description: Source network (CIDR)
+      requires_replace: true
+    destination:
+      computed_optional_required: required
+      description: Destination / next hop
+      requires_replace: true
+    default_route:
+      computed_optional_required: computed_optional
+      description: Whether this is the default route
+      default: false
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the route is enabled
+      default: true

--- a/specs/resources/option_list/config.yaml
+++ b/specs/resources/option_list/config.yaml
@@ -1,0 +1,46 @@
+option_list:
+  description: "Manages a Morpheus Library Option Type List resource."
+  moves:
+    - option_type_list: ""           # unnest wrapper (components/schemas/optionTypeListCreate.yaml)
+  removes:
+    - config                         # (components/schemas/optionTypeListCreate.yaml)
+    - credential                     # (components/schemas/optionTypeListCreate.yaml)
+    - ignore_sslerrors               # (components/schemas/optionTypeListCreate.yaml)
+    - initial_dataset                # (components/schemas/optionTypeListCreate.yaml)
+    - labels                         # (components/schemas/optionTypeListCreate.yaml)
+    - option_types                   # (components/schemas/optionTypeList.yaml) read-only
+    - request_script                 # (components/schemas/optionTypeListCreate.yaml)
+    - service_password               # (components/schemas/optionTypeListCreate.yaml)
+    - service_username               # (components/schemas/optionTypeListCreate.yaml)
+    - source_method                  # (components/schemas/optionTypeListCreate.yaml)
+    - success                        # (components/schemas/successId.yaml)
+    - translation_script             # (components/schemas/optionTypeListCreate.yaml)
+  overrides:
+    api_type:
+      computed_optional_required: optional
+      description: The API type of the option list.
+    description:
+      computed_optional_required: optional
+      description: The description of the option type list.
+    id:
+      computed_optional_required: computed
+      description: The ID of the option type list.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the option type list.
+    real_time:
+      computed_optional_required: computed_optional
+      description: Whether the option list is fetched in real time.
+      default: false
+    source_url:
+      computed_optional_required: optional
+      description: The source URL for the option list.
+    type:
+      computed_optional_required: optional
+      description: The type of the option list (rest, manual, ldap, api).
+      remove_default: true
+    visibility:
+      computed_optional_required: computed_optional
+      description: The visibility of the option type list.
+      default: "private"

--- a/specs/resources/os_type/config.yaml
+++ b/specs/resources/os_type/config.yaml
@@ -1,0 +1,55 @@
+os_type:
+  moves:
+    - os_type: "" # unnest os_type
+    - template-owner: owner
+  removes:
+    - success
+    - images
+  templates:
+    owner:
+      string:
+        computed_optional_required: computed
+        description: The owner of the osType.
+  overrides:
+    id:
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the osType.
+    code:
+      computed_optional_required: required
+      requires_replace: true
+      description: The code Morpheus uses as an internal identifier.
+    bit_count:
+      computed_optional_required: required
+      description: The architecture bit count (e.g. 32 or 64)
+    platform:
+      computed_optional_required: required
+      description: The platform of the osType (e.g. linux, windows).
+    category:
+      computed_optional_required: optional
+      description: The category of the osType.
+    cloud_init_version:
+      computed_optional_required: computed_optional
+      description: The version of CloudInit being used
+    description:
+      computed_optional_required: computed_optional
+      description: The description of the osType.
+    install_agent:
+      computed_optional_required: computed_optional
+      description: Whether to install the Morpheus agent on provisioned instances
+    os_codename:
+      computed_optional_required: optional
+      description: The osCodename of the osType.
+    os_family:
+      computed_optional_required: computed_optional
+      description: The osFamily of the osType.
+    os_name:
+      computed_optional_required: optional
+      description: The osName of the osType.
+    os_version:
+      computed_optional_required: computed_optional
+      description: The osVersion of the osType.
+    vendor:
+      computed_optional_required: optional
+      description: The vendor of the osType.

--- a/specs/resources/os_type_image/config.yaml
+++ b/specs/resources/os_type_image/config.yaml
@@ -1,0 +1,30 @@
+os_type_image:
+  moves:
+    - os_type_image: ""               # unnest wrapper
+    - os_type: os_type_id
+    - virtual_image: virtual_image_id
+    - provision_type: provision_type_id
+    - zone: cloud_id
+  removes:
+    - account
+    - compute_zone_type
+    - virtual_image_name
+  overrides:
+    id:
+      state_for_unknown: true
+    os_type_id:
+      computed_optional_required: required
+      requires_replace: true
+      description: ID of the OS type
+    virtual_image_id:
+      computed_optional_required: required
+      requires_replace: true
+      description: ID of the virtual image
+    provision_type_id:
+      computed_optional_required: computed_optional
+      requires_replace: true
+      description: ID of the provision type
+    cloud_id:
+      computed_optional_required: computed_optional
+      requires_replace: true
+      description: ID of the cloud

--- a/specs/resources/policy/config.yaml
+++ b/specs/resources/policy/config.yaml
@@ -1,0 +1,707 @@
+policy:
+  templates:
+    config:
+      dynamic:
+        description: Generic Policy Configuration
+        computed_optional_required: computed_optional
+   
+    # Template booleans to replace on/off fields 
+    config_lifecycle.lifecycle_auto_renew:
+      bool:
+        computed_optional_required: computed_optional
+    config_lifecycle.lifecycle_allow_extend:
+      bool:
+        computed_optional_required: computed_optional
+    
+    config_max_cores.exclude_containers:
+      bool:
+        computed_optional_required: computed_optional  
+    config_max_memory.exclude_containers:
+      bool:
+        computed_optional_required: computed_optional
+ 
+    config_max_storage.exclude_containers:
+      bool:
+        computed_optional_required: computed_optional
+    config_motd.fullpage.exclude_containers:
+      bool:
+        computed_optional_required: computed_optional
+
+    config_shutdown.shutdown_auto_renew:
+      bool:
+        computed_optional_required: computed_optional
+    config_shutdown.shutdown_allow_extend:
+      bool:
+        computed_optional_required: computed_optional
+
+    config_max_memory.max_memory:
+      string:
+        computed_optional_required: computed_optional
+
+    config_approval.flow_id:
+      string:
+        computed_optional_required: computed_optional
+        description: ID of ServiceNow Flow (set if workflowType is 'flow')
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("workflow_id"),
+                }...)
+
+    config_approval.workflow_id:
+      string:
+        computed_optional_required: computed_optional
+        description: ID of legacy ServiceNow workflow (set if workflowType is 'workflow')
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("flow_id"),
+                }...)
+
+    config_lifecycle.flow_id:
+      string:
+        computed_optional_required: computed_optional
+        description: ID of ServiceNow Flow (set if workflowType is 'flow')
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("lifecycle_workflow_id"),
+                }...)
+
+    config_lifecycle.lifecycle_workflow_id:
+      string:
+        computed_optional_required: computed_optional
+        description: ID of legacy ServiceNow workflow (set if workflowType is 'workflow')
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("flow_id"),
+                }...)
+
+    config_shutdown.flow_id:
+      string:
+        computed_optional_required: computed_optional
+        description: ID of ServiceNow Flow (set if workflowType is 'flow')
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("shutdown_workflow_id"),
+                }...)
+
+    config_shutdown.shutdown_workflow_id:
+      string:
+        computed_optional_required: computed_optional
+        description: ID of legacy ServiceNow workflow (set if workflowType is 'workflow')
+        validators:
+          - custom:
+              imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                - path: github.com/hashicorp/terraform-plugin-framework/path
+              schema_definition: |-
+                stringvalidator.ConflictsWith(path.Expressions{
+                  path.MatchRelative().AtParent().AtName("flow_id"),
+                }...)
+
+  moves:
+    - policy: "" # unnest policy
+    - ref_type.oneof0: associated_resource_type
+    - ref_id: associated_resource_id
+    - site: "group"
+    - zone: "cloud"
+    - accounts: "tenants"
+
+    # rename config elements to relevant policy type
+    - config.approve_policy_type_configuration: config_approval
+    - config.backup_creation_policy_type_configuration: config_create_backup
+    - config.backup_targets_policy_type_configuration: config_backup_storage
+    - config.budget_policy_type_configuration: config_max_price
+    - config.cluster_resource_name_policy_type_configuration: config_server_naming
+    - config.cypher_access_policy_type_configuration: config_cypher
+    - config.delayed_delete_policy_type_configuration: config_delayed_removal
+    - config.expiration_policy_type_configuration: config_lifecycle
+    - config.hostname_policy_type_configuration: config_host_naming
+    - config.instance_name_policy_type_configuration: config_naming
+    - config.max_containers_policy_type_configuration: config_max_containers
+    - config.max_cores_policy_type_configuration: config_max_cores
+    - config.max_hosts_policy_type_configuration: config_max_hosts
+    - config.max_load_balancer_pools_policy_type_configuration: config_max_pools
+    - config.max_memory_policy_type_configuration: config_max_memory
+    - config.max_pool_members_policy_type_configuration: config_max_pool_members
+    - config.max_snapshots_policy_type_configuration: config_max_snapshots
+    - config.max_storageand_object_storage_quota_policy_type_configuration: config_max_storage
+    - config.max_virtual_servers_policy_type_configuration: config_max_virtual_servers
+    - config.max_vms_policy_type_configuration: config_max_vms
+    - config.messageofthe_day_policy_type_configuration: config_motd
+    - config.network_quota_policy_type_configuration: config_max_networks
+    - config.power_schedule_policy_type_configuration: config_power_schedule
+    - config.required_network_policy_type_configuration: config_required_network
+    - config.router_quota_policy_type_configuration: config_max_routers
+    - config.shutdown_policy_type_configuration: config_shutdown
+    - config.storage_server_storage_quota_policy_type_configuration: config_storage_server_quota
+    - config.tags_policy_type_configuration: config_tags
+    - config.user_creation_policy_type_configuration: config_create_user
+    - config.user_group_creation_policy_type_configuration: config_create_user_group
+    - config.workflow_policy_type_configuration: config_workflow
+
+    - template-config_max_memory.max_memory: config_max_memory.max_memory
+
+    # Moving motdfull_page.oneof0 to motd_fullpage for simplicity
+    # note: moving to motdfull_page directly keeps motdfull_page as single-nested instead of string type
+    # therefore, slightly altering the name and removing it later.
+    - config_motd.motdfull_page.oneof0: config_motd.motd_fullpage
+
+    # Have a dynamic config as well as static schemas
+    - template-config: config
+
+    # Swap on/off fields with boolean templates
+    - template-config_lifecycle.lifecycle_auto_renew: config_lifecycle.lifecycle_auto_renew
+    - template-config_lifecycle.lifecycle_allow_extend: config_lifecycle.lifecycle_allow_extend
+    - template-config_max_cores.exclude_containers: config_max_cores.exclude_containers
+    - template-config_max_memory.exclude_containers: config_max_memory.exclude_containers
+    - template-config_max_storage.exclude_containers: config_max_storage.exclude_containers
+    - template-config_motd_fullpage.exclude_containers: config_motd_fullpage.exclude_containers
+    - template-config_shutdown.shutdown_auto_renew: config_shutdown.shutdown_auto_renew
+    - template-config_shutdown.shutdown_allow_extend: config_shutdown.shutdown_allow_extend
+
+    # Swap conflict fields with templates that use path expressions
+    - template-config_approval.flow_id: config_approval.flow_id
+    - template-config_approval.workflow_id: config_approval.workflow_id
+    - template-config_lifecycle.flow_id: config_lifecycle.flow_id
+    - template-config_lifecycle.lifecycle_workflow_id: config_lifecycle.lifecycle_workflow_id
+    - template-config_shutdown.flow_id: config_shutdown.flow_id
+    - template-config_shutdown.shutdown_workflow_id: config_shutdown.shutdown_workflow_id
+  removes:
+    - ref_type
+    - success
+    # Removing unneccessary inner motd and motdfull_page
+    - config_motd.motd
+    - config_motd.motdfull_page
+
+  overrides:
+    associated_resource_type: # Add Global, ComputeSite -> Group, ComputeZone -> Cloud
+      one_of: ["Global", "Group", "Cloud", "User", "Role", "Network", "Plan", "Label"]
+      description: Type of the resource this policy is associated with, can be 'Global', 'Group', 'Cloud', 'User', 'Role', 'Network', 'Plan' or 'Label'
+      computed_optional_required: required
+      requires_replace: true
+    associated_resource_id:
+      description: The ID of the resource this policy is associated with, e.g. Group, Cloud, User, Role, Network, Plan, Label
+      requires_replace: true
+    policy_type.code:
+      computed_optional_required: required
+      requires_replace: true
+
+    config:
+      conflicts_with: ["config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+
+    config_approval:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy types:
+        	- Approve Delete (deleteApproval)
+        	- Approve Provision (provisionApproval)
+        	- Approve Reconfigure (reconfigureApproval)
+        	- Approve Workflow Execute (workflowApproval)
+    
+    config_approval.account_integration_id:
+      computed_optional_required: required
+      description: ID of your ServiceNow or approval integration
+    
+    config_approval.workflow_type:
+      description: "Options: \"workflow\" (legacy workflow), \"flow\" (ServiceNow Flow)"
+
+
+    config_create_backup:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Backup Creation (createBackup)
+    
+    config_create_backup.create_backup:
+      description: Enforce backup creation
+    
+    config_create_backup.create_backup_type:
+      computed_optional_required: required
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict pattern)"
+
+
+    config_backup_storage:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Backup Targets (backupStorage)
+    
+    config_backup_storage.backup_storage_ids:
+      computed_optional_required: required
+      description: Array of backup storage IDs to restrict available backup targets
+
+    config_max_price:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Budget (maxPrice)
+    
+    config_max_price.max_price:
+      computed_optional_required: required
+      description: Maximum price limit
+    
+    config_max_price.max_price_currency:
+      description: Currency code (e.g., USD)
+    
+    config_max_price.max_price_unit:
+      description: "Options: \"hour\", \"month\""
+
+
+    config_server_naming:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Cluster Resource Name (serverNaming)
+    
+    config_server_naming.server_naming_conflict:
+      description: Auto-resolve conflicts
+    
+    config_server_naming.server_naming_pattern:
+      description: Name pattern uses ${variable} string interpolation.  Available variables are:<br>groupName, groupCode, cloudName, cloudCode, type, accountId, account, accountType, platform, username, userId, userInitials, provisionType
+    
+    config_server_naming.server_naming_type:
+      computed_optional_required: required
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict pattern)"
+
+
+    config_cypher:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Cypher Access (cypher)
+    
+    config_cypher.delete:
+      description: Allow delete access
+    
+    config_cypher.key_pattern:
+      computed_optional_required: required
+      description: Pattern to match Cypher keys (e.g., "secret/*", "password/*")
+    
+    config_cypher.list:
+      description: Allow list access
+    
+    config_cypher.read:
+      description: Allow read access
+    
+    config_cypher.update:
+      description: Allow update access
+    
+    config_cypher.write:
+      description: Allow write access
+
+
+    config_delayed_removal:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Delayed Delete (delayedRemoval)
+    
+    config_delayed_removal.removal_age:
+      computed_optional_required: required
+      description: Number of days to delay deletion
+
+
+    config_lifecycle:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Expiration (lifecycle)
+    
+    config_lifecycle.account_integration_id:
+      description: ID of your ServiceNow or approval integration
+    
+    config_lifecycle.lifecycle_age:
+      description: Days until expiration
+    
+    config_lifecycle.lifecycle_extensions_before_approval:
+      description: Number of extensions before requiring approval
+    
+    config_lifecycle.lifecycle_hide_fixed:
+      description: Hide fixed expiration from users
+    
+    config_lifecycle.lifecycle_message:
+      description: Notification message
+    
+    config_lifecycle.lifecycle_notify:
+      description: Days before expiration to notify
+    
+    config_lifecycle.lifecycle_renewal:
+      description: Days for renewal window
+    
+    config_lifecycle.lifecycle_type:
+      computed_optional_required: required
+      description: "Options: \"user\" (user configurable), \"fixed\" (fixed expiration)"
+    
+    config_lifecycle.workflow_type:
+      description: "Options: \"workflow\" (legacy workflow), \"flow\" (ServiceNow Flow)"
+
+
+    config_host_naming:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Hostname (hostNaming)
+    
+    config_host_naming.host_naming_pattern:
+      description: Name pattern uses ${variable} string interpolation.  Available variables are:<br>groupName, groupCode, cloudName, cloudCode, type, accountId, account, accountType, platform, username, userId, userInitials, provisionType
+    
+    config_host_naming.host_naming_type:
+      computed_optional_required: required
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict pattern)"
+
+
+    config_naming:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Instance Name (naming)
+    
+    config_naming.naming_conflict:
+      description: Auto-resolve conflicts
+    
+    config_naming.naming_pattern:
+      description: Name pattern uses ${variable} string interpolation.  Available variables are:<br>groupName, groupCode, cloudName, cloudCode, type, accountId, account, accountType, platform, username, userId, userInitials, provisionType
+    
+    config_naming.naming_type:
+      computed_optional_required: required
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict pattern)"
+
+
+    config_max_containers:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max Containers (maxContainers)
+    
+    config_max_containers.max_containers:
+      computed_optional_required: required
+      description: Max Containers
+
+
+    config_max_cores:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max Cores (maxCores)
+    
+    config_max_cores.max_cores:
+      computed_optional_required: required
+      description: Max Cores
+
+
+    config_max_hosts:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max Hosts (maxHosts)
+    
+    config_max_hosts.max_hosts:
+      computed_optional_required: required
+      description: Max Hosts
+
+
+    config_max_pools:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max Load Balancer Pools (maxPools)
+    
+    config_max_pools.max_pools:
+      computed_optional_required: required
+      description: Max Pools
+
+
+    config_max_memory:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max Memory (maxMemory)
+    
+    config_max_memory.max_memory:
+      computed_optional_required: required
+      description: Max Memory (GB)
+
+
+    config_max_pool_members:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max Pool Members (maxPoolMembers)
+    
+    config_max_pool_members.max_pool_members:
+      computed_optional_required: required
+      description: Max Pool Members
+
+
+    config_max_snapshots:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max Snapshots (maxSnapshots)
+    
+    config_max_snapshots.max_snapshots:
+      computed_optional_required: required
+      description: Max Snapshots
+
+
+    config_max_storage:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy types:
+        	- Max Storage (maxStorage)
+        	- Object Storage Quota (storageBucketQuota)
+        	- File Share Storage Quota (storageShareQuota)
+    
+    config_max_storage.max_storage:
+      computed_optional_required: required
+      description: Max Storage (GB)
+
+
+    config_max_virtual_servers:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max Virtual Servers (maxVirtualServers)
+    
+    config_max_virtual_servers.max_virtual_servers:
+      computed_optional_required: required
+      description: Max Virtual Servers
+
+
+    config_max_vms:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Max VMs (maxVms)
+    
+    config_max_vms.max_vms:
+      computed_optional_required: required
+      description: Max VMs
+
+
+    config_motd:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Message of the Day (motd)
+    
+    config_motd.motddate:
+      description: Display date for message
+    
+    config_motd.motdmessage:
+      description: Message content
+    
+    config_motd.motdtitle:
+      description: Message title
+    
+    config_motd.motdtype:
+      description: "Options: \"info\", \"warning\", \"critical\""
+
+
+    config_max_networks:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Network Quota (maxNetworks)
+    
+    config_max_networks.max_networks:
+      computed_optional_required: required
+      description: Max Networks
+
+
+    config_power_schedule:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Power Scheduling (powerSchedule)
+    
+    config_power_schedule.power_schedule:
+      description: ID of the power schedule
+    
+    config_power_schedule.power_schedule_hide_fixed:
+      description: Hide fixed schedule from users
+    
+    config_power_schedule.power_schedule_type:
+      computed_optional_required: required
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict schedule)"
+
+
+    config_required_network:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Instance Networks (requiredNetwork)
+    
+    config_required_network.required_networks:
+      computed_optional_required: required
+      description: Array of required network IDs
+
+    config_max_routers:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Router Quota (maxRouters)
+    
+    config_max_routers.max_routers:
+      computed_optional_required: required
+      description: Max Routers
+
+
+    config_shutdown:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Shutdown (shutdown)
+    
+    config_shutdown.account_integration_id:
+      description: ID of your ServiceNow or approval integration
+    
+    config_shutdown.shutdown_age:
+      description: Days instance is allowed to run before shutdown
+    
+    config_shutdown.shutdown_extensions_before_approval:
+      description: Number of extensions before requiring approval
+    
+    config_shutdown.shutdown_hide_fixed:
+      description: Hide fixed shutdown from users
+    
+    config_shutdown.shutdown_message:
+      description: Notification message
+    
+    config_shutdown.shutdown_notify:
+      description: Days before shutdown to notify via email
+    
+    config_shutdown.shutdown_renewal:
+      description: If the instance is renewed, this is the number of day increments the shutdown date is increased by
+    
+    config_shutdown.shutdown_type:
+      computed_optional_required: required
+      description: "Options: \"user\" (user configurable), \"fixed\" (strict shutdown)"
+    
+    config_shutdown.workflow_type:
+      description: "Options: \"workflow\" (legacy workflow), \"flow\" (ServiceNow Flow)"
+
+
+    config_storage_server_quota:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_tags", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Storage Server Storage Quota (storageServerQuota)
+    
+    config_storage_server_quota.max_storage:
+      description: Max Storage (GB)
+    
+    config_storage_server_quota.storage_server_id:
+      computed_optional_required: required
+      description: ID of the storage server
+
+
+    config_tags:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_create_user", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- Tags (tags)
+    
+    config_tags.key:
+      description: Tag key to enforce
+    
+    config_tags.strict:
+      computed_optional_required: required
+      description: Strict enforcement
+    
+    config_tags.value:
+      description: Tag value (optional, can be left empty for any value)
+    
+    config_tags.value_list_id:
+      description: ID of value from value list (optional)
+
+
+    config_create_user:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user_group", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- User Creation (createUser)
+    
+    config_create_user.create_user:
+      description: Enforce user creation
+    
+    config_create_user.create_user_type:
+      computed_optional_required: required
+      description: "Options: \"user\" (user configurable), \"fixed\""
+
+
+    config_create_user_group:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_workflow"]
+      description: |
+        Configuration for the following policy type:
+        	- User Group Creation (createUserGroup)
+    
+    config_create_user_group.user_group:
+      computed_optional_required: required
+      description: ID of the user group to assign
+
+
+    config_workflow:
+      computed_optional_required: optional
+      conflicts_with: ["config", "config_approval", "config_create_backup", "config_backup_storage", "config_max_price", "config_server_naming", "config_cypher", "config_delayed_removal", "config_lifecycle", "config_host_naming", "config_naming", "config_max_containers", "config_max_cores", "config_max_hosts", "config_max_pools", "config_max_memory", "config_max_pool_members", "config_max_snapshots", "config_max_storage", "config_max_virtual_servers", "config_max_vms", "config_motd", "config_max_networks", "config_power_schedule", "config_required_network", "config_max_routers", "config_shutdown", "config_storage_server_quota", "config_tags", "config_create_user", "config_create_user_group"]
+      description: |
+        Configuration for the following policy type:
+        	- Workflow (workflow)
+    
+    config_workflow.workflow_id:
+      computed_optional_required: required
+      description: ID of the workflow to execute

--- a/specs/resources/power_schedule/config.yaml
+++ b/specs/resources/power_schedule/config.yaml
@@ -1,0 +1,113 @@
+power_schedule:
+  description: "Manages a Morpheus Power Schedule resource."
+  templates:
+    totalMonthlyHoursSaved:
+      float64:
+        computed_optional_required: computed
+        description: The total monthly hours saved by the power schedule.
+  moves:
+    - schedule: ""
+    - template-totalMonthlyHoursSaved: total_monthly_hours_saved
+  removes:
+    - date_created
+    - friday_off
+    - friday_on
+    - instances
+    - last_updated
+    - monday_off
+    - monday_on
+    - saturday_off
+    - saturday_on
+    - servers
+    - success
+    - sunday_off
+    - sunday_on
+    - thursday_off
+    - thursday_on
+    - tuesday_off
+    - tuesday_on
+    - visibility
+    - wednesday_off
+    - wednesday_on
+  overrides:
+    description:
+      computed_optional_required: optional
+      description: The description of the power schedule.
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the power schedule is enabled.
+      default: true
+    friday_off_time:
+      computed_optional_required: computed_optional
+      description: The Friday off time for the power schedule.
+      state_for_unknown: true
+    friday_on_time:
+      computed_optional_required: computed_optional
+      description: The Friday on time for the power schedule.
+      state_for_unknown: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the power schedule.
+      state_for_unknown: true
+    monday_off_time:
+      computed_optional_required: computed_optional
+      description: The Monday off time for the power schedule.
+      state_for_unknown: true
+    monday_on_time:
+      computed_optional_required: computed_optional
+      description: The Monday on time for the power schedule.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the power schedule.
+    saturday_off_time:
+      computed_optional_required: computed_optional
+      description: The Saturday off time for the power schedule.
+      state_for_unknown: true
+    saturday_on_time:
+      computed_optional_required: computed_optional
+      description: The Saturday on time for the power schedule.
+      state_for_unknown: true
+    schedule_timezone:
+      computed_optional_required: computed_optional
+      description: The timezone of the power schedule.
+      default: "UTC"
+    schedule_type:
+      computed_optional_required: computed_optional
+      description: The schedule type of the power schedule.
+      default: "power"
+    sunday_off_time:
+      computed_optional_required: computed_optional
+      description: The Sunday off time for the power schedule.
+      state_for_unknown: true
+    sunday_on_time:
+      computed_optional_required: computed_optional
+      description: The Sunday on time for the power schedule.
+      state_for_unknown: true
+    thursday_off_time:
+      computed_optional_required: computed_optional
+      description: The Thursday off time for the power schedule.
+      state_for_unknown: true
+    thursday_on_time:
+      computed_optional_required: computed_optional
+      description: The Thursday on time for the power schedule.
+      state_for_unknown: true
+    total_monthly_hours_saved:
+      computed_optional_required: computed
+      description: The total monthly hours saved by the power schedule.
+    tuesday_off_time:
+      computed_optional_required: computed_optional
+      description: The Tuesday off time for the power schedule.
+      state_for_unknown: true
+    tuesday_on_time:
+      computed_optional_required: computed_optional
+      description: The Tuesday on time for the power schedule.
+      state_for_unknown: true
+    wednesday_off_time:
+      computed_optional_required: computed_optional
+      description: The Wednesday off time for the power schedule.
+      state_for_unknown: true
+    wednesday_on_time:
+      computed_optional_required: computed_optional
+      description: The Wednesday on time for the power schedule.
+      state_for_unknown: true

--- a/specs/resources/provisioning_license/config.yaml
+++ b/specs/resources/provisioning_license/config.yaml
@@ -1,0 +1,60 @@
+provisioning_license:
+  description: "Manages a Morpheus Provisioning License resource."
+  templates:
+    licenseKeyWo:
+      string:
+        computed_optional_required: required
+        description: The license key.
+        sensitive: true
+        write_only: true
+    licenseKeyWoVersion:
+      int64:
+        computed_optional_required: optional
+        description: License key version. Used to determine if license_key_wo has been updated.
+    tenantsList:
+      list:
+        computed_optional_required: optional
+        element_type:
+          int64: {}
+        description: List of tenant IDs associated with the license.
+    virtualImagesList:
+      list:
+        computed_optional_required: optional
+        element_type:
+          int64: {}
+        description: List of virtual image IDs associated with the license.
+  moves:
+    - license: ""
+    - template-licenseKeyWo: license_key_wo
+    - template-licenseKeyWoVersion: license_key_wo_version
+    - template-tenantsList: tenants
+    - template-virtualImagesList: virtual_images
+  removes:
+    - account
+    - copies
+    - full_name
+    - license_key
+    - license_version
+    - org_name
+    - reservation_count
+    - success
+  overrides:
+    description:
+      computed_optional_required: optional
+      description: The description of the provisioning license.
+    id:
+      computed_optional_required: computed
+      description: The ID of the provisioning license.
+      state_for_unknown: true
+    license_type:
+      computed_optional_required: required
+      description: The type of the license.
+    name:
+      computed_optional_required: required
+      description: The name of the provisioning license.
+    tenants:
+      computed_optional_required: optional
+      description: List of tenant IDs associated with the license.
+    virtual_images:
+      computed_optional_required: optional
+      description: List of virtual image IDs associated with the license.

--- a/specs/resources/role/config.yaml
+++ b/specs/resources/role/config.yaml
@@ -1,0 +1,554 @@
+role:
+  templates:
+    id:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the role
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
+            schema_definition: int64planmodifier.UseStateForUnknown()
+    default_persona_code:
+      string:
+        computed_optional_required: optional
+        description: The code of the default Persona to assign to the Role.
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+            schema_definition: |-
+              stringvalidator.OneOf(
+              "api",
+              "serviceCatalog",
+              "standard",
+              "vdi",
+              )
+    role_type:
+      string:
+        computed_optional_required: computed_optional
+        default:
+          static: user
+        description: Role type
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier
+            schema_definition: stringplanmodifier.RequiresReplace()
+        validators:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+            schema_definition: |-
+              stringvalidator.OneOf(
+              "user",
+              "tenant",
+              )
+
+    permissions:
+      single_nested:
+        computed_optional_required: optional
+        attributes:
+        - name: blueprint_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: required
+                  description: "`id` of the blueprint (appTemplate)"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified blueprints (appTemplates)
+        - name: catalog_item_type_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: required
+                  description: "`id` of the catalog item type"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified catalog item types
+        - name: cloud_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "read",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: required
+                  description: "`id` of the cloud (zone)"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified clouds (zones). Only applies to base account (tenant) roles.
+        - name: default_blueprint_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for blueprints
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_catalog_item_type_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for catalog item types
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_cloud_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for for clouds (zones). Only applies to base account (tenant) roles.
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "read",
+                  "none",
+                  )
+        - name: default_group_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for for groups (sites). Only applies to user roles.
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "read",
+                  "none",
+                  )
+        - name: default_instance_type_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for for instance types
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_persona_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for personas
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_report_type_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for report types
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_task_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for tasks
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_vdi_pool_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for VDI pools
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: default_workflow_access
+          string:
+            computed_optional_required: optional
+            description: Set the default access level for workflows (taskSets)
+            validators:
+            - custom:
+                imports:
+                - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                schema_definition: |-
+                  stringvalidator.OneOf(
+                  "full",
+                  "none",
+                  )
+        - name: feature_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "full",
+                        "full_decrypted",
+                        "group",
+                        "listfiles",
+                        "managerules",
+                        "no",
+                        "none",
+                        "provision",
+                        "read",
+                        "rolemappings",
+                        "user",
+                        "view",
+                        "yes",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: required
+                  description: "`code` of the feature permission"
+              - name: id
+                int64:
+                  computed_optional_required: computed
+              - name: name
+                string:
+                  computed_optional_required: computed
+              - name: sub_category
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified permissions.
+        - name: group_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "read",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: required
+                  description: "`id` of the group (site)"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified groups (sites). Only applies to user roles.
+        - name: instance_type_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: computed
+              - name: id
+                int64:
+                  computed_optional_required: required
+                  description: "`id` of the instance type"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified instance types
+        - name: persona_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: required
+                  description: "`code` of the persona"
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "standard",
+                        "serviceCatalog",
+                        "vdi",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: computed
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified personas
+        - name: report_type_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: required
+                  description: "`code` of the report type"
+              - name: id
+                int64:
+                  computed_optional_required: computed
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified report types
+        - name: task_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: code
+                string:
+                  computed_optional_required: computed
+              - name: id
+                int64:
+                  computed_optional_required: required
+                  description: "`id` of the task"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified tasks
+        - name: vdi_pool_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: required
+                  description: "`id` of the VDI pool"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified VDI pools
+        - name: workflow_permissions
+          set_nested:
+            computed_optional_required: optional
+            nested_object:
+              attributes:
+              - name: access
+                string:
+                  computed_optional_required: required
+                  description: The new access level.
+                  validators:
+                  - custom:
+                      imports:
+                      - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+                      schema_definition: |-
+                        stringvalidator.OneOf(
+                        "default",
+                        "full",
+                        "none",
+                        )
+              - name: id
+                int64:
+                  computed_optional_required: required
+                  description: "`id` of the workflow (taskSet)"
+              - name: name
+                string:
+                  computed_optional_required: computed
+            description: Set the access level for the specified workflows (taskSets)
+        description: The set of permissions to assign to the role
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier
+            schema_definition: objectplanmodifier.UseStateForUnknown()
+  includes:
+    - role.name
+    - role.description
+    - role.landing_url
+    - role.multitenant
+    - role.multitenant_locked
+  moves:
+    - role: "" # unnest role wrapper to root
+    - template-id: id
+    - template-default_persona_code: default_persona_code
+    - template-role_type: role_type
+    - template-permissions: permissions
+  overrides:
+    name:
+      computed_optional_required: required
+      description: A unique name for the role
+    description:
+      computed_optional_required: optional
+      description: Description
+    landing_url:
+      computed_optional_required: optional
+      description: An optional override for the default landing page after login for a user.
+    multitenant:
+      computed_optional_required: computed_optional
+      description: Multitenant roles are copied to all tenant accounts and kept in sync until a sub-tenant user modifies their copy of the role. *Only available to master tenant*
+    multitenant_locked:
+      computed_optional_required: computed_optional
+      description: Multitenant Locked, prevents sub-tenant users from modifying their copy of multienant roles. *Only available to master tenant*

--- a/specs/resources/security_group/config.yaml
+++ b/specs/resources/security_group/config.yaml
@@ -1,0 +1,79 @@
+security_group:
+  description: "Manages a Morpheus Security Group resource."
+  templates:
+    cloud_id:
+      int64:
+        computed_optional_required: optional
+        description: The cloud (zone) ID for the security group.
+    tenant_ids:
+      set:
+        computed_optional_required: optional
+        element_type:
+          int64: {}
+        description: Set of tenant IDs that are allowed access to the security group.
+    resource_permission_groups_all:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether all groups have access to the security group.
+    resource_permission_group_ids:
+      set:
+        computed_optional_required: optional
+        element_type:
+          int64: {}
+        description: Set of group IDs that have access to the security group. Only applicable when resource_permission_groups_all is false.
+  moves:
+    - security_group: ""
+    - template-cloud_id: cloud_id
+    - template-tenant_ids: tenant_ids
+    - template-resource_permission_groups_all: resource_permission_groups_all
+    - template-resource_permission_group_ids: resource_permission_group_ids
+  removes:
+    - account_id
+    - custom_options
+    - enabled
+    - external_id
+    - group_source
+    - locations
+    - network_server_id
+    - resource_permission
+    - resource_permissions
+    - rules
+    - success
+    - sync_source
+    - tenant_permissions
+    - tenants
+    - zone
+    - zone_id
+  overrides:
+    active:
+      computed_optional_required: computed_optional
+      description: Whether the security group is active.
+      default: true
+    description:
+      computed_optional_required: optional
+      description: The description of the security group.
+    id:
+      computed_optional_required: computed
+      description: The ID of the security group.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the security group.
+    visibility:
+      computed_optional_required: computed_optional
+      description: The visibility of the security group.
+      default: "private"
+    resource_permission_groups_all:
+      default: false
+      state_for_unknown: true
+      validators:
+        - custom:
+            imports:
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator
+              - path: github.com/hashicorp/terraform-plugin-framework/path
+            schema_definition: |-
+              boolvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("resource_permission_group_ids"))
+    tenant_ids:
+      computed_optional_required: computed_optional
+      state_for_unknown: true
+      requires_replace: true

--- a/specs/resources/security_group_rule/config.yaml
+++ b/specs/resources/security_group_rule/config.yaml
@@ -1,0 +1,66 @@
+security_group_rule:
+  description: "Manages a Morpheus Security Group Rule resource."
+  templates:
+    security_group_id:
+      int64:
+        computed_optional_required: required
+        description: The security group ID.
+  moves:
+    - rule: ""
+    - template-security_group_id: security_group_id
+  removes:
+    - custom_rule
+    - destination_group
+    - destination_port_range
+    - destination_tier
+    - enabled
+    - external_id
+    - instance_type_id
+    - sg_id
+    - source_group
+    - source_port_range
+    - source_tier
+    - success
+  overrides:
+    destination:
+      computed_optional_required: optional
+      description: The destination for the rule.
+    destination_type:
+      computed_optional_required: computed_optional
+      description: The destination type for the rule.
+      state_for_unknown: true
+    direction:
+      computed_optional_required: computed_optional
+      description: The direction of the rule (ingress or egress).
+      default: "ingress"
+    id:
+      computed_optional_required: computed
+      description: The ID of the security group rule.
+      state_for_unknown: true
+    name:
+      computed_optional_required: optional
+      description: The name of the rule.
+    policy:
+      computed_optional_required: computed_optional
+      description: The policy (accept or deny).
+      default: "accept"
+    port_range:
+      computed_optional_required: optional
+      description: The port range for the rule.
+    protocol:
+      computed_optional_required: required
+      description: The protocol (tcp, udp, icmp, etc.).
+    rule_type:
+      computed_optional_required: required
+      description: The rule type.
+      remove_default: true
+    security_group_id:
+      computed_optional_required: required
+      description: The ID of the parent security group.
+    source:
+      computed_optional_required: optional
+      description: The source for the rule.
+    source_type:
+      computed_optional_required: computed_optional
+      description: The source type for the rule.
+      state_for_unknown: true

--- a/specs/resources/service_plan/config.yaml
+++ b/specs/resources/service_plan/config.yaml
@@ -1,0 +1,137 @@
+service_plan:
+  templates:
+    provision_type_code:
+      string:
+        computed_optional_required: required
+        description: The provision type code of the Morpheus service plan
+    custom_cpu:
+      bool:
+        computed_optional_required: computed_optional
+        description: Can be used to enable / disable customizable cpu
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier
+            schema_definition: boolplanmodifier.UseStateForUnknown()
+    price_set_ids:
+      set:
+        computed_optional_required: computed_optional
+        element_type:
+          int64: {}
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier
+            schema_definition: setplanmodifier.UseStateForUnknown()
+    config_ranges:
+      single_nested:
+        computed_optional_required: optional
+        description: The min and max ranges that instances using this service plan must conform to.
+        attributes:
+          - name: min_storage
+            int64: {computed_optional_required: optional, description: Custom min storage in GB}
+          - name: max_storage
+            int64: {computed_optional_required: optional, description: Custom max storage in GB}
+          - name: min_per_disk_size
+            int64: {computed_optional_required: optional, description: Custom min per disk size in GB}
+          - name: max_per_disk_size
+            int64: {computed_optional_required: optional, description: Custom max per disk size in GB}
+          - name: min_memory
+            int64: {computed_optional_required: optional, description: Custom min memory in bytes}
+          - name: max_memory
+            int64: {computed_optional_required: optional, description: Custom max memory in bytes}
+          - name: min_cores
+            int64: {computed_optional_required: optional, description: Custom min cores}
+          - name: max_cores
+            int64: {computed_optional_required: optional, description: Custom max cores}
+          - name: min_sockets
+            int64: {computed_optional_required: optional, description: Custom min sockets}
+          - name: max_sockets
+            int64: {computed_optional_required: optional, description: Custom max sockets}
+          - name: min_cores_per_socket
+            int64: {computed_optional_required: optional, description: Custom min cores allowed per socket}
+          - name: max_cores_per_socket
+            int64: {computed_optional_required: optional, description: Custom max cores allowed per socket}
+  includes:
+    - service_plan.id
+    - service_plan.name
+    - service_plan.code
+    - service_plan.description
+    - service_plan.max_memory
+    - service_plan.max_storage
+    - service_plan.add_volumes
+    - service_plan.custom_cores
+    - service_plan.custom_max_storage
+    - service_plan.custom_max_memory
+    - service_plan.cores_per_socket
+    - service_plan.max_cores
+    - service_plan.max_cpu
+    - service_plan.max_disks
+    - service_plan.sort_order
+    - service_plan.config.storage_size_type
+    - service_plan.config.memory_size_type
+  moves:
+    - service_plan: "" # unnest servicePlan wrapper to root
+    - config: "" # unnest config to root
+    - template-config_ranges: config_ranges
+    - template-price_set_ids: price_set_ids
+    - template-provision_type_code: provision_type_code
+    - template-custom_cpu: custom_cpu
+  overrides:
+    id:
+      computed_optional_required: computed_optional
+      description: The ID of the role
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: Service plan name
+    code:
+      computed_optional_required: required
+      description: Service plan code, must be unique
+    description:
+      computed_optional_required: optional
+      description: Service plan description
+    max_memory:
+      computed_optional_required: required
+      description: Max memory size in bytes
+    max_storage:
+      computed_optional_required: required
+      description: Max storage size in bytes
+    add_volumes:
+      computed_optional_required: computed_optional
+      description: Can be used to enable / disable ability to add volumes
+    custom_cores:
+      computed_optional_required: computed_optional
+      description: Can be used to enable / disable customizable cores
+    custom_max_storage:
+      computed_optional_required: computed_optional
+      description: Can be used to enable / disable customizable storage
+    custom_max_memory:
+      computed_optional_required: computed_optional
+      description: Can be used to enable / disable customizable memory.
+    cores_per_socket:
+      computed_optional_required: required
+      description: Number of cores per CPU
+      state_for_unknown: true
+    max_cores:
+      computed_optional_required: computed_optional
+      description: Max number of total cores
+      state_for_unknown: true
+    max_cpu:
+      computed_optional_required: computed_optional
+      description: Max CPU's
+      state_for_unknown: true
+    max_disks:
+      computed_optional_required: computed_optional
+      description: Max disks allowed
+      state_for_unknown: true
+    sort_order:
+      computed_optional_required: computed_optional
+      description: Sort order
+      state_for_unknown: true
+    memory_size_type:
+      computed_optional_required: computed_optional
+      description: Specifies range min / max memory multiplier
+    storage_size_type:
+      computed_optional_required: computed_optional
+      description: Specifies range min / max storage multiplier

--- a/specs/resources/setting_whitelabel/config.yaml
+++ b/specs/resources/setting_whitelabel/config.yaml
@@ -1,4 +1,4 @@
-whitelabel_settings:
+setting_whitelabel:
   description: "Manages Morpheus Whitelabel Settings. This is a singleton resource — only one instance should exist. On destroy, all whitelabel settings will be reset to their zero values."
   templates:
     id:

--- a/specs/resources/storage_bucket/config.yaml
+++ b/specs/resources/storage_bucket/config.yaml
@@ -1,0 +1,105 @@
+storage_bucket:
+  description: "Manages a Morpheus Storage Bucket resource."
+  templates:
+    access_key:
+      string:
+        computed_optional_required: optional
+        description: The access key.
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    access_key_version:
+      int64:
+        computed_optional_required: optional
+        description: Access key version. Used to determine if access_key has been updated.
+    secret_key:
+      string:
+        computed_optional_required: optional
+        description: The secret key.
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    secret_key_version:
+      int64:
+        computed_optional_required: optional
+        description: Secret key version. Used to determine if secret_key has been updated.
+    endpoint:
+      string:
+        computed_optional_required: optional
+        description: The endpoint URL.
+    retention_days:
+      int64:
+        computed_optional_required: optional
+        description: The number of days to retain backups.
+  moves:
+    - storage_bucket: ""
+    - template-access_key: access_key
+    - template-access_key_version: access_key_version
+    - template-secret_key: secret_key
+    - template-secret_key_version: secret_key_version
+    - template-endpoint: endpoint
+    - template-retention_days: retention_days
+  removes:
+    - account_id
+    - active
+    - config
+    - copy_to_store
+    - create_bucket
+    - default_deployment_target
+    - default_virtual_image_target
+    - read_only
+    - retention_policy_days
+    - retention_policy_type
+    - retention_provider
+    - storage_server
+    - success
+  overrides:
+    access_key:
+      computed_optional_required: optional
+      description: The access key for the storage bucket.
+      sensitive: true
+      write_only: true
+    access_key_version:
+      computed_optional_required: optional
+      description: Access key version. Used to determine if access_key has been updated.
+    bucket_name:
+      computed_optional_required: optional
+      description: The name of the bucket.
+    default_backup_target:
+      computed_optional_required: computed_optional
+      description: Whether this is the default backup target.
+      default: false
+    endpoint:
+      computed_optional_required: optional
+      description: The endpoint URL for the storage bucket.
+    id:
+      computed_optional_required: computed
+      description: The ID of the storage bucket.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the storage bucket.
+    provider_type:
+      computed_optional_required: required
+      description: The type of storage bucket (e.g. s3, azure, etc.).
+    retention_days:
+      computed_optional_required: optional
+      description: The number of days to retain files before deletion.
+    secret_key:
+      computed_optional_required: optional
+      description: The secret key for the storage bucket.
+      sensitive: true
+      write_only: true
+    secret_key_version:
+      computed_optional_required: optional
+      description: Secret key version. Used to determine if secret_key has been updated.

--- a/specs/resources/storage_server/config.yaml
+++ b/specs/resources/storage_server/config.yaml
@@ -1,0 +1,119 @@
+storage_server:
+  description: "Manages a Morpheus Storage Server resource."
+  enable_timeouts: true
+  templates:
+    credential_id:
+      int64:
+        computed_optional_required: optional
+        description: The ID of a stored credential to use for authentication.
+    service_password_wo:
+      string:
+        computed_optional_required: optional
+        description: The service password for the storage server.
+        sensitive: true
+        write_only: true
+        plan_modifiers:
+        - custom:
+            imports:
+              - path: "github.com/HPE/terraform-provider-hpe/utils/modifiers"
+            schema_definition: |-
+              modifiers.NullableStringUpdateModifier{}
+    service_password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: Service password version. Used to determine if service_password_wo has been updated.
+    tenants:
+      list:
+        computed_optional_required: computed_optional
+        element_type:
+          int64: {}
+        description: List of tenant account IDs that are allowed access to this storage server.
+  moves:
+    - storage_server: ""
+    - template-credential_id: credential_id
+    - template-service_password_wo: service_password_wo
+    - template-service_password_wo_version: service_password_wo_version
+    - template-tenants: tenants
+  removes:
+    - admin_port
+    - api_port
+    - category
+    - chassis
+    - config
+    - credential
+    - date_created
+    - disk_count
+    - error_message
+    - external_id
+    - external_ip
+    - groups
+    - host_groups
+    - hosts
+    - internal_id
+    - internal_ip
+    - last_updated
+    - max_storage
+    - owner
+    - ref_id
+    - ref_type
+    - serial_number
+    - server_model
+    - server_vendor
+    - service_password
+    - service_password_hash
+    - service_path
+    - service_port
+    - service_token
+    - service_token_hash
+    - service_version
+    - status
+    - status_date
+    - status_message
+    - success
+    - used_storage
+  overrides:
+    description:
+      computed_optional_required: optional
+      description: The description of the storage server.
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the storage server is enabled.
+      default: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the storage server.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the storage server.
+    service_host:
+      computed_optional_required: optional
+      description: The host address of the storage server.
+    credential_id:
+      computed_optional_required: optional
+      description: The ID of a stored credential to use for authentication. Conflicts with service_username and service_password_wo.
+      conflicts_with: [service_username, service_password_wo]
+    service_password_wo:
+      computed_optional_required: optional
+      description: The service password for the storage server. Conflicts with credential_id.
+      conflicts_with: [credential_id]
+    service_password_wo_version:
+      computed_optional_required: optional
+      description: Service password version. Used to determine if service_password_wo has been updated.
+    service_url:
+      computed_optional_required: optional
+      description: The service URL of the storage server.
+    service_username:
+      computed_optional_required: optional
+      description: The service username for the storage server. Conflicts with credential_id.
+      conflicts_with: [credential_id]
+    type:
+      computed_optional_required: required
+      description: The storage type code or ID.
+    tenants:
+      computed_optional_required: computed_optional
+      description: List of tenant account IDs that are allowed access to this storage server.
+    visibility:
+      computed_optional_required: computed_optional
+      description: The visibility of the storage server (private or public).
+      default: private

--- a/specs/resources/storage_volume/config.yaml
+++ b/specs/resources/storage_volume/config.yaml
@@ -1,0 +1,61 @@
+storage_volume:
+  description: "Manages a Morpheus Storage Volume resource."
+  templates:
+    id_int:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the storage volume.
+    max_storage:
+      int64:
+        computed_optional_required: optional
+        description: The maximum storage size in bytes.
+    name:
+      string:
+        computed_optional_required: required
+        description: The name of the storage volume.
+    status:
+      string:
+        computed_optional_required: computed
+        description: The status of the storage volume.
+    storage_server_id:
+      int64:
+        computed_optional_required: optional
+        description: The ID of the storage server.
+    type_id:
+      int64:
+        computed_optional_required: required
+        description: The type ID of the storage volume.
+  moves:
+    - template-id_int: id
+    - template-max_storage: max_storage
+    - template-name: name
+    - template-status: status
+    - template-storage_server_id: storage_server_id
+    - template-type_id: type_id
+  removes:
+    - storage_volume
+    - success
+    - type
+  overrides:
+    id:
+      computed_optional_required: computed
+      description: The ID of the storage volume.
+      state_for_unknown: true
+    max_storage:
+      computed_optional_required: optional
+      description: The maximum storage size in bytes.
+    name:
+      computed_optional_required: required
+      description: The name of the storage volume.
+    status:
+      computed_optional_required: computed
+      description: The status of the storage volume.
+      state_for_unknown: true
+    storage_server_id:
+      computed_optional_required: optional
+      description: The ID of the storage server.
+      requires_replace: true
+    type_id:
+      computed_optional_required: required
+      description: The type ID of the storage volume.
+      requires_replace: true

--- a/specs/resources/subnet/config.yaml
+++ b/specs/resources/subnet/config.yaml
@@ -1,0 +1,148 @@
+subnet:
+  description: "Manages a Morpheus Subnet resource."
+  templates:
+    type_id:
+      int64:
+        computed_optional_required: required
+        description: The type ID of the subnet.
+    network_id:
+      int64:
+        computed_optional_required: required
+        description: The ID of the network this subnet belongs to.
+    pool_id:
+      int64:
+        computed_optional_required: optional
+        description: The ID of the network pool.
+    cloud_id:
+      int64:
+        computed_optional_required: computed
+        description: The ID of the cloud the subnet belongs to.
+    config:
+      dynamic:
+        computed_optional_required: optional
+        description: Configuration object. Settings vary by subnet type. This attribute is write-only and not stored in state.
+        write_only: true
+        validators:
+          - custom:
+              imports:
+                - path: github.com/HPE/terraform-provider-hpe/utils/validators
+              schema_definition: validators.ValidObjectMap()
+    config_version:
+      int64:
+        computed_optional_required: optional
+        description: Config version. Increment this value to trigger replacement of the subnet with updated config.
+    allow_static_override:
+      bool:
+        computed_optional_required: optional
+        description: Allow IP override.
+    tenant_ids:
+      set:
+        computed_optional_required: optional
+        element_type:
+          int64: {}
+        description: Set of tenant IDs that are allowed access to the subnet.
+    resource_permission_groups_all:
+      bool:
+        computed_optional_required: computed_optional
+        description: Whether all groups have access to the subnet.
+    resource_permission_group_ids:
+      set:
+        computed_optional_required: optional
+        element_type:
+          int64: {}
+        description: Set of group IDs that have access to the subnet. Only applicable when resource_permission_groups_all is false.
+  moves:
+    - subnet: ""
+    - template-type_id: type_id
+    - template-network_id: network_id
+    - template-pool_id: pool_id
+    - template-cloud_id: cloud_id
+    - template-config: config
+    - template-config_version: config_version
+    - template-allow_static_override: allow_static_override
+    - template-tenant_ids: tenant_ids
+    - template-resource_permission_groups_all: resource_permission_groups_all
+    - template-resource_permission_group_ids: resource_permission_group_ids
+  removes:
+    - account
+    - address_prefix
+    - assign_public_ip
+    - boot_file
+    - code
+    - default_network
+    - dhcp_end
+    - dhcp_ip
+    - dhcp_range
+    - dhcp_start
+    - dns_primary
+    - dns_secondary
+    - external_id
+    - has_floating_ips
+    - network
+    - network_domain
+    - network_proxy
+    - pool
+    - resource_permission
+    - search_domains
+    - security_groups
+    - status
+    - tenants
+    - tftp_server
+    - type
+    - unique_id
+    - zone
+  overrides:
+    active:
+      computed_optional_required: computed_optional
+      description: Whether the subnet is active.
+      state_for_unknown: true
+    cidr:
+      computed_optional_required: computed_optional
+      description: The CIDR of the subnet. Used directly by subnet types with cidrEditable (e.g. Google). For Azure subnets, this is derived from config.subnetCidr.
+      state_for_unknown: true
+    description:
+      computed_optional_required: optional
+      description: The description of the subnet.
+    dhcp_server:
+      computed_optional_required: computed_optional
+      description: Whether DHCP server is enabled.
+      state_for_unknown: true
+    gateway:
+      computed_optional_required: computed
+      description: The gateway of the subnet.
+      state_for_unknown: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the subnet.
+      state_for_unknown: true
+    labels:
+      computed_optional_required: optional
+      description: Labels for the subnet.
+    name:
+      computed_optional_required: computed_optional
+      description: The name of the subnet.
+      state_for_unknown: true
+    netmask:
+      computed_optional_required: computed
+      description: The netmask of the subnet.
+      state_for_unknown: true
+    subnet_address:
+      computed_optional_required: computed
+      description: The subnet address.
+      state_for_unknown: true
+    type_id:
+      computed_optional_required: required
+      description: The type ID of the subnet.
+      requires_replace: true
+    visibility:
+      computed_optional_required: computed_optional
+      description: The visibility of the subnet.
+      default: "private"
+    cloud_id:
+      state_for_unknown: true
+    config_version:
+      requires_replace: true
+    network_id:
+      requires_replace: true
+    tenant_ids:
+      requires_replace: true

--- a/specs/resources/task/config.yaml
+++ b/specs/resources/task/config.yaml
@@ -1,0 +1,85 @@
+task:
+  templates:
+    config:
+      dynamic:
+        computed_optional_required: computed_optional
+        description: Configuration object. Settings vary by type.
+        validators:
+        - custom:
+            imports:
+              - path: github.com/HPE/terraform-provider-hpe/utils/validators
+            schema_definition: validators.ValidObjectMap()
+    task_type_code:
+      string:
+        computed_optional_required: required
+        description: The code for the type of task
+    retry_delay_seconds:
+      int64:
+        computed_optional_required: computed_optional
+        description: The delay, between retries.
+        validators:
+        - custom:
+            imports:
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+            schema_definition: int64validator.AtLeast(0)
+
+  removes:
+    - account_id
+    - credential
+    - file
+    - task_options
+    - task_type
+    - ansible_playbook_task_config
+    - ansible_tower_task_config
+    - chef_bootstrap_task_config
+    - conditional_workflow_task_config
+    - email_task_config
+    - groovy_task_config
+    - httptask_config
+    - java_task_config
+    - library_script_task_config
+    - library_template_task_config
+    - nested_workflow_task_config
+    - power_shell_task_config
+    - puppet_task_config
+    - python_task_config
+    - restart_task_config
+    - shell_task_config
+    - v_realize_orchestrator_task_config
+    - write_attributes_task_config
+    - success
+    - date_created
+    - last_updated
+  moves:
+    - task: ""
+    - template-config: config
+    - template-task_type_code: task_type_code
+    - template-retry_delay_seconds: retry_delay_seconds
+    # - task_options.ansible_playbook_task_config: config_ansible_playbook
+    # - task_options.ansible_tower_task_config: config_ansible_tower
+    # - task_options.chef_bootstrap_task_config: config_chef_bootstrap
+    - task_options.conditional_workflow_task_config: config_conditional_workflow
+    # - task_options.email_task_config: config_email
+    # - task_options.groovy_task_config: config_groovy
+    # - task_options.httptask_config: config_http
+    # - task_options.java_task_config: config_java
+    # - task_options.library_script_task_config: config_library_script
+    # - task_options.library_template_task_config: config_library_template
+    # - task_options.nested_workflow_task_config: config_nested_workflow
+    # - task_options.power_shell_task_config: config_powershell
+    # - task_options.puppet_task_config: config_puppet
+    # - task_options.python_task_config: config_python
+    # - task_options.restart_task_config: config_restart
+    # - task_options.shell_task_config: config_shell
+    # - task_options.v_realize_orchestrator_task_config: config_vro
+    # - task_options.write_attributes_task_config: config_write_attributes
+    - result_type.oneof0: result_type
+  overrides:
+    task_type_code:
+      requires_replace: true
+    config_conditional_workflow.conditional_script:
+      trimmed_space_string: true
+    allow_custom_config:
+      description: When enabled, a text area is provided during manual Task execution to allow the user to pass extra variables or specify extra configuration
+      computed_optional_required: computed_optional
+    

--- a/specs/resources/user/config.yaml
+++ b/specs/resources/user/config.yaml
@@ -1,0 +1,124 @@
+user:
+  templates:
+    id:
+      int64:
+        computed_optional_required: computed
+        description: User id
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
+            schema_definition: int64planmodifier.UseStateForUnknown()
+    role_ids:
+      set:
+        computed_optional_required: required
+        element_type:
+          int64: {}
+    tenant_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: Tenant Id (accountId) create user in a sub tenant account instead of your own. Changing this attribute forces a deletion and recreation.
+        plan_modifiers:
+        - custom:
+            schema_definition: |-
+              int64planmodifier.UseStateForUnknown(),
+              int64planmodifier.RequiresReplace(), // force new
+    first_name:
+      string:
+        computed_optional_required: computed_optional
+        description: User's first name (optional)
+        plan_modifiers:
+        - custom:
+            schema_definition: modifiers.NullableStringUpdateModifier{}
+    last_name:
+      string:
+        computed_optional_required: computed_optional
+        description: User's last name (optional)
+        plan_modifiers:
+        - custom:
+            schema_definition: modifiers.NullableStringUpdateModifier{}
+    linux_key_pair_id:
+      int64:
+        computed_optional_required: computed_optional
+        description: Linux key pair id (optional)
+        plan_modifiers:
+        - custom:
+            schema_definition: modifiers.NullableInt64UpdateModifier{}
+    linux_username:
+      string:
+        computed_optional_required: computed_optional
+        description: Linux username
+        plan_modifiers:
+        - custom:
+            schema_definition: modifiers.NullableStringUpdateModifier{}
+    linux_password_wo:
+      string:
+        computed_optional_required: optional
+        description: Linux password (Write Only)
+        plan_modifiers:
+        - custom:
+            schema_definition: modifiers.NullableStringUpdateModifier{}
+        sensitive: true
+        write_only: true
+    linux_password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: Linux password version. Used to determine if linux_password_wo has been updated.
+    windows_username:
+      string:
+        computed_optional_required: computed_optional
+        description: Windows username
+        plan_modifiers:
+        - custom:
+            schema_definition: modifiers.NullableStringUpdateModifier{}
+
+    windows_password_wo:
+      string:
+        computed_optional_required: optional
+        description: Windows password (Write Only)
+        plan_modifiers:
+        - custom:
+            schema_definition: modifiers.NullableStringUpdateModifier{}
+        sensitive: true
+        write_only: true
+    windows_password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: Windows password version. Used to determine if windows_password_wo has been updated.
+    password_wo:
+      string:
+        computed_optional_required: optional
+        description: Password to apply to the user (Write Only)
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier
+            - path: github.com/HPE/terraform-provider-hpe/utils/modifiers
+            schema_definition: modifiers.RequireOnCreateModifier{}
+        sensitive: true
+        write_only: true
+    password_wo_version:
+      int64:
+        computed_optional_required: optional
+        description: Password version. Used to determine if password_wo has been updated.
+  includes:
+    - user.username
+    - user.email
+    - user.password_expired
+    - user.receive_notifications
+  moves:
+    - user: "" # unnest user wrapper to root
+    - template-id: id
+    - template-role_ids: role_ids
+    - template-tenant_id: tenant_id
+    - template-first_name: first_name
+    - template-last_name: last_name
+    - template-linux_key_pair_id: linux_key_pair_id
+    - template-linux_username: linux_username
+    - template-linux_password_wo: linux_password_wo
+    - template-linux_password_wo_version: linux_password_wo_version
+    - template-windows_username: windows_username
+    - template-windows_password_wo: windows_password_wo
+    - template-windows_password_wo_version: windows_password_wo_version
+    - template-password_wo: password_wo
+    - template-password_wo_version: password_wo_version

--- a/specs/resources/vdi_app/config.yaml
+++ b/specs/resources/vdi_app/config.yaml
@@ -1,0 +1,26 @@
+vdi_app:
+  description: "Manages a Morpheus VDI App resource."
+  moves:
+    - vdi_app: ""
+  removes:
+    - anyof0
+    - anyof1
+    - date_created
+    - icon_path
+    - last_updated
+    - logo
+    - oneof0
+  overrides:
+    description:
+      computed_optional_required: optional
+      description: The description of the VDI app.
+    id:
+      computed_optional_required: computed
+      description: The ID of the VDI app.
+      state_for_unknown: true
+    launch_prefix:
+      computed_optional_required: optional
+      description: The RDS app name prefix.
+    name:
+      computed_optional_required: required
+      description: The name of the VDI app.

--- a/specs/resources/vdi_gateway/config.yaml
+++ b/specs/resources/vdi_gateway/config.yaml
@@ -1,0 +1,25 @@
+vdi_gateway:
+  description: "Manages a Morpheus VDI Gateway resource."
+  moves:
+    - vdi_gateway: ""
+  removes:
+    - anyof0
+    - anyof1
+    - api_key
+    - date_created
+    - last_updated
+    - oneof0
+  overrides:
+    description:
+      computed_optional_required: optional
+      description: The description of the VDI gateway.
+    gateway_url:
+      computed_optional_required: required
+      description: The URL of the VDI gateway.
+    id:
+      computed_optional_required: computed
+      description: The ID of the VDI gateway.
+      state_for_unknown: true
+    name:
+      computed_optional_required: required
+      description: The name of the VDI gateway.

--- a/specs/resources/vdi_pool/config.yaml
+++ b/specs/resources/vdi_pool/config.yaml
@@ -1,0 +1,95 @@
+vdi_pool:
+  description: "Manages a Morpheus VDI Pool resource."
+  templates:
+    idle_timeout:
+      int64:
+        computed_optional_required: optional
+        description: The idle timeout in minutes.
+    max_session_timeout:
+      int64:
+        computed_optional_required: optional
+        description: The maximum session timeout in minutes.
+  moves:
+    - vdi_pool: ""
+    - template-idle_timeout: idle_timeout
+    - template-max_session_timeout: max_session_timeout
+  removes:
+    - allocation_timeout_minutes
+    - anyof0
+    - anyof1
+    - apps
+    - cloud
+    - config
+    - date_created
+    - gateway
+    - group
+    - guest_console_jump_host
+    - guest_console_jump_keypair
+    - guest_console_jump_password
+    - guest_console_jump_port
+    - guest_console_jump_username
+    - icon_path
+    - idle_count
+    - last_updated
+    - logo
+    - oneof0
+    - oneof1
+    - owner
+    - preparing_count
+    - reserved_count
+    - status
+    - used_count
+  overrides:
+    allow_copy:
+      computed_optional_required: computed_optional
+      description: Whether to allow copy operations.
+    allow_fileshare:
+      computed_optional_required: computed_optional
+      description: Whether to allow file sharing.
+    allow_hypervisor_console:
+      computed_optional_required: computed_optional
+      description: Whether to allow hypervisor console access.
+    allow_printer:
+      computed_optional_required: computed_optional
+      description: Whether to allow printer access.
+    auto_create_local_user_on_reservation:
+      computed_optional_required: computed_optional
+      description: Whether to auto-create a local user on reservation.
+    description:
+      computed_optional_required: optional
+      description: The description of the VDI pool.
+    enabled:
+      computed_optional_required: computed_optional
+      description: Whether the VDI pool is enabled.
+      default: true
+    id:
+      computed_optional_required: computed
+      description: The ID of the VDI pool.
+      state_for_unknown: true
+    idle_timeout:
+      computed_optional_required: optional
+      description: The idle timeout in minutes.
+    initial_pool_size:
+      computed_optional_required: computed_optional
+      description: The initial size of the pool to be allocated on creation.
+    max_idle:
+      computed_optional_required: computed_optional
+      description: Sets the maximum number of idle instances on standby in the pool.
+    max_pool_size:
+      computed_optional_required: required
+      description: Max limit on number of allocations and instances within the pool.
+    max_session_timeout:
+      computed_optional_required: optional
+      description: The maximum session timeout in minutes.
+    min_idle:
+      computed_optional_required: computed_optional
+      description: Sets the minimum number of idle instances on standby in the pool.
+    name:
+      computed_optional_required: required
+      description: The name of the VDI pool.
+    persistent_user:
+      computed_optional_required: computed_optional
+      description: Whether users are persistent across sessions.
+    recyclable:
+      computed_optional_required: computed_optional
+      description: Whether VDI pool instances are recyclable.

--- a/specs/resources/whitelabel_settings/config.yaml
+++ b/specs/resources/whitelabel_settings/config.yaml
@@ -1,0 +1,81 @@
+whitelabel_settings:
+  description: "Manages Morpheus Whitelabel Settings. This is a singleton resource — only one instance should exist. On destroy, all whitelabel settings will be reset to their zero values."
+  templates:
+    id:
+      string:
+        computed_optional_required: computed
+        description: The fixed identifier for the whitelabel settings singleton.
+      state_for_unknown: true
+    primary_color:
+      string:
+        computed_optional_required: optional
+        description: The primary button background color.
+    secondary_color:
+      string:
+        computed_optional_required: optional
+        description: The header background color.
+    support_menu_links_str:
+      string:
+        computed_optional_required: optional
+        description: Support menu links as a JSON string.
+  moves:
+    - whitelabel_settings: ""
+    - template-id: id
+    - template-primary_color: primary_color
+    - template-secondary_color: secondary_color
+    - template-support_menu_links_str: support_menu_links
+  removes:
+    - copyright_string
+    - disable_support_menu
+    - footer_bg_color
+    - footer_fg_color
+    - header_bg_color
+    - header_fg_color
+    - login_bg_color
+    - nav_bg_color
+    - nav_fg_color
+    - nav_hover_color
+    - override_css
+    - primary_button_bg_color
+    - primary_button_fg_color
+    - primary_button_hover_bg_color
+    - primary_button_hover_fg_color
+    - privacy_policy
+    - reset_favicon
+    - reset_footer_logo
+    - reset_header_logo
+    - reset_login_logo
+    - success
+    - terms_of_use
+  overrides:
+    appliance_name:
+      computed_optional_required: optional
+      description: The appliance name. Master account only.
+    enabled:
+      computed_optional_required: optional
+      description: Whether the whitelabel feature is enabled.
+    favicon:
+      computed_optional_required: optional
+      description: The favicon URL or path.
+    footer_logo:
+      computed_optional_required: optional
+      description: The footer logo URL or path.
+    header_logo:
+      computed_optional_required: optional
+      description: The header logo URL or path.
+    id:
+      computed_optional_required: computed
+      description: The fixed identifier for the whitelabel settings singleton.
+      state_for_unknown: true
+    login_logo:
+      computed_optional_required: optional
+      description: The login logo URL or path.
+    primary_color:
+      computed_optional_required: optional
+      description: The primary button background color.
+    secondary_color:
+      computed_optional_required: optional
+      description: The header background color.
+    support_menu_links:
+      computed_optional_required: optional
+      description: Support menu links as a JSON string.


### PR DESCRIPTION
## Summary

Add a top-level `specs/` directory holding the per-resource schema configuration (`config.yaml`) and `config-provider.yaml` that drive generation of the resource and data source `schema_gen.go` files. The split intermediates and any bundled OpenAPI spec are regenerated artifacts and are gitignored.

This consolidates the schema-generation inputs into the provider so schemas are generated directly into `morpheus/framework/{resources,datasources}/<name>/`.

## Changes

- `specs/` — 95 `config.yaml` (57 resources + 38 data sources) + `config-provider.yaml`
- `.gitignore` — ignore the regenerated intermediates (`spec.yaml`, `provider.yaml`, the merged spec, OpenAPI bundles)
- Rename the `whitelabel_settings` config to `setting_whitelabel` so it maps to the `settingwhitelabel` package; align the generated type names (`WhitelabelSettings*` → `SettingWhitelabel*`), schema content unchanged

## Verification

- `go build ./...` ✅
- The configs reproduce the committed schemas byte-identical (89/93; the 4 outstanding are pre-existing drift tracked separately), and `settingwhitelabel` now reproduces cleanly
