### PR TITLE
MORPH-10324/10323: Fix node_type template ID list read-back

### DIFF
--- a/morpheus/sdkv2/resources/blueprint/common.go
+++ b/morpheus/sdkv2/resources/blueprint/common.go
@@ -7,26 +7,41 @@ package blueprint
 //
 //nolint:unused
 func matchTemplatesWithSchema(templates []int64, declaredTemplates []any) []int64 {
-	result := make([]int64, len(declaredTemplates))
-
-	rMap := make(map[int64]int64, len(templates))
-	for _, template := range templates {
-		rMap[template] = template
+	// templates are the IDs returned by the API; declaredTemplates are the IDs
+	// from the practitioner's config/state. SDKv2 stores schema.TypeInt list
+	// elements as Go int, so accept both int and int64. The previous int64-only
+	// assertion silently failed for every element, which left zero-valued entries
+	// (from make([]int64, len(declared))) and then appended the entire API list —
+	// doubling the list and injecting phantom 0 IDs (a perpetual plan diff).
+	present := make(map[int64]bool, len(templates))
+	for _, t := range templates {
+		present[t] = true
 	}
 
-	for i, definedTemplate := range declaredTemplates {
-		// skip if type assertion failed
-		if definedTemplateInt64, ok := definedTemplate.(int64); ok {
-			if v, ok := rMap[definedTemplateInt64]; ok {
-				// matched node type declared by ID
-				result[i] = v
-				delete(rMap, v)
-			}
+	result := make([]int64, 0, len(templates))
+	// Keep the declared order for templates the API still returns.
+	for _, dt := range declaredTemplates {
+		var id int64
+		switch v := dt.(type) {
+		case int:
+			id = int64(v)
+		case int64:
+			id = v
+		default:
+			continue
+		}
+		if present[id] {
+			result = append(result, id)
+			delete(present, id)
 		}
 	}
-	// append unmatched node type to the result
-	for _, rcpt := range rMap {
-		result = append(result, rcpt)
+	// Append any server-added templates that were not declared, in the API's
+	// order (ranging the map directly would reorder the list on every read).
+	for _, t := range templates {
+		if present[t] {
+			result = append(result, t)
+			delete(present, t)
+		}
 	}
 
 	return result

--- a/morpheus/sdkv2/resources/blueprint/common_test.go
+++ b/morpheus/sdkv2/resources/blueprint/common_test.go
@@ -1,0 +1,82 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package blueprint
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMatchTemplatesWithSchema(t *testing.T) {
+	cases := []struct {
+		name      string
+		templates []int64 // IDs returned by the API
+		declared  []any   // IDs from config/state (SDKv2 stores TypeInt as int)
+		want      []int64
+	}{
+		{
+			name:      "MORPH-10324: declared ints are not doubled with phantom zeros",
+			templates: []int64{1, 2},
+			declared:  []any{int(1), int(2)},
+			want:      []int64{1, 2},
+		},
+		{
+			name:      "MORPH-10323: no phantom 0 entries / no perpetual diff",
+			templates: []int64{105, 106},
+			declared:  []any{int(105), int(106)},
+			want:      []int64{105, 106},
+		},
+		{
+			name:      "int64 declared elements are also accepted",
+			templates: []int64{1, 2},
+			declared:  []any{int64(1), int64(2)},
+			want:      []int64{1, 2},
+		},
+		{
+			name:      "server-added template is appended in API order",
+			templates: []int64{1, 2},
+			declared:  []any{int(1)},
+			want:      []int64{1, 2},
+		},
+		{
+			name:      "server-removed template is dropped, not zero-filled",
+			templates: []int64{1},
+			declared:  []any{int(1), int(2)},
+			want:      []int64{1},
+		},
+		{
+			name:      "declared order preserved, extras appended deterministically",
+			templates: []int64{1, 2, 3},
+			declared:  []any{int(3), int(1)},
+			want:      []int64{3, 1, 2},
+		},
+		{
+			name:      "empty declared returns all API templates in order",
+			templates: []int64{1, 2},
+			declared:  []any{},
+			want:      []int64{1, 2},
+		},
+		{
+			name:      "empty API returns empty, no zero padding",
+			templates: []int64{},
+			declared:  []any{int(1)},
+			want:      []int64{},
+		},
+		{
+			name:      "unexpected element types are skipped",
+			templates: []int64{1, 2},
+			declared:  []any{"1", int(2)},
+			want:      []int64{2, 1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchTemplatesWithSchema(tc.templates, tc.declared)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("matchTemplatesWithSchema(%v, %v) = %v, want %v",
+					tc.templates, tc.declared, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`hpe_morpheus_node_type` corrupted its `script_template_ids` and `file_template_ids` on read, producing two QA acceptance-test failures:
- **MORPH-10324** — `script_template_ids` count doubled (`expected "2", got "4"`).
- **MORPH-10323** — `file_template_ids` produced a perpetual plan removing phantom `0` entries.

## Root cause
`matchTemplatesWithSchema` (`morpheus/sdkv2/resources/blueprint/common.go`) type-asserted the declared IDs to `int64`, but Plugin SDKv2 stores `schema.TypeInt` list elements as Go `int`. The assertion therefore failed for **every** element: `result` was pre-sized with zeros (`make([]int64, len(declared))`) that were never filled, and the entire API list was then appended as "unmatched" — yielding `[0, 0, <all api ids>]`.

## Fix
- Accept both `int` and `int64` declared elements.
- Build the result by appending only matched IDs (no zero-padding).
- Append server-added IDs in the API's deterministic order (the previous `for range map` append was itself a latent perpetual-diff source).

```go
present := make(map[int64]bool, len(templates))
for _, t := range templates { present[t] = true }

result := make([]int64, 0, len(templates))
for _, dt := range declaredTemplates {
    var id int64
    switch v := dt.(type) {
    case int:   id = int64(v)
    case int64: id = v
    default:    continue
    }
    if present[id] { result = append(result, id); delete(present, id) }
}
for _, t := range templates {
    if present[t] { result = append(result, t); delete(present, t) }
}
```

## Testing
- New unit test `common_test.go` (9 cases, including both ticket regressions) — passes.
- `go build ./...` and `golangci-lint` (blueprint package) pass.
- The failing QA acceptance tests live in a separate suite; this adds in-repo coverage for the function.

## Note
`hpe_morpheus_node_type` is a legacy SDKv2 resource (hand-written SDK), so no schema/SDK regeneration is involved — the IDs are `int64` throughout the API and SDK; the bug was purely `int` vs `int64` handling on the Terraform side.
