### PR TITLE
Cache golangci-lint in CI and exclude SDK from test targets

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,8 +18,24 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
+        id: setup-go
         with:
           go-version-file: go.mod
+      # golangci-lint keeps its analysis cache in ~/.cache/golangci-lint, separate
+      # from the Go build cache setup-go restores. Without persisting it, every CI
+      # run re-type-checks the whole import graph from source -- including the
+      # 9.4k-file internal/sdk/oapigen package pulled in by ~105 packages -- which
+      # dominates lint time (~235s cold vs ~7s warm). A warm build cache does not
+      # help this; only this cache does.
+      - name: Cache golangci-lint
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-glci2.11.3-${{ hashFiles('**/go.sum', '.golangci.yml') }}-${{ github.sha }}
+          restore-keys: |
+            golangci-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-glci2.11.3-${{ hashFiles('**/go.sum', '.golangci.yml') }}-
+            golangci-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-glci2.11.3-
+            golangci-${{ runner.os }}-
       # Run lint via the Makefile so the vendored SDK (internal/sdk) exclusion
       # lives in one place. golangci-lint cannot skip analysis of those ~9k
       # generated files via config alone, so the lint target filters them out

--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,18 @@ lint:
 	golangci-lint run $$(go list -f '{{.Dir}}' ./... | grep -v '/internal/sdk')
 
 test:
+	pkgs=$$(go list ./... | grep -v '/internal/sdk'); \
 	env TF_ACC=1 \
-	go test -v -cover -count 1 -timeout 60m ./...
+	go test -v -cover -count 1 -timeout 60m $$pkgs
 
 # Same as `test` but emits machine-readable `go test -json` on stdout (and
 # nothing else, so the stream stays valid JSON). Used by the nightly runner to
 # capture a full, parseable log including API traces. The leading `@` keeps the
 # recipe command out of stdout.
 test-json:
-	@env TF_ACC=1 \
-	go test -json -cover -count 1 -timeout 60m ./...
+	@pkgs=$$(go list ./... | grep -v '/internal/sdk'); \
+	env TF_ACC=1 \
+	go test -json -cover -count 1 -timeout 60m $$pkgs
 
 unit-tests:
 	# exclude the framework and sdkv2 packages, the


### PR DESCRIPTION
## Summary

Vendoring the Morpheus SDK in-tree (`internal/sdk`) slowed CI lint and the
acceptance-test targets. The SDK's `oapigen` package is a single ~9.4k-file /
~140k-LOC package imported by ~105 provider packages, so it is compiled and
type-checked as a dependency of nearly everything — even though it is already
excluded from the lint *target set*.

This PR does not change that root cause (the monolithic generated package); it
removes two avoidable, repeated costs.

## Changes

### A. Persist golangci-lint's cache in CI (`.github/workflows/lint.yaml`)
golangci-lint keeps its analysis cache in `~/.cache/golangci-lint`, which is
**separate** from the Go build cache that `setup-go` already restores. Because CI
never persisted it, every run re-type-checked the whole import graph from source
(including `oapigen`). Added an `actions/cache` step for that directory.

Locally this is the difference between a cold `make lint` (~235s) and a warm one
(~7s). The benefit appears from the **second** CI run onward (run #1 seeds the
cache, later runs restore it). `make lint` itself is unchanged, so the SDK
exclusion stays single-sourced in the Makefile.

### B. Exclude `internal/sdk` from the `test` / `test-json` targets (`Makefile`)
These targets used unfiltered `go test ./...`, which also built and `go vet`-ed
the 9.4k-file SDK package despite it having no tests. They now filter
`/internal/sdk` with the same idiom already used by `lint` and `unit-tests`.
`oapigen` is still compiled as a dependency — this only removes the redundant
test-target build/vet. `test-json`'s pure-JSON stdout contract is preserved.

## Verification
- `make -n test` / `make -n test-json` expand to the expected single shell
  command; the filtered package set contains no `internal/sdk` packages.
- `test-json` stdout validated as pure JSON (the `go list` output is captured
  into the package variable and never reaches stdout).
- Lint workflow YAML validated.

## Not included
The underlying cause — the single monolithic generated SDK package — is left for
a follow-up (e.g. splitting or trimming the generated package).