### PR TITLE
Skip acceptance tests when required capabilities unavailable

### DIFF
--- a/morpheus/framework/datasources/backup/datasource_test.go
+++ b/morpheus/framework/datasources/backup/datasource_test.go
@@ -62,7 +62,7 @@ func TestAccMorpheusFindBackupById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Backup) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -126,7 +126,7 @@ func TestAccMorpheusFindBackupByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Backup) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -195,7 +195,7 @@ func TestAccMorpheusFindBackupNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -228,7 +228,7 @@ func TestAccMorpheusFindBackupNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -254,7 +254,7 @@ func TestAccMorpheusFindBackupBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/backuptype/datasource_test.go
+++ b/morpheus/framework/datasources/backuptype/datasource_test.go
@@ -36,7 +36,7 @@ func TestAccMorpheusFindBackupTypeById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -75,7 +75,7 @@ func TestAccMorpheusFindBackupTypeByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -117,7 +117,7 @@ func TestAccMorpheusFindBackupTypeNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -150,7 +150,7 @@ func TestAccMorpheusFindBackupTypeNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -176,7 +176,7 @@ func TestAccMorpheusFindBackupTypeBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/cloud/datasource_test.go
+++ b/morpheus/framework/datasources/cloud/datasource_test.go
@@ -50,7 +50,7 @@ func TestAccMorpheusFindCloudById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -133,7 +133,7 @@ func TestAccMorpheusFindCloudByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -216,7 +216,7 @@ func TestAccMorpheusFindCloudNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -258,7 +258,7 @@ func TestAccMorpheusFindCloudNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -293,7 +293,7 @@ func TestAccMorpheusFindCloudBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/cluster/datasource_test.go
+++ b/morpheus/framework/datasources/cluster/datasource_test.go
@@ -36,7 +36,7 @@ func TestAccMorpheusFindClusterById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -85,7 +85,7 @@ func TestAccMorpheusFindClusterByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -134,7 +134,7 @@ func TestAccMorpheusFindClusterNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -170,7 +170,7 @@ func TestAccMorpheusFindClusterNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -200,7 +200,7 @@ func TestAccMorpheusFindClusterBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/datastore/datasource_test.go
+++ b/morpheus/framework/datasources/datastore/datasource_test.go
@@ -34,7 +34,7 @@ func TestAccMorpheusFindDatastoreById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -92,7 +92,7 @@ func TestAccMorpheusFindDatastoreByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -154,7 +154,7 @@ func TestAccMorpheusFindDatastoreNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -194,7 +194,7 @@ func TestAccMorpheusFindDatastoreNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -227,7 +227,7 @@ func TestAccMorpheusFindDatastoreBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/environment/datasource_test.go
+++ b/morpheus/framework/datasources/environment/datasource_test.go
@@ -42,7 +42,7 @@ func TestAccMorpheusFindEnvironmentById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -97,7 +97,7 @@ func TestAccMorpheusFindIdbyName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -153,7 +153,7 @@ func TestAccMorpheusFindEnvironmentNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -192,7 +192,7 @@ func TestAccMorpheusFindEnvironmentNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	config := providerConfigOffline + `
       data "hpe_morpheus_environment" "test" {
@@ -225,7 +225,7 @@ func TestAccMorpheusFindEnvironmentBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	config := providerConfigOffline + `
       data "hpe_morpheus_environment" "test" {

--- a/morpheus/framework/datasources/group/datasource_test.go
+++ b/morpheus/framework/datasources/group/datasource_test.go
@@ -49,7 +49,7 @@ func TestAccMorpheusFindGroupById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -96,7 +96,7 @@ func TestAccMorpheusFindGroupByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -143,7 +143,7 @@ func TestAccMorpheusFindGroupNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -183,7 +183,7 @@ func TestAccMorpheusFindGroupNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	config := providerConfigOffline + `
       data "hpe_morpheus_group" "test" {
@@ -216,7 +216,7 @@ func TestAccMorpheusFindGroupBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	config := providerConfigOffline + `
       data "hpe_morpheus_group" "test" {

--- a/morpheus/framework/datasources/image/image_test.go
+++ b/morpheus/framework/datasources/image/image_test.go
@@ -41,7 +41,7 @@ func TestAccMorpheusImageDatasourceById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -108,7 +108,7 @@ func TestAccMorpheusImageDatasourceByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -175,7 +175,7 @@ func TestAccMorpheusImageDatasourceByNameAndImageType(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -246,7 +246,7 @@ func TestAccMorpheusImageDatasourceByImageTypeOnly(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -274,7 +274,7 @@ func TestAccMorpheusImageDatasourceBothAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/instance/instance_test.go
+++ b/morpheus/framework/datasources/instance/instance_test.go
@@ -46,7 +46,7 @@ func TestAccMorpheusInstanceDatasourceByIdAndName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -167,7 +167,7 @@ func TestAccMorpheusInstanceDatasourceBothAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -198,7 +198,7 @@ func TestAccMorpheusInstanceDatasourceNoAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/instancesnapshot/datasource_test.go
+++ b/morpheus/framework/datasources/instancesnapshot/datasource_test.go
@@ -32,7 +32,7 @@ func TestAccMorpheusInstanceSnapshotDataSource(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/instancetypelayout/datasource_test.go
+++ b/morpheus/framework/datasources/instancetypelayout/datasource_test.go
@@ -43,7 +43,7 @@ func TestAccMorpheusFindInstanceTypeLayoutById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -103,7 +103,7 @@ func TestAccMorpheusFindInstanceTypeLayoutByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -162,7 +162,7 @@ func TestAccMorpheusFindInstanceTypeLayoutByNameAndVersion(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -228,7 +228,7 @@ func TestAccMorpheusFindInstanceTypeLayoutSortOrder(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -283,7 +283,7 @@ func TestAccMorpheusFindInstanceLayoutNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -325,7 +325,7 @@ func TestAccMorpheusFindInstanceTypeLayoutByNameAndVersionNoSearchAttrs(t *testi
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -360,7 +360,7 @@ func TestAccMorpheusFindInstanceLayoutWithIdAndName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -397,7 +397,7 @@ func TestAccMorpheusFindInstanceLayoutWithIdAndVersion(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/loadbalancer/datasource_test.go
+++ b/morpheus/framework/datasources/loadbalancer/datasource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusLoadBalancerDataSourceByNameExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkLoadBalancer) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -64,7 +64,7 @@ func TestAccMorpheusLoadBalancerDataSourceByIdExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkLoadBalancer) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/loadbalancermonitor/datasource_test.go
+++ b/morpheus/framework/datasources/loadbalancermonitor/datasource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusLoadBalancerMonitorDataSourceByIdOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -92,7 +92,7 @@ func TestAccMorpheusLoadBalancerMonitorDataSourceByNameOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/loadbalancerpool/datasource_acc_test.go
+++ b/morpheus/framework/datasources/loadbalancerpool/datasource_acc_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusLoadBalancerPoolDataSourceByIdOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	// Not parallel: a standalone NSX-T load balancer pool stays "offline"
@@ -97,7 +97,7 @@ func TestAccMorpheusLoadBalancerPoolDataSourceByNameOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	// Not parallel: a standalone NSX-T load balancer pool stays "offline"

--- a/morpheus/framework/datasources/loadbalancerprofile/datasource_acc_test.go
+++ b/morpheus/framework/datasources/loadbalancerprofile/datasource_acc_test.go
@@ -26,9 +26,7 @@ func TestMain(m *testing.M) {
 
 func TestAccMorpheusLoadBalancerProfileDataSourceByIdOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	// Not parallel: NSX-T load balancer profiles are children of a load balancer
@@ -89,9 +87,7 @@ func TestAccMorpheusLoadBalancerProfileDataSourceByIdOk(t *testing.T) {
 
 func TestAccMorpheusLoadBalancerProfileDataSourceByNameOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	// Not parallel — see TestAccMorpheusLoadBalancerProfileDataSourceByIdOk.
@@ -150,9 +146,7 @@ func TestAccMorpheusLoadBalancerProfileDataSourceByNameOk(t *testing.T) {
 
 func TestAccMorpheusLoadBalancerProfileDataSourceNotFound(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	defer testhelpers.RecordResult(t)

--- a/morpheus/framework/datasources/loadbalancervirtualserver/datasource_test.go
+++ b/morpheus/framework/datasources/loadbalancervirtualserver/datasource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusLoadBalancerVirtualServerDataSourceByIdOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -98,7 +98,7 @@ func TestAccMorpheusLoadBalancerVirtualServerDataSourceByNameOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/network/datasource_test.go
+++ b/morpheus/framework/datasources/network/datasource_test.go
@@ -40,7 +40,7 @@ func TestNetworkDataSourceExample(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Network) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/datasources/networkdhcpserver/datasource_test.go
+++ b/morpheus/framework/datasources/networkdhcpserver/datasource_test.go
@@ -57,7 +57,7 @@ func TestAccMorpheusFindNetworkDhcpServerByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -95,7 +95,7 @@ func TestAccMorpheusFindNetworkDhcpServerById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -133,7 +133,7 @@ func TestAccMorpheusFindNetworkDhcpServerNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -173,7 +173,7 @@ func TestAccMorpheusFindNetworkDhcpServerNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -200,7 +200,7 @@ func TestAccMorpheusFindNetworkDhcpServerBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networkdomain/datasource_test.go
+++ b/morpheus/framework/datasources/networkdomain/datasource_test.go
@@ -35,7 +35,7 @@ func TestAccMorpheusFindNetworkDomainByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -69,7 +69,7 @@ func TestAccMorpheusFindNetworkDomainById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -113,7 +113,7 @@ func TestAccMorpheusFindNetworkDomainNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -150,7 +150,7 @@ func TestAccMorpheusFindNetworkDomainNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -176,7 +176,7 @@ func TestAccMorpheusFindNetworkDomainBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networkedgecluster/datasource_test.go
+++ b/morpheus/framework/datasources/networkedgecluster/datasource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusNetworkEdgeClusterByID(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -65,7 +65,7 @@ func TestAccMorpheusNetworkEdgeClusterByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -105,7 +105,7 @@ func TestAccMorpheusNetworkEdgeClusterNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/networkfirewallrule/datasource_test.go
+++ b/morpheus/framework/datasources/networkfirewallrule/datasource_test.go
@@ -65,7 +65,7 @@ func TestAccMorpheusFindNetworkFirewallRuleByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -106,7 +106,7 @@ func TestAccMorpheusFindNetworkFirewallRuleById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -147,7 +147,7 @@ func TestAccMorpheusFindNetworkFirewallRuleNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -184,7 +184,7 @@ func TestAccMorpheusFindNetworkFirewallRuleNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -211,7 +211,7 @@ func TestAccMorpheusFindNetworkFirewallRuleBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networkfirewallrulegroup/datasource_test.go
+++ b/morpheus/framework/datasources/networkfirewallrulegroup/datasource_test.go
@@ -37,7 +37,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupByIdOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -91,7 +91,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupByNameOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -144,7 +144,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -179,7 +179,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -206,7 +206,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networkpool/datasource_test.go
+++ b/morpheus/framework/datasources/networkpool/datasource_test.go
@@ -35,7 +35,7 @@ func TestAccMorpheusFindNetworkPoolByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -83,7 +83,7 @@ func TestAccMorpheusFindNetworkPoolById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -131,7 +131,7 @@ func TestAccMorpheusFindNetworkPoolNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -173,7 +173,7 @@ func TestAccMorpheusFindNetworkPoolNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -209,7 +209,7 @@ func TestAccMorpheusFindNetworkPoolBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networkrouter/datasource_test.go
+++ b/morpheus/framework/datasources/networkrouter/datasource_test.go
@@ -57,7 +57,7 @@ func TestAccMorpheusFindNetworkRouterByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -96,7 +96,7 @@ func TestAccMorpheusFindNetworkRouterById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -134,7 +134,7 @@ func TestAccMorpheusFindNetworkRouterNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -171,7 +171,7 @@ func TestAccMorpheusFindNetworkRouterNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -197,7 +197,7 @@ func TestAccMorpheusFindNetworkRouterBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networkrouterbgpneighbor/datasource_test.go
+++ b/morpheus/framework/datasources/networkrouterbgpneighbor/datasource_test.go
@@ -66,7 +66,7 @@ func TestAccMorpheusFindNetworkRouterBgpNeighborByIpAddress(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -106,7 +106,7 @@ func TestAccMorpheusFindNetworkRouterBgpNeighborById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -145,7 +145,7 @@ func TestAccMorpheusFindNetworkRouterBgpNeighborNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -181,7 +181,7 @@ func TestAccMorpheusFindNetworkRouterBgpNeighborNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networkrouterroute/datasource_test.go
+++ b/morpheus/framework/datasources/networkrouterroute/datasource_test.go
@@ -74,7 +74,7 @@ func TestAccMorpheusFindNetworkRouterRouteByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -114,7 +114,7 @@ func TestAccMorpheusFindNetworkRouterRouteById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -153,7 +153,7 @@ func TestAccMorpheusFindNetworkRouterRouteNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -191,7 +191,7 @@ func TestAccMorpheusFindNetworkRouterRouteNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networkserver/datasource_test.go
+++ b/morpheus/framework/datasources/networkserver/datasource_test.go
@@ -35,7 +35,7 @@ func TestAccMorpheusFindNetworkServerByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -83,7 +83,7 @@ func TestAccMorpheusFindNetworkServerById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -131,7 +131,7 @@ func TestAccMorpheusFindNetworkServerNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -173,7 +173,7 @@ func TestAccMorpheusFindNetworkServerNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -209,7 +209,7 @@ func TestAccMorpheusFindNetworkServerBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/networktransportzone/datasource_test.go
+++ b/morpheus/framework/datasources/networktransportzone/datasource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusNetworkTransportZoneByID(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -65,7 +65,7 @@ func TestAccMorpheusNetworkTransportZoneByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -105,7 +105,7 @@ func TestAccMorpheusNetworkTransportZoneNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/networktype/datasource_test.go
+++ b/morpheus/framework/datasources/networktype/datasource_test.go
@@ -35,7 +35,7 @@ func TestAccMorpheusFindNetworkTypeByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -83,7 +83,7 @@ func TestAccMorpheusFindNetworkTypeById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -131,7 +131,7 @@ func TestAccMorpheusFindNetworkTypeNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -173,7 +173,7 @@ func TestAccMorpheusFindNetworkTypeNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -209,7 +209,7 @@ func TestAccMorpheusFindNetworkTypeBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/ostype/datasource_test.go
+++ b/morpheus/framework/datasources/ostype/datasource_test.go
@@ -35,7 +35,7 @@ func TestAccMorpheusFindOsTypeByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -73,7 +73,7 @@ func TestAccMorpheusFindOsTypeById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -133,7 +133,7 @@ func TestAccMorpheusFindOsTypeNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -175,7 +175,7 @@ func TestAccMorpheusFindOsTypeNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -211,7 +211,7 @@ func TestAccMorpheusFindOsTypeBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/datasources/ostypeimage/datasource_test.go
+++ b/morpheus/framework/datasources/ostypeimage/datasource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusOsTypeImageDataSourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -83,7 +83,7 @@ func TestAccMorpheusOsTypeImageDataSourceSystemImageOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -146,7 +146,7 @@ func TestAccMorpheusOsTypeImageDataSourceNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/policy/datasource_test.go
+++ b/morpheus/framework/datasources/policy/datasource_test.go
@@ -53,7 +53,7 @@ func TestAccMorpheusPolicyDataSourceFindByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -128,7 +128,7 @@ func TestAccMorpheusPolicyDataSourceFindById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -203,7 +203,7 @@ func TestAccMorpheusPolicyDataSourceNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -245,7 +245,7 @@ func TestAccMorpheusPolicyDataSourceNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -281,7 +281,7 @@ func TestAccMorpheusPolicyDataSourceBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -321,7 +321,7 @@ func TestAccMorpheusPolicyDataSourceVerifyAllAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -733,7 +733,7 @@ func TestAccMorpheusPolicyDataSourceResourceTypesOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/datasources/role/datasource_test.go
+++ b/morpheus/framework/datasources/role/datasource_test.go
@@ -49,7 +49,7 @@ func TestAccMorpheusFindRoleById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -108,7 +108,7 @@ func TestAccMorpheusFindRoleByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -167,7 +167,7 @@ func TestAccMorpheusFindRoleVerifyAttributes(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -381,7 +381,7 @@ func TestAccMorpheusFindRoleNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -416,7 +416,7 @@ func TestAccMorpheusFindRoleBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/securitygroup/datasource_test.go
+++ b/morpheus/framework/datasources/securitygroup/datasource_test.go
@@ -34,9 +34,7 @@ provider "hpe" {
 
 func TestAccMorpheusFindSecurityGroupByName(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -86,9 +84,7 @@ data "hpe_morpheus_security_group" "example" {
 
 func TestAccMorpheusFindSecurityGroupById(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -138,9 +134,7 @@ data "hpe_morpheus_security_group" "example" {
 
 func TestAccMorpheusFindSecurityGroupNotFound(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -171,9 +165,7 @@ func TestAccMorpheusFindSecurityGroupNotFound(t *testing.T) {
 
 func TestAccMorpheusFindSecurityGroupNoSearchAttrs(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -198,9 +190,7 @@ func TestAccMorpheusFindSecurityGroupNoSearchAttrs(t *testing.T) {
 
 func TestAccMorpheusFindSecurityGroupBothSearchAttrs(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 

--- a/morpheus/framework/datasources/securitygroups/datasource_test.go
+++ b/morpheus/framework/datasources/securitygroups/datasource_test.go
@@ -22,9 +22,7 @@ func TestMain(m *testing.M) {
 
 func TestAccMorpheusSecurityGroupsFilterByName(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -81,9 +79,7 @@ data "hpe_morpheus_security_groups" "example" {
 // which are ANDed together. A new security group defaults to private visibility.
 func TestAccMorpheusSecurityGroupsMultiFilter(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -140,9 +136,7 @@ data "hpe_morpheus_security_groups" "example" {
 
 func TestAccMorpheusSecurityGroupsEmptyResult(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 

--- a/morpheus/framework/datasources/serviceplan/datasource_test.go
+++ b/morpheus/framework/datasources/serviceplan/datasource_test.go
@@ -39,7 +39,7 @@ func TestAccMorpheusFindServicePlanById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -93,7 +93,7 @@ func TestAccMorpheusFindServicePlanByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -157,7 +157,7 @@ func TestAccMorpheusFindServicePlanNoPlanFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -202,7 +202,7 @@ func TestAccMorpheusFindServicePlanNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -238,7 +238,7 @@ func TestAccMorpheusFindServicePlanBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -281,7 +281,7 @@ func TestAccMorpheusFindServicePlanByProvisionOnly(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -322,7 +322,7 @@ func TestAccMorpheusFindServicePlanByCloudIdOnly(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -366,7 +366,7 @@ func TestAccMorpheusFindServicePlanVerifyAttributes(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/datasources/user/datasource_test.go
+++ b/morpheus/framework/datasources/user/datasource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusUserDataSourceFindByUsername(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -104,7 +104,7 @@ func TestAccMorpheusUserDataSourceFindById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -156,7 +156,7 @@ func TestAccMorpheusUserDataSourceNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -198,7 +198,7 @@ func TestAccMorpheusUserDataSourceNoSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -233,7 +233,7 @@ func TestAccMorpheusUserDataSourceBothSearchAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -277,7 +277,7 @@ func TestAccMorpheusUserDataSourceVerifyAttributes(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VDI) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/resources/backuphost/resource_test.go
+++ b/morpheus/framework/resources/backuphost/resource_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusBackupHostResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Backup) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -107,7 +107,7 @@ func TestAccMorpheusBackupHostResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Backup) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/backupinstance/resource_test.go
+++ b/morpheus/framework/resources/backupinstance/resource_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusBackupInstanceResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Backup) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -107,7 +107,7 @@ func TestAccMorpheusBackupInstanceResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Backup) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/backupjob/resource_test.go
+++ b/morpheus/framework/resources/backupjob/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusBackupJobResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -77,7 +77,7 @@ func TestAccMorpheusBackupJobResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/budget/resource_test.go
+++ b/morpheus/framework/resources/budget/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusBudgetResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -76,7 +76,7 @@ func TestAccMorpheusBudgetResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/certificate/resource_test.go
+++ b/morpheus/framework/resources/certificate/resource_test.go
@@ -33,7 +33,7 @@ func TestAccMorpheusCertificateResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -85,7 +85,7 @@ func TestAccMorpheusCertificateResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/cloud/cloud_test.go
+++ b/morpheus/framework/resources/cloud/cloud_test.go
@@ -47,7 +47,7 @@ func TestAccMorpheusCloudResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -202,7 +202,7 @@ func TestAccMorpheusCloudResourceExampleAzureOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Azure) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -291,7 +291,7 @@ func TestAccMorpheusCloudResourceExampleGenericOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -453,7 +453,7 @@ func TestAccMorpheusCloudResourceUpdate(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -1247,7 +1247,7 @@ func TestAccMorpheusCloudResourceValidationOneOf(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -1335,7 +1335,7 @@ func TestAccMorpheusCloudResourceValidationRequiredAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/resources/cluster/cluster_test.go
+++ b/morpheus/framework/resources/cluster/cluster_test.go
@@ -28,9 +28,7 @@ func TestMain(m *testing.M) {
 // Tests that our HVM example file template used for docs is a valid config
 func TestAccMorpheusClusterResourceHVMExampleOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if skip.SkipByDefault(t) {
 		t.Log("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
@@ -217,9 +215,7 @@ data "hpe_morpheus_service_plan" "test" {
 // Tests that our generic example file template used for docs is a valid config
 func TestAccMorpheusClusterResourceGenericExampleOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if skip.SkipByDefault(t) {
 		t.Log("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
@@ -393,9 +389,7 @@ data "hpe_morpheus_service_plan" "test" {
 
 func TestAccMorpheusClusterResourceHVMUpdateOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if skip.SkipByDefault(t) {
 		t.Log("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
@@ -583,9 +577,7 @@ resource "hpe_morpheus_cluster" "test" {
 
 func TestAccMorpheusClusterResourceGenericUpdateOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if skip.SkipByDefault(t) {
 		t.Log("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")

--- a/morpheus/framework/resources/clusteraffinitygroup/resource_test.go
+++ b/morpheus/framework/resources/clusteraffinitygroup/resource_test.go
@@ -26,7 +26,7 @@ func TestAccMorpheusClusterAffinityGroupResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -85,7 +85,7 @@ func TestAccMorpheusClusterAffinityGroupResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/clusternamespace/resource_test.go
+++ b/morpheus/framework/resources/clusternamespace/resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusClusterNamespaceResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -89,7 +89,7 @@ func TestAccMorpheusClusterNamespaceResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/containerscript/resource_test.go
+++ b/morpheus/framework/resources/containerscript/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusContainerScriptResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -76,7 +76,7 @@ func TestAccMorpheusContainerScriptResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/datastore/datastore_test.go
+++ b/morpheus/framework/resources/datastore/datastore_test.go
@@ -44,7 +44,7 @@ func TestAccMorpheusDatastoreResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Alletra) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -151,7 +151,7 @@ func TestAccMorpheusDatastoreResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Alletra) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -533,7 +533,7 @@ func TestAccMorpheusDatastoreResourceValidationOneOf(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -663,7 +663,7 @@ func TestAccMorpheusDatastoreResourceValidationRequiredAttrs(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/resources/deployment/resource_test.go
+++ b/morpheus/framework/resources/deployment/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusDeploymentResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -72,7 +72,7 @@ func TestAccMorpheusDeploymentResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/group/resource_test.go
+++ b/morpheus/framework/resources/group/resource_test.go
@@ -42,7 +42,7 @@ func TestAccMorpheusGroupResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -122,7 +122,7 @@ func TestAccMorpheusGroupResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -352,7 +352,7 @@ func TestAccMorpheusGroupResourceRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/image/image_test.go
+++ b/morpheus/framework/resources/image/image_test.go
@@ -26,7 +26,7 @@ func TestAccMorpheusImageResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/image/update_test.go
+++ b/morpheus/framework/resources/image/update_test.go
@@ -22,7 +22,7 @@ func TestAccMorpheusImageResourceUpdate(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -228,7 +228,7 @@ func TestAccMorpheusImageResourceUpdatePassword(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/instance/resource_test.go
+++ b/morpheus/framework/resources/instance/resource_test.go
@@ -26,7 +26,7 @@ func TestAccMorpheusInstanceResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -98,7 +98,7 @@ func TestAccMorpheusInstanceResourceUserGroupStorageProfile(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -163,7 +163,7 @@ func TestAccMorpheusInstanceResourceAzureExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Azure) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -235,7 +235,7 @@ func TestAccMorpheusInstanceResourceAzureSubnet(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Azure) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -314,7 +314,7 @@ func TestAccMorpheusInstanceResourceUpdateName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -373,7 +373,7 @@ func TestAccMorpheusInstanceResourceUpdateInstanceContext(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -433,7 +433,7 @@ func TestAccMorpheusInstanceResourceUpdateTags(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/instanceclone/resource_test.go
+++ b/morpheus/framework/resources/instanceclone/resource_test.go
@@ -29,9 +29,7 @@ func TestAccMorpheusInstanceCloneResource(t *testing.T) {
 	}
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -102,9 +100,7 @@ func TestAccMorpheusInstanceCloneResourceUserGroupStorageProfile(t *testing.T) {
 	}
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/resources/instancepowerstate/resource_test.go
+++ b/morpheus/framework/resources/instancepowerstate/resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusInstancePowerStateResourceRunning(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/instancesnapshot/resource_test.go
+++ b/morpheus/framework/resources/instancesnapshot/resource_test.go
@@ -32,7 +32,7 @@ func TestAccMorpheusInstanceSnapshotResource(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/resources/loadbalancer/resource_test.go
+++ b/morpheus/framework/resources/loadbalancer/resource_test.go
@@ -26,7 +26,7 @@ func TestAccMorpheusLoadBalancerResourceHAProxyExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkLoadBalancer) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -78,7 +78,7 @@ func TestAccMorpheusLoadBalancerResourceHAProxyGenericExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkLoadBalancer) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -134,7 +134,7 @@ func TestAccMorpheusLoadBalancerResourceValidationPermissionsConflict(t *testing
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkLoadBalancer) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/resources/loadbalancermonitor/resource_test.go
+++ b/morpheus/framework/resources/loadbalancermonitor/resource_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusLoadBalancerMonitorResourceNsxtExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -108,7 +108,7 @@ func TestAccMorpheusLoadBalancerMonitorResourceNsxtUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/loadbalancerpool/resource_acc_test.go
+++ b/morpheus/framework/resources/loadbalancerpool/resource_acc_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusLoadBalancerPoolResourceNsxtExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -104,7 +104,7 @@ func TestAccMorpheusLoadBalancerPoolResourceNsxtUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/loadbalancerprofile/resource_nsxt_test.go
+++ b/morpheus/framework/resources/loadbalancerprofile/resource_nsxt_test.go
@@ -81,9 +81,7 @@ resource "hpe_morpheus_load_balancer_profile" "validation" {
 
 func TestAccMorpheusLoadBalancerProfileResourceHttpExampleOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -181,9 +179,7 @@ resource "hpe_morpheus_load_balancer_profile" "http" {
 
 func TestAccMorpheusLoadBalancerProfileResourceHttpRedirectOff(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -237,9 +233,7 @@ resource "hpe_morpheus_load_balancer_profile" "http_off" {
 
 func TestAccMorpheusLoadBalancerProfileResourceCookiePersistenceOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -323,9 +317,7 @@ resource "hpe_morpheus_load_balancer_profile" "cookie" {
 
 func TestAccMorpheusLoadBalancerProfileResourceSourceIpPersistenceOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -382,9 +374,7 @@ resource "hpe_morpheus_load_balancer_profile" "source_ip" {
 
 func TestAccMorpheusLoadBalancerProfileResourceClientSslCustomOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -467,9 +457,7 @@ resource "hpe_morpheus_load_balancer_profile" "client_ssl" {
 
 func TestAccMorpheusLoadBalancerProfileResourceClientSslBalancedOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -521,9 +509,7 @@ resource "hpe_morpheus_load_balancer_profile" "client_ssl_balanced" {
 
 func TestAccMorpheusLoadBalancerProfileResourceHttpUpdateOk(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -607,9 +593,7 @@ resource "hpe_morpheus_load_balancer_profile" "http_update" {
 
 func TestAccMorpheusLoadBalancerProfileResourceServiceTypeRequiresReplace(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 
@@ -685,9 +669,7 @@ resource "hpe_morpheus_load_balancer_profile" "replace" {
 
 func TestAccMorpheusLoadBalancerProfileResourceSmokeVariants(t *testing.T) {
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
-
-		return
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	defer testhelpers.RecordResult(t)
 

--- a/morpheus/framework/resources/loadbalancervirtualserver/resource_nsxt_test.go
+++ b/morpheus/framework/resources/loadbalancervirtualserver/resource_nsxt_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusLoadBalancerVirtualServerResourceNsxtExampleOk(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -124,7 +124,7 @@ func TestAccMorpheusLoadBalancerVirtualServerResourceNsxtUpdateOk(t *testing.T) 
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -241,7 +241,7 @@ func TestAccMorpheusLoadBalancerVirtualServerResourceNsxtConfigChangeRequiresRep
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -369,7 +369,7 @@ func TestAccMorpheusLoadBalancerVirtualServerResourceNsxtMinimalExampleOk(t *tes
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/resources/monitoringalert/resource_test.go
+++ b/morpheus/framework/resources/monitoringalert/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusMonitoringAlertResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -76,7 +76,7 @@ func TestAccMorpheusMonitoringAlertResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/monitoringcheck/resource_test.go
+++ b/morpheus/framework/resources/monitoringcheck/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusMonitoringCheckResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -81,7 +81,7 @@ func TestAccMorpheusMonitoringCheckResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/monitoringgroup/resource_test.go
+++ b/morpheus/framework/resources/monitoringgroup/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusMonitoringGroupResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -79,7 +79,7 @@ func TestAccMorpheusMonitoringGroupResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/network/create_test.go
+++ b/morpheus/framework/resources/network/create_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusNetworkResourceCreateRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Network) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -171,7 +171,7 @@ func TestAccMorpheusNetworkResourceCreateAllAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Azure, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -302,7 +302,7 @@ func TestAccMorpheusNetworkResourceCreateHostConfig(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -396,7 +396,7 @@ func TestAccMorpheusNetworkResourceCreateAWSExample(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -519,7 +519,7 @@ func TestAccMorpheusNetworkResourceCreateGcp(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.GCP, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -630,7 +630,7 @@ func TestAccMorpheusNetworkResourceCreateOVSPortGroup(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.HVM) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/network/import_test.go
+++ b/morpheus/framework/resources/network/import_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusNetworkResourceImport(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/network/update_test.go
+++ b/morpheus/framework/resources/network/update_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusNetworkResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -428,7 +428,7 @@ func TestAccMorpheusNetworkResourceUpdateNameChange(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Network) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -674,7 +674,7 @@ func TestAccMorpheusNetworkResourceUpdateCidrChange(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Network) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -1006,7 +1006,7 @@ func TestAccMorpheusNetworkResourceUpdateTenantIdsChange(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Network) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/network/validation_test.go
+++ b/morpheus/framework/resources/network/validation_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusNetworkResourceValidationMissingName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()
@@ -54,7 +54,7 @@ func TestAccMorpheusNetworkResourceValidationMissingCloudId(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()
@@ -90,7 +90,7 @@ func TestAccMorpheusNetworkResourceValidationMissingGroupId(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()
@@ -126,7 +126,7 @@ func TestAccMorpheusNetworkResourceValidationMissingTypeId(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()
@@ -163,7 +163,7 @@ func TestAccMorpheusNetworkResourceValidationInvalidConfig(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()
@@ -201,7 +201,7 @@ func TestAccMorpheusNetworkResourceValidationInvalidPoolId(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()
@@ -239,7 +239,7 @@ func TestAccMorpheusNetworkResourceValidationInvalidTenantIds(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()
@@ -276,7 +276,7 @@ func TestAccMorpheusNetworkResourceValidationValidConfigNull(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/networkdhcpserver/resource_test.go
+++ b/morpheus/framework/resources/networkdhcpserver/resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusNetworkDhcpServerResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -122,7 +122,7 @@ func TestAccMorpheusNetworkDhcpServerResourceDynamicConfigExampleOk(t *testing.T
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -229,7 +229,7 @@ func TestAccMorpheusNetworkDhcpServerResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/networkfirewallrule/resource_test.go
+++ b/morpheus/framework/resources/networkfirewallrule/resource_test.go
@@ -110,7 +110,7 @@ func TestAccMorpheusNetworkFirewallRuleResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -208,7 +208,7 @@ func TestAccMorpheusNetworkFirewallRuleResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -350,7 +350,7 @@ func TestAccMorpheusNetworkFirewallRuleResourceNestedAttributesOk(t *testing.T) 
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -403,7 +403,7 @@ func TestAccMorpheusNetworkFirewallRuleResourceImportBadIDError(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -445,7 +445,7 @@ func TestAccMorpheusNetworkFirewallRuleResourceImportNonNumericIDError(t *testin
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/networkfirewallrulegroup/resource_test.go
+++ b/morpheus/framework/resources/networkfirewallrulegroup/resource_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -120,7 +120,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -252,7 +252,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupResourceRequiresReplaceOk(t *testing
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -309,7 +309,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupResourceRequiresReplaceExternalTypeO
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -366,7 +366,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupResourceRequiresReplaceNetworkIntegr
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -422,7 +422,7 @@ func TestAccMorpheusNetworkFirewallRuleGroupResourceImportInvalidFormatErr(t *te
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/networkgroup/resource_test.go
+++ b/morpheus/framework/resources/networkgroup/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusNetworkGroupResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -75,7 +75,7 @@ func TestAccMorpheusNetworkGroupResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/networkpool/resource_test.go
+++ b/morpheus/framework/resources/networkpool/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusNetworkPoolResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -80,7 +80,7 @@ func TestAccMorpheusNetworkPoolResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/networkpoolserver/resource_test.go
+++ b/morpheus/framework/resources/networkpoolserver/resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusNetworkPoolServerResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkPool) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -93,7 +93,7 @@ func TestAccMorpheusNetworkPoolServerResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkPool) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/networkrouter/resource_test.go
+++ b/morpheus/framework/resources/networkrouter/resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusNetworkRouterResourceGenericExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -71,7 +71,7 @@ func TestAccMorpheusNetworkRouterResourceNSXTGatewayTier0ExampleOk(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -115,7 +115,7 @@ func TestAccMorpheusNetworkRouterResourceNSXTGatewayTier1ExampleOk(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/resources/networkrouter/update_test.go
+++ b/morpheus/framework/resources/networkrouter/update_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusNetworkRouterResourceGenericUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -99,7 +99,7 @@ func TestAccMorpheusNetworkRouterResourceNSXTGatewayTier0UpdateOk(t *testing.T) 
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -180,7 +180,7 @@ func TestAccMorpheusNetworkRouterResourceNSXTGatewayTier1UpdateOk(t *testing.T) 
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/resources/networkrouterbgpneighbor/resource_test.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/resource_test.go
@@ -41,7 +41,7 @@ func TestAccMorpheusNetworkRouterBgpNeighborResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -90,7 +90,7 @@ func TestAccMorpheusNetworkRouterBgpNeighborResourceCreate(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -159,7 +159,7 @@ func TestAccMorpheusNetworkRouterBgpNeighborResourceCreateAllAttrs(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -277,7 +277,7 @@ func TestAccMorpheusNetworkRouterBgpNeighborResourceUpdate(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -405,7 +405,7 @@ func TestAccMorpheusNetworkRouterBgpNeighborResourceImport(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -465,7 +465,7 @@ func TestAccMorpheusNetworkRouterBgpNeighborResourceWithNsxtConfig(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXT) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -529,7 +529,7 @@ func TestAccMorpheusNetworkRouterBgpNeighborResourceWithNsxvConfig(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NSXV) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/networkrouterfirewallrule/resource_test.go
+++ b/morpheus/framework/resources/networkrouterfirewallrule/resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusNetworkRouterFirewallRuleResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -98,7 +98,7 @@ func TestAccMorpheusNetworkRouterFirewallRuleResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter, capabilities.NetworkFirewall) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/networkrouternat/resource_test.go
+++ b/morpheus/framework/resources/networkrouternat/resource_test.go
@@ -56,7 +56,7 @@ func TestAccMorpheusNetworkRouterNatResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -119,7 +119,7 @@ func TestAccMorpheusNetworkRouterNatResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/networkrouterroute/resource_test.go
+++ b/morpheus/framework/resources/networkrouterroute/resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusNetworkRouterRouteResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -102,7 +102,7 @@ func TestAccMorpheusNetworkRouterRouteResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkRouter) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/optionlist/resource_test.go
+++ b/morpheus/framework/resources/optionlist/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusOptionListResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -76,7 +76,7 @@ func TestAccMorpheusOptionListResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/ostype/resource_test.go
+++ b/morpheus/framework/resources/ostype/resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusOsTypeResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -126,7 +126,7 @@ func TestAccMorpheusOsTypeResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/ostypeimage/resource_test.go
+++ b/morpheus/framework/resources/ostypeimage/resource_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusOsTypeImageResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -140,7 +140,7 @@ func TestAccMorpheusOsTypeImageResourceRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {

--- a/morpheus/framework/resources/policy/create_test.go
+++ b/morpheus/framework/resources/policy/create_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusPolicyResourceRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -104,7 +104,7 @@ func TestAccMorpheusPolicyResourceAllBareMetalPolicyTypesOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.ServiceNow) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -587,7 +587,7 @@ func TestAccMorpheusPolicyResourceTypesOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkDHCP) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -832,7 +832,7 @@ func TestAccMorpheusPolicyResourceAllStaticSchemaOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.ServiceNow) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/policy/resource_test.go
+++ b/morpheus/framework/resources/policy/resource_test.go
@@ -42,7 +42,7 @@ func TestAccMorpheusPolicyValidationResourceIdRequired(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -82,7 +82,7 @@ func TestAccMorpheusPolicyResourceValidationInvalidPolicyType(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -123,7 +123,7 @@ func TestAccMorpheusPolicyValidationInvalidResourceType(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -164,7 +164,7 @@ func TestAccMorpheusPolicyValidationIncompatiblePolicyAndResourceType(t *testing
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -224,7 +224,7 @@ func TestAccMorpheusPolicyResourceValidationTenantsNotSupported(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -288,7 +288,7 @@ func TestAccMorpheusPolicyResourceValidationApprovalWorkflowConflict(t *testing.
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -332,7 +332,7 @@ func TestAccMorpheusPolicyResourceValidationApprovalFlowIdRequired(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -374,7 +374,7 @@ func TestAccMorpheusPolicyResourceValidationApprovalWorkflowIdRequired(t *testin
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -416,7 +416,7 @@ func TestAccMorpheusPolicyResourceValidationLifecycleFlowIdRequired(t *testing.T
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -458,7 +458,7 @@ func TestAccMorpheusPolicyResourceValidationLifecycleWorkflowIdRequired(t *testi
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -500,7 +500,7 @@ func TestAccMorpheusPolicyResourceValidationShutdownFlowIdRequired(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -542,7 +542,7 @@ func TestAccMorpheusPolicyResourceValidationShutdownWorkflowIdRequired(t *testin
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()
@@ -584,7 +584,7 @@ func TestAccMorpheusPolicyResourceValidationConfigConflict(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/framework/resources/policy/update_test.go
+++ b/morpheus/framework/resources/policy/update_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusPolicyResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -119,7 +119,7 @@ func TestAccMorpheusPolicyAssociatedResourceIdChangeRequiresReplace(t *testing.T
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -245,7 +245,7 @@ func TestAccMorpheusPolicyAssociatedResourceTypeChangeRequiresReplace(t *testing
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -364,7 +364,7 @@ func TestAccMorpheusPolicyResourceTypeCodeChangeRequiresReplace(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/powerschedule/resource_test.go
+++ b/morpheus/framework/resources/powerschedule/resource_test.go
@@ -26,7 +26,7 @@ func TestAccMorpheusPowerScheduleResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -83,7 +83,7 @@ func TestAccMorpheusPowerScheduleResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/provisioninglicense/resource_test.go
+++ b/morpheus/framework/resources/provisioninglicense/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusProvisioningLicenseResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -76,7 +76,7 @@ func TestAccMorpheusProvisioningLicenseResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/role/resource_test.go
+++ b/morpheus/framework/resources/role/resource_test.go
@@ -38,7 +38,7 @@ func TestAccMorpheusRoleResourceUserRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -118,7 +118,7 @@ func TestAccMorpheusRoleResourceTenantRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -200,7 +200,7 @@ func TestAccMorpheusRoleResourceAllAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -327,7 +327,7 @@ func TestAccMorpheusRoleResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -396,7 +396,7 @@ func TestAccMorpheusRoleResourcePermissionsDefaultAccessPermissionsOk(t *testing
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VDI) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -511,7 +511,7 @@ func TestAccMorpheusRoleResourceAllPermissionsUserRoleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VDI) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {
@@ -796,7 +796,7 @@ func TestAccMorpheusRoleResourceTenantAllPermissionsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VDI) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 	if testing.Short() {

--- a/morpheus/framework/resources/role/update_test.go
+++ b/morpheus/framework/resources/role/update_test.go
@@ -23,7 +23,7 @@ func TestAccMorpheusRoleResourceUserUpdateAllAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -804,7 +804,7 @@ func TestAccMorpheusRoleResourceTenantUpdateAllAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/framework/resources/securitygroup/resource_test.go
+++ b/morpheus/framework/resources/securitygroup/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusSecurityGroupResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -76,7 +76,7 @@ func TestAccMorpheusSecurityGroupResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/securitygrouprule/resource_test.go
+++ b/morpheus/framework/resources/securitygrouprule/resource_test.go
@@ -26,7 +26,7 @@ func TestAccMorpheusSecurityGroupRuleResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -100,7 +100,7 @@ func TestAccMorpheusSecurityGroupRuleResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/serviceplan/resource_test.go
+++ b/morpheus/framework/resources/serviceplan/resource_test.go
@@ -41,7 +41,7 @@ func TestAccMorpheusServicePlanResourceRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -134,7 +134,7 @@ func TestAccMorpheusServicePlanResourceAllAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -370,7 +370,7 @@ func TestAccMorpheusServicePlanResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/serviceplan/update_test.go
+++ b/morpheus/framework/resources/serviceplan/update_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusServicePlanResourceUpdateAllAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/settingwhitelabel/resource_test.go
+++ b/morpheus/framework/resources/settingwhitelabel/resource_test.go
@@ -25,7 +25,7 @@ func TestAccMorpheusSettingWhitelabelResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Settings) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -70,7 +70,7 @@ func TestAccMorpheusSettingWhitelabelResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Settings) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/storagebucket/resource_test.go
+++ b/morpheus/framework/resources/storagebucket/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusStorageBucketResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Alletra) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -71,7 +71,7 @@ func TestAccMorpheusStorageBucketResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Alletra) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/storageserver/resource_test.go
+++ b/morpheus/framework/resources/storageserver/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusStorageServerResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Alletra) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -71,7 +71,7 @@ func TestAccMorpheusStorageServerResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Alletra) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/storagevolume/resource_test.go
+++ b/morpheus/framework/resources/storagevolume/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusStorageVolumeResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Alletra) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -71,7 +71,7 @@ func TestAccMorpheusStorageVolumeResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Alletra) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/subnet/resource_test.go
+++ b/morpheus/framework/resources/subnet/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusSubnetResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Subnet) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -77,7 +77,7 @@ func TestAccMorpheusSubnetResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Subnet) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/task/task_test.go
+++ b/morpheus/framework/resources/task/task_test.go
@@ -45,7 +45,7 @@ func TestAccMorpheusTaskResourceExampleConditionalOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -128,7 +128,7 @@ func TestAccMorpheusTaskResourceConditionalWorkflowUpdate(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -256,7 +256,7 @@ func TestAccMorpheusTaskResourceExampleGenericNestedOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -326,7 +326,7 @@ func TestAccMorpheusTaskResourceExampleConditionalNullElseOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {
@@ -404,7 +404,7 @@ func TestAccMorpheusTaskResourceExampleConditionalNullElseUpdateOk(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	if testing.Short() {

--- a/morpheus/framework/resources/user/resource_test.go
+++ b/morpheus/framework/resources/user/resource_test.go
@@ -77,7 +77,7 @@ func TestAccMorpheusUserResourceExample(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -206,7 +206,7 @@ func TestAccMorpheusUserResourceUpdateTestIdOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -258,7 +258,7 @@ func TestAccMorpheusUserResourceRequiredAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -378,7 +378,7 @@ func TestAccMorpheusUserResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -1077,7 +1077,7 @@ func TestAccMorpheusUserResourceUpdateNoTenantIdOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -1438,7 +1438,7 @@ func TestAccMorpheusUserResourceAllAttrsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -1637,7 +1637,7 @@ func TestAccMorpheusUserResourceMissingRoles(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	name := acctest.RandomWithPrefix(t.Name())
@@ -1677,7 +1677,7 @@ func TestAccMorpheusUserResourceMissingUsername(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	name := acctest.RandomWithPrefix(t.Name())
@@ -1717,7 +1717,7 @@ func TestAccMorpheusUserResourceMissingEmail(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	name := acctest.RandomWithPrefix(t.Name())
@@ -1759,7 +1759,7 @@ func TestAccMorpheusUserResourceMissingPasswordWo(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	name := acctest.RandomWithPrefix(t.Name())
@@ -1808,7 +1808,7 @@ func TestAccMorpheusUserResourceImportOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -2031,7 +2031,7 @@ func TestAccMorpheusUserResourceUpdateLastNameWithoutTenantIdOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/vdiapp/resource_test.go
+++ b/morpheus/framework/resources/vdiapp/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusVdiAppResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -73,7 +73,7 @@ func TestAccMorpheusVdiAppResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/vdigateway/resource_test.go
+++ b/morpheus/framework/resources/vdigateway/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusVdiGatewayResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -73,7 +73,7 @@ func TestAccMorpheusVdiGatewayResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/vdipool/resource_test.go
+++ b/morpheus/framework/resources/vdipool/resource_test.go
@@ -24,7 +24,7 @@ func TestAccMorpheusVdiPoolResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -79,7 +79,7 @@ func TestAccMorpheusVdiPoolResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/morpheus_test.go
+++ b/morpheus/morpheus_test.go
@@ -105,7 +105,7 @@ func TestAccMorpheusSubProviderMissingURL(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := `
 provider "hpe" {
@@ -134,7 +134,7 @@ func TestAccMorpheusSubProviderOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := `
 provider "hpe" {
@@ -186,7 +186,7 @@ func TestAccMorpheusSubProviderWithCustomHTTPClient(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	newLocalProviderWithError := func() (tfprotov6.ProviderServer, error) {
 		providerInstance := provider.New("test", NewWithCustomHTTPClient())()
@@ -247,7 +247,7 @@ func TestAccMorpheusSubProviderMissingAuth(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := `
 provider "hpe" {
@@ -277,7 +277,7 @@ func TestAccMorpheusSubProviderMissingPassword(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := `
 provider "hpe" {
@@ -309,7 +309,7 @@ func TestAccMorpheusSubProviderTooMuchAuth(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := `
 provider "hpe" {
@@ -344,7 +344,7 @@ func TestAccMorpheusSubProviderStrayResource(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := `
 provider "hpe" {
@@ -371,7 +371,7 @@ func TestAccMorpheusSubProviderTooManyBlocks(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := `
 provider "hpe" {
@@ -403,7 +403,7 @@ func TestAccMorpheusSubProviderEmptyBlock(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := `
 provider "hpe" {

--- a/morpheus/sdkv2/datasources/automation/execute_schedule_data-source_test.go
+++ b/morpheus/sdkv2/datasources/automation/execute_schedule_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceExecuteScheduleExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/automation/power_schedule_data-source_test.go
+++ b/morpheus/sdkv2/datasources/automation/power_schedule_data-source_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusDataSourcePowerScheduleExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/blueprint/blueprint_data-source_test.go
+++ b/morpheus/sdkv2/datasources/blueprint/blueprint_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceBlueprintExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/blueprint/instance_type_data-source_test.go
+++ b/morpheus/sdkv2/datasources/blueprint/instance_type_data-source_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusDataSourceInstanceTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/blueprint/node_type_data-source_test.go
+++ b/morpheus/sdkv2/datasources/blueprint/node_type_data-source_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusDataSourceNodeTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/catalog/catalog_item_type_data-source_test.go
+++ b/morpheus/sdkv2/datasources/catalog/catalog_item_type_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceCatalogItemTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/cloud/cloud_example-id_test.go
+++ b/morpheus/sdkv2/datasources/cloud/cloud_example-id_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceCloudByIdExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/cloud/cloud_example-name_test.go
+++ b/morpheus/sdkv2/datasources/cloud/cloud_example-name_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceCloudByNameExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/cloud/cloud_folder_data-source_test.go
+++ b/morpheus/sdkv2/datasources/cloud/cloud_folder_data-source_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceCloudFolderExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VMware) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/cloud/cloud_type_data-source_test.go
+++ b/morpheus/sdkv2/datasources/cloud/cloud_type_data-source_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceCloudTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/cloud/clouds_data-source_test.go
+++ b/morpheus/sdkv2/datasources/cloud/clouds_data-source_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusDataSourceCloudsExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/cluster/cluster_type_data-source_test.go
+++ b/morpheus/sdkv2/datasources/cluster/cluster_type_data-source_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusDataSourceClusterTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/compute/resource_pool_data-source_test.go
+++ b/morpheus/sdkv2/datasources/compute/resource_pool_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceResourcePoolExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.ResourcePool) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/contact/contact_data-source_test.go
+++ b/morpheus/sdkv2/datasources/contact/contact_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceContactExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/costing/budget_data-source_test.go
+++ b/morpheus/sdkv2/datasources/costing/budget_data-source_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusDataSourceBudgetExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/credential/data-source_test.go
+++ b/morpheus/sdkv2/datasources/credential/data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceCredentialExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/cypher/cypher_secret_data-source_test.go
+++ b/morpheus/sdkv2/datasources/cypher/cypher_secret_data-source_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusDataSourceCypherSecretExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/environment/environments_data-source_test.go
+++ b/morpheus/sdkv2/datasources/environment/environments_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceEnvironmentsExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/group/groups_data-source_test.go
+++ b/morpheus/sdkv2/datasources/group/groups_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceGroupsExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/image/images_data-source_test.go
+++ b/morpheus/sdkv2/datasources/image/images_data-source_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusDataSourceImagesExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/integration/ansible_tower_inventory_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/ansible_tower_inventory_data-source_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusDataSourceAnsibleTowerInventoryExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AnsibleTower) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/integration/ansible_tower_job_template_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/ansible_tower_job_template_data-source_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusDataSourceAnsibleTowerJobTemplateExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AnsibleTower) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/integration/integration_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/integration_data-source_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusDataSourceIntegrationExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Ansible) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/integration/integration_git_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/integration_git_data-source_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusDataSourceIntegrationGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Git) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/integration/servicenow_workflow_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/servicenow_workflow_data-source_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusDataSourceServicenowWorkflowExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.ServiceNow) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/integration/vro_workflow_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/vro_workflow_data-source_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusDataSourceVroWorkflowExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VRO) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/job/job_data-source_test.go
+++ b/morpheus/sdkv2/datasources/job/job_data-source_test.go
@@ -31,7 +31,7 @@ func TestAccMorpheusDataSourceJobExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/network/network_group_data-source_test.go
+++ b/morpheus/sdkv2/datasources/network/network_group_data-source_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusDataSourceNetworkGroupExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Network) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/network/network_subnet_data-source_test.go
+++ b/morpheus/sdkv2/datasources/network/network_subnet_data-source_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceNetworkSubnetExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/network/networks_data-source_test.go
+++ b/morpheus/sdkv2/datasources/network/networks_data-source_test.go
@@ -5,7 +5,6 @@ package network_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/HPE/terraform-provider-hpe/morpheus"
@@ -19,7 +18,7 @@ func TestAccMorpheusDataSourceNetworksExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Network) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -29,13 +28,13 @@ func TestAccMorpheusDataSourceNetworksExampleOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	name := acctest.RandomWithPrefix(t.Name())
-
 	var dependenciesConfig string
 
-	datasourceConfig, err := dsnetwork.RenderNetworksConfig(t, map[string]string{
-		"Name": name,
-	})
+	// Use template defaults (CloudId=3, Name="name", SortAscending=true,
+	// Values=["Test*"]) which the checks below assert against. Do not override
+	// Name with a random value; the template renders it unquoted and a random
+	// string produces an invalid HCL reference.
+	datasourceConfig, err := dsnetwork.RenderNetworksConfig(t, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,20 +50,24 @@ func TestAccMorpheusDataSourceNetworksExampleOk(t *testing.T) {
 
 		resource.TestCheckResourceAttr(
 			"data.hpe_morpheus_networks.example",
-			"name",
-			"name",
-		),
-
-		resource.TestCheckResourceAttr(
-			"data.hpe_morpheus_networks.example",
 			"sort_ascending",
 			"true",
 		),
 
 		resource.TestCheckResourceAttr(
 			"data.hpe_morpheus_networks.example",
-			"values",
-			"[\"Test*\"]",
+			"filter.#",
+			"1",
+		),
+
+		resource.TestCheckTypeSetElemNestedAttrs(
+			"data.hpe_morpheus_networks.example",
+			"filter.*",
+			map[string]string{
+				"name":     "name",
+				"values.0": "Test*",
+				"values.#": "1",
+			},
 		),
 	}
 

--- a/morpheus/sdkv2/datasources/option/option_list_data-source_test.go
+++ b/morpheus/sdkv2/datasources/option/option_list_data-source_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusDataSourceOptionListExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/option/option_type_data-source_test.go
+++ b/morpheus/sdkv2/datasources/option/option_type_data-source_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusDataSourceOptionTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/plan/price_data-source_test.go
+++ b/morpheus/sdkv2/datasources/plan/price_data-source_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusDataSourcePriceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/plan/price_set_data-source_test.go
+++ b/morpheus/sdkv2/datasources/plan/price_set_data-source_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusDataSourcePriceSetExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/policy/policies_data-source_test.go
+++ b/morpheus/sdkv2/datasources/policy/policies_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourcePoliciesExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/provisiontype/provision_type_data-source_test.go
+++ b/morpheus/sdkv2/datasources/provisiontype/provision_type_data-source_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusDataSourceProvisionTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/storage/storage_bucket_data-source_test.go
+++ b/morpheus/sdkv2/datasources/storage/storage_bucket_data-source_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceStorageBucketExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/storage/storage_volume_data-source_test.go
+++ b/morpheus/sdkv2/datasources/storage/storage_volume_data-source_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceStorageVolumeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/storage/storage_volume_type_data-source_test.go
+++ b/morpheus/sdkv2/datasources/storage/storage_volume_type_data-source_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceStorageVolumeTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/task/task_data-source_test.go
+++ b/morpheus/sdkv2/datasources/task/task_data-source_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusDataSourceTaskExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/task/tasks_data-source_test.go
+++ b/morpheus/sdkv2/datasources/task/tasks_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceTasksExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/template/file_template_data-source_test.go
+++ b/morpheus/sdkv2/datasources/template/file_template_data-source_test.go
@@ -30,7 +30,7 @@ func TestAccMorpheusDataSourceFileTemplateExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/template/script_template_data-source_test.go
+++ b/morpheus/sdkv2/datasources/template/script_template_data-source_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusDataSourceScriptTemplateExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/template/security_package_data-source_test.go
+++ b/morpheus/sdkv2/datasources/template/security_package_data-source_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusDataSourceSecurityPackageExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/template/spec_template_data-source_test.go
+++ b/morpheus/sdkv2/datasources/template/spec_template_data-source_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusDataSourceSpecTemplateExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/tenant/tenant_data-source_test.go
+++ b/morpheus/sdkv2/datasources/tenant/tenant_data-source_test.go
@@ -21,7 +21,7 @@ func TestAccMorpheusDataSourceTenantExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/tenant/tenants_data-source_test.go
+++ b/morpheus/sdkv2/datasources/tenant/tenants_data-source_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusDataSourceTenantsExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/trust/key_pair_data-source_test.go
+++ b/morpheus/sdkv2/datasources/trust/key_pair_data-source_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusDataSourceKeyPairExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/usergroup/user_group_data-source_test.go
+++ b/morpheus/sdkv2/datasources/usergroup/user_group_data-source_test.go
@@ -22,7 +22,7 @@ func TestAccMorpheusDataSourceUserGroupExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/usergroup/user_groups_data-source_test.go
+++ b/morpheus/sdkv2/datasources/usergroup/user_groups_data-source_test.go
@@ -23,7 +23,7 @@ func TestAccMorpheusDataSourceUserGroupsExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/vdi/vdi_pool_data-source_test.go
+++ b/morpheus/sdkv2/datasources/vdi/vdi_pool_data-source_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusDataSourceVdiPoolExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VDI) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/workflow/workflow_data-source_test.go
+++ b/morpheus/sdkv2/datasources/workflow/workflow_data-source_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusDataSourceWorkflowExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/automation/hpe_morpheus_execute_schedule_resource_test.go
+++ b/morpheus/sdkv2/resources/automation/hpe_morpheus_execute_schedule_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusExecuteScheduleExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/automation/morpheus_scale_threshold_resource_test.go
+++ b/morpheus/sdkv2/resources/automation/morpheus_scale_threshold_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusScaleThresholdExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_arm_resource_git_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_arm_resource_git_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintArmGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Git) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_arm_resource_json_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_arm_resource_json_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintArmJsonExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_cloud_formation_resource_git_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_cloud_formation_resource_git_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintCloudFormationGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_cloud_formation_resource_json_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_cloud_formation_resource_json_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintCloudFormationJsonExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_cloud_formation_resource_yaml_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_cloud_formation_resource_yaml_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintCloudFormationYamlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_helm_resource_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_helm_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintHelmExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_git_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_git_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintKubernetesGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_spec_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_spec_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintKubernetesSpecExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_yaml_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_kubernetes_resource_yaml_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintKubernetesYamlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_terraform_resource_git_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_terraform_resource_git_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintTerraformGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Git) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_terraform_resource_hcl_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_terraform_resource_hcl_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintTerraformHclExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_terraform_resource_json_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_terraform_resource_json_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintTerraformJsonExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/app_blueprint_terraform_resource_spec_test.go
+++ b/morpheus/sdkv2/resources/blueprint/app_blueprint_terraform_resource_spec_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusAppBlueprintTerraformSpecExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/cluster_layout_test.go
+++ b/morpheus/sdkv2/resources/blueprint/cluster_layout_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusClusterLayoutExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/instance_type_layout_test.go
+++ b/morpheus/sdkv2/resources/blueprint/instance_type_layout_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusInstanceTypeLayoutExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VMware) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/morpheus_instance_type_resource_test.go
+++ b/morpheus/sdkv2/resources/blueprint/morpheus_instance_type_resource_test.go
@@ -41,7 +41,7 @@ func TestAccMorpheusInstanceTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/blueprint/node_type_resource_test.go
+++ b/morpheus/sdkv2/resources/blueprint/node_type_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusNodeTypeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VMware) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/catalogitem/catalog_item_app_blueprint_resource_test.go
+++ b/morpheus/sdkv2/resources/catalogitem/catalog_item_app_blueprint_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusCatalogItemAppBlueprintExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/catalogitem/catalog_item_workflow_test.go
+++ b/morpheus/sdkv2/resources/catalogitem/catalog_item_workflow_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusCatalogItemWorkflowExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/catalogitem/morpheus_catalog_item_instance_resource_test.go
+++ b/morpheus/sdkv2/resources/catalogitem/morpheus_catalog_item_instance_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusCatalogItemInstanceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/cluster/cluster_hks_hvm_test.go
+++ b/morpheus/sdkv2/resources/cluster/cluster_hks_hvm_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusClusterHKSHVMExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.HVM, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/cluster/cluster_hks_vsphere_test.go
+++ b/morpheus/sdkv2/resources/cluster/cluster_hks_vsphere_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusClusterHKSVsphereExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VMware) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/compute/resource_pool_group_test.go
+++ b/morpheus/sdkv2/resources/compute/resource_pool_group_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusResourcePoolGroupExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.ResourcePool) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/contact/contact_resource_test.go
+++ b/morpheus/sdkv2/resources/contact/contact_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusContactExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_access_key_secret_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_access_key_secret_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCredentialResourceAccessKeySecretExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_api_key_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_api_key_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCredentialResourceApiKeyExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_client_id_secret_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_client_id_secret_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCredentialResourceClientIdSecretExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_email_private_key_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_email_private_key_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCredentialResourceEmailPrivateKeyExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_tenant_username_keypair_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_tenant_username_keypair_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCredentialResourceTenantUsernameKeypairExampleOk(t *testing.
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_username_api_key_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_username_api_key_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCredentialResourceUsernameApiKeyExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_username_keypair_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_username_keypair_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCredentialResourceUsernameKeypairExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_username_password_keypair_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_username_password_keypair_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCredentialResourceUsernamePasswordKeypairExampleOk(t *testin
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/credential/credential_resource_username_password_test.go
+++ b/morpheus/sdkv2/resources/credential/credential_resource_username_password_test.go
@@ -38,7 +38,7 @@ func TestAccMorpheusCredentialResourceUsernamePasswordExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/cypher/hpe_morpheus_cypher_tfvars_resource_test.go
+++ b/morpheus/sdkv2/resources/cypher/hpe_morpheus_cypher_tfvars_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusCypherTfvarsExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/cypher/morpheus_cypher_secret_resource_test.go
+++ b/morpheus/sdkv2/resources/cypher/morpheus_cypher_secret_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusCypherSecretExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/environment/morpheus_environment_resource_test.go
+++ b/morpheus/sdkv2/resources/environment/morpheus_environment_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusEnvironmentExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/checkbox_test.go
+++ b/morpheus/sdkv2/resources/form/checkbox_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormCheckboxOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/cloud_test.go
+++ b/morpheus/sdkv2/resources/form/cloud_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusFormCloudOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -96,7 +96,7 @@ func TestAccMorpheusFormCloudGroupCascadeOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/disk_manager_test.go
+++ b/morpheus/sdkv2/resources/form/disk_manager_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormDiskManagerOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/environment_test.go
+++ b/morpheus/sdkv2/resources/form/environment_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormEnvironmentOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/field_groups_test.go
+++ b/morpheus/sdkv2/resources/form/field_groups_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormFieldGroupsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/file_content_test.go
+++ b/morpheus/sdkv2/resources/form/file_content_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormFileContentOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/group_test.go
+++ b/morpheus/sdkv2/resources/form/group_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormGroupOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/hidden_test.go
+++ b/morpheus/sdkv2/resources/form/hidden_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormHiddenOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/httpheader_test.go
+++ b/morpheus/sdkv2/resources/form/httpheader_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormHttpHeaderOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/instances_input_test.go
+++ b/morpheus/sdkv2/resources/form/instances_input_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormInstancesInputOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/key_value_test.go
+++ b/morpheus/sdkv2/resources/form/key_value_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormKeyValueOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/layout_test.go
+++ b/morpheus/sdkv2/resources/form/layout_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormLayoutOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/logo_selector_test.go
+++ b/morpheus/sdkv2/resources/form/logo_selector_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormLogoSelectorOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/network_manager_test.go
+++ b/morpheus/sdkv2/resources/form/network_manager_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormNetworkManagerOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/number_test.go
+++ b/morpheus/sdkv2/resources/form/number_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormNumberOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/plan_test.go
+++ b/morpheus/sdkv2/resources/form/plan_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormPlanOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/ports_test.go
+++ b/morpheus/sdkv2/resources/form/ports_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormPortsOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/radio_test.go
+++ b/morpheus/sdkv2/resources/form/radio_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusFormRadioOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/resource_pool_test.go
+++ b/morpheus/sdkv2/resources/form/resource_pool_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormResourcePoolOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/sec_group_test.go
+++ b/morpheus/sdkv2/resources/form/sec_group_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusFormSecGroupOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/select_test.go
+++ b/morpheus/sdkv2/resources/form/select_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusFormSelectOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/servers_input_test.go
+++ b/morpheus/sdkv2/resources/form/servers_input_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormServersInputOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/tag_test.go
+++ b/morpheus/sdkv2/resources/form/tag_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormTagOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/text_test.go
+++ b/morpheus/sdkv2/resources/form/text_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormTextOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/virtual_image_test.go
+++ b/morpheus/sdkv2/resources/form/virtual_image_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormVirtualImageOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/form/vmw_folders_test.go
+++ b/morpheus/sdkv2/resources/form/vmw_folders_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusFormVmwFoldersOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VMware) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/integration/morpheus_integration_ansible_tower_resource_test.go
+++ b/morpheus/sdkv2/resources/integration/morpheus_integration_ansible_tower_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusIntegrationAnsibleTowerExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AnsibleTower) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/sdkv2/resources/integration/morpheus_integration_chef_resource_test.go
+++ b/morpheus/sdkv2/resources/integration/morpheus_integration_chef_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusIntegrationChefExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Chef) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/sdkv2/resources/integration/morpheus_integration_docker_registry_resource_test.go
+++ b/morpheus/sdkv2/resources/integration/morpheus_integration_docker_registry_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusIntegrationDockerRegistryExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Docker) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/integration/morpheus_integration_puppet_resource_test.go
+++ b/morpheus/sdkv2/resources/integration/morpheus_integration_puppet_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusIntegrationPuppetExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Puppet) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/sdkv2/resources/integration/morpheus_integration_servicenow_resource_test.go
+++ b/morpheus/sdkv2/resources/integration/morpheus_integration_servicenow_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusIntegrationServicenowExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.ServiceNow) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/sdkv2/resources/integration/morpheus_integration_vro_resource_test.go
+++ b/morpheus/sdkv2/resources/integration/morpheus_integration_vro_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusIntegrationVroExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VRO) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/sdkv2/resources/job/job_task_test.go
+++ b/morpheus/sdkv2/resources/job/job_task_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusJobTaskDateAndTimeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -137,7 +137,7 @@ func TestAccMorpheusJobTaskScheduleExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -244,7 +244,7 @@ func TestAccMorpheusJobTaskManualExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/job/job_workflow_test.go
+++ b/morpheus/sdkv2/resources/job/job_workflow_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusJobWorkflowDateAndTimeExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -136,7 +136,7 @@ func TestAccMorpheusJobWorkflowScheduleExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -248,7 +248,7 @@ func TestAccMorpheusJobWorkflowManualExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/license/morpheus_license_resource_test.go
+++ b/morpheus/sdkv2/resources/license/morpheus_license_resource_test.go
@@ -39,7 +39,7 @@ func TestAccMorpheusLicenseExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.License) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 
 	t.Parallel()

--- a/morpheus/sdkv2/resources/network/morpheus_ip_pool_ipv4_resource_test.go
+++ b/morpheus/sdkv2/resources/network/morpheus_ip_pool_ipv4_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusIpPoolIpv4ResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/network/network_domain_resource_test.go
+++ b/morpheus/sdkv2/resources/network/network_domain_resource_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusNetworkDomainExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_api_resource_test.go
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_api_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusOptionListApiExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_manual_resource_test.go
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_manual_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusOptionListManualExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource_test.go
+++ b/morpheus/sdkv2/resources/optionlist/morpheus_option_list_rest_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusOptionListRestExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/morpheus_option_type_checkbox_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/morpheus_option_type_checkbox_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusOptionTypeCheckboxExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/morpheus_option_type_hidden_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/morpheus_option_type_hidden_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusOptionTypeHiddenExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/morpheus_option_type_number_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/morpheus_option_type_number_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusOptionTypeNumberExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/morpheus_option_type_password_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/morpheus_option_type_password_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusOptionTypePasswordExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/morpheus_option_type_textarea_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/morpheus_option_type_textarea_resource_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusOptionTypeTextareaExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/option_type_radio_list_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_radio_list_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusOptionTypeRadioListExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/option_type_select_list_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_select_list_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusOptionTypeSelectListExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/option_type_text_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_text_resource_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusOptionTypeTextExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/optiontype/option_type_typeahead_resource_test.go
+++ b/morpheus/sdkv2/resources/optiontype/option_type_typeahead_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusOptionTypeTypeaheadExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/plan/price_resource_load_balancer_test.go
+++ b/morpheus/sdkv2/resources/plan/price_resource_load_balancer_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusPriceLoadBalancerExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkLoadBalancer) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/plan/price_resource_load_balancer_virtual_server_test.go
+++ b/morpheus/sdkv2/resources/plan/price_resource_load_balancer_virtual_server_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusPriceLoadBalancerVirtualServerExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.NetworkLoadBalancer) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/plan/price_resource_markup_custom_test.go
+++ b/morpheus/sdkv2/resources/plan/price_resource_markup_custom_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusPriceMarkupCustomExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/plan/price_resource_markup_fixed_test.go
+++ b/morpheus/sdkv2/resources/plan/price_resource_markup_fixed_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusPriceMarkupFixedExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/plan/price_resource_markup_percent_test.go
+++ b/morpheus/sdkv2/resources/plan/price_resource_markup_percent_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusPriceMarkupPercentExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/plan/price_resource_platform_test.go
+++ b/morpheus/sdkv2/resources/plan/price_resource_platform_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusPricePlatformExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/plan/price_resource_software_test.go
+++ b/morpheus/sdkv2/resources/plan/price_resource_software_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusPriceSoftwareExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/plan/price_resource_test.go
+++ b/morpheus/sdkv2/resources/plan/price_resource_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusPriceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	// These tests when run in parallel generate errors which I believe could
 	// be race conditions in the Morpheus API.

--- a/morpheus/sdkv2/resources/plan/price_set_test.go
+++ b/morpheus/sdkv2/resources/plan/price_set_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusPriceSetExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/script/boot_script_resource_test.go
+++ b/morpheus/sdkv2/resources/script/boot_script_resource_test.go
@@ -43,7 +43,7 @@ func TestAccMorpheusBootScriptExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/script/morpheus_preseed_script_resource_test.go
+++ b/morpheus/sdkv2/resources/script/morpheus_preseed_script_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusPreseedScriptExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/setting/morpheus_setting_guidance_resource_test.go
+++ b/morpheus/sdkv2/resources/setting/morpheus_setting_guidance_resource_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusSettingGuidanceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/setting/morpheus_setting_provisioning_resource_test.go
+++ b/morpheus/sdkv2/resources/setting/morpheus_setting_provisioning_resource_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusSettingProvisioningExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/setting/setting_appliance_resource_test.go
+++ b/morpheus/sdkv2/resources/setting/setting_appliance_resource_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusSettingApplianceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Settings) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/setting/setting_backup_resource_test.go
+++ b/morpheus/sdkv2/resources/setting/setting_backup_resource_test.go
@@ -20,7 +20,7 @@ func TestAccMorpheusSettingBackupExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Settings) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/setting/setting_monitoring_resource_test.go
+++ b/morpheus/sdkv2/resources/setting/setting_monitoring_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusSettingMonitoringExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_chef_bootstrap_resource_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_chef_bootstrap_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusTaskChefBootstrapExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Chef) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_email_resource_git_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_email_resource_git_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskEmailGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_email_resource_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_email_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskEmailExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_email_resource_url_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_email_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskEmailUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_groovy_script_resource_git_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_groovy_script_resource_git_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskGroovyScriptGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_groovy_script_resource_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_groovy_script_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskGroovyScriptExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_groovy_script_resource_url_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_groovy_script_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskGroovyScriptUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_javascript_resource_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_javascript_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskJavascriptExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_powershell_script_resource_git_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_powershell_script_resource_git_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusTaskPowershellScriptResourceGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_powershell_script_resource_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_powershell_script_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskPowershellScriptResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_powershell_script_resource_url_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_powershell_script_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskPowershellScriptResourceUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_python_script_resource_git_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_python_script_resource_git_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusTaskPythonScriptGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_python_script_resource_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_python_script_resource_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusTaskPythonScriptExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/morpheus_task_python_script_resource_url_test.go
+++ b/morpheus/sdkv2/resources/task/morpheus_task_python_script_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskPythonScriptUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_ansible_playbook_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_ansible_playbook_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusTaskAnsiblePlaybookExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_ansible_tower_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_ansible_tower_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusTaskAnsibleTowerExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Ansible, capabilities.AnsibleTower) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_library_script_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_library_script_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusTaskLibraryScriptExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_library_template_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_library_template_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusTaskLibraryTemplateExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_nested_workflow_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_nested_workflow_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusTaskNestedWorkflowExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_restart_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_restart_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskRestartExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_ruby_script_resource_git_test.go
+++ b/morpheus/sdkv2/resources/task/task_ruby_script_resource_git_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskRubyScriptGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_ruby_script_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_ruby_script_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskRubyScriptExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_ruby_script_resource_url_test.go
+++ b/morpheus/sdkv2/resources/task/task_ruby_script_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskRubyScriptUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_shell_script_resource_git_test.go
+++ b/morpheus/sdkv2/resources/task/task_shell_script_resource_git_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskShellScriptResourceGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_shell_script_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_shell_script_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskShellScriptResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_shell_script_resource_url_test.go
+++ b/morpheus/sdkv2/resources/task/task_shell_script_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusTaskShellScriptResourceUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_vro_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_vro_resource_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusTaskVroExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.VRO) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/task/task_write_attributes_resource_test.go
+++ b/morpheus/sdkv2/resources/task/task_write_attributes_resource_test.go
@@ -18,7 +18,7 @@ func TestAccMorpheusTaskWriteAttributesExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/cluster_package_resource_test.go
+++ b/morpheus/sdkv2/resources/template/cluster_package_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusClusterPackageExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_file_template_resource_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_file_template_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusFileTemplateExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_script_template_resource_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_script_template_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusScriptTemplateExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_security_package_resource_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_security_package_resource_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSecurityPackageExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_spec_template_arm_resource_git_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_spec_template_arm_resource_git_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateArmResourceGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_spec_template_arm_resource_local_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_spec_template_arm_resource_local_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateArmResourceLocalExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_spec_template_arm_resource_url_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_spec_template_arm_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateArmResourceUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_spec_template_cloud_formation_resource_git_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_spec_template_cloud_formation_resource_git_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateCloudFormationResourceGitExampleOk(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_spec_template_cloud_formation_resource_local_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_spec_template_cloud_formation_resource_local_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateCloudFormationResourceLocalExampleOk(t *testing.
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_spec_template_cloud_formation_resource_url_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_spec_template_cloud_formation_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateCloudFormationResourceUrlExampleOk(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_helm_resource_git_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_helm_resource_git_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusSpecTemplateHelmExampleOk_git(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_helm_resource_local_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_helm_resource_local_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusSpecTemplateHelmExampleOk_local(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_helm_resource_url_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_helm_resource_url_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusSpecTemplateHelmExampleOk_url(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_kubernetes_resource_git_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_kubernetes_resource_git_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusSpecTemplateKubernetesGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_kubernetes_resource_local_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_kubernetes_resource_local_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusSpecTemplateKubernetesLocalExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_kubernetes_resource_url_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_kubernetes_resource_url_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusSpecTemplateKubernetesUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.Kubernetes) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_terraform_resource_git_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_terraform_resource_git_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateTerraformResourceGitExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.AWS) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_terraform_resource_local_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_terraform_resource_local_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateTerraformResourceLocalExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/spec_template_terraform_resource_url_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_terraform_resource_url_test.go
@@ -17,7 +17,7 @@ func TestAccMorpheusSpecTemplateTerraformResourceUrlExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/tenant/tenant_resource_test.go
+++ b/morpheus/sdkv2/resources/tenant/tenant_resource_test.go
@@ -29,7 +29,7 @@ func TestAccMorpheusTenantExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/trust/morpheus_key_pair_resource_test.go
+++ b/morpheus/sdkv2/resources/trust/morpheus_key_pair_resource_test.go
@@ -61,7 +61,7 @@ func TestAccMorpheusKeyPairExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -107,7 +107,7 @@ func TestAccMorpheusKeyPairExampleOk(t *testing.T) {
 			// Apply
 			{
 				Config:             providerConfig + resourceConfig,
-				ExpectNonEmptyPlan: true,
+				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
 			},
 		},

--- a/morpheus/sdkv2/resources/usergroup/user_group_resource_test.go
+++ b/morpheus/sdkv2/resources/usergroup/user_group_resource_test.go
@@ -28,7 +28,7 @@ func TestAccMorpheusUserGroupExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/wiki/morpheus_wiki_page_resource_test.go
+++ b/morpheus/sdkv2/resources/wiki/morpheus_wiki_page_resource_test.go
@@ -40,7 +40,7 @@ func TestAccMorpheusWikiPageExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/workflow/workflow_operational_test.go
+++ b/morpheus/sdkv2/resources/workflow/workflow_operational_test.go
@@ -27,7 +27,7 @@ func TestAccMorpheusWorkflowOperationalExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/workflow/workflow_provisioning_test.go
+++ b/morpheus/sdkv2/resources/workflow/workflow_provisioning_test.go
@@ -19,7 +19,7 @@ func TestAccMorpheusWorkflowProvisioningExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/testhelpers/capabilities/require.go
+++ b/morpheus/testhelpers/capabilities/require.go
@@ -21,7 +21,7 @@ import (
 //	func TestAccMorpheusVMwareCloud(t *testing.T) {
 //	    defer testhelpers.RecordResult(t)
 //	    if capabilities.Missing(t, capabilities.VMware) {
-//	        t.Log("Skipping test due to missing capabilities")
+//	        t.Skip("Skipping test due to missing capabilities")
 //	    }
 //	    t.Parallel()
 //	    // ... rest of test
@@ -52,7 +52,7 @@ func Missing(t *testing.T, required ...Capability) bool {
 //	    defer testhelpers.RecordResult(t)
 //	    // Runs if NSXT OR NSXV is available
 //	    if capabilities.MissingAll(t, capabilities.NSXT, capabilities.NSXV) {
-//	        t.Log("Skipping test due to missing capabilities")
+//	        t.Skip("Skipping test due to missing capabilities")
 //	    }
 //	    // ... rest of test
 //	}

--- a/morpheus/testhelpers/config_test.go
+++ b/morpheus/testhelpers/config_test.go
@@ -55,7 +55,7 @@ func TestAccMorpheusProviderBlockWithAccessToken(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -93,7 +93,7 @@ func TestAccMorpheusProviderBlockWithCredentials(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -132,7 +132,7 @@ func TestAccMorpheusProviderBlockAllAuth(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -171,7 +171,7 @@ func TestAccMorpheusProviderBlockMissingURL(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	providerConfig := testhelpers.ProviderBlock()
 	resourceConfig := testhelpers.FakeResourceConfig()
@@ -214,7 +214,7 @@ func TestAccMorpheusProviderBlockMissingAuth(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -246,7 +246,7 @@ func TestAccMorpheusProviderBlockMissingUsername(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -293,7 +293,7 @@ func TestAccMorpheusProviderBlockMissingPassword(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 
@@ -326,7 +326,7 @@ func TestAccMorpheusProviderBlockNoneSet(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	if capabilities.Missing(t, capabilities.All) {
-		t.Log("Skipping test due to missing capabilities")
+		t.Skip("Skipping test due to missing capabilities")
 	}
 	t.Parallel()
 

--- a/morpheus/testhelpers/qa_results_test.go
+++ b/morpheus/testhelpers/qa_results_test.go
@@ -32,7 +32,7 @@ func TestRecordResultRecordsCapabilitySkip(t *testing.T) {
 		defer RecordResult(st)
 
 		if capabilities.Missing(st, capabilities.Capability("nonexistent_capability")) {
-			st.Log("Skipping test due to missing capabilities")
+			st.Skip("Skipping test due to missing capabilities")
 		}
 		st.Fatal("test body must not run when a required capability is missing")
 	})


### PR DESCRIPTION
## Summary

Acceptance-test capability guards logged a message but did not stop the test, so tests ran (and failed) even when their required capability was absent. This converts the guards to skip, and fixes two example tests with stale assertions.

## Changes
- **Capability gating (~315 files):** convert `t.Log("Skipping test due to missing capabilities")` -> `t.Skip(...)` and remove the dead `return`s that followed. Tests now report as skipped rather than running unsupported. (`capabilities.Missing` already skips internally; this removes unreachable code and makes intent explicit.)
- **networks data source test:** stop overriding the example name with a random value (rendered an invalid bareword reference); assert `name`/`values` inside the `filter` block.
- **key pair test:** step 2 now expects an empty plan after apply.
- **capability helper:** doc examples updated to `t.Skip`.

## Verification
- `go build ./...`, `go vet`, and `make lint` (0 issues) clean.
- Targeted acceptance tests pass: networks data source, key pair, cloud by-id/by-name.