### PR TITLE
Correct hpe_morpheus_instance volume matching on resize; document BMaaS volume attach

### DIFF
--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -41,6 +41,9 @@ the new settings but no `Morpheus` `Update` API calls will be made.  The default
 &nbsp;&nbsp;&nbsp;&nbsp;- **Do not** change the order of volumes or network_interfaces in HCL<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- The addition and removal of volumes is supported<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Existing volumes can have their size increased but not decreased<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- For BMaaS (bare metal) instances only datastore-backed volumes (e.g. HPE Alletra MP) can be<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  added or resized; local disk / RAID volumes such as the RAID1 boot volume are fixed hardware<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  and cannot be added, resized or removed via `Update`<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Network interface update is supported for Morpheus versions >= 8.1.2, for earlier<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  versions network_interfaces changes will force a new instance to be created.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Updates to `service_plan_options` for service plans that support the setting of options<br>
@@ -50,6 +53,12 @@ the new settings but no `Morpheus` `Update` API calls will be made.  The default
 We've added a `connection_info` section (read-only) which contains the IP address(es) by which the instance
 can be accessed<br><br>
 The `datastore_auto_selection` attribute is not supported for BMaaS instances.<br><br>
+The `volumes` block manages the disks provisioned as part of the instance. To instead attach an existing
+standalone HPE Alletra MP volume to a BMaaS instance, create an `hpe_morpheus_storage_volume` and export it to the
+instance with `config_alletramp_bmaas.instance_ids` (multi-attach - every node of each listed instance, requires
+`shared = true`) or to a single host with `compute_server_id`. These externally-attached (SAN) volumes are owned by
+the `hpe_morpheus_storage_volume` resource and are intentionally **not** tracked in this resource's `volumes` list, so
+they do not appear here or cause perpetual diffs.<br><br>
 When creating an instance with network bonding and/or LAGs we cannot reconcile the created list of `network_interfaces`
 with the HCL supplied.  In these cases the `connection_info` section will contain IP address(es).  To access the full
 network configuration use the `hpe_morpheus_instance` `data-source` to read back the created instance.

--- a/docs/resources/morpheus_storage_volume.md
+++ b/docs/resources/morpheus_storage_volume.md
@@ -102,9 +102,16 @@ resource "hpe_morpheus_storage_volume" "alletramp_bmaas" {
   # detect changes to a write-only value, increment config_alletramp_bmaas_wo_version
   # whenever you change this block to recreate the volume with the new configuration.
   config_alletramp_bmaas = {
-    datastore_id      = 5
+    datastore_id = 5
+
+    # Export the volume to a single bare metal host (single-attach):
     shared            = false
     compute_server_id = 10
+
+    # Or export it to every node of one or more instances (multi-attach). This
+    # requires shared = true and is mutually exclusive with compute_server_id:
+    #   shared       = true
+    #   instance_ids = [123]
   }
   config_alletramp_bmaas_wo_version = 1
 }

--- a/examples/resources/morpheus_storage_volume/example_alletramp_bmaas.tf
+++ b/examples/resources/morpheus_storage_volume/example_alletramp_bmaas.tf
@@ -9,9 +9,16 @@ resource "hpe_morpheus_storage_volume" "alletramp_bmaas" {
   # detect changes to a write-only value, increment config_alletramp_bmaas_wo_version
   # whenever you change this block to recreate the volume with the new configuration.
   config_alletramp_bmaas = {
-    datastore_id      = 5
+    datastore_id = 5
+
+    # Export the volume to a single bare metal host (single-attach):
     shared            = false
     compute_server_id = 10
+
+    # Or export it to every node of one or more instances (multi-attach). This
+    # requires shared = true and is mutually exclusive with compute_server_id:
+    #   shared       = true
+    #   instance_ids = [123]
   }
   config_alletramp_bmaas_wo_version = 1
 }

