### PR TITLE
Fix acceptance-test failures for firewall rule group, NAT, and integration data sources

### DIFF
--- a/morpheus/framework/datasources/networkrouternat/datasource_test.go
+++ b/morpheus/framework/datasources/networkrouternat/datasource_test.go
@@ -213,7 +213,9 @@ func natChecks() []resource.TestCheckFunc {
 		resource.TestCheckResourceAttrSet(ds, "id"),
 		resource.TestCheckResourceAttrSet(ds, "router_id"),
 		resource.TestCheckResourceAttrSet(ds, "name"),
-		resource.TestCheckResourceAttrSet(ds, "action"),
+		// action is a create-only input that the NAT read API does not return,
+		// so the data source cannot populate it. Follow-up: revisit whether
+		// action/firewall should remain in the data source schema.
 		resource.TestCheckResourceAttrSet(ds, "enabled"),
 	}
 }

--- a/morpheus/framework/resources/networkfirewallrulegroup/create.go
+++ b/morpheus/framework/resources/networkfirewallrulegroup/create.go
@@ -136,7 +136,11 @@ func (r *Resource) Create(
 	}
 
 	// Preserve plan value: API may silently drop tenant IDs that don't exist.
-	state.TenantIds = plan.TenantIds
+	// When tenant_ids is unset (Optional+Computed) the plan value is unknown;
+	// keep the known value derived from the API read in that case.
+	if !plan.TenantIds.IsUnknown() {
+		state.TenantIds = plan.TenantIds
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/morpheus/framework/resources/networkfirewallrulegroup/update.go
+++ b/morpheus/framework/resources/networkfirewallrulegroup/update.go
@@ -119,7 +119,11 @@ func (r *Resource) Update(
 	}
 
 	// Preserve plan value: API may silently drop tenant IDs that don't exist.
-	state.TenantIds = plan.TenantIds
+	// When tenant_ids is unset (Optional+Computed) the plan value is unknown;
+	// keep the known value derived from the API read in that case.
+	if !plan.TenantIds.IsUnknown() {
+		state.TenantIds = plan.TenantIds
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/morpheus/framework/resources/networkrouternat/resource.go
+++ b/morpheus/framework/resources/networkrouternat/resource.go
@@ -241,8 +241,10 @@ func getNatAsState(
 	// after apply.
 	if p := nat.Protocol.Get(); p != nil {
 		state.Protocol = types.StringValue(*p)
-	} else {
+	} else if !plan.Protocol.IsUnknown() {
 		state.Protocol = plan.Protocol
+	} else {
+		state.Protocol = types.StringNull()
 	}
 
 	// firewall and service are create-time config options. Read them back from

--- a/morpheus/framework/resources/networkrouternat/resource_test.go
+++ b/morpheus/framework/resources/networkrouternat/resource_test.go
@@ -100,7 +100,11 @@ func TestAccMorpheusNetworkRouterNatResourceExampleOk(t *testing.T) {
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				ResourceName:      "hpe_morpheus_network_router_nat.example",
+				// action and firewall are create-only inputs that the NAT read
+				// (GET) API does not return, so they cannot round-trip through
+				// import (verified: only these two differ after import).
+				ImportStateVerifyIgnore: []string{"action", "firewall"},
+				ResourceName:            "hpe_morpheus_network_router_nat.example",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources["hpe_morpheus_network_router_nat.example"]
 					if !ok {

--- a/morpheus/sdkv2/datasources/integration/integration_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/integration_data-source_test.go
@@ -3,9 +3,9 @@
 package integration_test
 
 import (
+	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
@@ -28,12 +28,10 @@ func TestAccMorpheusDataSourceIntegrationExampleOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	name := acctest.RandomWithPrefix(t.Name())
-
 	var dependenciesConfig string
 
 	datasourceConfig, err := dsintegration.RenderIntegrationConfig(t, map[string]string{
-		"Name": name,
+		"Name": strconv.Quote("ansible dev"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/morpheus/sdkv2/datasources/integration/integration_git.go
+++ b/morpheus/sdkv2/datasources/integration/integration_git.go
@@ -93,6 +93,10 @@ func dataSourceIntegrationGitRead(ctx context.Context, d *schema.ResourceData, m
 	}
 	log.Printf("API RESPONSE: %s", resp)
 
+	if resp.Result == nil {
+		return diag.FromErr(helpers.NotFoundInResponseError("Result"))
+	}
+
 	// store resource data
 	var result *morpheus.GetIntegrationResult
 	if v, ok := resp.Result.(*morpheus.GetIntegrationResult); ok {

--- a/morpheus/sdkv2/datasources/integration/integration_git_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/integration_git_data-source_test.go
@@ -3,9 +3,9 @@
 package integration_test
 
 import (
+	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
@@ -28,12 +28,10 @@ func TestAccMorpheusDataSourceIntegrationGitExampleOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	name := acctest.RandomWithPrefix(t.Name())
-
 	var dependenciesConfig string
 
 	datasourceConfig, err := dsintegration.RenderIntegrationGitConfig(t, map[string]string{
-		"Name": name,
+		"Name": strconv.Quote("MorpheusAutomation"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/morpheus/sdkv2/datasources/integration/vro_workflow.go
+++ b/morpheus/sdkv2/datasources/integration/vro_workflow.go
@@ -97,22 +97,35 @@ func dataSourceVROWorkflowRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	var workflow morpheus.OptionSourceOption
+	found := false
 	for i := range allWorkflows {
 		if value == 0 && name != "" {
 			if strings.EqualFold(allWorkflows[i].Name, name) {
 				workflow = allWorkflows[i]
+				found = true
 
 				break
 			}
 		} else if value != 0 {
 			if value == allWorkflows[i].Value {
 				workflow = allWorkflows[i]
+				found = true
 
 				break
 			}
 		} else {
 			return diag.Errorf("vRO workflow cannot be read without name or value")
 		}
+	}
+
+	// Return a clear not-found error instead of failing the value type
+	// assertion below on a zero-valued workflow.
+	if !found {
+		if name != "" {
+			return diag.Errorf("no vRO workflow found named %q", name)
+		}
+
+		return diag.Errorf("no vRO workflow found with value %d", value)
 	}
 
 	// store resource data

--- a/morpheus/sdkv2/datasources/integration/vro_workflow_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/vro_workflow_data-source_test.go
@@ -3,9 +3,9 @@
 package integration_test
 
 import (
+	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	sdkv2morpheus "github.com/HPE/terraform-provider-hpe/morpheus/sdkv2"
@@ -28,12 +28,10 @@ func TestAccMorpheusDataSourceVroWorkflowExampleOk(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
-	name := acctest.RandomWithPrefix(t.Name())
-
 	var dependenciesConfig string
 
 	datasourceConfig, err := dsintegration.RenderVroWorkflowConfig(t, map[string]string{
-		"Name": name,
+		"Name": strconv.Quote("Create an AD Computer Object"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/morpheus/sdkv2/datasources/integration/vro_workflow_data-source_test.go
+++ b/morpheus/sdkv2/datasources/integration/vro_workflow_data-source_test.go
@@ -3,6 +3,7 @@
 package integration_test
 
 import (
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -55,6 +56,40 @@ func TestAccMorpheusDataSourceVroWorkflowExampleOk(t *testing.T) {
 				Config:             providerConfig + dependenciesConfig + datasourceConfig,
 				ExpectNonEmptyPlan: false,
 				Check:              checkFn,
+			},
+		},
+	})
+}
+
+// TestAccMorpheusDataSourceVroWorkflowNotFound verifies that looking up a
+// non-existent vRO workflow returns a clear "not found" diagnostic instead of
+// the previous nil value type-assertion error.
+func TestAccMorpheusDataSourceVroWorkflowNotFound(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	capabilities.MustHaveOrSkip(t, capabilities.VRO)
+
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+
+	datasourceConfig, err := dsintegration.RenderVroWorkflowConfig(t, map[string]string{
+		"Name": strconv.Quote("______nonexistent vRO workflow______"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), sdkv2morpheus.Provider()),
+		Steps: []resource.TestStep{
+			{
+				Config:      providerConfig + datasourceConfig,
+				ExpectError: regexp.MustCompile(`no vRO workflow found named`),
 			},
 		},
 	})


### PR DESCRIPTION
> **Fixes 19 failing Terraform acceptance tests** — 15 in `network_firewall_rule_group` / `network_firewall_rule` and 4 in `network_router_nat` — with no regressions, plus a new not-found regression test for the vRO workflow data source. (Verified across successive acceptance runs.)

---

Fixes a batch of Terraform acceptance-test failures across the network firewall, NAT, and integration areas.

## Changes

### 1. `network_firewall_rule_group` — `tenant_ids` unknown after apply (provider fix)
`tenant_ids` is `Optional + Computed`. When unset in config its plan value is unknown, but Create and Update unconditionally copied the plan value into state — so the attribute stayed unknown after apply and Terraform aborted with *"Provider returned invalid result object after apply … still indicated an unknown value for `tenant_ids`."* Create/Update now preserve the plan value **only when it is known**, otherwise they keep the API-derived value. Unblocks the `network_firewall_rule_group` resource + data source and the dependent `network_firewall_rule` resource + data source (15 tests).

### 2. `network_router_nat` — `protocol` unknown after apply (provider fix)
Same class of issue for the deprecated `protocol` field: fall back to `null` (not the unknown plan value) when the API omits it.

### 3. `network_router_nat` — create-only fields on read-back (test fix)
`action` and `firewall` are create-only inputs that the NAT read (GET) API does not return, so they cannot round-trip. The import step now sets `ImportStateVerifyIgnore` for them, and the data source checks no longer assert `action`. Flips `NatResourceExampleOk`, `FindNat ById`, and `FindNat ByName`. (Follow-up tracked for whether `action`/`firewall` belong in the data source schema.)

### 4. Integration data-source example tests — invalid HCL (test fix)
The Ansible / Git / vRO example data-source tests passed a bare, randomly generated name into a config template that expects a **pre-quoted** value, producing invalid HCL. They now pass the quoted, real integration name each test asserts on. No template changes.

### 5. vRO workflow & git data sources — graceful not-found (provider fix)
The vRO workflow data source failed a nil value type-assertion when a workflow was not found; it now returns a clear `no vRO workflow found named "…"` error, covered by a new `TestAccMorpheusDataSourceVroWorkflowNotFound`. The git integration data source now guards a nil response result, matching the base integration data source.

## Testing
- Local: `gofmt -l`, `go build ./...`, `go vet`, and `go test -short` on the touched packages — all clean.
- Acceptance run: the `tenant_ids` fix (15 tests) and the NAT fixes verified green. The three integration `ExampleOk` data-source tests remain environment-dependent — they require the named integrations/workflow to be seeded — and are tracked separately.

## Notes
- Load balancer failures observed in the same environment are NSX-T edge-node capacity exhaustion (orphaned load balancer services), unrelated to this change.