### PR TITLE
Modifying Network Group test and reintroducing import for tenants/resourcePermissions

### DIFF
--- a/morpheus/framework/resources/networkgroup/resource.go
+++ b/morpheus/framework/resources/networkgroup/resource.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -181,6 +183,10 @@ func (r *networkGroupResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	// Detect import: ImportState sets only id; name is null.
+	// On normal refresh, name is always a known string from prior state.
+	isImport := state.Name.IsNull()
+
 	id := state.Id.ValueInt64()
 
 	result, httpResp, err := client.NetworksAPI.GetNetworkGroup(ctx, id).Execute()
@@ -203,13 +209,23 @@ func (r *networkGroupResource) Read(ctx context.Context, req resource.ReadReques
 	}
 	mapResponseToModel(&state, group)
 
-	// tenant_ids and resource_permissions are config-managed (Optional) and are
-	// not populated from the API response: mapResponseToModel leaves them
-	// untouched so they carry forward from prior state on a normal refresh. On
-	// import there is no prior state, so they remain null and the user
-	// re-declares them in config to manage them. This keeps create, refresh and
-	// import symmetric (avoids ImportStateVerify drift from API-assigned
-	// defaults such as the owner tenant).
+	// mapResponseToModel never touches tenant_ids or resource_permissions, so on
+	// a normal refresh those fields carry forward from the prior state naturally.
+	// On import there is no prior state, so we explicitly populate them from the
+	// API response. Note: the API always injects the owner (root) tenant into the
+	// Tenants slice on GET; the import state will therefore contain an extra entry
+	// in tenant_ids that was not present in the apply state when the user's config
+	// does not include the owner tenant. The acceptance test uses
+	// ImportStateVerifyIgnore for these fields accordingly.
+	if isImport {
+		tenantSet, tenantDiags := networkGroupTenantIdsFromAPI(group.Tenants)
+		resp.Diagnostics.Append(tenantDiags...)
+		state.TenantIds = tenantSet
+
+		rpVal, rpDiags := networkGroupResourcePermissionsFromAPI(group.ResourcePermission)
+		resp.Diagnostics.Append(rpDiags...)
+		state.ResourcePermissions = rpVal
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -370,4 +386,69 @@ func mapResponseToModel(model *NetworkGroupModel, group *sdk.GetNetworkGroup200R
 	if group.Active != nil {
 		model.Active = types.BoolValue(*group.Active)
 	}
+}
+
+// networkGroupTenantIdsFromAPI converts the Tenants slice from a GET response
+// into the types.Set used by the Terraform model. Used only on import.
+func networkGroupTenantIdsFromAPI(
+	tenants []sdk.GetNetworkGroup200ResponseNetworkGroupTenantsInner,
+) (types.Set, diag.Diagnostics) {
+	vals := make([]attr.Value, 0, len(tenants))
+	for _, t := range tenants {
+		if t.Id != nil {
+			vals = append(vals, types.Int64Value(*t.Id))
+		}
+	}
+
+	return types.SetValue(types.Int64Type, vals)
+}
+
+// networkGroupResourcePermissionsFromAPI converts the ResourcePermission object
+// from a GET response into the ResourcePermissionsValue used by the Terraform
+// model. Used only on import.
+func networkGroupResourcePermissionsFromAPI(
+	rp *sdk.GetNetworkGroup200ResponseNetworkGroupResourcePermission,
+) (ResourcePermissionsValue, diag.Diagnostics) {
+	if rp == nil {
+		return NewResourcePermissionsValueNull(), nil
+	}
+
+	var diags diag.Diagnostics
+
+	siteVals := make([]attr.Value, 0, len(rp.Sites))
+	for _, s := range rp.Sites {
+		if s.Id != nil {
+			siteVals = append(siteVals, types.Int64Value(*s.Id))
+		}
+	}
+
+	planVals := make([]attr.Value, 0, len(rp.Plans))
+	for _, p := range rp.Plans {
+		if p.Id != nil {
+			planVals = append(planVals, types.Int64Value(*p.Id))
+		}
+	}
+
+	groupIdsList, listDiags := types.ListValue(types.Int64Type, siteVals)
+	diags.Append(listDiags...)
+	planIdsList, planDiags := types.ListValue(types.Int64Type, planVals)
+	diags.Append(planDiags...)
+
+	val, rpDiags := NewResourcePermissionsValue(
+		map[string]attr.Type{
+			"all":       types.BoolType,
+			"all_plans": types.BoolType,
+			"group_ids": types.ListType{ElemType: types.Int64Type},
+			"plan_ids":  types.ListType{ElemType: types.Int64Type},
+		},
+		map[string]attr.Value{
+			"all":       types.BoolPointerValue(rp.All),
+			"all_plans": types.BoolPointerValue(rp.AllPlans.Get()),
+			"group_ids": groupIdsList,
+			"plan_ids":  planIdsList,
+		},
+	)
+	diags.Append(rpDiags...)
+
+	return val, diags
 }

--- a/morpheus/framework/resources/networkgroup/resource_test.go
+++ b/morpheus/framework/resources/networkgroup/resource_test.go
@@ -64,7 +64,13 @@ func TestAccMorpheusNetworkGroupResourceExampleOk(t *testing.T) {
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				ResourceName:      "hpe_morpheus_network_group.example",
+				// The API always injects the owner (root) tenant into the Tenants
+				// slice on GET, so the import state contains an extra entry in
+				// tenant_ids that was not present in the apply state. resource_permissions
+				// may similarly include API-assigned defaults. All other attributes
+				// (name, description, visibility, active, id) must still round-trip.
+				ImportStateVerifyIgnore: []string{"tenant_ids", "resource_permissions"},
+				ResourceName:            "hpe_morpheus_network_group.example",
 			},
 		},
 	})


### PR DESCRIPTION
A previous acceptance test fix PR removed the import only functionality of tenants and resource permissions population as it caused acceptance tests to fail when performing  the `ImportStateVerify` check - as what is set in state did not align with what was imported.

This is resolved in a similar manner in this PR as it is handled in datastore, what this implementation was based off, by ignoring `tenant_ids` and `resource_permissions` as part of the `ImportStateVerify` check:

```go
func TestAccMorpheusDatastoreResourceExampleOk(t *testing.T) {
  {
    ImportState: true,
    // Don't verify state after import as tenants list will have an extra entry for root tenant
    ImportStateVerify: false,
    ResourceName:      "hpe_morpheus_datastore.example",
    // Check that the root tenant is added upon import
    Check: checkFnImport,
  },
```

Here, we are a little more specific in excluding just tenant_ids and resource permissions from the import check. 


All network group acceptance tests have been ran to verify the solution:
```
=== RUN   TestAccMorpheusNetworkGroupResourceExampleOk
=== PAUSE TestAccMorpheusNetworkGroupResourceExampleOk
=== RUN   TestAccMorpheusNetworkGroupResourceUpdateOk
=== PAUSE TestAccMorpheusNetworkGroupResourceUpdateOk
=== CONT  TestAccMorpheusNetworkGroupResourceExampleOk
=== CONT  TestAccMorpheusNetworkGroupResourceUpdateOk
--- PASS: TestAccMorpheusNetworkGroupResourceExampleOk (1.92s)
--- PASS: TestAccMorpheusNetworkGroupResourceUpdateOk (2.47s)
PASS
ok  	github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkgroup	4.195s
```