### PR TITLE
MORPH-13276 - Fix os_type_image inconsistent os_type_id after apply

### DIFF
--- a/docs/resources/morpheus_os_type_image.md
+++ b/docs/resources/morpheus_os_type_image.md
@@ -49,3 +49,10 @@ OS type images can be imported using the `id`, e.g.
 ```bash
 terraform import hpe_morpheus_os_type_image.example 123
 ```
+
+~> On import, `os_type_id` cannot be read back from the Morpheus API — the
+`GET` os type image endpoint does not return the OS type. It is instead
+derived on a best-effort basis from the associated virtual image's own
+`os_type_id`. If that virtual image has no OS type set, or a different one,
+`os_type_id` may be imported as null or an incorrect value. Verify and set
+`os_type_id` explicitly in your configuration after importing.

--- a/morpheus/framework/resources/ostypeimage/resource.go
+++ b/morpheus/framework/resources/ostypeimage/resource.go
@@ -87,10 +87,6 @@ func getOsTypeImageAsState(
 		state.ProvisionTypeId = types.Int64Value(*provisionType)
 	}
 
-	if img.VirtualImageId == nil {
-		return state, diags
-	}
-
 	// os_type_id is not returned by the GET osTypeImage endpoint. It is a
 	// Required, RequiresReplace attribute, so when the value is already known
 	// (create/read) we preserve it rather than deriving it from the virtual
@@ -99,6 +95,11 @@ func getOsTypeImageAsState(
 	if !knownOsTypeId.IsNull() && !knownOsTypeId.IsUnknown() {
 		state.OsTypeId = knownOsTypeId
 
+		return state, diags
+	}
+
+	// The virtual-image fallback (import only) dereferences VirtualImageId.
+	if img.VirtualImageId == nil {
 		return state, diags
 	}
 

--- a/morpheus/framework/resources/ostypeimage/resource.go
+++ b/morpheus/framework/resources/ostypeimage/resource.go
@@ -47,11 +47,15 @@ func (r *Resource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *r
 }
 
 // getOsTypeImageAsState reads the remote object and maps it to the Terraform model.
-// It fetches the os_type_image record, then looks up the associated virtual image
-// to extract the OsTypeId from virtualImage.osType.id.
+// It fetches the os_type_image record. The os_type_id is not returned by that
+// endpoint, so when its value is already known (create/read) the caller passes it
+// in via knownOsTypeId and it is preserved. Only during import (where it is
+// unknown) is it derived best-effort from the associated virtual image's
+// virtualImage.osType.id.
 func getOsTypeImageAsState(
 	ctx context.Context,
 	id int64,
+	knownOsTypeId types.Int64,
 	client *sdk.APIClient,
 ) (OsTypeImageModel, diag.Diagnostics) {
 	var state OsTypeImageModel
@@ -84,6 +88,17 @@ func getOsTypeImageAsState(
 	}
 
 	if img.VirtualImageId == nil {
+		return state, diags
+	}
+
+	// os_type_id is not returned by the GET osTypeImage endpoint. It is a
+	// Required, RequiresReplace attribute, so when the value is already known
+	// (create/read) we preserve it rather than deriving it from the virtual
+	// image's osType, which is optional (nullable) and independent of the
+	// association. The virtual-image fallback below only runs during import.
+	if !knownOsTypeId.IsNull() && !knownOsTypeId.IsUnknown() {
+		state.OsTypeId = knownOsTypeId
+
 		return state, diags
 	}
 
@@ -182,7 +197,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	state, diags := getOsTypeImageAsState(ctx, createResp.ID, client)
+	state, diags := getOsTypeImageAsState(ctx, createResp.ID, plan.OsTypeId, client)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		cleanup.TaintResourceState(ctx, cleanup.TaintResourceStateConfig{
@@ -213,7 +228,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	}
 
 	id := current.Id.ValueInt64()
-	state, diags := getOsTypeImageAsState(ctx, id, client)
+	state, diags := getOsTypeImageAsState(ctx, id, current.OsTypeId, client)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/templates/resources/morpheus_os_type_image.md.tmpl
+++ b/templates/resources/morpheus_os_type_image.md.tmpl
@@ -27,3 +27,10 @@ OS type images can be imported using the `id`, e.g.
 ```bash
 terraform import hpe_morpheus_os_type_image.example 123
 ```
+
+~> On import, `os_type_id` cannot be read back from the Morpheus API — the
+`GET` os type image endpoint does not return the OS type. It is instead
+derived on a best-effort basis from the associated virtual image's own
+`os_type_id`. If that virtual image has no OS type set, or a different one,
+`os_type_id` may be imported as null or an incorrect value. Verify and set
+`os_type_id` explicitly in your configuration after importing.


### PR DESCRIPTION
## Summary

Fixes a "Provider produced inconsistent result after apply" error on `hpe_morpheus_os_type_image`, where `os_type_id` (a required attribute) collapsed from its configured value to `null` after apply.

## Root cause

The read logic derived `os_type_id` from the associated virtual image's own `osType.id`. That field is optional (nullable) and independent of the os_type_image association — the API's `GET` os type image endpoint does not return the OS type at all. When the virtual image had no OS type set (e.g. a plain qcow2 image), the derived value was `null`, diverging from the configured value and failing the apply.

## Fix

- Preserve the already-known `os_type_id` from plan (create) / prior state (read) instead of re-deriving it from the virtual image.
- The virtual-image-derived fallback now runs only during import, where the value is otherwise unknown.
- Document the import limitation: on import `os_type_id` cannot be reliably recovered from the API and should be verified/set explicitly.

## Testing

- `go build`, `go vet`, and `golangci-lint` pass clean.
- Existing acceptance tests: `TestAccMorpheusOsTypeImageResourceExampleOk`, `TestAccMorpheusOsTypeImageResourceRequiredAttrsOk`.
- Docs regenerated via `make docs`.

## Jira

- https://hpe.atlassian.net/browse/MORPH-13276

