### PR TITLE
MORPH-12346/12347: Validate hex color format in setting_whitelabel

### DIFF
--- a/morpheus/framework/resources/settingwhitelabel/resource_test.go
+++ b/morpheus/framework/resources/settingwhitelabel/resource_test.go
@@ -2,6 +2,7 @@ package settingwhitelabel_test
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -122,6 +123,70 @@ func TestAccMorpheusSettingWhitelabelResourceUpdateOk(t *testing.T) {
 			{Config: providerConfig + createConfig, Check: createChecks},
 			{Config: providerConfig + updateConfig, Check: updateChecks, ConfigPlanChecks: checkInPlaceUpdate},
 			{Config: providerConfig + updateConfig, ExpectNonEmptyPlan: false, PlanOnly: true},
+		},
+	})
+}
+
+// TestAccMorpheusSettingWhitelabel_validationInvalidPrimaryColor verifies that a
+// non-hex primary_color is rejected at plan time instead of being silently
+// accepted. The validation error fires before any API call.
+func TestAccMorpheusSettingWhitelabel_validationInvalidPrimaryColor(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	capabilities.MustHaveOrSkip(t, capabilities.Settings)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	resourceConfig, err := settingwhitelabel.RenderSettingWhitelabelConfig(t, map[string]string{
+		"PrimaryColor": "not-a-color",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile(`must be a valid hex color code`),
+			},
+		},
+	})
+}
+
+// TestAccMorpheusSettingWhitelabel_validationInvalidSecondaryColor verifies that a
+// non-hex secondary_color is rejected at plan time instead of being silently
+// accepted. The validation error fires before any API call.
+func TestAccMorpheusSettingWhitelabel_validationInvalidSecondaryColor(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	capabilities.MustHaveOrSkip(t, capabilities.Settings)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	resourceConfig, err := settingwhitelabel.RenderSettingWhitelabelConfig(t, map[string]string{
+		"SecondaryColor": "not-a-color",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + resourceConfig,
+				ExpectError: regexp.MustCompile(`must be a valid hex color code`),
+			},
 		},
 	})
 }

--- a/morpheus/framework/resources/settingwhitelabel/resource_validation_test.go
+++ b/morpheus/framework/resources/settingwhitelabel/resource_validation_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/settingwhitelabel"
 )
 
-// TestSettingWhitelabelColorValidators exercises the schema-level hex-color
-// validators on primary_color and secondary_color directly, without a live
-// Morpheus backend. It guards the regression reported where an invalid color
-// (e.g. "not-a-color") was accepted instead of rejected.
-func TestSettingWhitelabelColorValidators(t *testing.T) {
+// TestSettingWhitelabelColorValidators verifies that the hex-color validator is
+// wired to both primary_color and secondary_color in the generated schema and
+// rejects invalid colors, without a live Morpheus backend. It guards the
+// regression reported where an invalid color (e.g. "not-a-color") was accepted
+// instead of rejected. The validator's own behaviour is covered in depth by
+// utils/validators hex color tests.
+func TestUnitSettingWhitelabelColorValidators(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()

--- a/morpheus/framework/resources/settingwhitelabel/resource_validation_test.go
+++ b/morpheus/framework/resources/settingwhitelabel/resource_validation_test.go
@@ -1,0 +1,76 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package settingwhitelabel_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/settingwhitelabel"
+)
+
+// TestSettingWhitelabelColorValidators exercises the schema-level hex-color
+// validators on primary_color and secondary_color directly, without a live
+// Morpheus backend. It guards the regression reported where an invalid color
+// (e.g. "not-a-color") was accepted instead of rejected.
+func TestSettingWhitelabelColorValidators(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := settingwhitelabel.SettingWhitelabelResourceSchema(ctx)
+
+	cases := []struct {
+		name      string
+		attribute string
+		value     string
+		wantError bool
+	}{
+		{"primary valid six digit", "primary_color", "#1a73e8", false},
+		{"primary valid three digit", "primary_color", "#fff", false},
+		{"primary valid eight digit alpha", "primary_color", "#1a73e8ff", false},
+		{"primary valid uppercase", "primary_color", "#ABCDEF", false},
+		{"primary invalid word", "primary_color", "not-a-color", true},
+		{"primary invalid named", "primary_color", "red", true},
+		{"primary invalid missing hash", "primary_color", "1a73e8", true},
+		{"primary invalid too short", "primary_color", "#12", true},
+		{"primary invalid non hex", "primary_color", "#12345g", true},
+		{"primary invalid empty", "primary_color", "", true},
+		{"secondary valid six digit", "secondary_color", "#ffffff", false},
+		{"secondary valid three digit", "secondary_color", "#161", false},
+		{"secondary invalid word", "secondary_color", "not-a-color", true},
+		{"secondary invalid rgb", "secondary_color", "rgb(0,0,0)", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			attr, ok := s.Attributes[tc.attribute].(schema.StringAttribute)
+			if !ok {
+				t.Fatalf("attribute %q is not a schema.StringAttribute", tc.attribute)
+			}
+			if len(attr.Validators) == 0 {
+				t.Fatalf("attribute %q has no validators; expected a hex-color validator", tc.attribute)
+			}
+
+			req := validator.StringRequest{
+				Path:        path.Root(tc.attribute),
+				ConfigValue: types.StringValue(tc.value),
+			}
+			resp := &validator.StringResponse{}
+			for _, v := range attr.Validators {
+				v.ValidateString(ctx, req, resp)
+			}
+
+			if got := resp.Diagnostics.HasError(); got != tc.wantError {
+				t.Fatalf("value %q on %s: got error=%v, want error=%v (diagnostics: %v)",
+					tc.value, tc.attribute, got, tc.wantError, resp.Diagnostics)
+			}
+		})
+	}
+}

