### PR TITLE
Fix TestAccMorpheusSubProviderStrayResource

### DIFF
--- a/morpheus/provider_test.go
+++ b/morpheus/provider_test.go
@@ -376,7 +376,7 @@ resource "hpe_morpheus_fake" "foo" {
 	name = "bar"
 }
 `
-	expected := `missing morpheus`
+	expected := `The "morpheus" provider block is required but was not found`
 	testresource.Test(t, testresource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []testresource.TestStep{


### PR DESCRIPTION
This test previously hit the code path of the Morpheus ResourceWithConfigure implementation:

```
	cf, ok := req.ProviderData.(*clientfactory.ClientFactory)
	if !ok {
		tflog.Debug(ctx, "Nil ProviderData sub block")
		msg := `
Morpheus resource present, but possible missing morpheus provider block.

provider "hpe" {
  morpheus { <- missing or duplicate?
    url = "https://example.com"
  }
}`
```

Implement a one-line fix to check for new error format.

Some preamble for why this is needed:

With recent changes added to the adapter layer, we implement a safe extraction of ProviderData of a child provider to pass to the underlying provider's (`ProviderAdapter.in`) `Configure` method.
This is implemented on all Framework objects which the Adapter Layer supports that have a Configure method, e.g. Resource, DataSource, EphemeralResource...

```
func (r *ResourceAdapter) Configure(
	ctx context.Context,
	req resource.ConfigureRequest,
	resp *resource.ConfigureResponse,
) {
	if r.withConfigure == nil {
		return
	}

	// Extract child provider configure data for ConfigureRequest.ProviderData
	if providerData, ok := req.ProviderData.(map[string]any); ok {
		metaResp := &provider.MetadataResponse{}
		r.provider.Metadata(ctx, provider.MetadataRequest{}, metaResp)

		childData, exists := providerData[metaResp.TypeName]
		if !exists {
			resp.Diagnostics.AddError(
				"Missing provider configuration",
				fmt.Sprintf(
					"The %q provider block is required but was not found in the provider configuration.",
					metaResp.TypeName,
				),
			)

			return
		}

		req.ProviderData = childData
	}

	r.withConfigure.Configure(ctx, req, resp)
}
```

This means that the Provider Adapter checks for missing provider data BEFORE the Adapter's underlying provider has a chance to perform any checks - if they have even been implemented by a provider author.

e.g. if we are missing a `morpheus` block, but our config has a `morpheus` resource, we get this sort of diagnostic:


```
│ Error: Missing provider configuration
│
│   with hpe_morpheus_backup_job.example,
│   on backup.tf line 1, in resource "hpe_morpheus_backup_job" "example":
│    1: resource "hpe_morpheus_backup_job" "example" {
│
│ The "morpheus" provider block is required but was not found in the provider configuration.
```

This is a more safe and unified approach with varying underlying providers, which may or may not implement nil-safety checks for ProviderData in `Configure`.

However, it means that our old message `Morpheus resource present, but possible missing morpheus provider block.` doesn't have a chance to execute.
