### PR TITLE
MORPH-12175/MORPH-12176: fix hpe_morpheus_network_router import and enable_bgp

### DIFF
--- a/morpheus/framework/resources/networkrouter/config_import.go
+++ b/morpheus/framework/resources/networkrouter/config_import.go
@@ -1,0 +1,130 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package networkrouter
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/HPE/terraform-provider-hpe/utils/convert"
+)
+
+// The Morpheus API persists a network router's config as an opaque JSON object
+// and echoes it back on GET under the same keys/values that were sent. NSX-T
+// checkbox fields round-trip as "on"/"off" strings (not booleans) under their
+// uppercase keys (e.g. TIER1_CONNECTED); select/string fields round-trip under
+// their camelCase keys (e.g. ipManagementType). Keys that were never set come
+// back as null. These helpers reverse that map into the typed config objects so
+// that importing a router hydrates config_nsxt_gateway_tier0 /
+// config_nsxt_gateway_tier1 to match a freshly-applied resource.
+
+// configString reads a string config value, returning a null string when the
+// key is absent or not a string.
+func configString(m map[string]interface{}, key string) types.String {
+	if v, ok := m[key]; ok && v != nil {
+		if s, ok := v.(string); ok {
+			return types.StringValue(s)
+		}
+	}
+
+	return types.StringNull()
+}
+
+// configInt64 reads a numeric config value (JSON numbers decode as float64),
+// returning a null int64 when the key is absent or not numeric.
+func configInt64(m map[string]interface{}, key string) types.Int64 {
+	if v, ok := m[key]; ok && v != nil {
+		if f, ok := v.(float64); ok {
+			return types.Int64Value(int64(f))
+		}
+	}
+
+	return types.Int64Null()
+}
+
+// configBoolOnOff reads an NSX-T checkbox config value using convert.StringToBool
+// ("on"/"off" -> true/false). The typed schema fields are computed with a false
+// default, so an absent/null/unrecognized value maps to false (not null) to keep
+// import equivalent to a freshly-applied resource.
+func configBoolOnOff(ctx context.Context, m map[string]interface{}, key string) types.Bool {
+	if v, ok := m[key]; ok && v != nil {
+		if s, ok := v.(string); ok {
+			if b := convert.StringToBool(ctx, s); !b.IsNull() {
+				return b
+			}
+		}
+	}
+
+	return types.BoolValue(false)
+}
+
+// tier1ConfigFromMap builds a typed NSX-T Tier-1 config object from the API
+// config map returned by GET.
+func tier1ConfigFromMap(
+	ctx context.Context,
+	m map[string]interface{},
+) (ConfigNsxtGatewayTier1Value, diag.Diagnostics) {
+	attrs := map[string]attr.Value{
+		"edge_cluster":               configString(m, "edgeCluster"),
+		"fail_over":                  configString(m, "failOver"),
+		"ip_management_type":         configString(m, "ipManagementType"),
+		"ip_server_id":               configString(m, "ipServerId"),
+		"tier0_gateway":              configString(m, "tier0Gateway"),
+		"tier1_connected":            configBoolOnOff(ctx, m, "TIER1_CONNECTED"),
+		"tier1_dns_forwarder_ip":     configBoolOnOff(ctx, m, "TIER1_DNS_FORWARDER_IP"),
+		"tier1_ipsec_local_endpoint": configBoolOnOff(ctx, m, "TIER1_IPSEC_LOCAL_ENDPOINT"),
+		"tier1_lb_snat":              configBoolOnOff(ctx, m, "TIER1_LB_SNAT"),
+		"tier1_lb_vip":               configBoolOnOff(ctx, m, "TIER1_LB_VIP"),
+		"tier1_nat":                  configBoolOnOff(ctx, m, "TIER1_NAT"),
+		"tier1_static_routes":        configBoolOnOff(ctx, m, "TIER1_STATIC_ROUTES"),
+	}
+
+	return NewConfigNsxtGatewayTier1Value(
+		ConfigNsxtGatewayTier1Value{}.AttributeTypes(ctx), attrs,
+	)
+}
+
+// tier0ConfigFromMap builds a typed NSX-T Tier-0 config object from the API
+// config map returned by GET.
+func tier0ConfigFromMap(
+	ctx context.Context,
+	m map[string]interface{},
+) (ConfigNsxtGatewayTier0Value, diag.Diagnostics) {
+	attrs := map[string]attr.Value{
+		"ecmp":                       configBoolOnOff(ctx, m, "ECMP"),
+		"edge_cluster":               configString(m, "edgeCluster"),
+		"fail_over":                  configString(m, "failOver"),
+		"ha_mode":                    configString(m, "haMode"),
+		"inter_sr_ibgp":              configBoolOnOff(ctx, m, "INTER_SR_IBGP"),
+		"ip_management_type":         configString(m, "ipManagementType"),
+		"ip_server_id":               configString(m, "ipServerId"),
+		"local_as_num":               configString(m, "LOCAL_AS_NUM"),
+		"multipath_relax":            configBoolOnOff(ctx, m, "MULTIPATH_RELAX"),
+		"restart_mode":               configString(m, "RESTART_MODE"),
+		"restart_time":               configInt64(m, "RESTART_TIME"),
+		"stale_route_time":           configInt64(m, "STALE_ROUTE_TIME"),
+		"tier0_dns_forwarder_ip":     configBoolOnOff(ctx, m, "TIER0_DNS_FORWARDER_IP"),
+		"tier0_external_interface":   configBoolOnOff(ctx, m, "TIER0_EXTERNAL_INTERFACE"),
+		"tier0_ipsec_local_ip":       configBoolOnOff(ctx, m, "TIER0_IPSEC_LOCAL_IP"),
+		"tier0_loopback_interface":   configBoolOnOff(ctx, m, "TIER0_LOOPBACK_INTERFACE"),
+		"tier0_nat":                  configBoolOnOff(ctx, m, "TIER0_NAT"),
+		"tier0_segment":              configBoolOnOff(ctx, m, "TIER0_SEGMENT"),
+		"tier0_service_interface":    configBoolOnOff(ctx, m, "TIER0_SERVICE_INTERFACE"),
+		"tier0_static":               configBoolOnOff(ctx, m, "TIER0_STATIC"),
+		"tier1_dns_forwarder_ip":     configBoolOnOff(ctx, m, "TIER1_DNS_FORWARDER_IP"),
+		"tier1_ipsec_local_endpoint": configBoolOnOff(ctx, m, "TIER1_IPSEC_LOCAL_ENDPOINT"),
+		"tier1_lb_snat":              configBoolOnOff(ctx, m, "TIER1_LB_SNAT"),
+		"tier1_lb_vip":               configBoolOnOff(ctx, m, "TIER1_LB_VIP"),
+		"tier1_nat":                  configBoolOnOff(ctx, m, "TIER1_NAT"),
+		"tier1_segment":              configBoolOnOff(ctx, m, "TIER1_SEGMENT"),
+		"tier1_service_interface":    configBoolOnOff(ctx, m, "TIER1_SERVICE_INTERFACE"),
+		"tier1_static":               configBoolOnOff(ctx, m, "TIER1_STATIC"),
+	}
+
+	return NewConfigNsxtGatewayTier0Value(
+		ConfigNsxtGatewayTier0Value{}.AttributeTypes(ctx), attrs,
+	)
+}

