### PR TITLE
MORPH-13531: Fix write-only cloud secrets dropped on create and update

### DIFF
--- a/morpheus/framework/resources/cloud/cloud_create.go
+++ b/morpheus/framework/resources/cloud/cloud_create.go
@@ -20,6 +20,113 @@ import (
 
 const createOperation = "create cloud resource"
 
+// buildVmwareCloudConfig assembles the VMware (vSphere) cloud configuration for
+// the AddClouds request.
+//
+// The write-only password attribute is null in the plan - Terraform strips
+// write-only values from the plan and state - so it MUST be sourced from the
+// request configuration (configModel, populated from req.Config). Sourcing it
+// from the plan instead silently drops the password and the API rejects the
+// create with 400 "Enter your password". Every non-write-only field is taken
+// from the plan.
+func buildVmwareCloudConfig(plan, configModel CloudModel) *sdk.AddCloudsRequestZoneConfigAnyOf3 {
+	config := sdkfuncs.NewVmwareCloudConfig(
+		plan.ConfigVmware.ApiUrl.ValueString(),
+		plan.ConfigVmware.ApiVersion.ValueString(),
+		plan.ConfigVmware.Datacenter.ValueString(),
+	)
+
+	if !plan.ApplianceUrl.IsNull() && !plan.ApplianceUrl.IsUnknown() {
+		config.ApplianceUrl = plan.ApplianceUrl.ValueStringPointer()
+	}
+
+	if !plan.DataCenterName.IsNull() && !plan.DataCenterName.IsUnknown() {
+		config.DatacenterName = plan.DataCenterName.ValueStringPointer()
+	}
+
+	if !plan.ExternalId.IsNull() && !plan.ExternalId.IsUnknown() {
+		config.ExternalId.Set(plan.ExternalId.ValueStringPointer())
+	}
+
+	if !plan.ImportExistingVms.IsNull() && !plan.ImportExistingVms.IsUnknown() {
+		config.InventoryLevel = plan.ImportExistingVms.ValueStringPointer()
+	}
+
+	if !plan.KeyboardLayout.IsNull() && !plan.KeyboardLayout.IsUnknown() {
+		config.ConsoleKeymap = plan.KeyboardLayout.ValueStringPointer()
+	}
+
+	if !plan.ConfigVmware.CertificateProvider.IsNull() &&
+		!plan.ConfigVmware.CertificateProvider.IsUnknown() {
+		config.CertificateProvider = plan.ConfigVmware.CertificateProvider.ValueStringPointer()
+	}
+
+	if !plan.ConfigVmware.Cluster.IsNull() &&
+		!plan.ConfigVmware.Cluster.IsUnknown() {
+		config.Cluster = plan.ConfigVmware.Cluster.ValueStringPointer()
+	}
+
+	if !plan.ConfigVmware.ConfigManagementId.IsNull() &&
+		!plan.ConfigVmware.ConfigManagementId.IsUnknown() {
+		config.ConfigManagementId = plan.ConfigVmware.ConfigManagementId.ValueStringPointer()
+	}
+
+	if !plan.ConfigVmware.EnableDiskTypeSelection.IsNull() &&
+		!plan.ConfigVmware.EnableDiskTypeSelection.IsUnknown() {
+		config.EnableDiskTypeSelection.Set(
+			convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.EnableDiskTypeSelection),
+		)
+	}
+
+	if !plan.ConfigVmware.EnableNetworkTypeSelection.IsNull() &&
+		!plan.ConfigVmware.EnableNetworkTypeSelection.IsUnknown() {
+		config.EnableNetworkTypeSelection.Set(
+			convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.EnableNetworkTypeSelection),
+		)
+	}
+
+	if !plan.ConfigVmware.EnableStorageTypeSelection.IsNull() &&
+		!plan.ConfigVmware.EnableStorageTypeSelection.IsUnknown() {
+		config.EnableStorageTypeSelection.Set(
+			convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.EnableStorageTypeSelection),
+		)
+	}
+
+	if !plan.ConfigVmware.EnableVnc.IsNull() &&
+		!plan.ConfigVmware.EnableVnc.IsUnknown() {
+		config.EnableVnc.Set(convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.EnableVnc))
+	}
+
+	if !plan.ConfigVmware.HideHostSelection.IsNull() &&
+		!plan.ConfigVmware.HideHostSelection.IsUnknown() {
+		config.HideHostSelection.Set(convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.HideHostSelection))
+	}
+
+	// password is write-only: it is null in the plan, so read it from
+	// req.Config (captured in configModel).
+	if !configModel.ConfigVmware.Password.IsNull() &&
+		!configModel.ConfigVmware.Password.IsUnknown() {
+		config.Password = configModel.ConfigVmware.Password.ValueStringPointer()
+	}
+
+	if !plan.ConfigVmware.ResourcePool.IsNull() &&
+		!plan.ConfigVmware.ResourcePool.IsUnknown() {
+		config.ResourcePool = plan.ConfigVmware.ResourcePool.ValueStringPointer()
+	}
+
+	if !plan.ConfigVmware.RpcMode.IsNull() &&
+		!plan.ConfigVmware.RpcMode.IsUnknown() {
+		config.RpcMode.Set(plan.ConfigVmware.RpcMode.ValueStringPointer())
+	}
+
+	if !plan.ConfigVmware.Username.IsNull() &&
+		!plan.ConfigVmware.Username.IsUnknown() {
+		config.Username = plan.ConfigVmware.Username.ValueStringPointer()
+	}
+
+	return config
+}
+
 func (r *Resource) Create(
 	ctx context.Context,
 	req resource.CreateRequest,
@@ -36,8 +143,11 @@ func (r *Resource) Create(
 	name := plan.Name.ValueString()
 	tenantID := plan.TenantId.ValueInt64()
 
-	var config CloudModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	// configModel holds the raw request configuration. Write-only attributes
+	// (e.g. config_vmware.password, config_azure.client_secret) are null in the
+	// plan/state and must be read from req.Config, not the plan.
+	var configModel CloudModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -272,99 +382,7 @@ func (r *Resource) Create(
 	case !plan.ConfigVmware.IsNull() && !plan.ConfigVmware.IsUnknown():
 		cloudTypeCode = vmwareCloud
 
-		config := sdkfuncs.NewVmwareCloudConfig(
-			plan.ConfigVmware.ApiUrl.ValueString(),
-			plan.ConfigVmware.ApiVersion.ValueString(),
-			plan.ConfigVmware.Datacenter.ValueString(),
-		)
-
-		if !plan.ApplianceUrl.IsNull() && !plan.ApplianceUrl.IsUnknown() {
-			config.ApplianceUrl = plan.ApplianceUrl.ValueStringPointer()
-		}
-
-		if !plan.DataCenterName.IsNull() && !plan.DataCenterName.IsUnknown() {
-			config.DatacenterName = plan.DataCenterName.ValueStringPointer()
-		}
-
-		if !plan.ExternalId.IsNull() && !plan.ExternalId.IsUnknown() {
-			config.ExternalId.Set(plan.ExternalId.ValueStringPointer())
-		}
-
-		if !plan.ImportExistingVms.IsNull() && !plan.ImportExistingVms.IsUnknown() {
-			config.InventoryLevel = plan.ImportExistingVms.ValueStringPointer()
-		}
-
-		if !plan.KeyboardLayout.IsNull() && !plan.KeyboardLayout.IsUnknown() {
-			config.ConsoleKeymap = plan.KeyboardLayout.ValueStringPointer()
-		}
-
-		if !plan.ConfigVmware.CertificateProvider.IsNull() &&
-			!plan.ConfigVmware.CertificateProvider.IsUnknown() {
-			config.CertificateProvider = plan.ConfigVmware.CertificateProvider.ValueStringPointer()
-		}
-
-		if !plan.ConfigVmware.Cluster.IsNull() &&
-			!plan.ConfigVmware.Cluster.IsUnknown() {
-			config.Cluster = plan.ConfigVmware.Cluster.ValueStringPointer()
-		}
-
-		if !plan.ConfigVmware.ConfigManagementId.IsNull() &&
-			!plan.ConfigVmware.ConfigManagementId.IsUnknown() {
-			config.ConfigManagementId = plan.ConfigVmware.ConfigManagementId.ValueStringPointer()
-		}
-
-		if !plan.ConfigVmware.EnableDiskTypeSelection.IsNull() &&
-			!plan.ConfigVmware.EnableDiskTypeSelection.IsUnknown() {
-			config.EnableDiskTypeSelection.Set(
-				convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.EnableDiskTypeSelection),
-			)
-		}
-
-		if !plan.ConfigVmware.EnableNetworkTypeSelection.IsNull() &&
-			!plan.ConfigVmware.EnableNetworkTypeSelection.IsUnknown() {
-			config.EnableNetworkTypeSelection.Set(
-				convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.EnableNetworkTypeSelection),
-			)
-		}
-
-		if !plan.ConfigVmware.EnableStorageTypeSelection.IsNull() &&
-			!plan.ConfigVmware.EnableStorageTypeSelection.IsUnknown() {
-			config.EnableStorageTypeSelection.Set(
-				convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.EnableStorageTypeSelection),
-			)
-		}
-
-		if !plan.ConfigVmware.EnableVnc.IsNull() &&
-			!plan.ConfigVmware.EnableVnc.IsUnknown() {
-			config.EnableVnc.Set(convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.EnableVnc))
-		}
-
-		if !plan.ConfigVmware.HideHostSelection.IsNull() &&
-			!plan.ConfigVmware.HideHostSelection.IsUnknown() {
-			config.HideHostSelection.Set(convert.BoolTypeToStringPointerOnOff(plan.ConfigVmware.HideHostSelection))
-		}
-
-		if !plan.ConfigVmware.Password.IsNull() &&
-			!plan.ConfigVmware.Password.IsUnknown() {
-			config.Password = plan.ConfigVmware.Password.ValueStringPointer()
-		}
-
-		if !plan.ConfigVmware.ResourcePool.IsNull() &&
-			!plan.ConfigVmware.ResourcePool.IsUnknown() {
-			config.ResourcePool = plan.ConfigVmware.ResourcePool.ValueStringPointer()
-		}
-
-		if !plan.ConfigVmware.RpcMode.IsNull() &&
-			!plan.ConfigVmware.RpcMode.IsUnknown() {
-			config.RpcMode.Set(plan.ConfigVmware.RpcMode.ValueStringPointer())
-		}
-
-		if !plan.ConfigVmware.Username.IsNull() &&
-			!plan.ConfigVmware.Username.IsUnknown() {
-			config.Username = plan.ConfigVmware.Username.ValueStringPointer()
-		}
-
-		addCloudConfig.AddCloudsRequestZoneConfigAnyOf3 = config
+		addCloudConfig.AddCloudsRequestZoneConfigAnyOf3 = buildVmwareCloudConfig(plan, configModel)
 
 	case !plan.ConfigAzure.IsNull() && !plan.ConfigAzure.IsUnknown():
 		cloudTypeCode = azureCloud
