### PR TITLE
MORPH-12421/12420/12566: Fix hpe_morpheus_vdi_pool idle_timeout and max_session_timeout

### DIFF
--- a/docs/resources/morpheus_vdi_pool.md
+++ b/docs/resources/morpheus_vdi_pool.md
@@ -44,7 +44,7 @@ resource "hpe_morpheus_vdi_pool" "example" {
 - `idle_timeout` (Number) The idle timeout in minutes.
 - `initial_pool_size` (Number) The initial size of the pool to be allocated on creation.
 - `max_idle` (Number) Sets the maximum number of idle instances on standby in the pool.
-- `max_session_timeout` (Number) The maximum session timeout in minutes.
+- `max_session_timeout` (Number, Deprecated) Deprecated and non-functional: not backed by the Morpheus API. The value is retained in Terraform state only and will be removed in a future release.
 - `min_idle` (Number) Sets the minimum number of idle instances on standby in the pool.
 - `persistent_user` (Boolean) Whether users are persistent across sessions.
 - `recyclable` (Boolean) Whether VDI pool instances are recyclable.

--- a/morpheus/framework/resources/vdipool/resource.go
+++ b/morpheus/framework/resources/vdipool/resource.go
@@ -96,7 +96,11 @@ func (r *vdiPoolResource) Create(ctx context.Context, req resource.CreateRequest
 		v := float32(plan.MaxIdle.ValueInt64())
 		oneOf.MaxIdle = &v
 	}
-	if !plan.IdleTimeout.IsNull() {
+	// idle_timeout is Optional+Computed: when the practitioner omits it the plan
+	// value is unknown, so only send it when a concrete value was configured.
+	// Otherwise Morpheus applies its own default and the read-back stays
+	// consistent.
+	if !plan.IdleTimeout.IsNull() && !plan.IdleTimeout.IsUnknown() {
 		v := float32(plan.IdleTimeout.ValueInt64())
 		oneOf.AllocationTimeoutMinutes = &v
 	}
@@ -162,6 +166,10 @@ func (r *vdiPoolResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	// max_session_timeout is not backed by the Morpheus API (deprecated); retain
+	// the planned value in state rather than round-tripping it through the API.
+	state.MaxSessionTimeout = plan.MaxSessionTimeout
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -182,6 +190,10 @@ func (r *vdiPoolResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 		return
 	}
+
+	// max_session_timeout is not backed by the Morpheus API (deprecated); keep
+	// the existing value from prior state rather than round-tripping it.
+	model.MaxSessionTimeout = state.MaxSessionTimeout
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
@@ -249,7 +261,7 @@ func (r *vdiPoolResource) Update(ctx context.Context, req resource.UpdateRequest
 		v := float32(plan.InitialPoolSize.ValueInt64())
 		body.InitialPoolSize = &v
 	}
-	if !plan.IdleTimeout.IsNull() {
+	if !plan.IdleTimeout.IsNull() && !plan.IdleTimeout.IsUnknown() {
 		v := float32(plan.IdleTimeout.ValueInt64())
 		body.AllocationTimeoutMinutes = &v
 	}
@@ -268,6 +280,10 @@ func (r *vdiPoolResource) Update(ctx context.Context, req resource.UpdateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// max_session_timeout is not backed by the Morpheus API (deprecated); retain
+	// the planned value in state rather than round-tripping it through the API.
+	state.MaxSessionTimeout = plan.MaxSessionTimeout
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/morpheus/framework/resources/vdipool/schema_gen.go
+++ b/morpheus/framework/resources/vdipool/schema_gen.go
@@ -5,9 +5,11 @@ package vdipool
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -68,8 +70,12 @@ func VdiPoolResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"idle_timeout": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				Description:         "The idle timeout in minutes.",
 				MarkdownDescription: "The idle timeout in minutes.",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 			},
 			"initial_pool_size": schema.Int64Attribute{
 				Optional:            true,
@@ -90,8 +96,9 @@ func VdiPoolResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"max_session_timeout": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "The maximum session timeout in minutes.",
-				MarkdownDescription: "The maximum session timeout in minutes.",
+				Description:         "Deprecated and non-functional: not backed by the Morpheus API. The value is retained in Terraform state only and will be removed in a future release.",
+				MarkdownDescription: "Deprecated and non-functional: not backed by the Morpheus API. The value is retained in Terraform state only and will be removed in a future release.",
+				DeprecationMessage:  "max_session_timeout is not backed by the Morpheus API and has no effect; the value is retained in Terraform state only and will be removed in a future release.",
 			},
 			"min_idle": schema.Int64Attribute{
 				Optional:            true,

--- a/specs/resources/vdi_pool/config.yaml
+++ b/specs/resources/vdi_pool/config.yaml
@@ -3,12 +3,18 @@ vdi_pool:
   templates:
     idle_timeout:
       int64:
-        computed_optional_required: optional
+        computed_optional_required: computed_optional
         description: The idle timeout in minutes.
+        validators:
+        - custom:
+            imports:
+              - path: github.com/hashicorp/terraform-plugin-framework-validators/int64validator
+            schema_definition: int64validator.AtLeast(0)
     max_session_timeout:
       int64:
         computed_optional_required: optional
-        description: The maximum session timeout in minutes.
+        description: "Deprecated and non-functional: not backed by the Morpheus API. The value is retained in Terraform state only and will be removed in a future release."
+        deprecation_message: "max_session_timeout is not backed by the Morpheus API and has no effect; the value is retained in Terraform state only and will be removed in a future release."
   moves:
     - vdi_pool: ""
     - template-idle_timeout: idle_timeout
@@ -67,7 +73,7 @@ vdi_pool:
       description: The ID of the VDI pool.
       state_for_unknown: true
     idle_timeout:
-      computed_optional_required: optional
+      computed_optional_required: computed_optional
       description: The idle timeout in minutes.
     initial_pool_size:
       computed_optional_required: computed_optional
@@ -80,7 +86,7 @@ vdi_pool:
       description: Max limit on number of allocations and instances within the pool.
     max_session_timeout:
       computed_optional_required: optional
-      description: The maximum session timeout in minutes.
+      description: "Deprecated and non-functional: not backed by the Morpheus API. The value is retained in Terraform state only and will be removed in a future release."
     min_idle:
       computed_optional_required: computed_optional
       description: Sets the minimum number of idle instances on standby in the pool.


### PR DESCRIPTION
## What

Fixes three read-after-apply / validation issues on the `hpe_morpheus_vdi_pool` resource.

| Ticket | Attribute | Fix |
|---|---|---|
| MORPH-12421 | `idle_timeout` | `Optional` -> `Optional+Computed`; only sent on create/update when a concrete value is configured (guards the unknown plan value) |
| MORPH-12566 | `idle_timeout` | added `int64validator.AtLeast(0)` so negatives are rejected (`0` still allowed) |
| MORPH-12420 | `max_session_timeout` | deprecated; value retained from plan/state rather than round-tripped through the API |

## Why

- **`idle_timeout` (MORPH-12421):** as `Optional`-only, omitting it produced `Provider produced inconsistent result after apply: .idle_timeout was null, but now cty.NumberIntVal(10)` because Morpheus applies a default of 10. Making it `Optional+Computed` lets the provider surface that default without an inconsistency; the create/update guard avoids sending `0` for an unknown planned value so Morpheus still applies its own default.
- **`idle_timeout` negatives (MORPH-12566):** a negative lease timeout is invalid, so the provider now rejects it at plan time (`0` remains allowed).
- **`max_session_timeout` (MORPH-12420):** there is no corresponding field on the VDI pool API, so any configured value read back as `null` and failed apply. The attribute is deprecated (it has no effect) and its value is now retained from plan/state so it no longer triggers an inconsistency; it will be removed in a future release.

## Changes

- `specs/resources/vdi_pool/config.yaml` — codegen source of truth; the schema is regenerated from this.
- `morpheus/framework/resources/vdipool/schema_gen.go` — regenerated.
- `morpheus/framework/resources/vdipool/resource.go` — create/update unknown-guard for `idle_timeout`; `max_session_timeout` retained from plan (create/update) and prior state (read).
- `docs/resources/morpheus_vdi_pool.md` — regenerated.

## Testing

- `go build ./...` — clean
- `golangci-lint run ./morpheus/framework/resources/vdipool/...` — 0 issues
- vdi_pool test package compiles
- `make docs` — only `morpheus_vdi_pool.md` changed
- Acceptance tests (`TestAccMorpheusVdiPool_*`) require a live appliance and were not run here