--- a/morpheus/framework/resources/settingwhitelabel/schema_gen.go
+++ b/morpheus/framework/resources/settingwhitelabel/schema_gen.go
@@ -4,9 +4,12 @@ package settingwhitelabel
 
 import (
 	"context"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -57,11 +60,23 @@ func SettingWhitelabelResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				Description:         "The primary button background color.",
 				MarkdownDescription: "The primary button background color.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`),
+						"must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff",
+					),
+				},
 			},
 			"secondary_color": schema.StringAttribute{
 				Optional:            true,
 				Description:         "The header background color.",
 				MarkdownDescription: "The header background color.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`),
+						"must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff",
+					),
+				},
 			},
 			"support_menu_links": schema.StringAttribute{
 				Optional:            true,

--- a/morpheus/framework/resources/settingwhitelabel/schema_gen.go
+++ b/morpheus/framework/resources/settingwhitelabel/schema_gen.go
@@ -4,9 +4,8 @@ package settingwhitelabel
 
 import (
 	"context"
-	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/HPE/terraform-provider-hpe/utils/validators"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -61,10 +60,7 @@ func SettingWhitelabelResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The primary button background color.",
 				MarkdownDescription: "The primary button background color.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`),
-						"must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff",
-					),
+					validators.HexColor(),
 				},
 			},
 			"secondary_color": schema.StringAttribute{
@@ -72,10 +68,7 @@ func SettingWhitelabelResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The header background color.",
 				MarkdownDescription: "The header background color.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`),
-						"must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff",
-					),
+					validators.HexColor(),
 				},
 			},
 			"support_menu_links": schema.StringAttribute{

--- a/specs/resources/setting_whitelabel/config.yaml
+++ b/specs/resources/setting_whitelabel/config.yaml
@@ -76,26 +76,16 @@ setting_whitelabel:
       validators:
         - custom:
             imports:
-              - path: regexp
-              - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
-            schema_definition: |-
-              stringvalidator.RegexMatches(
-              regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`),
-              "must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff",
-              )
+              - path: github.com/HPE/terraform-provider-hpe/utils/validators
+            schema_definition: validators.HexColor()
     secondary_color:
       computed_optional_required: optional
       description: The header background color.
       validators:
         - custom:
             imports:
-              - path: regexp
-              - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
-            schema_definition: |-
-              stringvalidator.RegexMatches(
-              regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`),
-              "must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff",
-              )
+              - path: github.com/HPE/terraform-provider-hpe/utils/validators
+            schema_definition: validators.HexColor()
     support_menu_links:
       computed_optional_required: optional
       description: Support menu links as a JSON string.

--- a/specs/resources/setting_whitelabel/config.yaml
+++ b/specs/resources/setting_whitelabel/config.yaml
@@ -73,9 +73,29 @@ setting_whitelabel:
     primary_color:
       computed_optional_required: optional
       description: The primary button background color.
+      validators:
+        - custom:
+            imports:
+              - path: regexp
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+            schema_definition: |-
+              stringvalidator.RegexMatches(
+              regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`),
+              "must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff",
+              )
     secondary_color:
       computed_optional_required: optional
       description: The header background color.
+      validators:
+        - custom:
+            imports:
+              - path: regexp
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator
+            schema_definition: |-
+              stringvalidator.RegexMatches(
+              regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`),
+              "must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff",
+              )
     support_menu_links:
       computed_optional_required: optional
       description: Support menu links as a JSON string.

