### PR TITLE
MORPH-13145: Fix network router NAT protocol round-trip

### DIFF
--- a/morpheus/framework/resources/networkrouternat/resource.go
+++ b/morpheus/framework/resources/networkrouternat/resource.go
@@ -234,9 +234,16 @@ func getNatAsState(
 		state.Priority = types.Int64Null()
 	}
 
-	// protocol is deprecated (superseded by service) but still read back so
-	// existing state stays consistent.
-	state.Protocol = convert.StrToType(nat.Protocol.Get())
+	// protocol is deprecated (superseded by service) and the API no longer
+	// persists it, so it is omitted from the response. Fall back to the plan
+	// value when the API omits it (matching action/firewall/service) so the
+	// configured value round-trips and does not produce an inconsistent result
+	// after apply.
+	if p := nat.Protocol.Get(); p != nil {
+		state.Protocol = types.StringValue(*p)
+	} else {
+		state.Protocol = plan.Protocol
+	}
 
 	// firewall and service are create-time config options. Read them back from
 	// the response, falling back to the plan value when the API omits them.

--- a/morpheus/framework/resources/networkrouternat/resource_test.go
+++ b/morpheus/framework/resources/networkrouternat/resource_test.go
@@ -147,6 +147,7 @@ resource "hpe_morpheus_network_router_nat" "example" {
   source_network     = "10.1.0.0/24"
   translated_network = "192.168.1.1"
   description        = "Updated SNAT rule"
+  protocol           = "tcp"
 }
 `
 
@@ -162,6 +163,10 @@ resource "hpe_morpheus_network_router_nat" "example" {
 		resource.TestCheckResourceAttr(resourceName, "name", name),
 		resource.TestCheckResourceAttr(resourceName, "source_network", "10.1.0.0/24"),
 		resource.TestCheckResourceAttr(resourceName, "description", "Updated SNAT rule"),
+		// protocol is deprecated and dropped by the API; verify the configured
+		// value still round-trips (regression guard for the inconsistent-result
+		// -after-apply defect).
+		resource.TestCheckResourceAttr(resourceName, "protocol", "tcp"),
 	)
 
 	checkInPlaceUpdate := resource.ConfigPlanChecks{


### PR DESCRIPTION
## Summary

`hpe_morpheus_network_router_nat` produced `Provider produced inconsistent result after apply` when `protocol` was set in configuration: the configured value (for example `"tcp"`) came back as `null` after apply.

## Root cause

`protocol` is deprecated (superseded by `service`) and the API no longer persists it, so it is omitted from the read-back response. Unlike its sibling fields (`action`, `firewall`, `service`) — which fall back to the planned value when the API omits them — `protocol` was mapped unconditionally from the (null) API response, so state was set to `null` and conflicted with the configured value.

## Fix

Fall back to the planned value when the API omits `protocol`, matching the existing `action`/`firewall`/`service` handling. The configured value now round-trips cleanly, and refresh preserves the prior value (no perpetual diff).

## Test

Extended `TestAccMorpheusNetworkRouterNatResourceUpdateOk` to set `protocol = "tcp"` and assert it round-trips, reproducing the reported scenario. The apply step fails with the reported error if this regresses, and the plan-only step guards against a perpetual diff.

## Verification

- `go build ./...`, `go vet`, `gofmt`, `golangci-lint` (package) — all clean
- Acceptance test requires a live Morpheus environment (QA/CI)