--- a/morpheus/framework/resources/networkrouter/config_import_test.go
+++ b/morpheus/framework/resources/networkrouter/config_import_test.go
@@ -1,0 +1,174 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package networkrouter
+
+import (
+	"context"
+	"testing"
+)
+
+// TestUnitTier1ConfigFromMap mirrors the MORPH-12175 import scenario: a Tier1
+// router applied with ip_management_type = dhcpLocal and all tier1_* checkboxes
+// false round-trips from the API config map into the typed object.
+func TestUnitTier1ConfigFromMap(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	m := map[string]interface{}{
+		"ipManagementType":           "dhcpLocal",
+		"tier0Gateway":               nil,
+		"edgeCluster":                nil,
+		"failOver":                   nil,
+		"ipServerId":                 nil,
+		"TIER1_CONNECTED":            "off",
+		"TIER1_NAT":                  "off",
+		"TIER1_STATIC_ROUTES":        "off",
+		"TIER1_LB_VIP":               "off",
+		"TIER1_LB_SNAT":              "off",
+		"TIER1_DNS_FORWARDER_IP":     "off",
+		"TIER1_IPSEC_LOCAL_ENDPOINT": "off",
+	}
+
+	got, diags := tier1ConfigFromMap(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+
+	if got.IpManagementType.ValueString() != "dhcpLocal" {
+		t.Errorf("ip_management_type = %q, want dhcpLocal", got.IpManagementType.ValueString())
+	}
+
+	bools := map[string]bool{
+		"tier1_connected":            got.Tier1Connected.ValueBool(),
+		"tier1_nat":                  got.Tier1Nat.ValueBool(),
+		"tier1_static_routes":        got.Tier1StaticRoutes.ValueBool(),
+		"tier1_lb_vip":               got.Tier1LbVip.ValueBool(),
+		"tier1_lb_snat":              got.Tier1LbSnat.ValueBool(),
+		"tier1_dns_forwarder_ip":     got.Tier1DnsForwarderIp.ValueBool(),
+		"tier1_ipsec_local_endpoint": got.Tier1IpsecLocalEndpoint.ValueBool(),
+	}
+	for name, v := range bools {
+		if v {
+			t.Errorf("%s = true, want false", name)
+		}
+	}
+
+	// Unset string fields must be null so import matches a freshly-applied
+	// resource.
+	if !got.EdgeCluster.IsNull() || !got.FailOver.IsNull() ||
+		!got.IpServerId.IsNull() || !got.Tier0Gateway.IsNull() {
+		t.Errorf("expected unset string fields to be null")
+	}
+}
+
+// TestUnitTier1ConfigFromMapOnOff verifies "on" maps to true and that a checkbox
+// absent from the API map defaults to false (matching the computed schema
+// default), rather than becoming null.
+func TestUnitTier1ConfigFromMapOnOff(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	m := map[string]interface{}{
+		"TIER1_CONNECTED": "on",
+		"TIER1_NAT":       "on",
+	}
+
+	got, diags := tier1ConfigFromMap(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+
+	if !got.Tier1Connected.ValueBool() {
+		t.Errorf("tier1_connected = false, want true")
+	}
+	if !got.Tier1Nat.ValueBool() {
+		t.Errorf("tier1_nat = false, want true")
+	}
+	if got.Tier1LbVip.IsNull() || got.Tier1LbVip.ValueBool() {
+		t.Errorf("tier1_lb_vip = %v, want known false (absent -> false)", got.Tier1LbVip)
+	}
+}
+
+// TestUnitTier0ConfigFromMap exercises the string, numeric, and checkbox paths of
+// the Tier0 reverse-mapper.
+func TestUnitTier0ConfigFromMap(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	m := map[string]interface{}{
+		"haMode":       "ACTIVE_ACTIVE",
+		"LOCAL_AS_NUM": "65000",
+		"RESTART_TIME": float64(120),
+		"ECMP":         "on",
+		"TIER0_STATIC": "off",
+	}
+
+	got, diags := tier0ConfigFromMap(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+
+	if got.HaMode.ValueString() != "ACTIVE_ACTIVE" {
+		t.Errorf("ha_mode = %q, want ACTIVE_ACTIVE", got.HaMode.ValueString())
+	}
+	if got.LocalAsNum.ValueString() != "65000" {
+		t.Errorf("local_as_num = %q, want 65000", got.LocalAsNum.ValueString())
+	}
+	if got.RestartTime.ValueInt64() != 120 {
+		t.Errorf("restart_time = %d, want 120", got.RestartTime.ValueInt64())
+	}
+	if !got.Ecmp.ValueBool() {
+		t.Errorf("ecmp = false, want true")
+	}
+	if got.Tier0Static.ValueBool() {
+		t.Errorf("tier0_static = true, want false")
+	}
+	// An absent numeric field is null (not zero).
+	if !got.StaleRouteTime.IsNull() {
+		t.Errorf("stale_route_time = %v, want null when absent", got.StaleRouteTime)
+	}
+}
+
+// TestUnitConfigHelpers checks the low-level extraction helpers, including the
+// absent/null -> false default for checkboxes.
+func TestUnitConfigHelpers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	m := map[string]interface{}{
+		"str": "value",
+		"num": float64(7),
+		"on":  "on",
+		"off": "off",
+		"nil": nil,
+	}
+
+	if got := configString(m, "str"); got.ValueString() != "value" {
+		t.Errorf("configString(str) = %q, want value", got.ValueString())
+	}
+	if got := configString(m, "missing"); !got.IsNull() {
+		t.Errorf("configString(missing) should be null")
+	}
+	if got := configInt64(m, "num"); got.ValueInt64() != 7 {
+		t.Errorf("configInt64(num) = %d, want 7", got.ValueInt64())
+	}
+	if got := configInt64(m, "missing"); !got.IsNull() {
+		t.Errorf("configInt64(missing) should be null")
+	}
+	if got := configBoolOnOff(ctx, m, "on"); !got.ValueBool() {
+		t.Errorf("configBoolOnOff(on) = false, want true")
+	}
+	if got := configBoolOnOff(ctx, m, "off"); got.ValueBool() {
+		t.Errorf("configBoolOnOff(off) = true, want false")
+	}
+	if got := configBoolOnOff(ctx, m, "nil"); got.IsNull() || got.ValueBool() {
+		t.Errorf("configBoolOnOff(nil) = %v, want known false", got)
+	}
+	if got := configBoolOnOff(ctx, m, "missing"); got.IsNull() || got.ValueBool() {
+		t.Errorf("configBoolOnOff(missing) = %v, want known false", got)
+	}
+}

--- a/morpheus/framework/resources/networkrouter/create.go
+++ b/morpheus/framework/resources/networkrouter/create.go
@@ -44,6 +44,30 @@ func (r *Resource) Create(
 
 	name := plan.Name.ValueString()
 
+	// enable_bgp is only supported by NSX-T Tier0 gateways. Tier1 gateways
+	// inherit BGP from their parent Tier0 and have no BGP option server-side, so
+	// sending enable_bgp=true for a Tier1 router is silently dropped (causing an
+	// "inconsistent result after apply") or, on some appliance builds, an
+	// unhandled 500. Fail fast with a clear message instead.
+	if plan.EnableBgp.ValueBool() {
+		tier1, verr := usesTier1Gateway(ctx, client, plan)
+		if verr != nil {
+			resp.Diagnostics.AddError(createOperation, verr.Error())
+
+			return
+		}
+		if tier1 {
+			resp.Diagnostics.AddError(
+				createOperation,
+				"enable_bgp is not supported for NSX-T Tier1 gateways. BGP is "+
+					"configured on the parent Tier0 gateway; remove enable_bgp or "+
+					"set it to false.",
+			)
+
+			return
+		}
+	}
+
 	router := &sdk.CreateNetworkRouterRequestNetworkRouter{}
 	router.Name = name
 
@@ -270,4 +294,50 @@ func typeIdFromCode(ctx context.Context, client *sdk.APIClient, code string) (*i
 			"The network integration for the type may not yet be configured on the Morpheus appliance.",
 		code,
 	)
+}
+
+// usesTier1Gateway reports whether the planned router is an NSX-T Tier1 gateway,
+// which does not support BGP. Typed config blocks are checked directly; a
+// generic config is resolved to its type code via the API.
+func usesTier1Gateway(
+	ctx context.Context,
+	client *sdk.APIClient,
+	plan NetworkRouterModel,
+) (bool, error) {
+	switch {
+	case !plan.ConfigNsxtGatewayTier1.IsNull() && !plan.ConfigNsxtGatewayTier1.IsUnknown():
+		return true, nil
+	case !plan.ConfigNsxtGatewayTier0.IsNull() && !plan.ConfigNsxtGatewayTier0.IsUnknown():
+		return false, nil
+	case !plan.Config.IsNull() && !plan.Config.IsUnknown():
+		code, err := codeFromTypeId(ctx, client, plan.TypeId.ValueInt64())
+		if err != nil {
+			return false, err
+		}
+
+		return code == codeNSXTTier1Gateway, nil
+	default:
+		return false, nil
+	}
+}
+
+// codeFromTypeId resolves a network router type's code from its id. An unknown
+// id yields an empty code (rather than an error) so callers do not block on
+// types the API does not return.
+func codeFromTypeId(ctx context.Context, client *sdk.APIClient, id int64) (string, error) {
+	res, hresp, err := client.NetworksAPI.ListNetworkRouterTypes(ctx).Execute()
+	if err != nil || hresp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf(
+			"network router types GET failed: %s",
+			errfmt.ErrMsg(err, hresp),
+		)
+	}
+
+	for _, t := range res.NetworkRouterTypes {
+		if t.Id != nil && *t.Id == id && t.Code != nil {
+			return *t.Code, nil
+		}
+	}
+
+	return "", nil
 }

--- a/morpheus/framework/resources/networkrouter/read.go
+++ b/morpheus/framework/resources/networkrouter/read.go
@@ -82,12 +82,15 @@ func getRouterAsState(
 			state.TypeId = convert.Int64ToType(router.Type.Id)
 		}
 
-		if router.Zone != nil && router.Zone.Id != nil {
-			state.CloudId = convert.Int64ToType(router.Zone.Id)
-		}
-
+		// cloud_id is only meaningful for router types that do not use a network
+		// integration. When a networkServer is present the API derives the zone
+		// from it, and a freshly-applied resource leaves cloud_id unset, so only
+		// surface the zone as cloud_id when there is no integration - otherwise
+		// import would not match apply.
 		if router.NetworkServer != nil && router.NetworkServer.Id != nil {
 			state.NetworkIntegrationId = convert.Int64ToType(router.NetworkServer.Id)
+		} else if router.Zone != nil && router.Zone.Id != nil {
+			state.CloudId = convert.Int64ToType(router.Zone.Id)
 		}
 
 		// On import, site == null means shared group access
@@ -96,6 +99,15 @@ func getRouterAsState(
 		} else {
 			state.SharedGroupAccess = types.BoolValue(true)
 		}
+
+		// Hydrate the config from the API. NSX-T gateway types use their typed
+		// config block (matching how they are applied); any other type uses the
+		// generic dynamic config.
+		var typeCode string
+		if router.Type != nil && router.Type.Code != nil {
+			typeCode = *router.Type.Code
+		}
+		diags.Append(hydrateImportedConfig(ctx, typeCode, router.Config, &state)...)
 	}
 
 	// Preserve tenant_ids from prior state on normal refresh. The API may
