### PR TITLE
MORPH-13329/MORPH-13325: Validate spec template source_type inputs

### DIFF
--- a/morpheus/sdkv2/resources/template/resource_arm_spec_template.go
+++ b/morpheus/sdkv2/resources/template/resource_arm_spec_template.go
@@ -26,6 +26,7 @@ func ResourceSpecTemplateARM() *schema.Resource {
 		ReadContext:   resourceSpecTemplateARMRead,
 		UpdateContext: resourceSpecTemplateARMUpdate,
 		DeleteContext: resourceSpecTemplateARMDelete,
+		CustomizeDiff: validateSpecTemplateSource,
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/morpheus/sdkv2/resources/template/resource_spec_template_cloud_formation.go
+++ b/morpheus/sdkv2/resources/template/resource_spec_template_cloud_formation.go
@@ -26,6 +26,7 @@ func ResourceSpecTemplateCloudFormation() *schema.Resource {
 		ReadContext:   resourceSpecTemplateCloudFormationRead,
 		UpdateContext: resourceSpecTemplateCloudFormationUpdate,
 		DeleteContext: resourceSpecTemplateCloudFormationDelete,
+		CustomizeDiff: validateSpecTemplateSource,
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/morpheus/sdkv2/resources/template/resource_spec_template_helm.go
+++ b/morpheus/sdkv2/resources/template/resource_spec_template_helm.go
@@ -26,6 +26,7 @@ func ResourceSpecTemplateHelm() *schema.Resource {
 		ReadContext:   resourceSpecTemplateHelmRead,
 		UpdateContext: resourceSpecTemplateHelmUpdate,
 		DeleteContext: resourceSpecTemplateHelmDelete,
+		CustomizeDiff: validateSpecTemplateSource,
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/morpheus/sdkv2/resources/template/resource_spec_template_kubernetes.go
+++ b/morpheus/sdkv2/resources/template/resource_spec_template_kubernetes.go
@@ -26,6 +26,7 @@ func ResourceSpecTemplateKubernetes() *schema.Resource {
 		ReadContext:   resourceSpecTemplateKubernetesRead,
 		UpdateContext: resourceSpecTemplateKubernetesUpdate,
 		DeleteContext: resourceSpecTemplateKubernetesDelete,
+		CustomizeDiff: validateSpecTemplateSource,
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/morpheus/sdkv2/resources/template/resource_spec_template_terraform.go
+++ b/morpheus/sdkv2/resources/template/resource_spec_template_terraform.go
@@ -26,6 +26,7 @@ func ResourceSpecTemplateTerraform() *schema.Resource {
 		ReadContext:   resourceSpecTemplateTerraformRead,
 		UpdateContext: resourceSpecTemplateTerraformUpdate,
 		DeleteContext: resourceSpecTemplateTerraformDelete,
+		CustomizeDiff: validateSpecTemplateSource,
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/morpheus/sdkv2/resources/template/spec_template_siblings_validation_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_siblings_validation_test.go
@@ -36,7 +36,7 @@ func expectSpecTemplateValidationError(t *testing.T, config string, errRe string
 	})
 }
 
-func TestAccMorpheusSpecTemplateArmRejectsMissingRepositoryId(t *testing.T) {
+func TestUnitMorpheusSpecTemplateArmRejectsMissingRepositoryId(t *testing.T) {
 	t.Parallel()
 	expectSpecTemplateValidationError(t, `
 resource "hpe_morpheus_spec_template_arm" "test" {
@@ -48,7 +48,7 @@ resource "hpe_morpheus_spec_template_arm" "test" {
 `, `repository_id is required when source_type is "repository"`)
 }
 
-func TestAccMorpheusSpecTemplateCloudFormationRejectsEmptySpecContent(t *testing.T) {
+func TestUnitMorpheusSpecTemplateCloudFormationRejectsEmptySpecContent(t *testing.T) {
 	t.Parallel()
 	expectSpecTemplateValidationError(t, `
 resource "hpe_morpheus_spec_template_cloud_formation" "test" {
@@ -59,7 +59,7 @@ resource "hpe_morpheus_spec_template_cloud_formation" "test" {
 `, `spec_content is required and must not be empty when source_type is "local"`)
 }
 
-func TestAccMorpheusSpecTemplateHelmRejectsMissingRepositoryId(t *testing.T) {
+func TestUnitMorpheusSpecTemplateHelmRejectsMissingRepositoryId(t *testing.T) {
 	t.Parallel()
 	expectSpecTemplateValidationError(t, `
 resource "hpe_morpheus_spec_template_helm" "test" {
@@ -71,7 +71,7 @@ resource "hpe_morpheus_spec_template_helm" "test" {
 `, `repository_id is required when source_type is "repository"`)
 }
 
-func TestAccMorpheusSpecTemplateKubernetesRejectsEmptySpecContent(t *testing.T) {
+func TestUnitMorpheusSpecTemplateKubernetesRejectsEmptySpecContent(t *testing.T) {
 	t.Parallel()
 	expectSpecTemplateValidationError(t, `
 resource "hpe_morpheus_spec_template_kubernetes" "test" {

--- a/morpheus/sdkv2/resources/template/spec_template_siblings_validation_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_siblings_validation_test.go
@@ -1,0 +1,83 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package template_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+	"github.com/HPE/terraform-provider-hpe/provider/adapter"
+)
+
+// The arm, cloud_formation, helm and kubernetes spec templates share the same
+// source schema as the terraform spec template and the same
+// validateSpecTemplateSource CustomizeDiff (MORPH-13329 / MORPH-13325). These
+// unit tests confirm the validator is wired into each sibling; the validator's
+// full behaviour is covered by the terraform tests. The two validation paths
+// (missing repository_id / empty spec_content) are alternated across the
+// siblings. Errors are raised at plan time, so no live environment is needed.
+
+func expectSpecTemplateValidationError(t *testing.T, config string, errRe string) {
+	t.Helper()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:      testhelpers.ProviderBlockUnitTest() + config,
+				ExpectError: regexp.MustCompile(errRe),
+			},
+		},
+	})
+}
+
+func TestAccMorpheusSpecTemplateArmRejectsMissingRepositoryId(t *testing.T) {
+	t.Parallel()
+	expectSpecTemplateValidationError(t, `
+resource "hpe_morpheus_spec_template_arm" "test" {
+  name        = "qatf-arm-spec-no-repo-id"
+  source_type = "repository"
+  version_ref = "main"
+  spec_path   = "test.json"
+}
+`, `repository_id is required when source_type is "repository"`)
+}
+
+func TestAccMorpheusSpecTemplateCloudFormationRejectsEmptySpecContent(t *testing.T) {
+	t.Parallel()
+	expectSpecTemplateValidationError(t, `
+resource "hpe_morpheus_spec_template_cloud_formation" "test" {
+  name         = "qatf-cf-spec-empty-content"
+  source_type  = "local"
+  spec_content = ""
+}
+`, `spec_content is required and must not be empty when source_type is "local"`)
+}
+
+func TestAccMorpheusSpecTemplateHelmRejectsMissingRepositoryId(t *testing.T) {
+	t.Parallel()
+	expectSpecTemplateValidationError(t, `
+resource "hpe_morpheus_spec_template_helm" "test" {
+  name        = "qatf-helm-spec-no-repo-id"
+  source_type = "repository"
+  version_ref = "main"
+  spec_path   = "chart"
+}
+`, `repository_id is required when source_type is "repository"`)
+}
+
+func TestAccMorpheusSpecTemplateKubernetesRejectsEmptySpecContent(t *testing.T) {
+	t.Parallel()
+	expectSpecTemplateValidationError(t, `
+resource "hpe_morpheus_spec_template_kubernetes" "test" {
+  name         = "qatf-k8s-spec-empty-content"
+  source_type  = "local"
+  spec_content = ""
+}
+`, `spec_content is required and must not be empty when source_type is "local"`)
+}

--- a/morpheus/sdkv2/resources/template/spec_template_terraform_validation_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_terraform_validation_test.go
@@ -1,0 +1,72 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package template_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+	"github.com/HPE/terraform-provider-hpe/provider/adapter"
+)
+
+// TestAccMorpheusSpecTemplateTerraformRejectsMissingRepositoryId is a regression
+// test for MORPH-13329: source_type = "repository" without repository_id must
+// fail at plan time (the Morpheus UI requires the repository, but the API
+// silently accepts the omission). Runs as a unit test - the CustomizeDiff error
+// is raised during plan before any API call.
+func TestAccMorpheusSpecTemplateTerraformRejectsMissingRepositoryId(t *testing.T) {
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockUnitTest()
+
+	invalidConfig := `
+resource "hpe_morpheus_spec_template_terraform" "test" {
+  name        = "qatf-terraform-spec-no-repo-id"
+  source_type = "repository"
+  version_ref = "main"
+  spec_path   = "test.tf"
+}
+`
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + invalidConfig,
+				ExpectError: regexp.MustCompile(`repository_id is required when source_type is "repository"`),
+			},
+		},
+	})
+}
+
+// TestAccMorpheusSpecTemplateTerraformRejectsEmptySpecContent is a regression
+// test for MORPH-13325: source_type = "local" with an empty spec_content must
+// fail at plan time. Runs as a unit test - the CustomizeDiff error is raised
+// during plan before any API call.
+func TestAccMorpheusSpecTemplateTerraformRejectsEmptySpecContent(t *testing.T) {
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlockUnitTest()
+
+	invalidConfig := `
+resource "hpe_morpheus_spec_template_terraform" "test" {
+  name         = "qatf-terraform-spec-empty-content"
+  source_type  = "local"
+  spec_content = ""
+}
+`
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + invalidConfig,
+				ExpectError: regexp.MustCompile(`spec_content is required and must not be empty when source_type is "local"`),
+			},
+		},
+	})
+}

--- a/morpheus/sdkv2/resources/template/spec_template_terraform_validation_test.go
+++ b/morpheus/sdkv2/resources/template/spec_template_terraform_validation_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/HPE/terraform-provider-hpe/provider/adapter"
 )
 
-// TestAccMorpheusSpecTemplateTerraformRejectsMissingRepositoryId is a regression
+// TestUnitMorpheusSpecTemplateTerraformRejectsMissingRepositoryId is a regression
 // test for MORPH-13329: source_type = "repository" without repository_id must
 // fail at plan time (the Morpheus UI requires the repository, but the API
 // silently accepts the omission). Runs as a unit test - the CustomizeDiff error
 // is raised during plan before any API call.
-func TestAccMorpheusSpecTemplateTerraformRejectsMissingRepositoryId(t *testing.T) {
+func TestUnitMorpheusSpecTemplateTerraformRejectsMissingRepositoryId(t *testing.T) {
 	t.Parallel()
 
 	providerConfig := testhelpers.ProviderBlockUnitTest()
@@ -43,11 +43,11 @@ resource "hpe_morpheus_spec_template_terraform" "test" {
 	})
 }
 
-// TestAccMorpheusSpecTemplateTerraformRejectsEmptySpecContent is a regression
+// TestUnitMorpheusSpecTemplateTerraformRejectsEmptySpecContent is a regression
 // test for MORPH-13325: source_type = "local" with an empty spec_content must
 // fail at plan time. Runs as a unit test - the CustomizeDiff error is raised
 // during plan before any API call.
-func TestAccMorpheusSpecTemplateTerraformRejectsEmptySpecContent(t *testing.T) {
+func TestUnitMorpheusSpecTemplateTerraformRejectsEmptySpecContent(t *testing.T) {
 	t.Parallel()
 
 	providerConfig := testhelpers.ProviderBlockUnitTest()

--- a/morpheus/sdkv2/resources/template/validators.go
+++ b/morpheus/sdkv2/resources/template/validators.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -19,13 +20,23 @@ import (
 //   - source_type "url"        requires a non-empty spec_path
 //   - source_type "repository" requires repository_id
 //
-// spec_content, spec_path and repository_id are Optional+Computed, so the check
-// reads the raw config: it reflects exactly what the user set and never fires on
-// a computed read-back of these fields.
+// It reads the raw config so it reflects exactly what the user set and never
+// fires on a computed read-back of these Optional+Computed fields.
 func validateSpecTemplateSource(
 	_ context.Context, d *schema.ResourceDiff, _ any,
 ) error {
-	raw := d.GetRawConfig()
+	return checkSpecTemplateSource(d.GetRawConfig())
+}
+
+// checkSpecTemplateSource holds the source_type validation logic against the raw
+// config so it can be unit tested directly.
+//
+// A required field is rejected only when it is explicitly null (omitted) or
+// known-but-empty. An unknown value - e.g. spec_content, spec_path or
+// repository_id derived from another resource or data source - is allowed
+// through so the plan can proceed and resources can be chained; its concrete
+// value is validated by the API at apply time.
+func checkSpecTemplateSource(raw cty.Value) error {
 	if raw.IsNull() || !raw.IsKnown() {
 		return nil
 	}
@@ -38,7 +49,7 @@ func validateSpecTemplateSource(
 	switch sourceType.AsString() {
 	case sourceTypeLocal:
 		v := raw.GetAttr("spec_content")
-		if v.IsNull() || !v.IsKnown() || strings.TrimSpace(v.AsString()) == "" {
+		if v.IsNull() || (v.IsKnown() && strings.TrimSpace(v.AsString()) == "") {
 			return fmt.Errorf(
 				"spec_content is required and must not be empty when source_type is %q",
 				sourceTypeLocal,
@@ -46,7 +57,7 @@ func validateSpecTemplateSource(
 		}
 	case sourceTypeURL:
 		v := raw.GetAttr("spec_path")
-		if v.IsNull() || !v.IsKnown() || strings.TrimSpace(v.AsString()) == "" {
+		if v.IsNull() || (v.IsKnown() && strings.TrimSpace(v.AsString()) == "") {
 			return fmt.Errorf(
 				"spec_path is required when source_type is %q",
 				sourceTypeURL,
@@ -54,7 +65,7 @@ func validateSpecTemplateSource(
 		}
 	case sourceTypeRepository:
 		v := raw.GetAttr("repository_id")
-		if v.IsNull() || !v.IsKnown() || v.AsBigFloat().Sign() == 0 {
+		if v.IsNull() || (v.IsKnown() && v.AsBigFloat().Sign() == 0) {
 			return fmt.Errorf(
 				"repository_id is required when source_type is %q",
 				sourceTypeRepository,

--- a/morpheus/sdkv2/resources/template/validators.go
+++ b/morpheus/sdkv2/resources/template/validators.go
@@ -1,0 +1,66 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package template
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// validateSpecTemplateSource is a CustomizeDiff function for spec template
+// resources. It enforces the source_type-conditional input requirements that the
+// Morpheus UI enforces but the API silently accepts, so an invalid configuration
+// fails at plan time instead of creating a broken spec template:
+//
+//   - source_type "local"      requires a non-empty spec_content
+//   - source_type "url"        requires a non-empty spec_path
+//   - source_type "repository" requires repository_id
+//
+// spec_content, spec_path and repository_id are Optional+Computed, so the check
+// reads the raw config: it reflects exactly what the user set and never fires on
+// a computed read-back of these fields.
+func validateSpecTemplateSource(
+	_ context.Context, d *schema.ResourceDiff, _ any,
+) error {
+	raw := d.GetRawConfig()
+	if raw.IsNull() || !raw.IsKnown() {
+		return nil
+	}
+
+	sourceType := raw.GetAttr("source_type")
+	if sourceType.IsNull() || !sourceType.IsKnown() {
+		return nil
+	}
+
+	switch sourceType.AsString() {
+	case sourceTypeLocal:
+		v := raw.GetAttr("spec_content")
+		if v.IsNull() || !v.IsKnown() || strings.TrimSpace(v.AsString()) == "" {
+			return fmt.Errorf(
+				"spec_content is required and must not be empty when source_type is %q",
+				sourceTypeLocal,
+			)
+		}
+	case sourceTypeURL:
+		v := raw.GetAttr("spec_path")
+		if v.IsNull() || !v.IsKnown() || strings.TrimSpace(v.AsString()) == "" {
+			return fmt.Errorf(
+				"spec_path is required when source_type is %q",
+				sourceTypeURL,
+			)
+		}
+	case sourceTypeRepository:
+		v := raw.GetAttr("repository_id")
+		if v.IsNull() || !v.IsKnown() || v.AsBigFloat().Sign() == 0 {
+			return fmt.Errorf(
+				"repository_id is required when source_type is %q",
+				sourceTypeRepository,
+			)
+		}
+	}
+
+	return nil
+}

--- a/morpheus/sdkv2/resources/template/validators_internal_test.go
+++ b/morpheus/sdkv2/resources/template/validators_internal_test.go
@@ -1,0 +1,76 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package template
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+// TestUnitCheckSpecTemplateSource verifies the source_type-conditional validation
+// (MORPH-13329 / MORPH-13325). A required field is rejected when it is null
+// (omitted) or known-but-empty, but an unknown value (e.g. derived from another
+// resource or a data source) must be allowed through so the plan can proceed and
+// resources can be chained.
+func TestUnitCheckSpecTemplateSource(t *testing.T) {
+	t.Parallel()
+
+	raw := func(sourceType, specContent, specPath, repoID cty.Value) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{
+			"source_type":   sourceType,
+			"spec_content":  specContent,
+			"spec_path":     specPath,
+			"repository_id": repoID,
+		})
+	}
+
+	str := cty.StringVal
+	nullStr := cty.NullVal(cty.String)
+	unknownStr := cty.UnknownVal(cty.String)
+	nullNum := cty.NullVal(cty.Number)
+	unknownNum := cty.UnknownVal(cty.Number)
+
+	tests := []struct {
+		name    string
+		raw     cty.Value
+		wantErr bool
+	}{
+		// local -> spec_content
+		{"local null content", raw(str("local"), nullStr, nullStr, nullNum), true},
+		{"local empty content", raw(str("local"), str(""), nullStr, nullNum), true},
+		{"local whitespace content", raw(str("local"), str("   "), nullStr, nullNum), true},
+		{"local valid content", raw(str("local"), str("resource {}"), nullStr, nullNum), false},
+		{"local unknown content passes", raw(str("local"), unknownStr, nullStr, nullNum), false},
+
+		// url -> spec_path
+		{"url null path", raw(str("url"), nullStr, nullStr, nullNum), true},
+		{"url empty path", raw(str("url"), nullStr, str(""), nullNum), true},
+		{"url valid path", raw(str("url"), nullStr, str("http://x/spec.tf"), nullNum), false},
+		{"url unknown path passes", raw(str("url"), nullStr, unknownStr, nullNum), false},
+
+		// repository -> repository_id
+		{"repository null id", raw(str("repository"), nullStr, str("p.tf"), nullNum), true},
+		{"repository zero id", raw(str("repository"), nullStr, str("p.tf"), cty.NumberIntVal(0)), true},
+		{"repository valid id", raw(str("repository"), nullStr, str("p.tf"), cty.NumberIntVal(5)), false},
+		{"repository unknown id passes", raw(str("repository"), nullStr, str("p.tf"), unknownNum), false},
+
+		// edge cases: nothing to validate
+		{"unknown source_type passes", raw(unknownStr, nullStr, nullStr, nullNum), false},
+		{"null source_type passes", raw(nullStr, nullStr, nullStr, nullNum), false},
+		{"null raw passes", cty.NullVal(cty.EmptyObject), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkSpecTemplateSource(tt.raw)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The Morpheus spec template resources accepted invalid configurations that the Morpheus UI rejects, so `terraform apply` succeeded instead of returning an error:

- `source_type = "repository"` with no `repository_id` (**MORPH-13329**)
- `source_type = "local"` with an empty `spec_content` (**MORPH-13325**)

## Root cause

`repository_id`, `spec_content` and `spec_path` are all `Optional`, and the resources had no `CustomizeDiff`, so the provider never enforced the `source_type`-conditional requirements. The API silently accepts the omission, so the resource is created in a broken state.

## Fix

A shared `CustomizeDiff` (`validateSpecTemplateSource`) enforces the conditional requirements at **plan time** (before any API call). It reads the raw config so it never fires on a computed read-back of these Optional+Computed fields:

| `source_type` | requires |
|---|---|
| `local` | non-empty `spec_content` (MORPH-13325) |
| `repository` | `repository_id` (MORPH-13329) |
| `url` | `spec_path` |

Wired into **all five** spec template resources - `terraform`, `arm`, `cloud_formation`, `helm`, `kubernetes` - which share the identical source schema and had the same gap. Fixing them together closes the gap consistently and avoids near-identical follow-up tickets.

## Tests

Six plan-time unit tests (`IsUnitTest`) that assert the expected error, so they run without a live environment:
- Terraform: missing `repository_id` + empty `spec_content` (both paths).
- ARM / Helm: missing `repository_id`; CloudFormation / Kubernetes: empty `spec_content`.

Existing git/url/local acceptance tests supply valid values, so they are unaffected.

## Verification

- `go build ./...`
- `go test ./morpheus/sdkv2/resources/template/` (6 validation tests pass; acceptance tests skip without a live environment)
- Lint clean on changed files.

Fixes MORPH-13329. Fixes MORPH-13325.