### PR TITLE
Fix acceptance-test bugs in storage, network, LB profile, and integrations

### DIFF
--- a/internal/sdk/oapigen/model_load_balancer_profile_config_tag.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_config_tag.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileConfigTag{}
 
 // LoadBalancerProfileConfigTag NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileConfigTag struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileConfigTag) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileConfigTag) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag{}
 
 // LoadBalancerProfileTag NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_1.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_1.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag1{}
 
 // LoadBalancerProfileTag1 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag1 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag1) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag1) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_10.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_10.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag10{}
 
 // LoadBalancerProfileTag10 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag10 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag10) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag10) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_11.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_11.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag11{}
 
 // LoadBalancerProfileTag11 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag11 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag11) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag11) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_12.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_12.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag12{}
 
 // LoadBalancerProfileTag12 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag12 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag12) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag12) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_13.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_13.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag13{}
 
 // LoadBalancerProfileTag13 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag13 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag13) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag13) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_14.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_14.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag14{}
 
 // LoadBalancerProfileTag14 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag14 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag14) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag14) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_15.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_15.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag15{}
 
 // LoadBalancerProfileTag15 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag15 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag15) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag15) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_16.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_16.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag16{}
 
 // LoadBalancerProfileTag16 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag16 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag16) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag16) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_17.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_17.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag17{}
 
 // LoadBalancerProfileTag17 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag17 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag17) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag17) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_18.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_18.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag18{}
 
 // LoadBalancerProfileTag18 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag18 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag18) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag18) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_19.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_19.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag19{}
 
 // LoadBalancerProfileTag19 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag19 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag19) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag19) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_2.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_2.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag2{}
 
 // LoadBalancerProfileTag2 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag2 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag2) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag2) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_20.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_20.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag20{}
 
 // LoadBalancerProfileTag20 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag20 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag20) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag20) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_21.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_21.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag21{}
 
 // LoadBalancerProfileTag21 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag21 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag21) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag21) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_22.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_22.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag22{}
 
 // LoadBalancerProfileTag22 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag22 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag22) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag22) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_23.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_23.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag23{}
 
 // LoadBalancerProfileTag23 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag23 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag23) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag23) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_24.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_24.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag24{}
 
 // LoadBalancerProfileTag24 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag24 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag24) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag24) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_25.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_25.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag25{}
 
 // LoadBalancerProfileTag25 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag25 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag25) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag25) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_26.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_26.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag26{}
 
 // LoadBalancerProfileTag26 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag26 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag26) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag26) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_27.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_27.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag27{}
 
 // LoadBalancerProfileTag27 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag27 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag27) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag27) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_28.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_28.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag28{}
 
 // LoadBalancerProfileTag28 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag28 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag28) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag28) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_29.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_29.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag29{}
 
 // LoadBalancerProfileTag29 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag29 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag29) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag29) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_3.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_3.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag3{}
 
 // LoadBalancerProfileTag3 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag3 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag3) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag3) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_30.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_30.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag30{}
 
 // LoadBalancerProfileTag30 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag30 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag30) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag30) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_31.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_31.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag31{}
 
 // LoadBalancerProfileTag31 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag31 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag31) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag31) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_32.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_32.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag32{}
 
 // LoadBalancerProfileTag32 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag32 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag32) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag32) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_33.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_33.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag33{}
 
 // LoadBalancerProfileTag33 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag33 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag33) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag33) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_34.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_34.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag34{}
 
 // LoadBalancerProfileTag34 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag34 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag34) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag34) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_35.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_35.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag35{}
 
 // LoadBalancerProfileTag35 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag35 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag35) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag35) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_36.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_36.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag36{}
 
 // LoadBalancerProfileTag36 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag36 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag36) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag36) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_37.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_37.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag37{}
 
 // LoadBalancerProfileTag37 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag37 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag37) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag37) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_38.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_38.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag38{}
 
 // LoadBalancerProfileTag38 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag38 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag38) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag38) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_39.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_39.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag39{}
 
 // LoadBalancerProfileTag39 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag39 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag39) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag39) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_4.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_4.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag4{}
 
 // LoadBalancerProfileTag4 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag4 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag4) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag4) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_40.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_40.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag40{}
 
 // LoadBalancerProfileTag40 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag40 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag40) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag40) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_41.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_41.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag41{}
 
 // LoadBalancerProfileTag41 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag41 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag41) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag41) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_42.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_42.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag42{}
 
 // LoadBalancerProfileTag42 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag42 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag42) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag42) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_43.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_43.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag43{}
 
 // LoadBalancerProfileTag43 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag43 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag43) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag43) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_44.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_44.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag44{}
 
 // LoadBalancerProfileTag44 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag44 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag44) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag44) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_45.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_45.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag45{}
 
 // LoadBalancerProfileTag45 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag45 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag45) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag45) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_46.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_46.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag46{}
 
 // LoadBalancerProfileTag46 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag46 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag46) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag46) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_47.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_47.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag47{}
 
 // LoadBalancerProfileTag47 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag47 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag47) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag47) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_48.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_48.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag48{}
 
 // LoadBalancerProfileTag48 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag48 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag48) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag48) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_49.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_49.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag49{}
 
 // LoadBalancerProfileTag49 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag49 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag49) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag49) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_5.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_5.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag5{}
 
 // LoadBalancerProfileTag5 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag5 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag5) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag5) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_50.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_50.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag50{}
 
 // LoadBalancerProfileTag50 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag50 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag50) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag50) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_51.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_51.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag51{}
 
 // LoadBalancerProfileTag51 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag51 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag51) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag51) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_52.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_52.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag52{}
 
 // LoadBalancerProfileTag52 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag52 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag52) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag52) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_53.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_53.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag53{}
 
 // LoadBalancerProfileTag53 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag53 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag53) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag53) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_54.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_54.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag54{}
 
 // LoadBalancerProfileTag54 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag54 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag54) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag54) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_55.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_55.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag55{}
 
 // LoadBalancerProfileTag55 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag55 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag55) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag55) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_6.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_6.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag6{}
 
 // LoadBalancerProfileTag6 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag6 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag6) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag6) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_7.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_7.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag7{}
 
 // LoadBalancerProfileTag7 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag7 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag7) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag7) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_8.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_8.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag8{}
 
 // LoadBalancerProfileTag8 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag8 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag8) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag8) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/internal/sdk/oapigen/model_load_balancer_profile_tag_9.go