@@ -413,8 +431,10 @@ func (r *Resource) Create(
 			config.ClientId = plan.ConfigAzure.ClientId.ValueStringPointer()
 		}
 
-		if !plan.ConfigAzure.ClientSecret.IsNull() && !plan.ConfigAzure.ClientSecret.IsUnknown() {
-			config.ClientSecret = plan.ConfigAzure.ClientSecret.ValueStringPointer()
+		// client_secret is write-only: it is null in the plan, so read it from
+		// req.Config (captured in configModel above).
+		if !configModel.ConfigAzure.ClientSecret.IsNull() && !configModel.ConfigAzure.ClientSecret.IsUnknown() {
+			config.ClientSecret = configModel.ConfigAzure.ClientSecret.ValueStringPointer()
 		}
 
 		if !plan.ConfigAzure.ResourceGroup.IsNull() && !plan.ConfigAzure.ResourceGroup.IsUnknown() {

--- a/morpheus/framework/resources/cloud/cloud_create_internal_test.go
+++ b/morpheus/framework/resources/cloud/cloud_create_internal_test.go
@@ -1,0 +1,103 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package cloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestUnitBuildVmwareCloudConfigPassword pins the write-only contract for
+// config_vmware.password.
+//
+// Because the attribute is declared WriteOnly, Terraform strips its value from
+// the plan (and state), leaving it null there - the value is only present in
+// the request config. buildVmwareCloudConfig must therefore source the password
+// from configModel (req.Config), never the plan. Sourcing it from the plan was
+// the regression that dropped the password and made VMware cloud creation fail
+// with HTTP 400 {"errors":{"password":"Enter your password"}}.
+func TestUnitBuildVmwareCloudConfigPassword(t *testing.T) {
+	t.Parallel()
+
+	const secret = "s3cret-from-config"
+
+	tests := []struct {
+		name         string
+		planPassword types.String
+		cfgPassword  types.String
+		wantPassword string
+		wantSet      bool
+	}{
+		{
+			// The real write-only scenario: null in the plan, set in config.
+			// A plan-sourced read would yield nil here and fail.
+			name:         "sourced from config when plan is null",
+			planPassword: types.StringNull(),
+			cfgPassword:  types.StringValue(secret),
+			wantPassword: secret,
+			wantSet:      true,
+		},
+		{
+			// Config always wins; guards against re-introducing a plan read
+			// even if a stale value somehow appears in the plan.
+			name:         "config wins over any plan value",
+			planPassword: types.StringValue("stale-plan-value"),
+			cfgPassword:  types.StringValue(secret),
+			wantPassword: secret,
+			wantSet:      true,
+		},
+		{
+			// No password in config -> nothing sent to the API.
+			name:         "unset when config is null",
+			planPassword: types.StringNull(),
+			cfgPassword:  types.StringNull(),
+			wantSet:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := CloudModel{
+				ConfigVmware: ConfigVmwareValue{
+					ApiUrl:     types.StringValue("https://vcenter.example.local"),
+					ApiVersion: types.StringValue("7.0"),
+					Datacenter: types.StringValue("DC9"),
+					Username:   types.StringValue("administrator@vsphere.local"),
+					Password:   tc.planPassword,
+					state:      attr.ValueStateKnown,
+				},
+			}
+			configModel := CloudModel{
+				ConfigVmware: ConfigVmwareValue{
+					Password: tc.cfgPassword,
+					state:    attr.ValueStateKnown,
+				},
+			}
+
+			got := buildVmwareCloudConfig(plan, configModel)
+
+			if tc.wantSet {
+				if got.Password == nil {
+					t.Fatalf("password: got nil, want %q (write-only value must come from req.Config)", tc.wantPassword)
+				}
+				if *got.Password != tc.wantPassword {
+					t.Fatalf("password: got %q, want %q", *got.Password, tc.wantPassword)
+				}
+			} else if got.Password != nil {
+				t.Fatalf("password: got %q, want unset (nil)", *got.Password)
+			}
+
+			// Non-write-only fields must still be sourced from the plan.
+			if got.Username == nil || *got.Username != "administrator@vsphere.local" {
+				t.Fatalf("username: got %v, want administrator@vsphere.local", got.Username)
+			}
+			if got.ApiUrl != "https://vcenter.example.local" {
+				t.Fatalf("api_url: got %q, want https://vcenter.example.local", got.ApiUrl)
+			}
+		})
+	}
+}

--- a/morpheus/framework/resources/cloud/cloud_read.go
+++ b/morpheus/framework/resources/cloud/cloud_read.go
@@ -436,11 +436,8 @@ func getCloudAsState(
 			attrValues["hide_host_selection"] = types.BoolNull()
 		}
 
-		if cfg.Password.Get() != nil {
-			attrValues["password"] = convert.StrToType(cfg.Password.Get())
-		} else {
-			attrValues["password"] = types.StringNull()
-		}
+		// password is write-only: it must never be persisted to state.
+		attrValues["password"] = types.StringNull()
 
 		if cfg.ResourcePool != nil {
 			attrValues["resource_pool"] = convert.StrToType(cfg.ResourcePool)

--- a/morpheus/framework/resources/cloud/cloud_update.go
+++ b/morpheus/framework/resources/cloud/cloud_update.go
@@ -315,8 +315,9 @@ func (r *Resource) Update(
 			updateCloud.Config["datacenter"] = plan.ConfigVmware.Datacenter.ValueString()
 		}
 
-		if !plan.ConfigVmware.Password.IsNull() && !plan.ConfigVmware.Password.IsUnknown() {
-			updateCloud.Config["password"] = plan.ConfigVmware.Password.ValueString()
+		// password is write-only: read it from req.Config, not the plan.
+		if !config.ConfigVmware.Password.IsNull() && !config.ConfigVmware.Password.IsUnknown() {
+			updateCloud.Config["password"] = config.ConfigVmware.Password.ValueString()
 		}
 
 		if !plan.ConfigVmware.ResourcePool.IsNull() && !plan.ConfigVmware.ResourcePool.IsUnknown() {
@@ -379,8 +380,9 @@ func (r *Resource) Update(
 			updateCloud.Config["clientId"] = plan.ConfigAzure.ClientId.ValueString()
 		}
 
-		if !plan.ConfigAzure.ClientSecret.IsNull() && !plan.ConfigAzure.ClientSecret.IsUnknown() {
-			updateCloud.Config["clientSecret"] = plan.ConfigAzure.ClientSecret.ValueString()
+		// client_secret is write-only: read it from req.Config, not the plan.
+		if !config.ConfigAzure.ClientSecret.IsNull() && !config.ConfigAzure.ClientSecret.IsUnknown() {
+			updateCloud.Config["clientSecret"] = config.ConfigAzure.ClientSecret.ValueString()
 		}
 
 		if !plan.ConfigAzure.ResourceGroup.IsNull() && !plan.ConfigAzure.ResourceGroup.IsUnknown() {


### PR DESCRIPTION
## Problem

Creating a VMware cloud via the typed `config_vmware` block fails with:

```
400 (Bad Request): {"success":false,"errors":{"password":"Enter your password"}}
```

even though the password is set in the HCL. The same defect affects `config_azure.client_secret`.

## Root cause

`config_vmware.password` and `config_azure.client_secret` are **write-only** attributes. Terraform strips write-only values from the plan and state — they are only available via `req.Config`. Create and Update read them from the **plan** (always null for a write-only attribute), so the secret is silently dropped and never sent to the API. In Create, the outer `req.Config` model was additionally shadowed by the SDK `config` variable inside each `case`. Read also persisted the VMware password back to state, which is invalid for a write-only attribute.

## Fix

- **create** — source the write-only values from `req.Config` (`configModel`), not the plan; extract `buildVmwareCloudConfig` so the contract is unit-testable.
- **update** — read the write-only values from `req.Config`.
- **read** — never persist the write-only VMware password to state (always null), matching how Azure `client_secret` is already handled.

## Test

`TestUnitBuildVmwareCloudConfigPassword` pins the write-only contract: password sourced from config even when the plan is null, config wins over any plan value, unset when config is null.

## Verification

`go build ./...`, `go vet`, and `golangci-lint` all clean; new unit test passes.