### PR TITLE
MORPH-13817: Fix instance Read panic on 404 from env-vars endpoint

### DIFF
--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -1108,13 +1108,28 @@ func getInstanceEnvVars(
 	client *sdk.APIClient,
 ) ([]sdk.GetEnvVariables200ResponseEnvsInner, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	resp, hresp, _ := client.InstancesAPI.GetEnvVariables(ctx, id).Execute()
-	// The SDK can return a decode error on an otherwise-valid 200 response
-	// (polymorphic fields it cannot model), so the error is intentionally ignored
-	// and we gate on the HTTP status instead. Some platforms (e.g. HPE VME) do not
-	// expose this endpoint and return 404; treat a nil response or any non-200
-	// status as "no env vars" rather than dereferencing a nil resp and panicking.
+	resp, hresp, err := client.InstancesAPI.GetEnvVariables(ctx, id).Execute()
+
+	// Some platforms (e.g. HPE VME) do not expose this endpoint and return 404.
+	// That is expected — there simply are no env vars — so return quietly without
+	// a diagnostic (erroring here would fail the whole instance Read, and reading
+	// resp.Envs would panic on the nil resp).
+	if hresp != nil && hresp.StatusCode == http.StatusNotFound {
+		return nil, diags
+	}
+
+	// Any other failure (nil response or a non-200 status) is unexpected. Surface
+	// a warning rather than failing the Read (env vars are supplementary) and
+	// return none. The SDK's decode error is unreliable on valid 200s (polymorphic
+	// fields it cannot model), so the HTTP status is the primary signal and err is
+	// only used for context.
 	if hresp == nil || hresp.StatusCode != http.StatusOK || resp == nil {
+		diags.AddWarning(
+			"Could not read instance environment variables",
+			fmt.Sprintf("Environment variables were not populated for instance %d: %s",
+				id, errfmt.ErrMsg(err, hresp)),
+		)
+
 		return nil, diags
 	}
 

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -1110,13 +1110,15 @@ func getInstanceEnvVars(
 	var diags diag.Diagnostics
 	resp, hresp, err := client.InstancesAPI.GetEnvVariables(ctx, id).Execute()
 
-	// GET /api/instances/{id}/envs is not always reachable — e.g. MORPH-13817
-	// observed it returning 404 against an HPE VME appliance (root cause on that
-	// platform unconfirmed). On a nil response or any non-200 there are no env vars
-	// to set: surface a warning for visibility, but never error (that would fail
-	// the whole instance Read) and never dereference the nil resp (the panic this
-	// guards against). The SDK's decode error is unreliable on valid 200s
-	// (polymorphic fields it cannot model), so the HTTP status is the primary
+	// GET /api/instances/{id}/envs is gated by the "provisioning-environment"
+	// permission, which requires the "environmentVariables" license feature.
+	// Reduced editions that do not license it (e.g. HPE VM Essentials) — or a role
+	// lacking the permission — disable the endpoint, so it returns a non-200
+	// (MORPH-13817 saw a 404 on VME). On a nil response or any non-200 there are no
+	// env vars to set: surface a warning for visibility, but never error (that
+	// would fail the whole instance Read) and never dereference the nil resp (the
+	// panic this guards against). The SDK's decode error is unreliable on valid
+	// 200s (polymorphic fields it cannot model), so the HTTP status is the primary
 	// signal and err is only used for context.
 	if hresp == nil || hresp.StatusCode != http.StatusOK || resp == nil {
 		diags.AddWarning(

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -1108,18 +1108,15 @@ func getInstanceEnvVars(
 	client *sdk.APIClient,
 ) ([]sdk.GetEnvVariables200ResponseEnvsInner, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	resp, _, _ := client.InstancesAPI.GetEnvVariables(ctx, id).Execute()
-	// ignoring errors for now, the sdk can't parse some of the unused fields
-	// due to polymorphic values
-
-	// if err != nil || hresp.StatusCode != http.StatusOK {
-	// diags.AddError(
-	// 	"populate instance resource",
-	// 	fmt.Sprintf("instance %d GET failed: ", id)+errfmt.ErrMsg(err, hresp),
-	// )
-
-	// return nil, diags
-	// }
+	resp, hresp, _ := client.InstancesAPI.GetEnvVariables(ctx, id).Execute()
+	// The SDK can return a decode error on an otherwise-valid 200 response
+	// (polymorphic fields it cannot model), so the error is intentionally ignored
+	// and we gate on the HTTP status instead. Some platforms (e.g. HPE VME) do not
+	// expose this endpoint and return 404; treat a nil response or any non-200
+	// status as "no env vars" rather than dereferencing a nil resp and panicking.
+	if hresp == nil || hresp.StatusCode != http.StatusOK || resp == nil {
+		return nil, diags
+	}
 
 	return resp.Envs, diags
 }

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -1110,23 +1110,19 @@ func getInstanceEnvVars(
 	var diags diag.Diagnostics
 	resp, hresp, err := client.InstancesAPI.GetEnvVariables(ctx, id).Execute()
 
-	// Some platforms (e.g. HPE VME) do not expose this endpoint and return 404.
-	// That is expected — there simply are no env vars — so return quietly without
-	// a diagnostic (erroring here would fail the whole instance Read, and reading
-	// resp.Envs would panic on the nil resp).
-	if hresp != nil && hresp.StatusCode == http.StatusNotFound {
-		return nil, diags
-	}
-
-	// Any other failure (nil response or a non-200 status) is unexpected. Surface
-	// a warning rather than failing the Read (env vars are supplementary) and
-	// return none. The SDK's decode error is unreliable on valid 200s (polymorphic
-	// fields it cannot model), so the HTTP status is the primary signal and err is
-	// only used for context.
+	// GET /api/instances/{id}/envs is not always reachable — e.g. MORPH-13817
+	// observed it returning 404 against an HPE VME appliance (root cause on that
+	// platform unconfirmed). On a nil response or any non-200 there are no env vars
+	// to set: surface a warning for visibility, but never error (that would fail
+	// the whole instance Read) and never dereference the nil resp (the panic this
+	// guards against). The SDK's decode error is unreliable on valid 200s
+	// (polymorphic fields it cannot model), so the HTTP status is the primary
+	// signal and err is only used for context.
 	if hresp == nil || hresp.StatusCode != http.StatusOK || resp == nil {
 		diags.AddWarning(
 			"Could not read instance environment variables",
-			fmt.Sprintf("Environment variables were not populated for instance %d: %s",
+			fmt.Sprintf("The environment variables endpoint returned no usable result "+
+				"for instance %d, so no environment variables were read into state: %s",
 				id, errfmt.ErrMsg(err, hresp)),
 		)
 


### PR DESCRIPTION
## Summary
`hpe_morpheus_instance` Read panicked with a nil-pointer dereference whenever the environment-variables endpoint returned a non-200. On platforms that don't expose it (e.g. HPE VME, which returns 404), every `apply`/`refresh`/`import` crashed the provider — and on create the VM was provisioned but the post-create Read crashed, leaving it orphaned (not in state).

## Root cause
`getInstanceEnvVars` (`morpheus/framework/resources/instance/instance_read.go`) discarded both the HTTP response and error from `GetEnvVariables(...).Execute()` and then returned `resp.Envs`. On a non-200 the SDK yields a nil `resp`, so `resp.Envs` dereferenced a nil pointer. (Regression: the pre-1.1 code path was nil-safe.)

## Fix
Capture the HTTP response and gate on status — return no env vars unless the call is `200 OK` with a non-nil body:

```go
resp, hresp, _ := client.InstancesAPI.GetEnvVariables(ctx, id).Execute()
if hresp == nil || hresp.StatusCode != http.StatusOK || resp == nil {
    return nil, diags
}
return resp.Envs, diags
```

The SDK's decode error is intentionally ignored — it's unreliable on valid 200 responses (this endpoint carries polymorphic fields the SDK can't model), so HTTP status is the correct signal. This matches the expected behavior: an instance with no env vars, or a platform lacking the endpoint, returns no env vars.

## Testing
- `go build ./...` and `golangci-lint` (instance package) pass.
- The failure path is a 404 from a live VME appliance, not reproducible in unit tests without that platform; the guard is defensive and the happy path (200 + envs) is unchanged.