+++ b/internal/sdk/oapigen/model_load_balancer_profile_tag_9.go
@@ -20,10 +20,10 @@ var _ MappedNullable = &LoadBalancerProfileTag9{}
 
 // LoadBalancerProfileTag9 NSX-T tag applied to the load balancer profile.
 type LoadBalancerProfileTag9 struct {
-	// Tag name.
-	Name *string `json:"name,omitempty"`
-	// Tag scope/value.
-	Value                *string                `json:"value,omitempty"`
+	// Tag scope. Maps to the Terraform tag \"value\".
+	Scope *string `json:"scope,omitempty"`
+	// Tag name. Maps to the Terraform tag \"name\".
+	Tag                  *string                `json:"tag,omitempty"`
 	AdditionalProperties map[string]interface{} `json:",remain"`
 }
 
@@ -39,11 +39,11 @@ func (o LoadBalancerProfileTag9) MarshalJSON() ([]byte, error) {
 
 func (o LoadBalancerProfileTag9) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
+	if !IsNil(o.Scope) {
+		toSerialize["scope"] = o.Scope
 	}
-	if !IsNil(o.Value) {
-		toSerialize["value"] = o.Value
+	if !IsNil(o.Tag) {
+		toSerialize["tag"] = o.Tag
 	}
 
 	for key, value := range o.AdditionalProperties {

--- a/morpheus/framework/datasources/loadbalancerprofile/datasource.go
+++ b/morpheus/framework/datasources/loadbalancerprofile/datasource.go
@@ -586,8 +586,8 @@ func populateServerSSLConfig(
 func populateTagsFromHTTP(ctx context.Context, state *LoadBalancerProfileModel, tags []sdk.LoadBalancerProfileTag24) {
 	tagSet, diags := convert.ToSetType(ctx, tags, func(t sdk.LoadBalancerProfileTag24) TagsValue {
 		return TagsValue{
-			Name:  convert.StrToType(t.Name),
-			Value: convert.StrToType(t.Value),
+			Name:  convert.StrToType(t.Tag),
+			Value: convert.StrToType(t.Scope),
 			state: attr.ValueStateKnown,
 		}
 	})
@@ -603,8 +603,8 @@ func populateTagsFromFastTCP(
 ) {
 	tagSet, diags := convert.ToSetType(ctx, tags, func(t sdk.LoadBalancerProfileTag25) TagsValue {
 		return TagsValue{
-			Name:  convert.StrToType(t.Name),
-			Value: convert.StrToType(t.Value),
+			Name:  convert.StrToType(t.Tag),
+			Value: convert.StrToType(t.Scope),
 			state: attr.ValueStateKnown,
 		}
 	})
@@ -620,8 +620,8 @@ func populateTagsFromFastUDP(
 ) {
 	tagSet, diags := convert.ToSetType(ctx, tags, func(t sdk.LoadBalancerProfileTag26) TagsValue {
 		return TagsValue{
-			Name:  convert.StrToType(t.Name),
-			Value: convert.StrToType(t.Value),
+			Name:  convert.StrToType(t.Tag),
+			Value: convert.StrToType(t.Scope),
 			state: attr.ValueStateKnown,
 		}
 	})
@@ -637,8 +637,8 @@ func populateTagsFromCookiePersistence(
 ) {
 	tagSet, diags := convert.ToSetType(ctx, tags, func(t sdk.LoadBalancerProfileTag27) TagsValue {
 		return TagsValue{
-			Name:  convert.StrToType(t.Name),
-			Value: convert.StrToType(t.Value),
+			Name:  convert.StrToType(t.Tag),
+			Value: convert.StrToType(t.Scope),
 			state: attr.ValueStateKnown,
 		}
 	})
@@ -654,8 +654,8 @@ func populateTagsFromSourceIPPersistence(
 ) {
 	tagSet, diags := convert.ToSetType(ctx, tags, func(t sdk.LoadBalancerProfileTag28) TagsValue {
 		return TagsValue{
-			Name:  convert.StrToType(t.Name),
-			Value: convert.StrToType(t.Value),
+			Name:  convert.StrToType(t.Tag),
+			Value: convert.StrToType(t.Scope),
 			state: attr.ValueStateKnown,
 		}
 	})
@@ -671,8 +671,8 @@ func populateTagsFromGenericPersistence(
 ) {
 	tagSet, diags := convert.ToSetType(ctx, tags, func(t sdk.LoadBalancerProfileTag29) TagsValue {
 		return TagsValue{
-			Name:  convert.StrToType(t.Name),
-			Value: convert.StrToType(t.Value),
+			Name:  convert.StrToType(t.Tag),
+			Value: convert.StrToType(t.Scope),
 			state: attr.ValueStateKnown,
 		}
 	})
@@ -688,8 +688,8 @@ func populateTagsFromClientSSL(
 ) {
 	tagSet, diags := convert.ToSetType(ctx, tags, func(t sdk.LoadBalancerProfileTag30) TagsValue {
 		return TagsValue{
-			Name:  convert.StrToType(t.Name),
-			Value: convert.StrToType(t.Value),
+			Name:  convert.StrToType(t.Tag),
+			Value: convert.StrToType(t.Scope),
 			state: attr.ValueStateKnown,
 		}
 	})
@@ -705,8 +705,8 @@ func populateTagsFromServerSSL(
 ) {
 	tagSet, diags := convert.ToSetType(ctx, tags, func(t sdk.LoadBalancerProfileTag31) TagsValue {
 		return TagsValue{
-			Name:  convert.StrToType(t.Name),
-			Value: convert.StrToType(t.Value),
+			Name:  convert.StrToType(t.Tag),
+			Value: convert.StrToType(t.Scope),
 			state: attr.ValueStateKnown,
 		}
 	})

--- a/morpheus/framework/datasources/loadbalancerprofile/datasource_acc_test.go
+++ b/morpheus/framework/datasources/loadbalancerprofile/datasource_acc_test.go
@@ -191,7 +191,7 @@ resource "hpe_morpheus_load_balancer_profile" "http" {
   load_balancer_id = hpe_morpheus_load_balancer.lb.id
   name             = %q
   service_type     = "LBHttpProfile"
-  config_http {
+  config_http = {
     https_redirect = true
   }
 }

--- a/morpheus/framework/datasources/networkedgecluster/datasource_test.go
+++ b/morpheus/framework/datasources/networkedgecluster/datasource_test.go
@@ -34,6 +34,10 @@ func TestAccMorpheusNetworkEdgeClusterByID(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" || os.Getenv("TF_ACC_EDGE_CLUSTER_ID") == "" {
+		t.Skip("set TF_ACC_NETWORK_SERVER_ID and TF_ACC_EDGE_CLUSTER_ID to run this test")
+	}
+
 	dsConfig, err := networkedgecluster.RenderNetworkEdgeClusterDataSourceByIDConfig(t, map[string]string{
 		"NetworkServerId": os.Getenv("TF_ACC_NETWORK_SERVER_ID"),
 		"Id":              os.Getenv("TF_ACC_EDGE_CLUSTER_ID"),
@@ -73,6 +77,10 @@ func TestAccMorpheusNetworkEdgeClusterByName(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" || os.Getenv("TF_ACC_EDGE_CLUSTER_NAME") == "" {
+		t.Skip("set TF_ACC_NETWORK_SERVER_ID and TF_ACC_EDGE_CLUSTER_NAME to run this test")
+	}
+
 	dsConfig, err := networkedgecluster.RenderNetworkEdgeClusterDataSourceByNameConfig(t, map[string]string{
 		"NetworkServerId": os.Getenv("TF_ACC_NETWORK_SERVER_ID"),
 		"Name":            os.Getenv("TF_ACC_EDGE_CLUSTER_NAME"),
@@ -108,6 +116,10 @@ func TestAccMorpheusNetworkEdgeClusterNotFound(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
+	}
+
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" {
+		t.Skip("set TF_ACC_NETWORK_SERVER_ID to run this test")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()

--- a/morpheus/framework/datasources/networktransportzone/datasource_test.go
+++ b/morpheus/framework/datasources/networktransportzone/datasource_test.go
@@ -34,6 +34,10 @@ func TestAccMorpheusNetworkTransportZoneByID(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" || os.Getenv("TF_ACC_TRANSPORT_ZONE_ID") == "" {
+		t.Skip("set TF_ACC_NETWORK_SERVER_ID and TF_ACC_TRANSPORT_ZONE_ID to run this test")
+	}
+
 	dsConfig, err := networktransportzone.RenderNetworkTransportZoneDataSourceByIDConfig(t, map[string]string{
 		"NetworkServerId": os.Getenv("TF_ACC_NETWORK_SERVER_ID"),
 		"Id":              os.Getenv("TF_ACC_TRANSPORT_ZONE_ID"),
@@ -73,6 +77,10 @@ func TestAccMorpheusNetworkTransportZoneByName(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" || os.Getenv("TF_ACC_TRANSPORT_ZONE_NAME") == "" {
+		t.Skip("set TF_ACC_NETWORK_SERVER_ID and TF_ACC_TRANSPORT_ZONE_NAME to run this test")
+	}
+
 	dsConfig, err := networktransportzone.RenderNetworkTransportZoneDataSourceByNameConfig(t, map[string]string{
 		"NetworkServerId": os.Getenv("TF_ACC_NETWORK_SERVER_ID"),
 		"Name":            os.Getenv("TF_ACC_TRANSPORT_ZONE_NAME"),
@@ -108,6 +116,10 @@ func TestAccMorpheusNetworkTransportZoneNotFound(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
+	}
+
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" {
+		t.Skip("set TF_ACC_NETWORK_SERVER_ID to run this test")
 	}
 
 	providerConfig := testhelpers.ProviderBlock()

--- a/morpheus/framework/resources/loadbalancerprofile/config.go
+++ b/morpheus/framework/resources/loadbalancerprofile/config.go
@@ -375,57 +375,57 @@ func readTagsFromConfig(
 	case cfg.HTTPLoadBalancerProfileConfig3 != nil:
 		for _, t := range cfg.HTTPLoadBalancerProfileConfig3.Tags {
 			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
+				name:  ptrStr(t.Tag),
+				value: ptrStr(t.Scope),
 			})
 		}
 	case cfg.FastTCPLoadBalancerProfileConfig3 != nil:
 		for _, t := range cfg.FastTCPLoadBalancerProfileConfig3.Tags {
 			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
+				name:  ptrStr(t.Tag),
+				value: ptrStr(t.Scope),
 			})
 		}
 	case cfg.FastUDPLoadBalancerProfileConfig3 != nil:
 		for _, t := range cfg.FastUDPLoadBalancerProfileConfig3.Tags {
 			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
+				name:  ptrStr(t.Tag),
+				value: ptrStr(t.Scope),
 			})
 		}
 	case cfg.CookiePersistenceLoadBalancerProfileConfig3 != nil:
 		for _, t := range cfg.CookiePersistenceLoadBalancerProfileConfig3.Tags {
 			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
+				name:  ptrStr(t.Tag),
+				value: ptrStr(t.Scope),
 			})
 		}
 	case cfg.SourceIPPersistenceLoadBalancerProfileConfig3 != nil:
 		for _, t := range cfg.SourceIPPersistenceLoadBalancerProfileConfig3.Tags {
 			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
+				name:  ptrStr(t.Tag),
+				value: ptrStr(t.Scope),
 			})
 		}
 	case cfg.GenericPersistenceLoadBalancerProfileConfig3 != nil:
 		for _, t := range cfg.GenericPersistenceLoadBalancerProfileConfig3.Tags {
 			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
+				name:  ptrStr(t.Tag),
+				value: ptrStr(t.Scope),
 			})
 		}
 	case cfg.ClientSSLLoadBalancerProfileConfig3 != nil:
 		for _, t := range cfg.ClientSSLLoadBalancerProfileConfig3.Tags {
 			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
+				name:  ptrStr(t.Tag),
+				value: ptrStr(t.Scope),
 			})
 		}
 	case cfg.ServerSSLLoadBalancerProfileConfig3 != nil:
 		for _, t := range cfg.ServerSSLLoadBalancerProfileConfig3.Tags {
 			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
+				name:  ptrStr(t.Tag),
+				value: ptrStr(t.Scope),
 			})
 		}
 	}
@@ -520,8 +520,8 @@ func buildTagsForHTTPCreate(ctx context.Context, tags types.Set) []sdk.LoadBalan
 	result := make([]sdk.LoadBalancerProfileTag8, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag8{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -536,8 +536,8 @@ func buildTagsForFastTCPCreate(ctx context.Context, tags types.Set) []sdk.LoadBa
 	result := make([]sdk.LoadBalancerProfileTag9, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag9{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -552,8 +552,8 @@ func buildTagsForFastUDPCreate(ctx context.Context, tags types.Set) []sdk.LoadBa
 	result := make([]sdk.LoadBalancerProfileTag10, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag10{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -568,8 +568,8 @@ func buildTagsForCookieCreate(ctx context.Context, tags types.Set) []sdk.LoadBal
 	result := make([]sdk.LoadBalancerProfileTag11, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag11{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -584,8 +584,8 @@ func buildTagsForSourceIPCreate(ctx context.Context, tags types.Set) []sdk.LoadB
 	result := make([]sdk.LoadBalancerProfileTag12, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag12{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -600,8 +600,8 @@ func buildTagsForGenericCreate(ctx context.Context, tags types.Set) []sdk.LoadBa
 	result := make([]sdk.LoadBalancerProfileTag13, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag13{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -616,8 +616,8 @@ func buildTagsForClientSSLCreate(ctx context.Context, tags types.Set) []sdk.Load
 	result := make([]sdk.LoadBalancerProfileTag14, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag14{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -632,8 +632,8 @@ func buildTagsForServerSSLCreate(ctx context.Context, tags types.Set) []sdk.Load
 	result := make([]sdk.LoadBalancerProfileTag15, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag15{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -649,8 +649,8 @@ func buildTagsForHTTPUpdate(ctx context.Context, tags types.Set) []sdk.LoadBalan
 	result := make([]sdk.LoadBalancerProfileTag32, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag32{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -665,8 +665,8 @@ func buildTagsForFastTCPUpdate(ctx context.Context, tags types.Set) []sdk.LoadBa
 	result := make([]sdk.LoadBalancerProfileTag33, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag33{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -681,8 +681,8 @@ func buildTagsForFastUDPUpdate(ctx context.Context, tags types.Set) []sdk.LoadBa
 	result := make([]sdk.LoadBalancerProfileTag34, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag34{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -697,8 +697,8 @@ func buildTagsForCookieUpdate(ctx context.Context, tags types.Set) []sdk.LoadBal
 	result := make([]sdk.LoadBalancerProfileTag35, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag35{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -713,8 +713,8 @@ func buildTagsForSourceIPUpdate(ctx context.Context, tags types.Set) []sdk.LoadB
 	result := make([]sdk.LoadBalancerProfileTag36, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag36{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -729,8 +729,8 @@ func buildTagsForGenericUpdate(ctx context.Context, tags types.Set) []sdk.LoadBa
 	result := make([]sdk.LoadBalancerProfileTag37, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag37{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -745,8 +745,8 @@ func buildTagsForClientSSLUpdate(ctx context.Context, tags types.Set) []sdk.Load
 	result := make([]sdk.LoadBalancerProfileTag38, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag38{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 
@@ -761,8 +761,8 @@ func buildTagsForServerSSLUpdate(ctx context.Context, tags types.Set) []sdk.Load
 	result := make([]sdk.LoadBalancerProfileTag39, 0, len(pairs))
 	for _, p := range pairs {
 		result = append(result, sdk.LoadBalancerProfileTag39{
-			Name:  sdk.PtrString(p.name),
-			Value: sdk.PtrString(p.value),
+			Tag:   sdk.PtrString(p.name),
+			Scope: sdk.PtrString(p.value),
 		})
 	}
 

--- a/morpheus/framework/resources/loadbalancerprofile/schema_gen.go
+++ b/morpheus/framework/resources/loadbalancerprofile/schema_gen.go
@@ -293,25 +293,21 @@ func LoadBalancerProfileResourceSchema(ctx context.Context) schema.Schema {
 					},
 					"https_redirect": schema.BoolAttribute{
 						Optional:            true,
-						Computed:            true,
 						Description:         "Whether to redirect HTTP traffic to HTTPS. Maps to the API \"on\"/\"off\" value; leave unset for no redirection. When false (\"off\"), set redirect_address.",
 						MarkdownDescription: "Whether to redirect HTTP traffic to HTTPS. Maps to the API \"on\"/\"off\" value; leave unset for no redirection. When false (\"off\"), set redirect_address.",
 					},
 					"ntlm_authentication": schema.BoolAttribute{
 						Optional:            true,
-						Computed:            true,
 						Description:         "Whether NTLM authentication is enabled.",
 						MarkdownDescription: "Whether NTLM authentication is enabled.",
 					},
 					"redirect_address": schema.StringAttribute{
 						Optional:            true,
-						Computed:            true,
 						Description:         "Redirect address. Required when httpsRedirect is \"off\".",
 						MarkdownDescription: "Redirect address. Required when httpsRedirect is \"off\".",
 					},
 					"request_body_size": schema.Int64Attribute{
 						Optional:            true,
-						Computed:            true,
 						Description:         "Maximum request body size in bytes. Range 1-2147483647.",
 						MarkdownDescription: "Maximum request body size in bytes. Range 1-2147483647.",
 					},
@@ -338,7 +334,6 @@ func LoadBalancerProfileResourceSchema(ctx context.Context) schema.Schema {
 					},
 					"x_forwarded_for": schema.StringAttribute{
 						Optional:            true,
-						Computed:            true,
 						Description:         "X-Forwarded-For header handling.",
 						MarkdownDescription: "X-Forwarded-For header handling.",
 						Validators: []validator.String{

--- a/morpheus/framework/resources/networkrouterbgpneighbor/read.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/read.go
@@ -59,7 +59,9 @@ func getNetworkRouterBgpNeighborAsState(
 	if neighbor.Description.IsSet() {
 		state.Description = convert.StrToType(neighbor.Description.Get())
 	} else {
-		state.Description = types.StringNull()
+		// The API accepts description on write but never echoes it back on read.
+		// Preserve the planned/prior value to avoid an inconsistent-result error.
+		state.Description = plan.Description
 	}
 
 	if neighbor.ForwardingAddress.IsSet() {

--- a/morpheus/framework/resources/storagebucket/resource.go
+++ b/morpheus/framework/resources/storagebucket/resource.go
@@ -56,6 +56,14 @@ func (r *storageBucketResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	// access_key and secret_key are write-only, so their values are available
+	// only from the configuration (they are null in the plan and state).
+	var config StorageBucketModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	body := sdk.AddStorageBucketsRequestStorageBucket{
 		Name:         plan.Name.ValueString(),
 		ProviderType: plan.ProviderType.ValueString(),
@@ -71,18 +79,22 @@ func (r *storageBucketResource) Create(ctx context.Context, req resource.CreateR
 		retType := "delete"
 		body.RetentionPolicyType = &retType
 	}
-	if !plan.Endpoint.IsNull() || !plan.AccessKey.IsNull() || !plan.SecretKey.IsNull() {
-		// These are typically passed via config; set as additional properties
-		body.AdditionalProperties = map[string]interface{}{}
-		if !plan.Endpoint.IsNull() {
-			body.AdditionalProperties["endpoint"] = plan.Endpoint.ValueString()
-		}
-		if !plan.AccessKey.IsNull() {
-			body.AdditionalProperties["accessKey"] = plan.AccessKey.ValueString()
-		}
-		if !plan.SecretKey.IsNull() {
-			body.AdditionalProperties["secretKey"] = plan.SecretKey.ValueString()
-		}
+	// The SDK serializes the request's `config` oneOf unconditionally, and an
+	// unset oneOf marshals to empty bytes ("unexpected end of JSON input"). The
+	// schema exposes only S3-style credentials (access_key/secret_key/endpoint),
+	// so always attach a (possibly empty) S3 config variant.
+	s3 := sdk.AddStorageBucketsRequestStorageBucketConfigOneOf{}
+	if !config.AccessKey.IsNull() {
+		s3.AccessKey = config.AccessKey.ValueStringPointer()
+	}
+	if !config.SecretKey.IsNull() {
+		s3.SecretKey = config.SecretKey.ValueStringPointer()
+	}
+	if !plan.Endpoint.IsNull() {
+		s3.Endpoint = plan.Endpoint.ValueStringPointer()
+	}
+	body.Config = sdk.AddStorageBucketsRequestStorageBucketConfig{
+		AddStorageBucketsRequestStorageBucketConfigOneOf: &s3,
 	}
 
 	result, httpResp, err := client.StorageAPI.AddStorageBuckets(ctx).
@@ -179,6 +191,13 @@ func (r *storageBucketResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	// access_key and secret_key are write-only, so read them from config.
+	var config StorageBucketModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	id := plan.Id.ValueInt64()
 
 	body := sdk.UpdateStorageBucketsRequestStorageBucket{
@@ -196,16 +215,22 @@ func (r *storageBucketResource) Update(ctx context.Context, req resource.UpdateR
 		retType := "delete"
 		body.RetentionPolicyType = &retType
 	}
-	if !plan.Endpoint.IsNull() || !plan.AccessKey.IsNull() || !plan.SecretKey.IsNull() {
-		body.AdditionalProperties = map[string]interface{}{}
+	// Only attach the config oneOf when there is a credential value to send. A
+	// non-nil wrapper with an empty oneOf fails to marshal, and sending an empty
+	// config on a metadata-only update could clear stored credentials.
+	if !config.AccessKey.IsNull() || !config.SecretKey.IsNull() || !plan.Endpoint.IsNull() {
+		s3 := sdk.UpdateStorageBucketsRequestStorageBucketConfigOneOf{}
+		if !config.AccessKey.IsNull() {
+			s3.AccessKey = config.AccessKey.ValueStringPointer()
+		}
+		if !config.SecretKey.IsNull() {
+			s3.SecretKey = config.SecretKey.ValueStringPointer()
+		}
 		if !plan.Endpoint.IsNull() {
-			body.AdditionalProperties["endpoint"] = plan.Endpoint.ValueString()
+			s3.Endpoint = plan.Endpoint.ValueStringPointer()
 		}
-		if !plan.AccessKey.IsNull() {
-			body.AdditionalProperties["accessKey"] = plan.AccessKey.ValueString()
-		}
-		if !plan.SecretKey.IsNull() {
-			body.AdditionalProperties["secretKey"] = plan.SecretKey.ValueString()
+		body.Config = &sdk.UpdateStorageBucketsRequestStorageBucketConfig{
+			UpdateStorageBucketsRequestStorageBucketConfigOneOf: &s3,
 		}
 	}
 

--- a/morpheus/sdkv2/datasources/integration/integration_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/integration_data-source_test.go
@@ -5,7 +5,6 @@ package integration_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
@@ -28,13 +27,11 @@ func TestAccMorpheusDataSourceIntegrationExampleOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	name := acctest.RandomWithPrefix(t.Name())
-
 	var dependenciesConfig string
 
-	datasourceConfig, err := dsintegration.RenderIntegrationConfig(t, map[string]string{
-		"Name": name,
-	})
+	// Look up the seeded integration by its real name (the render default),
+	// which matches the Check below. The template quotes the value itself.
+	datasourceConfig, err := dsintegration.RenderIntegrationConfig(t, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/morpheus/sdkv2/datasources/integration/integration_git_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/integration_git_data-source_test.go
@@ -5,7 +5,6 @@ package integration_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
@@ -28,13 +27,11 @@ func TestAccMorpheusDataSourceIntegrationGitExampleOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	name := acctest.RandomWithPrefix(t.Name())
-
 	var dependenciesConfig string
 
-	datasourceConfig, err := dsintegration.RenderIntegrationGitConfig(t, map[string]string{
-		"Name": name,
-	})
+	// Look up the seeded git integration by its real name (the render default),
+	// which matches the Check below. The template quotes the value itself.
+	datasourceConfig, err := dsintegration.RenderIntegrationGitConfig(t, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/morpheus/sdkv2/datasources/integration/vro_workflow_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/vro_workflow_data-source_test.go
@@ -5,7 +5,6 @@ package integration_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
@@ -28,13 +27,11 @@ func TestAccMorpheusDataSourceVroWorkflowExampleOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	name := acctest.RandomWithPrefix(t.Name())
-
 	var dependenciesConfig string
 
-	datasourceConfig, err := dsintegration.RenderVroWorkflowConfig(t, map[string]string{
-		"Name": name,
-	})
+	// Look up the seeded workflow by its real name (the render default), which
+	// matches the Check below. The template quotes the value itself.
+	datasourceConfig, err := dsintegration.RenderVroWorkflowConfig(t, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/morpheus/sdkv2/resources/integration/integration_chef.go
+++ b/morpheus/sdkv2/resources/integration/integration_chef.go
@@ -4,10 +4,7 @@ package integration
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -81,17 +78,10 @@ func ResourceIntegrationChef() *schema.Resource {
 				ConflictsWith: []string{"credential_id"},
 			},
 			"private_key": {
-				Type:        schema.TypeString,
-				Description: "The private key of the account used to connect to the Chef server",
-				Optional:    true,
-				Sensitive:   true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					h := sha256.New()
-					h.Write([]byte(new))
-					sha256Hash := hex.EncodeToString(h.Sum(nil))
-
-					return strings.EqualFold(old, sha256Hash)
-				},
+				Type:          schema.TypeString,
+				Description:   "The private key of the account used to connect to the Chef server",
+				Optional:      true,
+				Sensitive:     true,
 				ConflictsWith: []string{"credential_id"},
 			},
 			"credential_id": {
@@ -106,13 +96,6 @@ func ResourceIntegrationChef() *schema.Resource {
 				Description: "The organization validator key used to connect to the Chef server",
 				Optional:    true,
 				Sensitive:   true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					h := sha256.New()
-					h.Write([]byte(new))
-					sha256Hash := hex.EncodeToString(h.Sum(nil))
-
-					return strings.EqualFold(old, sha256Hash)
-				},
 			},
 			/* AWAITING API SUPPORT
 			"databags": {
@@ -367,12 +350,16 @@ func resourceIntegrationChefRead(ctx context.Context, d *schema.ResourceData, me
 
 	if integration.Credential.ID == 0 {
 		d.Set("username", integration.Config.ChefUser)
-		d.Set("private_key", integration.Config.UserKeyHash)
+		// private_key is write-only: the API returns only a hash, so preserve
+		// the configured value instead of overwriting state with the hash.
+		d.Set("private_key", d.Get("private_key"))
 	} else {
 		d.Set("credential_id", integration.Credential.ID)
 	}
 
-	d.Set("organization_validator_key", integration.Config.OrgKeyHash)
+	// organization_validator_key is write-only: preserve the configured value
+	// rather than storing the API-returned hash.
+	d.Set("organization_validator_key", d.Get("organization_validator_key"))
 
 	// databags
 	/* AWAITING API SUPPORT

--- a/morpheus/sdkv2/resources/integration/integration_vro.go
+++ b/morpheus/sdkv2/resources/integration/integration_vro.go
@@ -4,11 +4,8 @@ package integration
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -125,26 +122,11 @@ func ResourceIntegrationVRO() *schema.Resource {
 				Description: "The password of the account used to connect to vRO (required for non-aria auth types)",
 				Optional:    true,
 				Sensitive:   true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					h := sha256.New()
-					h.Write([]byte(new))
-					sha256Hash := hex.EncodeToString(h.Sum(nil))
-
-					return strings.EqualFold(old, sha256Hash)
-				},
-				DiffSuppressOnRefresh: true,
 			},
 			"tenant": {
 				Type:        schema.TypeString,
 				Description: "The tenant of the account used to connect to vRO (required for non-aria auth types)",
 				Optional:    true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					h := sha256.New()
-					h.Write([]byte(new))
-					sha256Hash := hex.EncodeToString(h.Sum(nil))
-
-					return strings.EqualFold(old, sha256Hash)
-				},
 			},
 			"auth_id": {
 				Type:        schema.TypeString,
@@ -340,8 +322,11 @@ func resourceIntegrationVRORead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("enabled", integration.Enabled)
 	d.Set("url", integration.URL)
 	d.Set("username", integration.Username)
-	d.Set("password", integration.PasswordHash)
-	d.Set("tenant", integration.TokenHash)
+	// password and tenant are write-only from the API's perspective (it returns
+	// only hashes), so preserve the configured values instead of overwriting
+	// state with the hash.
+	d.Set("password", d.Get("password"))
+	d.Set("tenant", d.Get("tenant"))
 	// d.Set("auth_type", integration.Config)
 
 	return diags

--- a/morpheus/sdkv2/resources/task/resource_task_chef_bootstrap.go
+++ b/morpheus/sdkv2/resources/task/resource_task_chef_bootstrap.go
@@ -2,11 +2,8 @@ package task
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"log"
 	"strconv"
-	"strings"
 
 	"github.com/HPE/terraform-provider-hpe/morpheus/sdkv2/convert"
 	"github.com/HPE/terraform-provider-hpe/morpheus/sdkv2/helpers"
@@ -69,14 +66,7 @@ func ResourceTaskChefBootstrap() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The chef databag key",
 				Sensitive:   true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					h := sha256.New()
-					h.Write([]byte(new))
-					sha256Hash := hex.EncodeToString(h.Sum(nil))
-
-					return strings.EqualFold(old, sha256Hash)
-				},
-				Optional: true,
+				Optional:    true,
 			},
 			"data_bag_key_path": {
 				Type:        schema.TypeString,
@@ -378,7 +368,9 @@ func resourceTaskChefBootstrapRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("chef_server_id", serverId)
 	d.Set("environment", chefBootstrapTask.TaskOptions.ChefEnv)
 	d.Set("run_list", chefBootstrapTask.TaskOptions.ChefRunList)
-	d.Set("data_bag_key", chefBootstrapTask.TaskOptions.ChefDataKeyHash)
+	// data_bag_key is write-only: the API returns only a hash, so preserve the
+	// configured value to keep the plan stable after apply.
+	d.Set("data_bag_key", d.Get("data_bag_key"))
 	d.Set("data_bag_key_path", chefBootstrapTask.TaskOptions.ChefDataKeyPath)
 	d.Set("node_name", chefBootstrapTask.TaskOptions.ChefNodeName)
 	d.Set("node_attributes", chefBootstrapTask.TaskOptions.ChefAttributes)

--- a/specs/resources/load_balancer_profile/config.yaml
+++ b/specs/resources/load_balancer_profile/config.yaml
@@ -4,7 +4,7 @@ load_balancer_profile:
     # it to the API "on"/"off" string. Replaces the auto-extracted string enum.
     config_http_https_redirect:
       bool:
-        computed_optional_required: computed_optional
+        computed_optional_required: optional
         description: >-
           Whether to redirect HTTP traffic to HTTPS. Maps to the API "on"/"off"
           value; leave unset for no redirection. When false ("off"), set
@@ -104,6 +104,18 @@ load_balancer_profile:
       description: >-
         Cookie time type: `session` (LBSessionCookieTime) or `persistence`
         (LBPersistenceCookieTime). Required when cookie_mode is INSERT.
+    # config_http sub-attributes are Optional-only (not Computed) so omitted
+    # values plan as known-null instead of unknown. Read copies the planned
+    # config_http block verbatim into state, so a Computed value left unset would
+    # stay unknown after apply ("All values must be known after apply").
+    config_http.ntlm_authentication:
+      computed_optional_required: optional
+    config_http.redirect_address:
+      computed_optional_required: optional
+    config_http.request_body_size:
+      computed_optional_required: optional
+    config_http.x_forwarded_for:
+      computed_optional_required: optional
     # The 8 config blocks are mutually exclusive (only the one matching
     # service_type may be set).
     config_http:


### PR DESCRIPTION
## Summary

Fixes a batch of bugs surfaced by an acceptance-test run. Each item below is an independent fix; grouped by area.

## Resource / behavior fixes
- **storage_bucket** — Create/Update now send a valid `config` payload. Previously the request body failed to serialize, so **every** create and update errored out before reaching the API.
- **network_router_bgp_neighbor** — preserve the configured `description`. The API accepts it on write but does not return it on read, which produced a *"Provider produced inconsistent result after apply"* error.
- **integration (chef, vro)** and **task chef bootstrap** — keep the configured secret values in state instead of overwriting them with the API's hashed values. This removes perpetual/after-apply diffs on `private_key`, `organization_validator_key`, `password`, `tenant`, and `data_bag_key`.
- **load_balancer_profile** —
  - Make the optional `config_http` sub-attributes (`https_redirect`, `ntlm_authentication`, `redirect_address`, `request_body_size`, `x_forwarded_for`) plan as *known* when omitted, fixing *"all values must be known after apply"*.
  - Send NSX-T profile tags using the `{scope, tag}` keys NSX-T expects (the Terraform-facing schema keeps `name`/`value`). The bundled Morpheus SDK tag models are updated to match.

## Test / fixture fixes
- Fix the `load_balancer_profile` data-source seed config (attribute vs block syntax).
- Look up the integration / git / vro-workflow data sources by their seeded names so config and assertions are consistent.
- Skip the network **edge-cluster** and **transport-zone** data-source tests when their `TF_ACC_*` IDs are unset, instead of rendering invalid HCL.

## Running the suite
The remaining environment-dependent tests are gated by capabilities. A run that exercises the fixes above without the infra-limited cases:

```
TF_ACC_CAPABILITIES="nsxt,network_router,network_firewall,network_dhcp,vmware,chef,vro,ansible,subnet"
```

## Validation
- `go build ./...` ✅
- `make lint` ✅ (0 issues)
- `make docs` ✅ (no diff)

## Notes
- The vendored SDK change is self-contained in this PR.
- Draft: the NSX-T load_balancer_profile fixes still need validation on an NSX-T environment with available edge-node capacity.