### PR TITLE
Redact credentials from API traces

### DIFF
--- a/utils/httptrace/httptrace.go
+++ b/utils/httptrace/httptrace.go
@@ -7,16 +7,104 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"regexp"
+	"strings"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var _ http.RoundTripper = TraceRoundTripper{}
 
+const (
+	// EnvEnabled turns API request/response tracing on when set.
+	EnvEnabled = "MORPHEUS_API_HTTPTRACE"
+
+	// EnvShowSecrets disables redaction of credentials in those traces.
+	// #nosec G101 -- environment variable name, not an embedded credential.
+	EnvShowSecrets = "MORPHEUS_API_HTTPTRACE_SHOW_SECRETS"
+)
+
+// redactedValue replaces any secret found in a traced request or response.
+const redactedValue = "[REDACTED]"
+
+var (
+	// Credential-bearing headers. Matched per line against a dumped
+	// request/response, which uses CRLF separators.
+	secretHeaderRE = regexp.MustCompile(
+		`(?im)^(Authorization|Proxy-Authorization|Cookie|Set-Cookie):[^\r\n]*`,
+	)
+
+	// Secrets in form-encoded bodies, e.g. the OAuth password grant
+	// "grant_type=password&username=u&password=p" sent to /oauth/token.
+	secretFormRE = regexp.MustCompile(
+		`(?i)\b(password|client_secret|access_token|refresh_token)=[^&\r\n]*`,
+	)
+
+	// Secrets in JSON bodies, e.g. the token response
+	// {"access_token":"...","refresh_token":"..."}.
+	secretJSONRE = regexp.MustCompile(
+		`(?i)"(password|clientSecret|client_secret|accessToken|access_token` +
+			`|refreshToken|refresh_token)"(\s*:\s*)"[^"]*"`,
+	)
+
+	// showSecretsWarning ensures the clear-text warning is emitted once per
+	// process rather than on every request.
+	showSecretsWarning sync.Once
+)
+
+// IsEnabled reports whether API tracing is turned on.
 func IsEnabled() bool {
-	_, enabled := os.LookupEnv("MORPHEUS_API_HTTPTRACE")
+	_, enabled := os.LookupEnv(EnvEnabled)
 
 	return enabled
+}
+
+// ShowSecrets reports whether credential redaction has been switched off.
+//
+// Redaction is on by default so that traces captured by CI can be published
+// safely. Set MORPHEUS_API_HTTPTRACE_SHOW_SECRETS to an affirmative value
+// (e.g. "1" or "true") to emit raw traces when debugging an authentication
+// problem locally.
+//
+// Unlike IsEnabled, which only tests for presence, an empty or explicitly
+// falsey value keeps redaction on. This is a security control, so an
+// accidentally blank export -- easily produced when a value is threaded
+// through CI tooling -- must not silently expose credentials.
+func ShowSecrets() bool {
+	value, ok := os.LookupEnv(EnvShowSecrets)
+	if !ok {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// Redact removes credentials from a dumped HTTP request or response so that
+// traces can be published safely.
+//
+// Tracing is typically enabled on CI runners whose `go test -json` output is
+// published as a build artifact. Because the dumps include bodies, an
+// appliance password (sent to /oauth/token when the provider authenticates
+// with username/password) and the resulting bearer tokens would otherwise be
+// written to that artifact in clear text.
+//
+// Redaction is skipped entirely when ShowSecrets reports true.
+func Redact(dump string) string {
+	if ShowSecrets() {
+		return dump
+	}
+
+	dump = secretHeaderRE.ReplaceAllString(dump, "$1: "+redactedValue)
+	dump = secretFormRE.ReplaceAllString(dump, "$1="+redactedValue)
+	dump = secretJSONRE.ReplaceAllString(dump, `"$1"$2"`+redactedValue+`"`)
+
+	return dump
 }
 
 func New(
@@ -32,11 +120,19 @@ type TraceRoundTripper struct {
 }
 
 func (t TraceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if ShowSecrets() {
+		showSecretsWarning.Do(func() {
+			tflog.Warn(req.Context(),
+				EnvShowSecrets+" is set: API traces include credentials in "+
+					"clear text. Do not publish this log.")
+		})
+	}
+
 	reqBytes, err := httputil.DumpRequestOut(req, true)
 	if err == nil {
 		tflog.Info(req.Context(),
 			"\n\n->TX\n\n"+
-				string(reqBytes)+
+				Redact(string(reqBytes))+
 				"--\n")
 	} else {
 		msg := fmt.Sprintf("Error tracing request: %v", err)
@@ -52,7 +148,7 @@ func (t TraceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	if err == nil {
 		tflog.Info(req.Context(),
 			"\n\n<-RX\n\n"+
-				string(respBytes)+
+				Redact(string(respBytes))+
 				"\n--\n")
 	} else {
 		msg := fmt.Sprintf("Error tracing response: %v", err)

--- a/utils/httptrace/httptrace_test.go
+++ b/utils/httptrace/httptrace_test.go
@@ -1,0 +1,150 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package httptrace_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/HPE/terraform-provider-hpe/utils/httptrace"
+)
+
+// secret values that must never survive Redact.
+const (
+	secretPassword = "sup3r-s3cret-pw"
+	secretToken    = "abcdef0123456789"
+)
+
+// These tests mutate the environment, so they must not run in parallel.
+
+func TestRedact(t *testing.T) {
+	// Redaction is the default; pin it so an ambient export cannot skew this.
+	t.Setenv(httptrace.EnvShowSecrets, "")
+
+	tests := map[string]struct {
+		dump        string
+		mustNotHave []string
+		mustHave    []string
+	}{
+		"oauth password grant body": {
+			dump: "POST /oauth/token HTTP/1.1\r\n" +
+				"Host: morpheus.example.com\r\n" +
+				"Content-Type: application/x-www-form-urlencoded\r\n" +
+				"\r\n" +
+				"grant_type=password&username=svc@example.com&password=" +
+				secretPassword,
+			mustNotHave: []string{secretPassword},
+			// The non-secret parts of the trace stay intact for debugging.
+			mustHave: []string{"POST /oauth/token", "username=svc@example.com"},
+		},
+		"authorization header": {
+			dump: "GET /api/networks/routers/28 HTTP/1.1\r\n" +
+				"Authorization: Bearer " + secretToken + "\r\n" +
+				"Connection: keep-alive\r\n",
+			mustNotHave: []string{secretToken},
+			mustHave: []string{
+				"GET /api/networks/routers/28",
+				"Connection: keep-alive",
+			},
+		},
+		"token response body": {
+			dump: "HTTP/1.1 200 OK\r\n" +
+				"Content-Type: application/json\r\n" +
+				"\r\n" +
+				`{"access_token":"` + secretToken +
+				`","refresh_token":"` + secretToken + `","expires_in":3600}`,
+			mustNotHave: []string{secretToken},
+			mustHave:    []string{`"expires_in":3600`},
+		},
+		"json password field": {
+			dump:        `{"username":"svc@example.com","password":"` + secretPassword + `"}`,
+			mustNotHave: []string{secretPassword},
+			mustHave:    []string{`"username":"svc@example.com"`},
+		},
+		"set-cookie header": {
+			dump: "HTTP/1.1 200 OK\r\n" +
+				"Set-Cookie: JSESSIONID=" + secretToken + "; Path=/\r\n",
+			mustNotHave: []string{secretToken},
+		},
+		"nothing sensitive is left untouched": {
+			dump:     "GET /api/whoami HTTP/1.1\r\nAccept: application/json\r\n",
+			mustHave: []string{"GET /api/whoami", "Accept: application/json"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := httptrace.Redact(tc.dump)
+
+			for _, secret := range tc.mustNotHave {
+				if strings.Contains(got, secret) {
+					t.Errorf("secret leaked into trace:\n%s", got)
+				}
+			}
+
+			for _, want := range tc.mustHave {
+				if !strings.Contains(got, want) {
+					t.Errorf("expected %q to be preserved, got:\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestShowSecrets(t *testing.T) {
+	tests := map[string]struct {
+		value string
+		set   bool
+		want  bool
+	}{
+		"unset":            {set: false, want: false},
+		"empty":            {value: "", set: true, want: false},
+		"zero":             {value: "0", set: true, want: false},
+		"false":            {value: "false", set: true, want: false},
+		"FALSE mixed case": {value: "FaLsE", set: true, want: false},
+		"no":               {value: "no", set: true, want: false},
+		"off":              {value: "off", set: true, want: false},
+		"whitespace only":  {value: "  ", set: true, want: false},
+		"one":              {value: "1", set: true, want: true},
+		"true":             {value: "true", set: true, want: true},
+		"TRUE mixed case":  {value: "TrUe", set: true, want: true},
+		"yes":              {value: "yes", set: true, want: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(httptrace.EnvShowSecrets, tc.value)
+			} else {
+				// t.Setenv restores the prior value on cleanup, so setting a
+				// falsey value is equivalent to "not requested" here.
+				t.Setenv(httptrace.EnvShowSecrets, "")
+			}
+
+			if got := httptrace.ShowSecrets(); got != tc.want {
+				t.Errorf("ShowSecrets() = %v, want %v (value %q)",
+					got, tc.want, tc.value)
+			}
+		})
+	}
+}
+
+// TestRedactDisabled proves the opt-out returns the dump untouched.
+func TestRedactDisabled(t *testing.T) {
+	t.Setenv(httptrace.EnvShowSecrets, "1")
+
+	dump := "GET /api/whoami HTTP/1.1\r\n" +
+		"Authorization: Bearer " + secretToken + "\r\n"
+
+	if got := httptrace.Redact(dump); got != dump {
+		t.Errorf("expected dump to be returned verbatim, got:\n%s", got)
+	}
+}
+
+func TestIsEnabled(t *testing.T) {
+	t.Setenv(httptrace.EnvEnabled, "true")
+
+	if !httptrace.IsEnabled() {
+		t.Error("IsEnabled() = false, want true when the variable is set")
+	}
+}


### PR DESCRIPTION
API tracing (`MORPHEUS_API_HTTPTRACE`) dumps full HTTP requests and
responses **including bodies** via `httputil.DumpRequestOut(req, true)`, with
no redaction. Those traces are captured in `go test -json` output and kept as
build artifacts, so credentials were being written to logs in clear text:

- the `Authorization: Bearer …` header on every API call, and
- the appliance password, when the provider authenticates with
  username/password and POSTs the credentials to `/oauth/token`, plus the
  `access_token` / `refresh_token` in the response.

## Changes

- Add `Redact()`, applied to both the request and response dumps. It scrubs
  `Authorization` / `Proxy-Authorization` / `Cookie` / `Set-Cookie` headers,
  `password` / `client_secret` / `access_token` / `refresh_token` in
  form-encoded bodies, and the same keys in JSON bodies, replacing each value
  with `[REDACTED]`.
- Add `MORPHEUS_API_HTTPTRACE_SHOW_SECRETS` to disable redaction when
  debugging an authentication problem locally.
- Emit a one-time warning when redaction is disabled.
- Promote the env var names to exported constants (`EnvEnabled`,
  `EnvShowSecrets`).

Non-secret parts of the trace are deliberately preserved (request line,
`username=`, other headers) so traces remain useful for debugging.

### Opt-out semantics

Unlike `IsEnabled()`, which only tests for presence, `ShowSecrets()` requires
an affirmative value. This is a security control, so an accidentally blank
export must not silently expose credentials.

| Value | Redaction |
|---|---|
| unset, `""`, `0`, `false`, `no`, `off` | **on** (default) |
| `1`, `true`, `yes`, any other value | off |

## Testing

- New unit tests: redaction vectors (OAuth password grant, `Authorization`
  header, token response, JSON password, `Set-Cookie`), a 12-case
  `ShowSecrets` matrix, the opt-out path, and `IsEnabled`.
- Verified end-to-end against a live appliance by running an acceptance test
  with tracing enabled: 10 request/response traces captured, `Authorization:
  [REDACTED]`, and the real token appeared **nowhere** in the log. Re-running
  with `MORPHEUS_API_HTTPTRACE_SHOW_SECRETS=true` restored the raw value and
  logged the warning exactly once.
- `make lint` clean (0 issues); `make unit-tests` passes.