@@ -120,6 +132,41 @@ func getRouterAsState(
 	}
 
 	return state, diags
+}
+
+// hydrateImportedConfig populates the config representation on import. The typed
+// NSX-T blocks are used for the NSX-T gateway types (so import matches how they
+// are applied); any other type uses the generic dynamic config.
+func hydrateImportedConfig(
+	ctx context.Context,
+	typeCode string,
+	config map[string]interface{},
+	state *NetworkRouterModel,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch typeCode {
+	case codeNSXTTier0Gateway:
+		cfg, d := tier0ConfigFromMap(ctx, config)
+		diags.Append(d...)
+		state.ConfigNsxtGatewayTier0 = cfg
+	case codeNSXTTier1Gateway:
+		cfg, d := tier1ConfigFromMap(ctx, config)
+		diags.Append(d...)
+		state.ConfigNsxtGatewayTier1 = cfg
+	default:
+		if len(config) > 0 {
+			dyn, err := convert.MapToDynamic(ctx, config)
+			if err != nil {
+				diags.AddError(readOperation,
+					"failed to map network router config: "+err.Error())
+			} else {
+				state.Config = dyn
+			}
+		}
+	}
+
+	return diags
 }
 
 func (r *Resource) Read(


### PR DESCRIPTION
## Summary

Fixes two `hpe_morpheus_network_router` issues found by system integration testing.

### MORPH-12175 — import drift

Importing a router lost its config and mis-populated `cloud_id`:
- The import/read path never rebuilt the typed NSX-T config block, so `config_nsxt_gateway_tier0` / `config_nsxt_gateway_tier1` were dropped after import (an `ImportStateVerify` mismatch).
- `cloud_id` was read from the API-derived zone even when a network integration supplied it, whereas a freshly-applied resource leaves `cloud_id` unset.

Import now:
- Rebuilds the typed config block from the API `config` map, keyed off the router type code (NSX-T checkbox fields round-trip as `"on"`/`"off"`), falling back to the generic dynamic `config` for non-NSX-T types.
- Only surfaces the zone as `cloud_id` when the router has no network integration, so import matches apply.

### MORPH-12176 — create 500

`enable_bgp` is only supported by NSX-T Tier0 gateways. Tier1 gateways inherit BGP from their parent Tier0 and have no BGP option server-side, so `enable_bgp = true` on a Tier1 router is silently dropped (surfacing as "Provider produced inconsistent result after apply") or, on some appliance builds, returns an unhandled 500 (`"the server threw a gasket"`). Create now rejects `enable_bgp = true` for Tier1 routers — the typed `config_nsxt_gateway_tier1` block, or a generic `config` whose `type_id` resolves to the Tier1 type code — with a clear diagnostic.

## Testing

- New unit tests for the config reverse-mappers (`config_import_test.go`).
- `go build`, `go vet`, `golangci-lint` (0 issues), and `make docs` all pass.
- Not yet exercised against a live appliance (the reporter's import / full-configuration scenarios); a live acceptance run is recommended before release.

## Notes

- Import prefers the typed NSX-T block for NSX-T type codes. A router originally applied via the generic `config` map with an NSX-T type would import into the typed block instead (the two representations of the same router are otherwise indistinguishable on import).
