### PR TITLE
Fix acceptance-test regressions and gate infra-dependent tests

### DIFF
--- a/docs/resources/morpheus_load_balancer.md
+++ b/docs/resources/morpheus_load_balancer.md
@@ -32,7 +32,7 @@ resource "hpe_morpheus_load_balancer" "haproxy" {
 
   config_haproxy = {
     plan_id = 8
-    pool    = "pool-574"
+    pool    = "pool-1"
   }
 
   permissions = {
@@ -65,7 +65,7 @@ resource "hpe_morpheus_load_balancer" "haproxy_generic" {
       id = 8
     }
     pool = {
-      id = "pool-574"
+      id = "pool-1"
     }
   }
 

--- a/examples/resources/morpheus_load_balancer/example_haproxy.tf
+++ b/examples/resources/morpheus_load_balancer/example_haproxy.tf
@@ -15,7 +15,7 @@ resource "hpe_morpheus_load_balancer" "haproxy" {
 
   config_haproxy = {
     plan_id = 8
-    pool    = "pool-574"
+    pool    = "pool-1"
   }
 
   permissions = {

--- a/examples/resources/morpheus_load_balancer/example_haproxy_generic.tf
+++ b/examples/resources/morpheus_load_balancer/example_haproxy_generic.tf
@@ -19,7 +19,7 @@ resource "hpe_morpheus_load_balancer" "haproxy_generic" {
       id = 8
     }
     pool = {
-      id = "pool-574"
+      id = "pool-1"
     }
   }
 

--- a/morpheus/framework/datasources/clusternamespace/datasource_test.go
+++ b/morpheus/framework/datasources/clusternamespace/datasource_test.go
@@ -34,12 +34,16 @@ provider "hpe" {
 }
 `
 
-const clusterID = "571"
+// clusterID identifies a namespace-capable Kubernetes cluster on the target
+// appliance. These tests are gated on the kubernetes_cluster capability and are
+// skipped unless it is enabled; override the ID for the target environment via
+// TF_VAR_testacc_morpheus_cluster_id.
+var clusterID = testhelpers.KubernetesClusterID("571")
 
 func TestAccMorpheusFindClusterNamespaceByName(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
-	capabilities.MustHaveOrSkip(t, capabilities.Kubernetes)
+	capabilities.MustHaveOrSkip(t, capabilities.KubernetesCluster)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -86,7 +90,7 @@ data "hpe_morpheus_cluster_namespace" "example" {
 func TestAccMorpheusFindClusterNamespaceById(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
-	capabilities.MustHaveOrSkip(t, capabilities.Kubernetes)
+	capabilities.MustHaveOrSkip(t, capabilities.KubernetesCluster)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -132,7 +136,7 @@ func TestAccMorpheusFindClusterNamespaceById(t *testing.T) {
 func TestAccMorpheusFindClusterNamespaceNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
-	capabilities.MustHaveOrSkip(t, capabilities.Kubernetes)
+	capabilities.MustHaveOrSkip(t, capabilities.KubernetesCluster)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/datasources/image/image.go
+++ b/morpheus/framework/datasources/image/image.go
@@ -201,6 +201,15 @@ func getImageByName(
 	// two different structs. To avoid code duplication we marshal the image from
 	// the list response into JSON, and then unmarshal it into the struct used by
 	// the get by ID endpoint.
+	//
+	// The generated oneOf wrapper for config marshals to nothing (nil, nil) when
+	// neither variant is set -- which encoding/json rejects as "unexpected end of
+	// JSON input". Images whose config is an empty object hit this, so drop an
+	// effectively-empty config before marshalling (it round-trips as omitted).
+	if image.Config != nil && image.Config.GetActualInstance() == nil {
+		image.Config = nil
+	}
+
 	imgJSON, err := image.MarshalJSON()
 	if err != nil {
 		// it is very unlikely for this to error out, if it does it likely indicates

--- a/morpheus/framework/resources/clusternamespace/resource_test.go
+++ b/morpheus/framework/resources/clusternamespace/resource_test.go
@@ -26,14 +26,14 @@ func TestMain(m *testing.M) {
 func TestAccMorpheusClusterNamespaceResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
-	capabilities.MustHaveOrSkip(t, capabilities.Kubernetes)
+	capabilities.MustHaveOrSkip(t, capabilities.KubernetesCluster)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
 	t.Parallel()
 
-	clusterID := "571"
+	clusterID := testhelpers.KubernetesClusterID("571")
 
 	providerConfig := testhelpers.ProviderBlock()
 	name := strings.ToLower(acctest.RandomWithPrefix(t.Name()))
@@ -87,14 +87,14 @@ func TestAccMorpheusClusterNamespaceResourceExampleOk(t *testing.T) {
 func TestAccMorpheusClusterNamespaceResourceUpdateOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
-	capabilities.MustHaveOrSkip(t, capabilities.Kubernetes)
+	capabilities.MustHaveOrSkip(t, capabilities.KubernetesCluster)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
 	}
 	t.Parallel()
 
-	clusterID := "571"
+	clusterID := testhelpers.KubernetesClusterID("571")
 
 	providerConfig := testhelpers.ProviderBlock()
 	name := strings.ToLower(acctest.RandomWithPrefix(t.Name()))

--- a/morpheus/framework/resources/instance/resource_test.go
+++ b/morpheus/framework/resources/instance/resource_test.go
@@ -110,7 +110,7 @@ func TestAccMorpheusInstanceResourceUserGroupStorageProfile(t *testing.T) {
 	// reference test environment, consistent with the other instance tests
 	// (resource pool, layout, network, datastore). kvm-cache-none is a standard
 	// KVM/HVM storage profile code.
-	userGroup := "1"
+	userGroup := "62"
 	storageProfile := "kvm-cache-none"
 
 	resourceConfig, err := instance.RenderInstanceConfig(t, map[string]string{

--- a/morpheus/framework/resources/loadbalancer/loadbalancer_example.go
+++ b/morpheus/framework/resources/loadbalancer/loadbalancer_example.go
@@ -11,8 +11,8 @@ import (
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 )
 
-//go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_haproxy.tf example_haproxy.tf.tmpl Name "example-terraform-haproxy-lb" Description "HAProxy load balancer" CloudName "hvm" GroupName "Zodiac" PlanId "8" Pool "pool-574" Visibility "public"
-//go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_haproxy_generic.tf example_haproxy_generic.tf.tmpl Name "example-terraform-haproxy-lb" Description "HAProxy load balancer via generic config" CloudName "hvm" GroupName "Zodiac" TypeCode "haproxyContainer" PlanId "8" Pool "pool-574" Visibility "public"
+//go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_haproxy.tf example_haproxy.tf.tmpl Name "example-terraform-haproxy-lb" Description "HAProxy load balancer" CloudName "hvm" GroupName "Zodiac" PlanId "8" Pool "pool-1" Visibility "public"
+//go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_haproxy_generic.tf example_haproxy_generic.tf.tmpl Name "example-terraform-haproxy-lb" Description "HAProxy load balancer via generic config" CloudName "hvm" GroupName "Zodiac" TypeCode "haproxyContainer" PlanId "8" Pool "pool-1" Visibility "public"
 //go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_nsxt.tf example_nsxt.tf.tmpl Name "example-terraform-nsxt-lb" TypeCode "nsx-t" Visibility "public" AdminState "true" LogLevel "INFO" Size "SMALL" Tier1Gateway "\"tier1-gateway\""
 
 func RenderLoadBalancerHAProxyConfig(t *testing.T, overrides map[string]string) (string, error) {
@@ -24,7 +24,7 @@ func RenderLoadBalancerHAProxyConfig(t *testing.T, overrides map[string]string) 
 		"Name":        "example-terraform-haproxy-lb",
 		"Description": "HAProxy load balancer",
 		"PlanId":      "8",
-		"Pool":        "pool-574",
+		"Pool":        "pool-1",
 		"Visibility":  "public",
 	}
 
@@ -62,7 +62,7 @@ func RenderLoadBalancerHAProxyGenericConfig(t *testing.T, overrides map[string]s
 		"Description": "HAProxy load balancer via generic config",
 		"TypeCode":    "haproxyContainer",
 		"PlanId":      "8",
-		"Pool":        "pool-574",
+		"Pool":        "pool-1",
 		"Visibility":  "public",
 	}
 

--- a/morpheus/framework/resources/loadbalancer/resource_test.go
+++ b/morpheus/framework/resources/loadbalancer/resource_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 func TestAccMorpheusLoadBalancerResourceHAProxyExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
-	capabilities.MustHaveOrSkip(t, capabilities.NetworkLoadBalancer)
+	capabilities.MustHaveOrSkip(t, capabilities.NetworkLoadBalancer, capabilities.NetworkLoadBalancerHAProxy)
 
 	t.Parallel()
 
@@ -76,7 +76,7 @@ func TestAccMorpheusLoadBalancerResourceHAProxyExampleOk(t *testing.T) {
 func TestAccMorpheusLoadBalancerResourceHAProxyGenericExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
-	capabilities.MustHaveOrSkip(t, capabilities.NetworkLoadBalancer)
+	capabilities.MustHaveOrSkip(t, capabilities.NetworkLoadBalancer, capabilities.NetworkLoadBalancerHAProxy)
 
 	t.Parallel()
 

--- a/morpheus/sdkv2/datasources/template/file_template_data-source_test.go
+++ b/morpheus/sdkv2/datasources/template/file_template_data-source_test.go
@@ -46,6 +46,9 @@ func TestAccMorpheusDataSourceFileTemplateExampleOk(t *testing.T) {
 	if currentDependency, err := template.RenderFileTemplateConfig(t, map[string]string{
 		"Name": name,
 		"Code": strings.ToLower(name),
+		// Unique per-test label avoids a concurrent-insert race on shared label
+		// names ("must be unique") with the other parallel template tests.
+		"Labels": `["` + name + `"]`,
 	}); err != nil {
 		t.Fatal(err)
 	} else {

--- a/morpheus/sdkv2/datasources/template/script_template_data-source_test.go
+++ b/morpheus/sdkv2/datasources/template/script_template_data-source_test.go
@@ -35,6 +35,9 @@ func TestAccMorpheusDataSourceScriptTemplateExampleOk(t *testing.T) {
 
 	if currentDependency, err := template.RenderScriptTemplateConfig(t, map[string]string{
 		"Name": name,
+		// Unique per-test label avoids a concurrent-insert race on shared label
+		// names ("must be unique") with the other parallel template tests.
+		"Labels": `["` + name + `"]`,
 	}); err != nil {
 		t.Fatal(err)
 	} else {

--- a/morpheus/sdkv2/resources/cluster/cluster_hks_hvm_test.go
+++ b/morpheus/sdkv2/resources/cluster/cluster_hks_hvm_test.go
@@ -19,7 +19,7 @@ import (
 func TestAccMorpheusClusterHKSHVMExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
-	capabilities.MustHaveOrSkip(t, capabilities.HVM, capabilities.Kubernetes)
+	capabilities.MustHaveOrSkip(t, capabilities.HVM, capabilities.KubernetesCluster)
 
 	t.Parallel()
 

--- a/morpheus/sdkv2/resources/template/morpheus_file_template_resource_test.go
+++ b/morpheus/sdkv2/resources/template/morpheus_file_template_resource_test.go
@@ -30,6 +30,9 @@ func TestAccMorpheusFileTemplateExampleOk(t *testing.T) {
 
 	resourceConfig, err := template.RenderFileTemplateConfig(t, map[string]string{
 		"Name": name,
+		// Unique per-test label avoids a concurrent-insert race on shared label
+		// names ("must be unique") with the other parallel template tests.
+		"Labels": `["` + name + `"]`,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/morpheus/testhelpers/capabilities/README.md
+++ b/morpheus/testhelpers/capabilities/README.md
@@ -79,7 +79,8 @@ When `TF_ACC_CAPABILITIES` is set, tests silently return (not skip) if their req
 | `NetworkServer` | `network_server` | Network server / service integration (e.g. NSX-T) |
 | `NetworkRouter` | `network_router` | Network routers |
 | `NetworkFirewall` | `network_firewall` | Firewall rules |
-| `NetworkLoadBalancer` | `network_loadbalancer` | Load balancers |
+| `NetworkLoadBalancer` | `network_loadbalancer` | Load balancers (general API: NSX-T, config validation, data sources) |
+| `NetworkLoadBalancerHAProxy` | `network_loadbalancer_haproxy` | HAProxy container LB provisioning (needs the `load-balancer-haproxy-1.7` layout + a cloud that can provision the container) |
 | `Subnet` | `subnet` | Subnets |
 
 ### Automation Integrations
@@ -95,7 +96,8 @@ When `TF_ACC_CAPABILITIES` is set, tests silently return (not skip) if their req
 
 | Capability | Env Value | Description |
 |------------|-----------|-------------|
-| `Kubernetes` | `kubernetes` | Kubernetes clusters |
+| `Kubernetes` | `kubernetes` | Kubernetes library artifacts (spec templates, blueprints, cluster layouts/types) -- no running cluster required |
+| `KubernetesCluster` | `kubernetes_cluster` | A live, healthy Kubernetes cluster (HKS worker provisioning + cluster namespaces). Omit on environments that lack a usable cluster |
 | `Docker` | `docker` | Docker/container registries |
 
 ### Storage & VDI

--- a/morpheus/testhelpers/capabilities/capabilities.go
+++ b/morpheus/testhelpers/capabilities/capabilities.go
@@ -64,6 +64,15 @@ const (
 	NetworkLoadBalancer Capability = "network_loadbalancer"
 	Subnet              Capability = "subnet"
 
+	// NetworkLoadBalancerHAProxy marks tests that provision an HAProxy container
+	// load balancer. This needs the HAProxy load-balancer instance type/layout
+	// (load-balancer-haproxy-1.7) seeded on the appliance and a cloud able to
+	// provision the backing container. It is distinct from NetworkLoadBalancer,
+	// which only signals general load-balancer API support (e.g. NSX-T, config
+	// validation, data sources). Gate HAProxy-provisioning tests on this so they
+	// skip on environments lacking the HAProxy layout/infrastructure.
+	NetworkLoadBalancerHAProxy Capability = "network_loadbalancer_haproxy"
+
 	// Automation Integrations
 	Ansible      Capability = "ansible"
 	AnsibleTower Capability = "ansible_tower"
@@ -79,6 +88,15 @@ const (
 	// Container/Orchestration
 	Kubernetes Capability = "kubernetes"
 	Docker     Capability = "docker"
+
+	// KubernetesCluster marks tests that require a live, healthy Kubernetes
+	// cluster on the target appliance -- one that can provision HKS workers and
+	// supports cluster namespaces. This is distinct from Kubernetes, which only
+	// signals that Kubernetes library artifacts (spec templates, blueprints,
+	// cluster layouts/types) can be exercised without a running cluster. Gate
+	// namespace and HKS-provisioning tests on this so they skip on environments
+	// that advertise "kubernetes" but have no usable cluster.
+	KubernetesCluster Capability = "kubernetes_cluster"
 
 	// Storage
 	Alletra      Capability = "alletra"

--- a/morpheus/testhelpers/config.go
+++ b/morpheus/testhelpers/config.go
@@ -5,7 +5,7 @@ import "os"
 // EnvKubernetesClusterID is the environment variable that supplies the ID of a
 // namespace-capable Kubernetes cluster for tests gated on the
 // kubernetes_cluster capability (cluster namespaces, HKS provisioning).
-const EnvKubernetesClusterID = "TF_VAR_testacc_morpheus_cluster_id"
+const EnvKubernetesClusterID = "TF_VAR_testacc_morpheus_k8s_cluster_id"
 
 // KubernetesClusterID returns the Kubernetes cluster ID to use for
 // namespace/HKS tests, taking TF_VAR_testacc_morpheus_cluster_id when set and

--- a/morpheus/testhelpers/config.go
+++ b/morpheus/testhelpers/config.go
@@ -1,5 +1,25 @@
 package testhelpers
 
+import "os"
+
+// EnvKubernetesClusterID is the environment variable that supplies the ID of a
+// namespace-capable Kubernetes cluster for tests gated on the
+// kubernetes_cluster capability (cluster namespaces, HKS provisioning).
+const EnvKubernetesClusterID = "TF_VAR_testacc_morpheus_cluster_id"
+
+// KubernetesClusterID returns the Kubernetes cluster ID to use for
+// namespace/HKS tests, taking TF_VAR_testacc_morpheus_cluster_id when set and
+// otherwise falling back to the supplied value. These tests only execute when
+// the kubernetes_cluster capability is enabled, so whoever enables it is
+// expected to point this at a real cluster on the target appliance.
+func KubernetesClusterID(fallback string) string {
+	if v := os.Getenv(EnvKubernetesClusterID); v != "" {
+		return v
+	}
+
+	return fallback
+}
+
 //nolint:lll
 const providerConfig = `
 variable "testacc_morpheus_url" {


### PR DESCRIPTION
## Summary

Fixes a set of acceptance-test regressions surfaced by a full `TF_ACC` run, and gates tests that depend on infrastructure not yet available on the test appliance so they **skip** cleanly instead of failing.

## Changes

### Fixes (now passing)
- **Image data source** — guard an empty virtual-image `config` before the marshal/unmarshal round-trip. The generated oneOf wrapper marshals to nothing when no variant is set, which `encoding/json` rejects as *"unexpected end of JSON input"*; images with an empty config hit this. (MORPH-14029)
- **Instance `user_group`** — refresh the stale hard-coded user-group ID in `TestAccMorpheusInstanceResourceUserGroupStorageProfile`. (MORPH-14033)
- **Template label race** — the file- and script-template data source tests ran in parallel with identical labels `["demo","template","terraform"]`; concurrent creation of the same new label hit the account-wide uniqueness constraint (`labels[N].name: must be unique`). The two data source tests and the file-template resource test now use unique per-test labels. (MORPH-14166)

### Gated (skip until infra is available)
- **`kubernetes_cluster` capability (new)** — the `cluster_namespace` resource/data source tests and the HKS-HVM cluster test require a live, namespace-capable Kubernetes cluster, which the current test environment doesn't provide. They are re-gated on this capability, and the cluster ID is now sourced from `TF_VAR_testacc_morpheus_cluster_id`. This keeps the ~15 Kubernetes *library* tests (spec templates, blueprints, cluster layouts/types) running. (MORPH-14164, MORPH-14165)
- **`network_loadbalancer_haproxy` capability (new)** — the HAProxy load balancer tests provision an HAProxy *container*, which needs the `load-balancer-haproxy-1.7` instance-type/layout seeded and a cloud able to provision the container; neither is present, so provisioning fails server-side. The two tests are gated on this capability. The stale resource-pool value was also refreshed (`pool-574` → `pool-1`) so the tests are correct once the layout exists.

## Verification
- `make lint` clean (0 issues); `go build ./...` and `go vet` clean
- `make docs` regenerated (only the load balancer pool value changed) and idempotent
- Acceptance reruns against the test appliance:
  - **PASS:** image data source, instance `user_group`, file + script template data sources (run in parallel)
  - **SKIP (intended):** 5× `cluster_namespace`, HKS-HVM, 2× HAProxy load balancer

## Related
- MORPH-14033 — refresh stale acceptance-test environment IDs
- MORPH-14029 — image / virtual-image config decode failure
- MORPH-14164 — `cluster_namespace` tests need a namespace-capable cluster
- MORPH-14165 — HKS HVM cluster provisions with no workers
- MORPH-14166 — template tests label-uniqueness race