### PR TITLE
fix MORPH-12561 - Mark hpe_morpheus_vdi_app launch_prefix as required

### DIFF
--- a/docs/resources/morpheus_vdi_app.md
+++ b/docs/resources/morpheus_vdi_app.md
@@ -23,12 +23,12 @@ resource "hpe_morpheus_vdi_app" "example" {
 
 ### Required
 
+- `launch_prefix` (String) The RDS app name prefix.
 - `name` (String) The name of the VDI app.
 
 ### Optional
 
 - `description` (String) The description of the VDI app.
-- `launch_prefix` (String) The RDS app name prefix.
 
 ### Read-Only
 

--- a/morpheus/framework/resources/vdiapp/resource.go
+++ b/morpheus/framework/resources/vdiapp/resource.go
@@ -55,10 +55,10 @@ func (r *vdiAppResource) Create(ctx context.Context, req resource.CreateRequest,
 	body := sdk.AddVDIAppsRequestVdiAppOneOf{
 		Name: plan.Name.ValueString(),
 	}
-	if !plan.Description.IsNull() {
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		body.Description = plan.Description.ValueStringPointer()
 	}
-	if !plan.LaunchPrefix.IsNull() {
+	if !plan.LaunchPrefix.IsNull() && !plan.LaunchPrefix.IsUnknown() {
 		body.LaunchPrefix = plan.LaunchPrefix.ValueStringPointer()
 	}
 
@@ -161,10 +161,10 @@ func (r *vdiAppResource) Update(ctx context.Context, req resource.UpdateRequest,
 	body := sdk.UpdateVDIAppsRequestVdiAppOneOf{
 		Name: plan.Name.ValueStringPointer(),
 	}
-	if !plan.Description.IsNull() {
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		body.Description = plan.Description.ValueStringPointer()
 	}
-	if !plan.LaunchPrefix.IsNull() {
+	if !plan.LaunchPrefix.IsNull() && !plan.LaunchPrefix.IsUnknown() {
 		body.LaunchPrefix = plan.LaunchPrefix.ValueStringPointer()
 	}
 

--- a/morpheus/framework/resources/vdiapp/schema_gen.go
+++ b/morpheus/framework/resources/vdiapp/schema_gen.go
@@ -29,7 +29,7 @@ func VdiAppResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"launch_prefix": schema.StringAttribute{
-				Optional:            true,
+				Required:            true,
 				Description:         "The RDS app name prefix.",
 				MarkdownDescription: "The RDS app name prefix.",
 			},

--- a/specs/resources/vdi_app/config.yaml
+++ b/specs/resources/vdi_app/config.yaml
@@ -19,7 +19,7 @@ vdi_app:
       description: The ID of the VDI app.
       state_for_unknown: true
     launch_prefix:
-      computed_optional_required: optional
+      computed_optional_required: required
       description: The RDS app name prefix.
     name:
       computed_optional_required: required


### PR DESCRIPTION
## Summary

The Morpheus API requires a launch prefix when creating a VDI app, but the `hpe_morpheus_vdi_app` schema and docs listed `launch_prefix` as **optional**. A config supplying only `name` therefore failed at apply time with a runtime error:

```
vdi_app "..." failed: 400 (Bad Request):
{"success":false,"errors":{"launchPrefix":"launchPrefix is required"}}
```

This change marks `launch_prefix` as **required** so the mismatch surfaces at `terraform validate`/plan time with a clear message, instead of a confusing 400 during apply.

## Changes

- Mark `launch_prefix` as required in the `vdi_app` resource schema (`config.yaml` + regenerated `schema_gen.go`).
- Regenerate `docs/resources/morpheus_vdi_app.md` (moves `launch_prefix` to the Required section).
- Guard optional create/update fields against unknown values.

## Testing

- `go build ./...`
- `make lint` (0 issues)
- `make docs` leaves a clean tree (DocsDiff gate)
- Existing acceptance tests already supply `launch_prefix`; a `name`-only config now fails fast at plan time as intended.

Resolves MORPH-12561.