--- a/utils/validators/hex_color_validator.go
+++ b/utils/validators/hex_color_validator.go
@@ -1,0 +1,54 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package validators
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// hexColorRegexp matches CSS hex color codes with 3, 4, 6, or 8 hex digits,
+// for example #fff, #abcd, #1a73e8, or #1a73e8ff.
+var hexColorRegexp = regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`)
+
+var _ validator.String = HexColorValidator{}
+
+// HexColorValidator rejects a configured string that is not a valid hex color
+// code, so an invalid color is reported at validate/plan time instead of being
+// silently accepted by the API.
+type HexColorValidator struct{}
+
+func (v HexColorValidator) Description(_ context.Context) string {
+	return "string value must be a valid hex color code, for example #1a73e8, #fff, or #1a73e8ff"
+}
+
+func (v HexColorValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v HexColorValidator) ValidateString(
+	_ context.Context,
+	request validator.StringRequest,
+	response *validator.StringResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+	if !hexColorRegexp.MatchString(value) {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Invalid Hex Color",
+			"Attribute "+request.Path.String()+" must be a valid hex color code, "+
+				"for example #1a73e8, #fff, or #1a73e8ff, got: "+value,
+		)
+	}
+}
+
+// HexColor returns a validator that ensures a string is a valid hex color code.
+func HexColor() HexColorValidator {
+	return HexColorValidator{}
+}

--- a/utils/validators/hex_color_validator_test.go
+++ b/utils/validators/hex_color_validator_test.go
@@ -1,0 +1,64 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package validators_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/HPE/terraform-provider-hpe/utils/validators"
+)
+
+// TestHexColor exercises the HexColor validator directly, covering valid hex
+// forms, skipped null/unknown values, and invalid input that must be rejected
+// with an attribute error.
+func TestUnitHexColor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name      string
+		value     types.String
+		wantError bool
+	}{
+		{"valid six digit", types.StringValue("#1a73e8"), false},
+		{"valid three digit", types.StringValue("#fff"), false},
+		{"valid four digit alpha", types.StringValue("#abcd"), false},
+		{"valid eight digit alpha", types.StringValue("#1a73e8ff"), false},
+		{"valid uppercase", types.StringValue("#ABCDEF"), false},
+		{"null skipped", types.StringNull(), false},
+		{"unknown skipped", types.StringUnknown(), false},
+		{"invalid word", types.StringValue("not-a-color"), true},
+		{"invalid named", types.StringValue("red"), true},
+		{"invalid missing hash", types.StringValue("1a73e8"), true},
+		{"invalid too short", types.StringValue("#12"), true},
+		{"invalid non hex", types.StringValue("#12345g"), true},
+		{"invalid empty", types.StringValue(""), true},
+		{"invalid rgb", types.StringValue("rgb(0,0,0)"), true},
+	}
+
+	v := validators.HexColor()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := validator.StringRequest{
+				Path:        path.Root("primary_color"),
+				ConfigValue: tc.value,
+			}
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, req, resp)
+
+			if got := resp.Diagnostics.HasError(); got != tc.wantError {
+				t.Fatalf("value %v: got error=%v, want error=%v (diagnostics: %v)",
+					tc.value, got, tc.wantError, resp.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`hpe_morpheus_setting_whitelabel` did not validate the format of `primary_color` and `secondary_color`, so an invalid value such as `"not-a-color"` was silently accepted. This adds plan-time hex-color validation to both attributes.

Fixes MORPH-12346 (`primary_color`) and MORPH-12347 (`secondary_color`).

## Change

Both color attributes now carry a hex-color validator (added via the resource config and regenerated into the schema):

```
^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$
```

- Accepts 3/4/6/8-digit hex, for example `#fff`, `#1a73e8`, `#1a73e8ff`
- Rejects non-hex values (`not-a-color`, `red`, `rgb(...)`, missing `#`, and so on) at plan time, with a clear message

## Tests

- Unit test exercising both validators directly (no live backend), covering valid and invalid forms
- Acceptance tests `TestAccMorpheusSettingWhitelabel_validationInvalidPrimaryColor` / `...InvalidSecondaryColor` asserting the plan-time error

## Verification

- `go build ./...`, `go vet`, `gofmt`, `golangci-lint` — all clean
- Unit tests pass; `make docs` produces no diff