--- a/morpheus/framework/resources/instance/instance_update.go
+++ b/morpheus/framework/resources/instance/instance_update.go
@@ -299,8 +299,6 @@ func addVolumesToResizeRequest(
 	plan, state InstanceModel,
 	resizeRequest *sdk.ResizeInstanceRequest,
 ) diag.Diagnostics {
-	resizing := false
-
 	var pVolumes []VolumesValue
 	pdiags := plan.Volumes.ElementsAs(ctx, &pVolumes, false)
 	if pdiags.HasError() {
@@ -317,29 +315,11 @@ func addVolumesToResizeRequest(
 		return sdiags
 	}
 
-	// Always resize if the number of volumes in the plan and state are different
-	if len(pVolumes) != len(sVolumes) {
-		resizing = true
-	}
-
-	// Go through the lists of volumes from state and in the plan.  Assume that volumes are in the same order
-	// in both lists.  If the volume in the plan is different from the volume in the state, then we add the volume
-	// from the plan to the list of volumes for the resize request.  If the volume in the plan is the same as the
-	// volume in the state, then we add the volume from the state to the list of volumes for the resize request.
-	var volumes []VolumesValue
-	for i, pVolume := range pVolumes {
-		if i < len(sVolumes) {
-			sVolume := sVolumes[i]
-			volForRequest, different := createVolumeFromPlanAndState(pVolume, sVolume)
-			// Resize if the volume for the request is different from the volume in the state
-			if different {
-				resizing = true
-			}
-			volumes = append(volumes, volForRequest)
-		} else {
-			volumes = append(volumes, pVolume)
-		}
-	}
+	// Build the resize volume list (see buildResizeVolumes) and only issue a resize
+	// when it reports an actual change - a volume added, removed, or resized (a
+	// per-volume size change). A rename or reorder of the same set of volumes is not
+	// a change that requires a resize.
+	volumes, resizing := buildResizeVolumes(pVolumes, sVolumes)
 
 	if resizing {
 		volumesForRequest := make([]sdk.ResizeInstanceRequestVolumesInner, len(volumes))
@@ -351,6 +331,97 @@ func addVolumesToResizeRequest(
 	}
 
 	return diag.Diagnostics{}
+}
+
+// buildResizeVolumes builds the ordered volume list for an instance resize request
+// from the planned and current (state) volumes, and reports whether a resize is
+// required. The morpheus-ui resize changelist
+// (CloudPluginProvisioningService.buildResizeRequest -> provider.buildVolumeChangelist)
+// keys existing volumes on their id, so each request volume must carry the right id:
+// an existing volume keeps its state id (> 0) to be kept/resized, an added volume is
+// left with a null id (updateVolumeMapper sends -1) for the API to create, and any
+// state volume with no planned counterpart is omitted so the API removes it.
+//
+// When the plan and state hold the same number of volumes, volumes are paired
+// positionally — this preserves the existing behaviour exactly: a resize is
+// triggered only by a per-volume size change, so a rename or reorder of the same set
+// of volumes is not misread as an add+remove and does not force an unnecessary
+// resize. Only when the counts differ (a volume was genuinely added or removed) do we
+// match by name (falling back to position for unnamed volumes), because that is the
+// only case where positional pairing mis-assigns ids for an insert or remove in the
+// middle of the list. This mirrors the read side (getVolumes).
+func buildResizeVolumes(
+	planVolumes, stateVolumes []VolumesValue,
+) ([]VolumesValue, bool) {
+	// Equal counts: positional pairing (unchanged behaviour). A resize is triggered
+	// only by a per-volume size change.
+	if len(planVolumes) == len(stateVolumes) {
+		volumes := make([]VolumesValue, 0, len(planVolumes))
+		resizing := false
+
+		for i, pVolume := range planVolumes {
+			volForRequest, different := createVolumeFromPlanAndState(pVolume, stateVolumes[i])
+			if different {
+				resizing = true
+			}
+			volumes = append(volumes, volForRequest)
+		}
+
+		return volumes, resizing
+	}
+
+	// Counts differ: a volume was added or removed, so a resize is always required.
+	// Match by name (positional fallback for unnamed volumes) so each existing
+	// volume keeps its id and genuinely new volumes are identified.
+	consumed := make([]bool, len(stateVolumes))
+	volumes := make([]VolumesValue, 0, len(planVolumes))
+
+	for i, pVolume := range planVolumes {
+		si := matchStateVolume(pVolume, stateVolumes, consumed, i)
+		if si == -1 {
+			// No existing counterpart: a newly added volume. updateVolumeMapper
+			// sends id=-1 when the plan volume has no id, so the API creates it.
+			volumes = append(volumes, pVolume)
+
+			continue
+		}
+
+		consumed[si] = true
+		// Keep the existing volume's id and pick up any size change from the plan.
+		volForRequest, _ := createVolumeFromPlanAndState(pVolume, stateVolumes[si])
+		volumes = append(volumes, volForRequest)
+	}
+
+	return volumes, true
+}
+
+// matchStateVolume returns the index of the state volume corresponding to the
+// planned volume, or -1 when there is none (a newly added volume). A named plan
+// volume is matched to the first unconsumed state volume with the same name; a
+// named plan volume with no such match is treated as new. An unnamed plan volume
+// falls back to the state volume at the same position when it is still unconsumed.
+func matchStateVolume(
+	planVolume VolumesValue,
+	stateVolumes []VolumesValue,
+	consumed []bool,
+	i int,
+) int {
+	name := planVolume.Name.ValueString()
+	if name != "" {
+		for s := range stateVolumes {
+			if !consumed[s] && stateVolumes[s].Name.ValueString() == name {
+				return s
+			}
+		}
+
+		return -1
+	}
+
+	if i < len(stateVolumes) && !consumed[i] {
+		return i
+	}
+
+	return -1
 }
 
 func createVolumeFromPlanAndState(

--- a/morpheus/framework/resources/instance/instance_update_internal_test.go
+++ b/morpheus/framework/resources/instance/instance_update_internal_test.go
@@ -1,0 +1,222 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// mkVol builds a VolumesValue for the resize-matching tests. A null id represents
+// a volume the user has just added (no server id yet); a set id represents an
+// existing volume carried in state.
+func mkVol(id types.Int64, name string, size int64) VolumesValue {
+	return VolumesValue{
+		Id:                     id,
+		Name:                   types.StringValue(name),
+		RootVolume:             types.BoolNull(),
+		Size:                   types.Int64Value(size),
+		StorageTypeId:          types.Int64Null(),
+		DatastoreId:            types.Int64Null(),
+		DatastoreAutoSelection: types.StringNull(),
+		StorageProfile:         types.StringNull(),
+	}
+}
+
+func ptrInt64(v int64) *int64 { return &v }
+
+// TestUnitBuildResizeVolumes pins the plan<->state volume matching used to build an
+// instance resize request. The morpheus-ui resize changelist matches existing
+// volumes by id, so the request must carry the existing (state) id for kept/resized
+// volumes, id=-1 (null in the model, set by updateVolumeMapper) for added volumes,
+// and omit dropped volumes. When the counts match, pairing is positional (unchanged
+// behaviour: a rename with no size change is not a resize); when they differ, matching
+// is by name so a middle insert/remove does not mis-assign ids.
+func TestUnitBuildResizeVolumes(t *testing.T) {
+	t.Parallel()
+
+	type wantVol struct {
+		id   *int64 // nil => new/null id
+		name string
+		size int64
+	}
+
+	tests := []struct {
+		name         string
+		plan         []VolumesValue
+		state        []VolumesValue
+		wantResizing bool
+		want         []wantVol
+	}{
+		{
+			name: "no change keeps state ids and does not resize",
+			state: []VolumesValue{
+				mkVol(types.Int64Value(1), "root", 10),
+				mkVol(types.Int64Value(2), "data", 20),
+			},
+			plan: []VolumesValue{
+				mkVol(types.Int64Null(), "root", 10),
+				mkVol(types.Int64Null(), "data", 20),
+			},
+			wantResizing: false,
+			want: []wantVol{
+				{ptrInt64(1), "root", 10},
+				{ptrInt64(2), "data", 20},
+			},
+		},
+		{
+			name: "size change resizes the matched volume",
+			state: []VolumesValue{
+				mkVol(types.Int64Value(1), "root", 10),
+				mkVol(types.Int64Value(2), "data", 20),
+			},
+			plan: []VolumesValue{
+				mkVol(types.Int64Null(), "root", 10),
+				mkVol(types.Int64Null(), "data", 30),
+			},
+			wantResizing: true,
+			want: []wantVol{
+				{ptrInt64(1), "root", 10},
+				{ptrInt64(2), "data", 30},
+			},
+		},
+		{
+			name: "add at end",
+			state: []VolumesValue{
+				mkVol(types.Int64Value(1), "root", 10),
+			},
+			plan: []VolumesValue{
+				mkVol(types.Int64Null(), "root", 10),
+				mkVol(types.Int64Null(), "extra", 5),
+			},
+			wantResizing: true,
+			want: []wantVol{
+				{ptrInt64(1), "root", 10},
+				{nil, "extra", 5},
+			},
+		},
+		{
+			// The case the old positional logic got wrong: inserting "mid" between
+			// "root" and "data" must not steal data's id.
+			name: "add in the middle keeps existing ids by name",
+			state: []VolumesValue{
+				mkVol(types.Int64Value(1), "root", 10),
+				mkVol(types.Int64Value(2), "data", 20),
+			},
+			plan: []VolumesValue{
+				mkVol(types.Int64Null(), "root", 10),
+				mkVol(types.Int64Null(), "mid", 5),
+				mkVol(types.Int64Null(), "data", 20),
+			},
+			wantResizing: true,
+			want: []wantVol{
+				{ptrInt64(1), "root", 10},
+				{nil, "mid", 5},
+				{ptrInt64(2), "data", 20},
+			},
+		},
+		{
+			// Removing "mid" must drop id 2 and keep data's id 3 (positional logic
+			// would have mis-mapped data to id 2).
+			name: "remove in the middle drops the right volume",
+			state: []VolumesValue{
+				mkVol(types.Int64Value(1), "root", 10),
+				mkVol(types.Int64Value(2), "mid", 5),
+				mkVol(types.Int64Value(3), "data", 20),
+			},
+			plan: []VolumesValue{
+				mkVol(types.Int64Null(), "root", 10),
+				mkVol(types.Int64Null(), "data", 20),
+			},
+			wantResizing: true,
+			want: []wantVol{
+				{ptrInt64(1), "root", 10},
+				{ptrInt64(3), "data", 20},
+			},
+		},
+		{
+			// Count is unchanged, so positional pairing applies (unchanged
+			// behaviour): a rename with no size change must NOT trigger a resize —
+			// the volume keeps its state id and name.
+			name: "rename with same size does not resize",
+			state: []VolumesValue{
+				mkVol(types.Int64Value(1), "data", 20),
+			},
+			plan: []VolumesValue{
+				mkVol(types.Int64Null(), "newdata", 20),
+			},
+			wantResizing: false,
+			want: []wantVol{
+				{ptrInt64(1), "data", 20},
+			},
+		},
+		{
+			name: "unnamed volumes fall back to positional matching",
+			state: []VolumesValue{
+				mkVol(types.Int64Value(1), "", 10),
+				mkVol(types.Int64Value(2), "", 20),
+			},
+			plan: []VolumesValue{
+				mkVol(types.Int64Null(), "", 10),
+				mkVol(types.Int64Null(), "", 30),
+			},
+			wantResizing: true,
+			want: []wantVol{
+				{ptrInt64(1), "", 10},
+				{ptrInt64(2), "", 30},
+			},
+		},
+		{
+			name: "unnamed add appends a new volume",
+			state: []VolumesValue{
+				mkVol(types.Int64Value(1), "", 10),
+			},
+			plan: []VolumesValue{
+				mkVol(types.Int64Null(), "", 10),
+				mkVol(types.Int64Null(), "", 5),
+			},
+			wantResizing: true,
+			want: []wantVol{
+				{ptrInt64(1), "", 10},
+				{nil, "", 5},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, resizing := buildResizeVolumes(tc.plan, tc.state)
+
+			if resizing != tc.wantResizing {
+				t.Errorf("resizing = %v, want %v", resizing, tc.wantResizing)
+			}
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d volumes, want %d", len(got), len(tc.want))
+			}
+
+			for i, w := range tc.want {
+				gotID := got[i].Id.ValueInt64Pointer()
+				switch {
+				case w.id == nil && gotID != nil:
+					t.Errorf("volume %d (%s): id = %d, want null (new volume)", i, w.name, *gotID)
+				case w.id != nil && gotID == nil:
+					t.Errorf("volume %d (%s): id = null, want %d", i, w.name, *w.id)
+				case w.id != nil && gotID != nil && *gotID != *w.id:
+					t.Errorf("volume %d (%s): id = %d, want %d", i, w.name, *gotID, *w.id)
+				}
+
+				if gotName := got[i].Name.ValueString(); gotName != w.name {
+					t.Errorf("volume %d: name = %q, want %q", i, gotName, w.name)
+				}
+
+				if gotSize := got[i].Size.ValueInt64(); gotSize != w.size {
+					t.Errorf("volume %d (%s): size = %d, want %d", i, w.name, gotSize, w.size)
+				}
+			}
+		})
+	}
+}

--- a/morpheus/framework/resources/instance/mappings.go
+++ b/morpheus/framework/resources/instance/mappings.go
@@ -18,6 +18,10 @@ func createVolumeMapper(
 	vol VolumesValue,
 ) sdk.AddInstanceRequestVolumesInner {
 	volume := sdk.AddInstanceRequestVolumesInner{}
+	// The volume id selects create vs keep: a real id (> 0) tells Morpheus to keep
+	// (and, on resize, resize) that existing volume, while -1 is the sentinel for
+	// "create a new volume". A volume the user just added has no id in the plan
+	// (null/unknown), so it maps to -1 and the API provisions it.
 	if !vol.Id.IsNull() && !vol.Id.IsUnknown() {
 		volume.Id = vol.Id.ValueInt64Pointer()
 	} else {
@@ -66,6 +70,10 @@ func updateVolumeMapper(
 	vol VolumesValue,
 ) sdk.ResizeInstanceRequestVolumesInner {
 	volume := sdk.ResizeInstanceRequestVolumesInner{}
+	// The volume id selects create vs keep: a real id (> 0) tells Morpheus to keep
+	// (and, on resize, resize) that existing volume, while -1 is the sentinel for
+	// "create a new volume". A volume the user just added has no id in the plan
+	// (null/unknown), so it maps to -1 and the API provisions it.
 	if !vol.Id.IsNull() && !vol.Id.IsUnknown() {
 		volume.Id = vol.Id.ValueInt64Pointer()
 	} else {

--- a/morpheus/framework/resources/storagevolume/example_alletramp_bmaas.tf.tmpl
+++ b/morpheus/framework/resources/storagevolume/example_alletramp_bmaas.tf.tmpl
@@ -9,9 +9,16 @@ resource "hpe_morpheus_storage_volume" "alletramp_bmaas" {
   # detect changes to a write-only value, increment config_alletramp_bmaas_wo_version
   # whenever you change this block to recreate the volume with the new configuration.
   config_alletramp_bmaas = {
-    datastore_id      = 5
+    datastore_id = 5
+
+    # Export the volume to a single bare metal host (single-attach):
     shared            = false
     compute_server_id = 10
+
+    # Or export it to every node of one or more instances (multi-attach). This
+    # requires shared = true and is mutually exclusive with compute_server_id:
+    #   shared       = true
+    #   instance_ids = [123]
   }
   config_alletramp_bmaas_wo_version = {{.WoVersion}}
 }

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -41,6 +41,9 @@ the new settings but no `Morpheus` `Update` API calls will be made.  The default
 &nbsp;&nbsp;&nbsp;&nbsp;- **Do not** change the order of volumes or network_interfaces in HCL<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- The addition and removal of volumes is supported<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Existing volumes can have their size increased but not decreased<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- For BMaaS (bare metal) instances only datastore-backed volumes (e.g. HPE Alletra MP) can be<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  added or resized; local disk / RAID volumes such as the RAID1 boot volume are fixed hardware<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  and cannot be added, resized or removed via `Update`<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Network interface update is supported for Morpheus versions >= 8.1.2, for earlier<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;  versions network_interfaces changes will force a new instance to be created.<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- Updates to `service_plan_options` for service plans that support the setting of options<br>
@@ -50,6 +53,12 @@ the new settings but no `Morpheus` `Update` API calls will be made.  The default
 We've added a `connection_info` section (read-only) which contains the IP address(es) by which the instance
 can be accessed<br><br>
 The `datastore_auto_selection` attribute is not supported for BMaaS instances.<br><br>
+The `volumes` block manages the disks provisioned as part of the instance. To instead attach an existing
+standalone HPE Alletra MP volume to a BMaaS instance, create an `hpe_morpheus_storage_volume` and export it to the
+instance with `config_alletramp_bmaas.instance_ids` (multi-attach - every node of each listed instance, requires
+`shared = true`) or to a single host with `compute_server_id`. These externally-attached (SAN) volumes are owned by
+the `hpe_morpheus_storage_volume` resource and are intentionally **not** tracked in this resource's `volumes` list, so
+they do not appear here or cause perpetual diffs.<br><br>
 When creating an instance with network bonding and/or LAGs we cannot reconcile the created list of `network_interfaces`
 with the HCL supplied.  In these cases the `connection_info` section will contain IP address(es).  To access the full
 network configuration use the `hpe_morpheus_instance` `data-source` to read back the created instance.


### PR DESCRIPTION
## Summary

Improves `hpe_morpheus_instance` volume handling on **Update**, and documents how volumes are added/resized and how standalone volumes attach to an instance.

## Changes

**1. Correct volume matching on resize** (`d7074d32`)

`addVolumesToResizeRequest` paired planned and current (state) volumes **positionally**, so inserting or removing a volume in the middle of the `volumes` list mis-assigned volume ids in the resize request — the server-side resize changelist matches existing volumes by id, so a wrong id could keep/resize/delete the wrong volume.

`buildResizeVolumes` now:
- Pairs **positionally when the counts are equal** — unchanged behaviour: a resize is issued only on a per-volume **size change**; a rename or reorder of the same set of volumes is *not* a resize (preserving "only call resize when it's actually needed").
- Matches **by name (positional fallback for unnamed volumes) only when the counts differ** — the sole case where positional pairing mis-assigns ids on a middle insert/remove. An existing volume keeps its id, a genuinely new volume gets id=-1 for the API to create, and a dropped volume is omitted for the API to remove. This mirrors the read side.

Adds `TestUnitBuildResizeVolumes` (8 cases: no-change, size-change, add-at-end, add-in-middle, remove-in-middle, rename-same-size, unnamed-positional, unnamed-add) and documents the id convention (`-1` = create, `> 0` = keep/resize) on the volume mappers.

**2. Docs: BMaaS volume constraints + storage_volume export** (`c6147c21`)
- On a BMaaS (bare metal) Update, only datastore-backed volumes (e.g. HPE Alletra MP) can be added or resized; local disk / RAID volumes (such as the RAID1 boot volume) are fixed hardware.
- How to attach a standalone Alletra MP volume to a BMaaS instance via `hpe_morpheus_storage_volume` (`config_alletramp_bmaas.instance_ids` for multi-attach, or `compute_server_id` for a single host). These externally-attached (SAN) volumes are owned by the `storage_volume` resource and are intentionally not tracked in the instance's `volumes` list.
- The `storage_volume` Alletra MP example now shows the `instance_ids` alternative.

## Testing
- `go build`, `go vet`, `golangci-lint` (v2) — clean.
- `TestUnitBuildResizeVolumes` + instance unit tests pass; `make docs` idempotent.
- :warning: **Live acceptance testing is still required before merge.** The resize request-building is unit-verified but unproven against a live API. Scenarios to run on both a **BMaaS (metal)** and a **KVM/VMware (virtual)** instance: add a datastore-backed data volume via update, resize it, remove it, and an insert/remove in the middle of the list — confirming no drift and correct id assignment.

## Notes
- Metal volume constraints are surfaced as documentation rather than validation: `ValidateConfig` sees config only, so it cannot detect a shrink (needs plan-vs-state) or distinguish local-disk from datastore volumes; the server enforces these at resize time.
