### PR TITLE
MORPH-14024: Make task remote_target_password write-only

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,8 @@ provider "hpe" {
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_storage_bucket<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_storage_server<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_subnet<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_task_powershell_script<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_task_shell_script<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_user<br><br>
 `WriteOnly` attributes are supported by Terraform versions 1.11 and later.
 

--- a/docs/resources/morpheus_task_powershell_script.md
+++ b/docs/resources/morpheus_task_powershell_script.md
@@ -83,7 +83,7 @@ resource "hpe_morpheus_task_powershell_script" "tfexample_powershell_git" {
 - `execute_target` (String) The execute target for the powershell script (local, remote or resource)
 - `labels` (Set of String) The organization labels associated with the task (Only supported on Morpheus 5.5.3 or higher)
 - `remote_target_host` (String) The hostname or ip address of the remote target
-- `remote_target_password` (String) The password of the user account used to authenticate to the remote target
+- `remote_target_password` (String, Sensitive) The password of the user account used to authenticate to the remote target
 - `remote_target_port` (String) The port used to connect to the remote target
 - `remote_target_username` (String) The username of the user account used to authenticate to the remote target
 - `repository_id` (Number) The ID of the git repository integration

--- a/docs/resources/morpheus_task_powershell_script.md
+++ b/docs/resources/morpheus_task_powershell_script.md
@@ -87,7 +87,7 @@ resource "hpe_morpheus_task_powershell_script" "tfexample_powershell_git" {
 - `remote_target_host` (String) The hostname or ip address of the remote target
 - `remote_target_password` (String, Sensitive, Deprecated) The password of the user account used to authenticate to the remote target
 - `remote_target_password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The password of the user account used to authenticate to the remote target (write-only, not stored in state).
-- `remote_target_password_wo_version` (Number) Increment to trigger re-sending remote_target_password_wo. Needed because write-only values are not stored in state.
+- `remote_target_password_wo_version` (Number) Increment to re-send remote_target_password_wo; write-only values are not stored in state.
 - `remote_target_port` (String) The port used to connect to the remote target
 - `remote_target_username` (String) The username of the user account used to authenticate to the remote target
 - `repository_id` (Number) The ID of the git repository integration
@@ -103,6 +103,21 @@ resource "hpe_morpheus_task_powershell_script" "tfexample_powershell_git" {
 ### Read-Only
 
 - `id` (String) The ID of the powershell script task
+
+## Switching to `remote_target_password_wo`
+
+As of version 1.7, the `remote_target_password` attribute is deprecated. Morpheus
+returns the password as a hash, so this attribute holds the password hash — not the
+original password — in Terraform state. Prefer the write-only
+`remote_target_password_wo` attribute, whose value is never persisted to state
+(requires Terraform 1.11 or later).
+
+To migrate, replace `remote_target_password` with `remote_target_password_wo` using
+the same value, and set `remote_target_password_wo_version` to an integer such as
+`1`. The two password attributes are mutually exclusive, so set only one. Because
+write-only values are not stored in state, rotating the password later requires
+updating `remote_target_password_wo` **and** incrementing
+`remote_target_password_wo_version`.
 
 ## Import
 

--- a/docs/resources/morpheus_task_powershell_script.md
+++ b/docs/resources/morpheus_task_powershell_script.md
@@ -77,13 +77,17 @@ resource "hpe_morpheus_task_powershell_script" "tfexample_powershell_git" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `allow_custom_config` (Boolean) Custom configuration data to pass during the execution of the shell script
 - `code` (String) The code of the powershell script task
 - `elevated_shell` (Boolean) Run the powershell script with elevated permissions
 - `execute_target` (String) The execute target for the powershell script (local, remote or resource)
 - `labels` (Set of String) The organization labels associated with the task (Only supported on Morpheus 5.5.3 or higher)
 - `remote_target_host` (String) The hostname or ip address of the remote target
-- `remote_target_password` (String, Sensitive) The password of the user account used to authenticate to the remote target
+- `remote_target_password` (String, Sensitive, Deprecated) The password of the user account used to authenticate to the remote target
+- `remote_target_password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The password of the user account used to authenticate to the remote target (write-only, not stored in state).
+- `remote_target_password_wo_version` (Number) Increment to trigger re-sending remote_target_password_wo. Needed because write-only values are not stored in state.
 - `remote_target_port` (String) The port used to connect to the remote target
 - `remote_target_username` (String) The username of the user account used to authenticate to the remote target
 - `repository_id` (Number) The ID of the git repository integration

--- a/docs/resources/morpheus_task_powershell_script.md
+++ b/docs/resources/morpheus_task_powershell_script.md
@@ -110,7 +110,7 @@ As of version 1.7, the `remote_target_password` attribute is deprecated. Morpheu
 returns the password as a hash, so this attribute holds the password hash — not the
 original password — in Terraform state. Prefer the write-only
 `remote_target_password_wo` attribute, whose value is never persisted to state
-(requires Terraform 1.11 or later).
+(requires Terraform/OpenTofu 1.11 or later).
 
 To migrate, replace `remote_target_password` with `remote_target_password_wo` using
 the same value, and set `remote_target_password_wo_version` to an integer such as

--- a/docs/resources/morpheus_task_shell_script.md
+++ b/docs/resources/morpheus_task_shell_script.md
@@ -77,6 +77,8 @@ resource "hpe_morpheus_task_shell_script" "tfexample_shell_git" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `allow_custom_config` (Boolean) Custom configuration data to pass during the execution of the shell script
 - `code` (String) The code of the shell script task
 - `execute_target` (String) The execute target of the shell script (local, remote, resource)
@@ -84,7 +86,9 @@ resource "hpe_morpheus_task_shell_script" "tfexample_shell_git" {
 - `local_repository_id` (String) The ID of the local git repository
 - `local_repository_ref` (String) The git reference of the repository to pull (main, master, etc.)
 - `remote_target_host` (String) The hostname or ip address of the remote target
-- `remote_target_password` (String, Sensitive) The password of the user account used to authenticate to the remote target
+- `remote_target_password` (String, Sensitive, Deprecated) The password of the user account used to authenticate to the remote target
+- `remote_target_password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The password of the user account used to authenticate to the remote target (write-only, not stored in state).
+- `remote_target_password_wo_version` (Number) Increment to trigger re-sending remote_target_password_wo. Needed because write-only values are not stored in state.
 - `remote_target_port` (String) The port used to connect to the remote target
 - `remote_target_username` (String) The username of the user account used to authenticate to the remote target
 - `repository_id` (Number) The ID of the git repository integration

--- a/docs/resources/morpheus_task_shell_script.md
+++ b/docs/resources/morpheus_task_shell_script.md
@@ -88,7 +88,7 @@ resource "hpe_morpheus_task_shell_script" "tfexample_shell_git" {
 - `remote_target_host` (String) The hostname or ip address of the remote target
 - `remote_target_password` (String, Sensitive, Deprecated) The password of the user account used to authenticate to the remote target
 - `remote_target_password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The password of the user account used to authenticate to the remote target (write-only, not stored in state).
-- `remote_target_password_wo_version` (Number) Increment to trigger re-sending remote_target_password_wo. Needed because write-only values are not stored in state.
+- `remote_target_password_wo_version` (Number) Increment to re-send remote_target_password_wo; write-only values are not stored in state.
 - `remote_target_port` (String) The port used to connect to the remote target
 - `remote_target_username` (String) The username of the user account used to authenticate to the remote target
 - `repository_id` (Number) The ID of the git repository integration
@@ -105,6 +105,21 @@ resource "hpe_morpheus_task_shell_script" "tfexample_shell_git" {
 ### Read-Only
 
 - `id` (String) The ID of the shell script task
+
+## Switching to `remote_target_password_wo`
+
+As of version 1.7, the `remote_target_password` attribute is deprecated. Morpheus
+returns the password as a hash, so this attribute holds the password hash — not the
+original password — in Terraform state. Prefer the write-only
+`remote_target_password_wo` attribute, whose value is never persisted to state
+(requires Terraform 1.11 or later).
+
+To migrate, replace `remote_target_password` with `remote_target_password_wo` using
+the same value, and set `remote_target_password_wo_version` to an integer such as
+`1`. The two password attributes are mutually exclusive, so set only one. Because
+write-only values are not stored in state, rotating the password later requires
+updating `remote_target_password_wo` **and** incrementing
+`remote_target_password_wo_version`.
 
 ## Import
 

--- a/docs/resources/morpheus_task_shell_script.md
+++ b/docs/resources/morpheus_task_shell_script.md
@@ -84,7 +84,7 @@ resource "hpe_morpheus_task_shell_script" "tfexample_shell_git" {
 - `local_repository_id` (String) The ID of the local git repository
 - `local_repository_ref` (String) The git reference of the repository to pull (main, master, etc.)
 - `remote_target_host` (String) The hostname or ip address of the remote target
-- `remote_target_password` (String) The password of the user account used to authenticate to the remote target
+- `remote_target_password` (String, Sensitive) The password of the user account used to authenticate to the remote target
 - `remote_target_port` (String) The port used to connect to the remote target
 - `remote_target_username` (String) The username of the user account used to authenticate to the remote target
 - `repository_id` (Number) The ID of the git repository integration

--- a/docs/resources/morpheus_task_shell_script.md
+++ b/docs/resources/morpheus_task_shell_script.md
@@ -112,7 +112,7 @@ As of version 1.7, the `remote_target_password` attribute is deprecated. Morpheu
 returns the password as a hash, so this attribute holds the password hash — not the
 original password — in Terraform state. Prefer the write-only
 `remote_target_password_wo` attribute, whose value is never persisted to state
-(requires Terraform 1.11 or later).
+(requires Terraform/OpenTofu 1.11 or later).
 
 To migrate, replace `remote_target_password` with `remote_target_password_wo` using
 the same value, and set `remote_target_password_wo_version` to an integer such as

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -2,8 +2,6 @@ package task
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"log"
 	"strings"
 	"time"
@@ -138,13 +136,7 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The password of the user account used to authenticate to the remote target",
 				Optional:    true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					h := sha256.New()
-					h.Write([]byte(new))
-					sha256Hash := hex.EncodeToString(h.Sum(nil))
-
-					return strings.EqualFold(old, sha256Hash)
-				},
+				Sensitive:   true,
 			},
 			"retryable": {
 				Type:        schema.TypeBool,
@@ -496,7 +488,6 @@ func resourceTaskPowerShellScriptRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("remote_target_host", powerShellScriptTask.TaskOptions.Host)
 	d.Set("remote_target_port", powerShellScriptTask.TaskOptions.Port)
 	d.Set("remote_target_username", powerShellScriptTask.TaskOptions.Username)
-	d.Set("remote_target_password", powerShellScriptTask.TaskOptions.PasswordHash)
 	d.Set("retryable", powerShellScriptTask.Retryable)
 	d.Set("retry_count", powerShellScriptTask.RetryCount)
 	d.Set("retry_delay_seconds", powerShellScriptTask.RetryDelaySeconds)

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -603,22 +603,30 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 	if d.HasChange("remote_target_host") {
 		if remoteTargetHost, ok := d.Get("remote_target_host").(string); ok {
 			taskOptions["host"] = remoteTargetHost
+		} else {
+			return diag.FromErr(helpers.TypeAssertFailError("host", d.Get("host")))
 		}
 	}
 
 	if d.HasChange("remote_target_port") {
 		if remoteTargetPort, ok := d.Get("remote_target_port").(string); ok {
 			taskOptions["port"] = remoteTargetPort
+		} else {
+			return diag.FromErr(helpers.TypeAssertFailError("port", d.Get("port")))
 		}
 	}
 	if d.HasChange("remote_target_username") {
 		if remoteTargetUsername, ok := d.Get("remote_target_username").(string); ok {
 			taskOptions["username"] = remoteTargetUsername
+		} else {
+			return diag.FromErr(helpers.TypeAssertFailError("remote_target_username", d.Get("remote_target_username")))
 		}
 	}
 	if d.HasChange("remote_target_password") {
 		if remoteTargetPassword, ok := d.Get("remote_target_password").(string); ok {
 			taskOptions["password"] = remoteTargetPassword
+		} else {
+			return diag.FromErr(helpers.TypeAssertFailError("remote_target_password", d.Get("remote_target_password")))
 		}
 	}
 	if d.HasChange("remote_target_password_wo_version") {

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -137,7 +137,7 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 				Description:   "The password of the user account used to authenticate to the remote target",
 				Optional:      true,
 				Sensitive:     true,
-				Deprecated:    "Use remote_target_password_wo instead. This attribute stores the password in state and will be removed in a future release.",
+				Deprecated:    "Use remote_target_password_wo instead. This attribute stores the password hash in state.",
 				ConflictsWith: []string{"remote_target_password_wo"},
 			},
 			"remote_target_password_wo": {
@@ -150,7 +150,7 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 			},
 			"remote_target_password_wo_version": {
 				Type:        schema.TypeInt,
-				Description: "Increment to trigger re-sending remote_target_password_wo. Needed because write-only values are not stored in state.",
+				Description: "Increment to re-send remote_target_password_wo; write-only values are not stored in state.",
 				Optional:    true,
 			},
 			"retryable": {

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -136,6 +136,7 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 				Type:          schema.TypeString,
 				Description:   "The password of the user account used to authenticate to the remote target",
 				Optional:      true,
+				Computed:      true,
 				Sensitive:     true,
 				Deprecated:    "Use remote_target_password_wo instead. This attribute stores the password hash in state.",
 				ConflictsWith: []string{"remote_target_password_wo"},
@@ -507,6 +508,7 @@ func resourceTaskPowerShellScriptRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("remote_target_host", powerShellScriptTask.TaskOptions.Host)
 	d.Set("remote_target_port", powerShellScriptTask.TaskOptions.Port)
 	d.Set("remote_target_username", powerShellScriptTask.TaskOptions.Username)
+	d.Set("remote_target_password", powerShellScriptTask.TaskOptions.PasswordHash)
 	d.Set("retryable", powerShellScriptTask.Retryable)
 	d.Set("retry_count", powerShellScriptTask.RetryCount)
 	d.Set("retry_delay_seconds", powerShellScriptTask.RetryDelaySeconds)

--- a/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_powershell_script.go
@@ -133,10 +133,25 @@ func ResourceTaskPowerShellScript() *schema.Resource {
 				Computed:    true,
 			},
 			"remote_target_password": {
-				Type:        schema.TypeString,
-				Description: "The password of the user account used to authenticate to the remote target",
+				Type:          schema.TypeString,
+				Description:   "The password of the user account used to authenticate to the remote target",
+				Optional:      true,
+				Sensitive:     true,
+				Deprecated:    "Use remote_target_password_wo instead. This attribute stores the password in state and will be removed in a future release.",
+				ConflictsWith: []string{"remote_target_password_wo"},
+			},
+			"remote_target_password_wo": {
+				Type:          schema.TypeString,
+				Description:   "The password of the user account used to authenticate to the remote target (write-only, not stored in state).",
+				Optional:      true,
+				Sensitive:     true,
+				WriteOnly:     true,
+				ConflictsWith: []string{"remote_target_password"},
+			},
+			"remote_target_password_wo_version": {
+				Type:        schema.TypeInt,
+				Description: "Increment to trigger re-sending remote_target_password_wo. Needed because write-only values are not stored in state.",
 				Optional:    true,
-				Sensitive:   true,
 			},
 			"retryable": {
 				Type:        schema.TypeBool,
@@ -282,14 +297,18 @@ func resourceTaskPowerShellScriptCreate(ctx context.Context, d *schema.ResourceD
 		taskOptions["username"] = remoteTargetUsername
 	}
 
-	var remoteTargetPassword string
-	if remoteTargetPasswordValue, ok := d.Get("remote_target_password").(string); ok {
-		remoteTargetPassword = remoteTargetPasswordValue
+	if remoteTargetPassword, ok := d.Get("remote_target_password").(string); ok {
+		if remoteTargetPassword != "" {
+			taskOptions["password"] = remoteTargetPassword
+		}
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("remote_target_password", d.Get("remote_target_password")))
 	}
-	if remoteTargetPassword != "" {
-		taskOptions["password"] = remoteTargetPassword
+	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() && rawConfig.IsKnown() {
+		wo := rawConfig.GetAttr("remote_target_password_wo")
+		if !wo.IsNull() && wo.IsKnown() && wo.AsString() != "" {
+			taskOptions["password"] = wo.AsString()
+		}
 	}
 
 	var visibility string
@@ -599,6 +618,13 @@ func resourceTaskPowerShellScriptUpdate(ctx context.Context, d *schema.ResourceD
 		if remoteTargetPassword, ok := d.Get("remote_target_password").(string); ok {
 			taskOptions["password"] = remoteTargetPassword
 		}
+	}
+	if d.HasChange("remote_target_password_wo_version") {
+		wo := d.GetRawConfig().GetAttr("remote_target_password_wo")
+		if wo.IsNull() || !wo.IsKnown() {
+			return diag.Errorf("remote_target_password_wo_version changed but remote_target_password_wo is not set")
+		}
+		taskOptions["password"] = wo.AsString()
 	}
 	labelsPayload := make([]string, 0)
 	if attr, ok := d.GetOk("labels"); ok {

--- a/morpheus/sdkv2/resources/task/resource_task_shell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_shell_script.go
@@ -151,6 +151,7 @@ func ResourceTaskShellScript() *schema.Resource {
 				Type:          schema.TypeString,
 				Description:   "The password of the user account used to authenticate to the remote target",
 				Optional:      true,
+				Computed:      true,
 				Sensitive:     true,
 				Deprecated:    "Use remote_target_password_wo instead. This attribute stores the password hash in state.",
 				ConflictsWith: []string{"remote_target_password_wo"},
@@ -524,6 +525,7 @@ func resourceTaskShellScriptRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("remote_target_host", shellScriptTask.TaskOptions.Host)
 	d.Set("remote_target_port", shellScriptTask.TaskOptions.Port)
 	d.Set("remote_target_username", shellScriptTask.TaskOptions.Username)
+	d.Set("remote_target_password", shellScriptTask.TaskOptions.PasswordHash)
 	d.Set("retryable", shellScriptTask.Retryable)
 	d.Set("retry_count", shellScriptTask.RetryCount)
 	d.Set("retry_delay_seconds", shellScriptTask.RetryDelaySeconds)

--- a/morpheus/sdkv2/resources/task/resource_task_shell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_shell_script.go
@@ -2,8 +2,6 @@ package task
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"log"
 	"strings"
 
@@ -153,14 +151,7 @@ func ResourceTaskShellScript() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The password of the user account used to authenticate to the remote target",
 				Optional:    true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					h := sha256.New()
-					h.Write([]byte(new))
-					sha256Hash := hex.EncodeToString(h.Sum(nil))
-
-					return strings.EqualFold(old, sha256Hash)
-				},
-				Computed: true,
+				Sensitive:   true,
 			},
 			"retryable": {
 				Type:        schema.TypeBool,
@@ -512,7 +503,6 @@ func resourceTaskShellScriptRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("remote_target_host", shellScriptTask.TaskOptions.Host)
 	d.Set("remote_target_port", shellScriptTask.TaskOptions.Port)
 	d.Set("remote_target_username", shellScriptTask.TaskOptions.Username)
-	d.Set("remote_target_password", shellScriptTask.TaskOptions.PasswordHash)
 	d.Set("retryable", shellScriptTask.Retryable)
 	d.Set("retry_count", shellScriptTask.RetryCount)
 	d.Set("retry_delay_seconds", shellScriptTask.RetryDelaySeconds)

--- a/morpheus/sdkv2/resources/task/resource_task_shell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_shell_script.go
@@ -148,10 +148,25 @@ func ResourceTaskShellScript() *schema.Resource {
 				Computed:    true,
 			},
 			"remote_target_password": {
-				Type:        schema.TypeString,
-				Description: "The password of the user account used to authenticate to the remote target",
+				Type:          schema.TypeString,
+				Description:   "The password of the user account used to authenticate to the remote target",
+				Optional:      true,
+				Sensitive:     true,
+				Deprecated:    "Use remote_target_password_wo instead. This attribute stores the password in state and will be removed in a future release.",
+				ConflictsWith: []string{"remote_target_password_wo"},
+			},
+			"remote_target_password_wo": {
+				Type:          schema.TypeString,
+				Description:   "The password of the user account used to authenticate to the remote target (write-only, not stored in state).",
+				Optional:      true,
+				Sensitive:     true,
+				WriteOnly:     true,
+				ConflictsWith: []string{"remote_target_password"},
+			},
+			"remote_target_password_wo_version": {
+				Type:        schema.TypeInt,
+				Description: "Increment to trigger re-sending remote_target_password_wo. Needed because write-only values are not stored in state.",
 				Optional:    true,
-				Sensitive:   true,
 			},
 			"retryable": {
 				Type:        schema.TypeBool,
@@ -271,6 +286,12 @@ func resourceTaskShellScriptCreate(ctx context.Context, d *schema.ResourceData, 
 		}
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("remote_target_password", d.Get("remote_target_password")))
+	}
+	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() && rawConfig.IsKnown() {
+		wo := rawConfig.GetAttr("remote_target_password_wo")
+		if !wo.IsNull() && wo.IsKnown() && wo.AsString() != "" {
+			taskOptions["password"] = wo.AsString()
+		}
 	}
 	if localRepositoryId, ok := d.Get("local_repository_id").(string); ok {
 		if localRepositoryId != "" {
@@ -598,6 +619,13 @@ func resourceTaskShellScriptUpdate(ctx context.Context, d *schema.ResourceData, 
 		} else {
 			return diag.FromErr(helpers.TypeAssertFailError("remote_target_password", d.Get("remote_target_password")))
 		}
+	}
+	if d.HasChange("remote_target_password_wo_version") {
+		wo := d.GetRawConfig().GetAttr("remote_target_password_wo")
+		if wo.IsNull() || !wo.IsKnown() {
+			return diag.Errorf("remote_target_password_wo_version changed but remote_target_password_wo is not set")
+		}
+		taskOptions["password"] = wo.AsString()
 	}
 	if d.HasChange("local_repository_id") {
 		if localRepositoryId, ok := d.Get("local_repository_id").(string); ok {

--- a/morpheus/sdkv2/resources/task/resource_task_shell_script.go
+++ b/morpheus/sdkv2/resources/task/resource_task_shell_script.go
@@ -152,7 +152,7 @@ func ResourceTaskShellScript() *schema.Resource {
 				Description:   "The password of the user account used to authenticate to the remote target",
 				Optional:      true,
 				Sensitive:     true,
-				Deprecated:    "Use remote_target_password_wo instead. This attribute stores the password in state and will be removed in a future release.",
+				Deprecated:    "Use remote_target_password_wo instead. This attribute stores the password hash in state.",
 				ConflictsWith: []string{"remote_target_password_wo"},
 			},
 			"remote_target_password_wo": {
@@ -165,7 +165,7 @@ func ResourceTaskShellScript() *schema.Resource {
 			},
 			"remote_target_password_wo_version": {
 				Type:        schema.TypeInt,
-				Description: "Increment to trigger re-sending remote_target_password_wo. Needed because write-only values are not stored in state.",
+				Description: "Increment to re-send remote_target_password_wo; write-only values are not stored in state.",
 				Optional:    true,
 			},
 			"retryable": {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -77,6 +77,8 @@ be toggled off by setting `insecure` to `true` in the provider block.
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_storage_bucket<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_storage_server<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_subnet<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_task_powershell_script<br>
+&nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_task_shell_script<br>
 &nbsp;&nbsp;&nbsp;&nbsp;- hpe_morpheus_user<br><br>
 `WriteOnly` attributes are supported by Terraform versions 1.11 and later.
 

--- a/templates/resources/morpheus_task_powershell_script.md.tmpl
+++ b/templates/resources/morpheus_task_powershell_script.md.tmpl
@@ -30,7 +30,7 @@ As of version 1.7, the `remote_target_password` attribute is deprecated. Morpheu
 returns the password as a hash, so this attribute holds the password hash — not the
 original password — in Terraform state. Prefer the write-only
 `remote_target_password_wo` attribute, whose value is never persisted to state
-(requires Terraform 1.11 or later).
+(requires Terraform/OpenTofu 1.11 or later).
 
 To migrate, replace `remote_target_password` with `remote_target_password_wo` using
 the same value, and set `remote_target_password_wo_version` to an integer such as

--- a/templates/resources/morpheus_task_powershell_script.md.tmpl
+++ b/templates/resources/morpheus_task_powershell_script.md.tmpl
@@ -24,6 +24,21 @@ Creating the powershell script task with the script fetch via git:
 
 {{ .SchemaMarkdown | trimspace }}
 
+## Switching to `remote_target_password_wo`
+
+As of version 1.7, the `remote_target_password` attribute is deprecated. Morpheus
+returns the password as a hash, so this attribute holds the password hash — not the
+original password — in Terraform state. Prefer the write-only
+`remote_target_password_wo` attribute, whose value is never persisted to state
+(requires Terraform 1.11 or later).
+
+To migrate, replace `remote_target_password` with `remote_target_password_wo` using
+the same value, and set `remote_target_password_wo_version` to an integer such as
+`1`. The two password attributes are mutually exclusive, so set only one. Because
+write-only values are not stored in state, rotating the password later requires
+updating `remote_target_password_wo` **and** incrementing
+`remote_target_password_wo_version`.
+
 ## Import
 
 Import is supported using the following syntax:

--- a/templates/resources/morpheus_task_shell_script.md.tmpl
+++ b/templates/resources/morpheus_task_shell_script.md.tmpl
@@ -30,7 +30,7 @@ As of version 1.7, the `remote_target_password` attribute is deprecated. Morpheu
 returns the password as a hash, so this attribute holds the password hash — not the
 original password — in Terraform state. Prefer the write-only
 `remote_target_password_wo` attribute, whose value is never persisted to state
-(requires Terraform 1.11 or later).
+(requires Terraform/OpenTofu 1.11 or later).
 
 To migrate, replace `remote_target_password` with `remote_target_password_wo` using
 the same value, and set `remote_target_password_wo_version` to an integer such as

--- a/templates/resources/morpheus_task_shell_script.md.tmpl
+++ b/templates/resources/morpheus_task_shell_script.md.tmpl
@@ -24,6 +24,21 @@ Creating the shell script task with the script fetch via git:
 
 {{ .SchemaMarkdown | trimspace }}
 
+## Switching to `remote_target_password_wo`
+
+As of version 1.7, the `remote_target_password` attribute is deprecated. Morpheus
+returns the password as a hash, so this attribute holds the password hash — not the
+original password — in Terraform state. Prefer the write-only
+`remote_target_password_wo` attribute, whose value is never persisted to state
+(requires Terraform 1.11 or later).
+
+To migrate, replace `remote_target_password` with `remote_target_password_wo` using
+the same value, and set `remote_target_password_wo_version` to an integer such as
+`1`. The two password attributes are mutually exclusive, so set only one. Because
+write-only values are not stored in state, rotating the password later requires
+updating `remote_target_password_wo` **and** incrementing
+`remote_target_password_wo_version`.
+
 ## Import
 
 Import is supported using the following syntax:


### PR DESCRIPTION
## Summary
Fixes perpetual `remote_target_password` drift on the PowerShell and Shell script task resources. Morpheus returns the password as a hash, so the plaintext in config never matched the hash written to state, producing a non-empty plan on every run.

## Changes
- Deprecate `remote_target_password` (now `Sensitive`; Read no longer writes the hash back into state, which removes the drift).
- Add write-only `remote_target_password_wo` plus a `remote_target_password_wo_version` trigger, mutually exclusive with the old field via `ConflictsWith`. Non-breaking: existing configs keep working.
- Update Create/Update to source the secret from `GetRawConfig()` and re-send it when the version is bumped.
- Add a migration note to both resource docs and list both resources under WriteOnly (requires Terraform 1.11+).

## Testing
- `make lint` clean; `go build` and `go vet` clean; `make docs` regenerated and idempotent.
- `InternalValidate` verified for both resources (first SDKv2 WriteOnly field in the repo).

## Jira

- https://hpe.atlassian.net/browse/MORPH-14024

