### PR TITLE
Fix load balancer sweeper leaks and post-apply contract violations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ docs: build-render-tool
 	go generate ./...
 	cd tools && go generate
 
+# -sweep-allow-failures keeps the run going when an individual sweeper fails.
+# Without it the first failure aborts the whole sweep in map-iteration order,
+# so unrelated resources are left on the appliance and the leak compounds.
 sweep:
 	env TF_ACC_SWEEP_PREFIX=$(SWEEP_PREFIX) \
-	go test -v -tags sweep ./morpheus/testhelpers/sweep/... -sweep=$(SWEEP_SYSTEMS) $(SWEEP_RUN_ARGS)
+	go test -v -tags sweep ./morpheus/testhelpers/sweep/... -sweep=$(SWEEP_SYSTEMS) -sweep-allow-failures $(SWEEP_RUN_ARGS)

--- a/morpheus/framework/resources/loadbalancer/sweep/sweep.go
+++ b/morpheus/framework/resources/loadbalancer/sweep/sweep.go
@@ -36,7 +36,8 @@ func init() {
 			*http.Response,
 			error,
 		) {
-			resp, hresp, err := client.LoadBalancersAPI.ListLoadBalancers(ctx).Execute()
+			resp, hresp, err := client.LoadBalancersAPI.ListLoadBalancers(ctx).
+				Max(testsweep.ListPageSize).Execute()
 			if resp == nil {
 				return nil, hresp, err
 			}
@@ -67,9 +68,14 @@ func init() {
 
 			return hresp, err
 		},
+		// Children must be removed before the load balancer itself: NSX-T
+		// refuses to delete an lb-service that still has pools or profiles
+		// attached.
 		testsweep.WithDependencies[sdk.ListLoadBalancers200ResponseAllOfLoadBalancersInner](
 			"hpe_morpheus_load_balancer_monitor",
 			"hpe_morpheus_load_balancer_virtual_server",
+			"hpe_morpheus_load_balancer_pool",
+			"hpe_morpheus_load_balancer_profile",
 		),
 	)
 

--- a/morpheus/framework/resources/loadbalancer/sweep_import.go
+++ b/morpheus/framework/resources/loadbalancer/sweep_import.go
@@ -7,5 +7,7 @@ package loadbalancer
 import (
 	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/loadbalancer/sweep"
 	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/loadbalancermonitor/sweep"
+	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/loadbalancerpool/sweep"
+	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/loadbalancerprofile/sweep"
 	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/loadbalancervirtualserver/sweep"
 )

--- a/morpheus/framework/resources/loadbalancermonitor/resource_create.go
+++ b/morpheus/framework/resources/loadbalancermonitor/resource_create.go
@@ -271,5 +271,8 @@ func (r *Resource) Create(
 		state.Config = plan.Config
 	}
 
+	// Restore fields the API accepts but does not return.
+	preserveUnreturnedFields(&state, plan)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/morpheus/framework/resources/loadbalancermonitor/resource_read.go
+++ b/morpheus/framework/resources/loadbalancermonitor/resource_read.go
@@ -86,6 +86,9 @@ func (r *Resource) Read(
 		state.Config = data.Config
 	}
 
+	// Restore fields the API accepts but does not return.
+	preserveUnreturnedFields(&state, data)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -189,4 +192,32 @@ func getLoadBalancerMonitorAsState(
 	}
 
 	return state, diags
+}
+
+// preserveUnreturnedFields restores values the API accepts on create/update but
+// does not echo back, so the post-apply state matches the plan (or, on refresh,
+// prior state). Without this the provider reports "Provider produced
+// inconsistent result after apply".
+//
+//   - receive_data: stored as an encrypted string, and an empty value comes
+//     back as null rather than "".
+//   - data_length: only round-tripped for ICMP monitors, so any other monitor
+//     type that sets it always reads back null.
+//
+// Both attributes are Optional+Computed. An unknown prior value is deliberately
+// left alone: it has to be resolved from the API response (or null), never
+// copied, or an unknown would leak into state.
+func preserveUnreturnedFields(
+	state *LoadBalancerMonitorModel,
+	prior LoadBalancerMonitorModel,
+) {
+	if state.ReceiveData.IsNull() &&
+		!prior.ReceiveData.IsNull() && !prior.ReceiveData.IsUnknown() {
+		state.ReceiveData = prior.ReceiveData
+	}
+
+	if state.DataLength.IsNull() &&
+		!prior.DataLength.IsNull() && !prior.DataLength.IsUnknown() {
+		state.DataLength = prior.DataLength
+	}
 }

--- a/morpheus/framework/resources/loadbalancermonitor/resource_read_unit_test.go
+++ b/morpheus/framework/resources/loadbalancermonitor/resource_read_unit_test.go
@@ -1,0 +1,107 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package loadbalancermonitor
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestPreserveUnreturnedFields covers the fields the Morpheus API accepts on
+// create/update but does not echo back: an empty receive_data comes back as
+// null, and data_length is only round-tripped for ICMP monitors. Without the
+// preservation the apply fails with "Provider produced inconsistent result
+// after apply".
+func TestPreserveUnreturnedFields(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		state    LoadBalancerMonitorModel
+		prior    LoadBalancerMonitorModel
+		wantRecv types.String
+		wantLen  types.Int64
+	}{
+		"empty string configured, API returned null": {
+			state: LoadBalancerMonitorModel{
+				ReceiveData: types.StringNull(),
+				DataLength:  types.Int64Null(),
+			},
+			prior: LoadBalancerMonitorModel{
+				ReceiveData: types.StringValue(""),
+				DataLength:  types.Int64Value(0),
+			},
+			wantRecv: types.StringValue(""),
+			wantLen:  types.Int64Value(0),
+		},
+		"non-empty configured, API returned null": {
+			state: LoadBalancerMonitorModel{
+				ReceiveData: types.StringNull(),
+				DataLength:  types.Int64Null(),
+			},
+			prior: LoadBalancerMonitorModel{
+				ReceiveData: types.StringValue("HTTP/1.1 200"),
+				DataLength:  types.Int64Value(56),
+			},
+			wantRecv: types.StringValue("HTTP/1.1 200"),
+			wantLen:  types.Int64Value(56),
+		},
+		"API returned a value: API wins over prior": {
+			state: LoadBalancerMonitorModel{
+				ReceiveData: types.StringValue("from-api"),
+				DataLength:  types.Int64Value(99),
+			},
+			prior: LoadBalancerMonitorModel{
+				ReceiveData: types.StringValue("from-plan"),
+				DataLength:  types.Int64Value(1),
+			},
+			wantRecv: types.StringValue("from-api"),
+			wantLen:  types.Int64Value(99),
+		},
+		"unset by practitioner: unknown prior must not leak into state": {
+			state: LoadBalancerMonitorModel{
+				ReceiveData: types.StringNull(),
+				DataLength:  types.Int64Null(),
+			},
+			prior: LoadBalancerMonitorModel{
+				ReceiveData: types.StringUnknown(),
+				DataLength:  types.Int64Unknown(),
+			},
+			wantRecv: types.StringNull(),
+			wantLen:  types.Int64Null(),
+		},
+		"null prior (import): stays null": {
+			state: LoadBalancerMonitorModel{
+				ReceiveData: types.StringNull(),
+				DataLength:  types.Int64Null(),
+			},
+			prior: LoadBalancerMonitorModel{
+				ReceiveData: types.StringNull(),
+				DataLength:  types.Int64Null(),
+			},
+			wantRecv: types.StringNull(),
+			wantLen:  types.Int64Null(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			state := tc.state
+			preserveUnreturnedFields(&state, tc.prior)
+
+			if !state.ReceiveData.Equal(tc.wantRecv) {
+				t.Errorf("receive_data = %v, want %v", state.ReceiveData, tc.wantRecv)
+			}
+
+			if !state.DataLength.Equal(tc.wantLen) {
+				t.Errorf("data_length = %v, want %v", state.DataLength, tc.wantLen)
+			}
+
+			if state.ReceiveData.IsUnknown() || state.DataLength.IsUnknown() {
+				t.Error("unknown value leaked into state")
+			}
+		})
+	}
+}

--- a/morpheus/framework/resources/loadbalancermonitor/resource_update.go
+++ b/morpheus/framework/resources/loadbalancermonitor/resource_update.go
@@ -251,5 +251,8 @@ func (r *Resource) Update(
 		state.Config = plan.Config
 	}
 
+	// Restore fields the API accepts but does not return.
+	preserveUnreturnedFields(&state, plan)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/morpheus/framework/resources/loadbalancermonitor/sweep/sweep.go
+++ b/morpheus/framework/resources/loadbalancermonitor/sweep/sweep.go
@@ -34,7 +34,8 @@ func init() {
 			*http.Response,
 			error,
 		) {
-			lbResp, hresp, err := client.LoadBalancersAPI.ListLoadBalancers(ctx).Execute()
+			lbResp, hresp, err := client.LoadBalancersAPI.ListLoadBalancers(ctx).
+				Max(testsweep.ListPageSize).Execute()
 			if err != nil {
 				return nil, hresp, err
 			}
@@ -48,7 +49,8 @@ func init() {
 				}
 
 				monResp, _, err := client.LoadBalancersAPI.
-					ListLoadBalancerMonitors(ctx, *lbID).Execute()
+					ListLoadBalancerMonitors(ctx, *lbID).
+					Max(testsweep.ListPageSize).Execute()
 				if err != nil || monResp == nil {
 					continue
 				}

--- a/morpheus/framework/resources/loadbalancerpool/sweep/sweep.go
+++ b/morpheus/framework/resources/loadbalancerpool/sweep/sweep.go
@@ -33,7 +33,8 @@ func init() {
 			*http.Response,
 			error,
 		) {
-			lbResp, hresp, err := client.LoadBalancersAPI.ListLoadBalancers(ctx).Execute()
+			lbResp, hresp, err := client.LoadBalancersAPI.ListLoadBalancers(ctx).
+				Max(testsweep.ListPageSize).Execute()
 			if err != nil {
 				return nil, hresp, err
 			}
@@ -47,7 +48,8 @@ func init() {
 				}
 
 				poolResp, _, err := client.LoadBalancersAPI.
-					ListLoadBalancerPools(ctx, *lbID).Execute()
+					ListLoadBalancerPools(ctx, *lbID).
+					Max(testsweep.ListPageSize).Execute()
 				if err != nil || poolResp == nil {
 					continue
 				}

--- a/morpheus/framework/resources/loadbalancerprofile/read.go
+++ b/morpheus/framework/resources/loadbalancerprofile/read.go
@@ -173,19 +173,17 @@ func getLoadBalancerProfileAsState(
 	// Tags: read from config response
 	state.Tags = readTagsFromConfig(ctx, p.Config, prior.Tags)
 
-	// Config blocks: on a normal refresh, preserve the prior state config block.
-	// The API applies its own config defaults that Terraform did not send (for
-	// example x_forwarded_for defaults to INSERT server-side), so reconstructing
-	// the block on every read would produce a "Provider produced inconsistent
-	// result after apply" error.
-	state.ConfigHttp = prior.ConfigHttp
-	state.ConfigFastTcp = prior.ConfigFastTcp
-	state.ConfigFastUdp = prior.ConfigFastUdp
-	state.ConfigCookiePersistence = prior.ConfigCookiePersistence
-	state.ConfigSourceIpPersistence = prior.ConfigSourceIpPersistence
-	state.ConfigGenericPersistence = prior.ConfigGenericPersistence
-	state.ConfigClientSsl = prior.ConfigClientSsl
-	state.ConfigServerSsl = prior.ConfigServerSsl
+	// Config blocks: preserve every value the practitioner configured, while
+	// resolving any attribute that arrived unknown from the API response.
+	//
+	// Optional+Computed attributes omitted from the configuration are unknown in
+	// the plan. Copying the prior block verbatim would write those unknowns into
+	// state ("Provider returned invalid result object after apply"), whereas
+	// rebuilding it purely from the response would overwrite configured values
+	// with the API's own defaults (for example x_forwarded_for defaults to
+	// INSERT server-side) and produce "Provider produced inconsistent result
+	// after apply". Merging per attribute avoids both.
+	mergeConfigBlocks(ctx, &state, prior, p.Config)
 
 	// On import the prior state has no typed config block (ImportState only sets
 	// id and load_balancer_id). Reconstruct the active block from the API

--- a/morpheus/framework/resources/loadbalancerprofile/read_config.go
+++ b/morpheus/framework/resources/loadbalancerprofile/read_config.go
@@ -84,6 +84,343 @@ func nullableInt64ToType(n sdk.NullableInt64) types.Int64 {
 	return types.Int64Null()
 }
 
+// knownOr returns prior when it is known, otherwise the value resolved from the
+// API response.
+//
+// Optional+Computed attributes that the configuration omits arrive as unknown
+// in the plan. They must be resolved before state is written, or Terraform
+// reports "Provider returned invalid result object after apply". Attributes the
+// practitioner did configure are known and are always preserved, so the API's
+// own defaults never overwrite them.
+func knownOr[T attr.Value](prior, fromAPI T) T {
+	if prior.IsUnknown() {
+		return fromAPI
+	}
+
+	return prior
+}
+
+// mergeConfigBlocks writes the typed config_* blocks into state, preserving
+// every value the practitioner configured while resolving any attribute that
+// arrived unknown from the API response.
+//
+// Copying the prior block verbatim would leak the plan's unknown attributes
+// into state; rebuilding it purely from the response would overwrite configured
+// values with the API's own defaults (for example x_forwarded_for defaults to
+// INSERT server-side) and produce "Provider produced inconsistent result after
+// apply". Merging per attribute avoids both failure modes.
+func mergeConfigBlocks(
+	ctx context.Context,
+	state *LoadBalancerProfileModel,
+	prior LoadBalancerProfileModel,
+	cfg *sdk.GetLoadBalancerProfile200ResponseLoadBalancerProfileConfig,
+) {
+	var (
+		httpCfg      *sdk.HTTPLoadBalancerProfileConfig3
+		fastTCPCfg   *sdk.FastTCPLoadBalancerProfileConfig3
+		fastUDPCfg   *sdk.FastUDPLoadBalancerProfileConfig3
+		cookieCfg    *sdk.CookiePersistenceLoadBalancerProfileConfig3
+		sourceIPCfg  *sdk.SourceIPPersistenceLoadBalancerProfileConfig3
+		genericCfg   *sdk.GenericPersistenceLoadBalancerProfileConfig3
+		clientSSLCfg *sdk.ClientSSLLoadBalancerProfileConfig3
+		serverSSLCfg *sdk.ServerSSLLoadBalancerProfileConfig3
+	)
+
+	if cfg != nil {
+		httpCfg = cfg.HTTPLoadBalancerProfileConfig3
+		fastTCPCfg = cfg.FastTCPLoadBalancerProfileConfig3
+		fastUDPCfg = cfg.FastUDPLoadBalancerProfileConfig3
+		cookieCfg = cfg.CookiePersistenceLoadBalancerProfileConfig3
+		sourceIPCfg = cfg.SourceIPPersistenceLoadBalancerProfileConfig3
+		genericCfg = cfg.GenericPersistenceLoadBalancerProfileConfig3
+		clientSSLCfg = cfg.ClientSSLLoadBalancerProfileConfig3
+		serverSSLCfg = cfg.ServerSSLLoadBalancerProfileConfig3
+	}
+
+	state.ConfigHttp = mergeHTTPConfig(ctx, prior.ConfigHttp, httpCfg)
+	state.ConfigFastTcp = mergeFastTCPConfig(prior.ConfigFastTcp, fastTCPCfg)
+	state.ConfigFastUdp = mergeFastUDPConfig(prior.ConfigFastUdp, fastUDPCfg)
+	state.ConfigCookiePersistence = mergeCookiePersistenceConfig(
+		prior.ConfigCookiePersistence, cookieCfg,
+	)
+	state.ConfigSourceIpPersistence = mergeSourceIPPersistenceConfig(
+		prior.ConfigSourceIpPersistence, sourceIPCfg,
+	)
+	state.ConfigGenericPersistence = mergeGenericPersistenceConfig(
+		prior.ConfigGenericPersistence, genericCfg,
+	)
+	state.ConfigClientSsl = mergeClientSSLConfig(prior.ConfigClientSsl, clientSSLCfg)
+	state.ConfigServerSsl = mergeServerSSLConfig(prior.ConfigServerSsl, serverSSLCfg)
+}
+
+func mergeHTTPConfig(
+	ctx context.Context,
+	prior ConfigHttpValue,
+	cfg *sdk.HTTPLoadBalancerProfileConfig3,
+) ConfigHttpValue {
+	if prior.IsNull() {
+		return prior
+	}
+
+	var fromAPI ConfigHttpValue
+	if cfg != nil {
+		fromAPI = httpConfigFromResponse(ctx, cfg)
+	}
+
+	if prior.IsUnknown() {
+		if cfg == nil {
+			return NewConfigHttpValueNull()
+		}
+
+		return fromAPI
+	}
+
+	return ConfigHttpValue{
+		HttpIdleTimeout:    knownOr(prior.HttpIdleTimeout, fromAPI.HttpIdleTimeout),
+		HttpsRedirect:      knownOr(prior.HttpsRedirect, fromAPI.HttpsRedirect),
+		NtlmAuthentication: knownOr(prior.NtlmAuthentication, fromAPI.NtlmAuthentication),
+		RedirectAddress:    knownOr(prior.RedirectAddress, fromAPI.RedirectAddress),
+		RequestBodySize:    knownOr(prior.RequestBodySize, fromAPI.RequestBodySize),
+		RequestHeaderSize:  knownOr(prior.RequestHeaderSize, fromAPI.RequestHeaderSize),
+		ResponseHeaderSize: knownOr(prior.ResponseHeaderSize, fromAPI.ResponseHeaderSize),
+		ResponseTimeout:    knownOr(prior.ResponseTimeout, fromAPI.ResponseTimeout),
+		XForwardedFor:      knownOr(prior.XForwardedFor, fromAPI.XForwardedFor),
+		state:              attr.ValueStateKnown,
+	}
+}
+
+func mergeFastTCPConfig(
+	prior ConfigFastTcpValue,
+	cfg *sdk.FastTCPLoadBalancerProfileConfig3,
+) ConfigFastTcpValue {
+	if prior.IsNull() {
+		return prior
+	}
+
+	var fromAPI ConfigFastTcpValue
+	if cfg != nil {
+		fromAPI = fastTCPConfigFromResponse(cfg)
+	}
+
+	if prior.IsUnknown() {
+		if cfg == nil {
+			return NewConfigFastTcpValueNull()
+		}
+
+		return fromAPI
+	}
+
+	return ConfigFastTcpValue{
+		ConnectionCloseTimeout: knownOr(
+			prior.ConnectionCloseTimeout, fromAPI.ConnectionCloseTimeout,
+		),
+		FastTcpIdleTimeout: knownOr(prior.FastTcpIdleTimeout, fromAPI.FastTcpIdleTimeout),
+		HaFlowMirroring:    knownOr(prior.HaFlowMirroring, fromAPI.HaFlowMirroring),
+		state:              attr.ValueStateKnown,
+	}
+}
+
+func mergeFastUDPConfig(
+	prior ConfigFastUdpValue,
+	cfg *sdk.FastUDPLoadBalancerProfileConfig3,
+) ConfigFastUdpValue {
+	if prior.IsNull() {
+		return prior
+	}
+
+	var fromAPI ConfigFastUdpValue
+	if cfg != nil {
+		fromAPI = fastUDPConfigFromResponse(cfg)
+	}
+
+	if prior.IsUnknown() {
+		if cfg == nil {
+			return NewConfigFastUdpValueNull()
+		}
+
+		return fromAPI
+	}
+
+	return ConfigFastUdpValue{
+		FastUdpIdleTimeout: knownOr(prior.FastUdpIdleTimeout, fromAPI.FastUdpIdleTimeout),
+		HaFlowMirroring:    knownOr(prior.HaFlowMirroring, fromAPI.HaFlowMirroring),
+		state:              attr.ValueStateKnown,
+	}
+}
+
+func mergeCookiePersistenceConfig(
+	prior ConfigCookiePersistenceValue,
+	cfg *sdk.CookiePersistenceLoadBalancerProfileConfig3,
+) ConfigCookiePersistenceValue {
+	if prior.IsNull() {
+		return prior
+	}
+
+	var fromAPI ConfigCookiePersistenceValue
+	if cfg != nil {
+		fromAPI = cookiePersistenceConfigFromResponse(cfg)
+	}
+
+	if prior.IsUnknown() {
+		if cfg == nil {
+			return NewConfigCookiePersistenceValueNull()
+		}
+
+		return fromAPI
+	}
+
+	return ConfigCookiePersistenceValue{
+		CookieDomain:     knownOr(prior.CookieDomain, fromAPI.CookieDomain),
+		CookieFallback:   knownOr(prior.CookieFallback, fromAPI.CookieFallback),
+		CookieGarbling:   knownOr(prior.CookieGarbling, fromAPI.CookieGarbling),
+		CookieMode:       knownOr(prior.CookieMode, fromAPI.CookieMode),
+		CookieName:       knownOr(prior.CookieName, fromAPI.CookieName),
+		CookiePath:       knownOr(prior.CookiePath, fromAPI.CookiePath),
+		CookieType:       knownOr(prior.CookieType, fromAPI.CookieType),
+		MaxCookieAge:     knownOr(prior.MaxCookieAge, fromAPI.MaxCookieAge),
+		MaxIdleTime:      knownOr(prior.MaxIdleTime, fromAPI.MaxIdleTime),
+		SharePersistence: knownOr(prior.SharePersistence, fromAPI.SharePersistence),
+		state:            attr.ValueStateKnown,
+	}
+}
+
+func mergeSourceIPPersistenceConfig(
+	prior ConfigSourceIpPersistenceValue,
+	cfg *sdk.SourceIPPersistenceLoadBalancerProfileConfig3,
+) ConfigSourceIpPersistenceValue {
+	if prior.IsNull() {
+		return prior
+	}
+
+	var fromAPI ConfigSourceIpPersistenceValue
+	if cfg != nil {
+		fromAPI = sourceIPPersistenceConfigFromResponse(cfg)
+	}
+
+	if prior.IsUnknown() {
+		if cfg == nil {
+			return NewConfigSourceIpPersistenceValueNull()
+		}
+
+		return fromAPI
+	}
+
+	return ConfigSourceIpPersistenceValue{
+		HaPersistenceMirroring: knownOr(
+			prior.HaPersistenceMirroring, fromAPI.HaPersistenceMirroring,
+		),
+		PersistenceEntryTimeout: knownOr(
+			prior.PersistenceEntryTimeout, fromAPI.PersistenceEntryTimeout,
+		),
+		PurgeEntries:     knownOr(prior.PurgeEntries, fromAPI.PurgeEntries),
+		SharePersistence: knownOr(prior.SharePersistence, fromAPI.SharePersistence),
+		state:            attr.ValueStateKnown,
+	}
+}
+
+func mergeGenericPersistenceConfig(
+	prior ConfigGenericPersistenceValue,
+	cfg *sdk.GenericPersistenceLoadBalancerProfileConfig3,
+) ConfigGenericPersistenceValue {
+	if prior.IsNull() {
+		return prior
+	}
+
+	var fromAPI ConfigGenericPersistenceValue
+	if cfg != nil {
+		fromAPI = genericPersistenceConfigFromResponse(cfg)
+	}
+
+	if prior.IsUnknown() {
+		if cfg == nil {
+			return NewConfigGenericPersistenceValueNull()
+		}
+
+		return fromAPI
+	}
+
+	return ConfigGenericPersistenceValue{
+		HaPersistenceMirroring: knownOr(
+			prior.HaPersistenceMirroring, fromAPI.HaPersistenceMirroring,
+		),
+		PersistenceEntryTimeout: knownOr(
+			prior.PersistenceEntryTimeout, fromAPI.PersistenceEntryTimeout,
+		),
+		SharePersistence: knownOr(prior.SharePersistence, fromAPI.SharePersistence),
+		state:            attr.ValueStateKnown,
+	}
+}
+
+func mergeClientSSLConfig(
+	prior ConfigClientSslValue,
+	cfg *sdk.ClientSSLLoadBalancerProfileConfig3,
+) ConfigClientSslValue {
+	if prior.IsNull() {
+		return prior
+	}
+
+	var fromAPI ConfigClientSslValue
+	if cfg != nil {
+		fromAPI = clientSSLConfigFromResponse(cfg)
+	}
+
+	if prior.IsUnknown() {
+		if cfg == nil {
+			return NewConfigClientSslValueNull()
+		}
+
+		return fromAPI
+	}
+
+	return ConfigClientSslValue{
+		PreferServerCipher:  knownOr(prior.PreferServerCipher, fromAPI.PreferServerCipher),
+		SessionCache:        knownOr(prior.SessionCache, fromAPI.SessionCache),
+		SessionCacheTimeout: knownOr(prior.SessionCacheTimeout, fromAPI.SessionCacheTimeout),
+		SslSuite:            knownOr(prior.SslSuite, fromAPI.SslSuite),
+		SupportedSslCiphers: knownOr(
+			prior.SupportedSslCiphers, fromAPI.SupportedSslCiphers,
+		),
+		SupportedSslProtocols: knownOr(
+			prior.SupportedSslProtocols, fromAPI.SupportedSslProtocols,
+		),
+		state: attr.ValueStateKnown,
+	}
+}
+
+func mergeServerSSLConfig(
+	prior ConfigServerSslValue,
+	cfg *sdk.ServerSSLLoadBalancerProfileConfig3,
+) ConfigServerSslValue {
+	if prior.IsNull() {
+		return prior
+	}
+
+	var fromAPI ConfigServerSslValue
+	if cfg != nil {
+		fromAPI = serverSSLConfigFromResponse(cfg)
+	}
+
+	if prior.IsUnknown() {
+		if cfg == nil {
+			return NewConfigServerSslValueNull()
+		}
+
+		return fromAPI
+	}
+
+	return ConfigServerSslValue{
+		SessionCache: knownOr(prior.SessionCache, fromAPI.SessionCache),
+		SslSuite:     knownOr(prior.SslSuite, fromAPI.SslSuite),
+		SupportedSslCiphers: knownOr(
+			prior.SupportedSslCiphers, fromAPI.SupportedSslCiphers,
+		),
+		SupportedSslProtocols: knownOr(
+			prior.SupportedSslProtocols, fromAPI.SupportedSslProtocols,
+		),
+		state: attr.ValueStateKnown,
+	}
+}
+
 func httpConfigFromResponse(
 	ctx context.Context,
 	cfg *sdk.HTTPLoadBalancerProfileConfig3,

--- a/morpheus/framework/resources/loadbalancerprofile/read_config_unit_test.go
+++ b/morpheus/framework/resources/loadbalancerprofile/read_config_unit_test.go
@@ -1,0 +1,242 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package loadbalancerprofile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
+)
+
+// TestMergeHTTPConfig covers the two failure modes the merge exists to prevent:
+//
+//   - copying the plan verbatim leaks unknown Optional+Computed attributes into
+//     state ("Provider returned invalid result object after apply");
+//   - rebuilding purely from the API response overwrites configured values with
+//     server-side defaults ("Provider produced inconsistent result after
+//     apply").
+func TestMergeHTTPConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	apiCfg := &sdk.HTTPLoadBalancerProfileConfig3{
+		RedirectAddress: sdk.PtrString("https://api.example.com"),
+		XForwardedFor:   sdk.PtrString("INSERT"),
+	}
+
+	t.Run("unknown attributes are resolved from the API response", func(t *testing.T) {
+		t.Parallel()
+
+		prior := ConfigHttpValue{
+			RedirectAddress: types.StringUnknown(),
+			XForwardedFor:   types.StringUnknown(),
+			RequestBodySize: types.Int64Unknown(),
+			state:           attr.ValueStateKnown,
+		}
+
+		got := mergeHTTPConfig(ctx, prior, apiCfg)
+
+		if got.RedirectAddress.IsUnknown() || got.XForwardedFor.IsUnknown() ||
+			got.RequestBodySize.IsUnknown() {
+			t.Fatal("unknown value leaked into state")
+		}
+
+		if got.XForwardedFor.ValueString() != "INSERT" {
+			t.Errorf("x_forwarded_for = %q, want the API value %q",
+				got.XForwardedFor.ValueString(), "INSERT")
+		}
+
+		// Not returned by the API and unknown in the plan: must resolve to null.
+		if !got.RequestBodySize.IsNull() {
+			t.Errorf("request_body_size = %v, want null", got.RequestBodySize)
+		}
+	})
+
+	t.Run("configured values are preserved over API defaults", func(t *testing.T) {
+		t.Parallel()
+
+		prior := ConfigHttpValue{
+			RedirectAddress: types.StringValue("https://configured.example.com"),
+			XForwardedFor:   types.StringValue("REPLACE"),
+			state:           attr.ValueStateKnown,
+		}
+
+		got := mergeHTTPConfig(ctx, prior, apiCfg)
+
+		if got.XForwardedFor.ValueString() != "REPLACE" {
+			t.Errorf("x_forwarded_for = %q, want the configured value %q",
+				got.XForwardedFor.ValueString(), "REPLACE")
+		}
+
+		if got.RedirectAddress.ValueString() != "https://configured.example.com" {
+			t.Errorf("redirect_address = %q, want the configured value",
+				got.RedirectAddress.ValueString())
+		}
+	})
+
+	t.Run("explicit null is preserved, not overwritten by the API", func(t *testing.T) {
+		t.Parallel()
+
+		prior := ConfigHttpValue{
+			XForwardedFor: types.StringNull(),
+			state:         attr.ValueStateKnown,
+		}
+
+		got := mergeHTTPConfig(ctx, prior, apiCfg)
+
+		if !got.XForwardedFor.IsNull() {
+			t.Errorf("x_forwarded_for = %v, want null to be preserved", got.XForwardedFor)
+		}
+	})
+
+	t.Run("null block stays null", func(t *testing.T) {
+		t.Parallel()
+
+		if got := mergeHTTPConfig(ctx, NewConfigHttpValueNull(), apiCfg); !got.IsNull() {
+			t.Errorf("got %v, want a null block", got)
+		}
+	})
+
+	t.Run("nil API config still resolves unknowns to null", func(t *testing.T) {
+		t.Parallel()
+
+		prior := ConfigHttpValue{
+			RedirectAddress: types.StringUnknown(),
+			state:           attr.ValueStateKnown,
+		}
+
+		got := mergeHTTPConfig(ctx, prior, nil)
+
+		if got.RedirectAddress.IsUnknown() {
+			t.Error("unknown value leaked into state when the API returned no config")
+		}
+
+		if !got.RedirectAddress.IsNull() {
+			t.Errorf("redirect_address = %v, want null", got.RedirectAddress)
+		}
+	})
+}
+
+// TestMergeCookiePersistenceConfig covers cookie_path, max_cookie_age and
+// max_idle_time — the Optional+Computed attributes without a default that were
+// reported as still-unknown after apply.
+func TestMergeCookiePersistenceConfig(t *testing.T) {
+	t.Parallel()
+
+	apiCfg := &sdk.CookiePersistenceLoadBalancerProfileConfig3{
+		CookiePath: sdk.PtrString("/from-api"),
+	}
+
+	prior := ConfigCookiePersistenceValue{
+		CookieName:   types.StringValue("configured-cookie"),
+		CookiePath:   types.StringUnknown(),
+		MaxCookieAge: types.Int64Unknown(),
+		MaxIdleTime:  types.Int64Unknown(),
+		state:        attr.ValueStateKnown,
+	}
+
+	got := mergeCookiePersistenceConfig(prior, apiCfg)
+
+	if got.CookiePath.IsUnknown() || got.MaxCookieAge.IsUnknown() ||
+		got.MaxIdleTime.IsUnknown() {
+		t.Fatal("unknown value leaked into state")
+	}
+
+	if got.CookieName.ValueString() != "configured-cookie" {
+		t.Errorf("cookie_name = %q, want the configured value", got.CookieName.ValueString())
+	}
+
+	if got.CookiePath.ValueString() != "/from-api" {
+		t.Errorf("cookie_path = %q, want the API value %q",
+			got.CookiePath.ValueString(), "/from-api")
+	}
+
+	if !got.MaxCookieAge.IsNull() || !got.MaxIdleTime.IsNull() {
+		t.Error("attributes absent from the API response should resolve to null")
+	}
+}
+
+// TestMergeClientSSLConfig covers the Set-typed supported_ssl_ciphers and
+// supported_ssl_protocols attributes.
+func TestMergeClientSSLConfig(t *testing.T) {
+	t.Parallel()
+
+	apiCfg := &sdk.ClientSSLLoadBalancerProfileConfig3{
+		SupportedSslProtocols: []string{"TLS_V1_2"},
+	}
+
+	prior := ConfigClientSslValue{
+		SslSuite:              types.StringValue("CUSTOM"),
+		SupportedSslCiphers:   types.SetUnknown(types.StringType),
+		SupportedSslProtocols: types.SetUnknown(types.StringType),
+		state:                 attr.ValueStateKnown,
+	}
+
+	got := mergeClientSSLConfig(prior, apiCfg)
+
+	if got.SupportedSslCiphers.IsUnknown() || got.SupportedSslProtocols.IsUnknown() {
+		t.Fatal("unknown value leaked into state")
+	}
+
+	if got.SslSuite.ValueString() != "CUSTOM" {
+		t.Errorf("ssl_suite = %q, want the configured value", got.SslSuite.ValueString())
+	}
+
+	if got.SupportedSslProtocols.IsNull() {
+		t.Error("supported_ssl_protocols should have been resolved from the API response")
+	}
+
+	if !got.SupportedSslCiphers.IsNull() {
+		t.Errorf("supported_ssl_ciphers = %v, want null", got.SupportedSslCiphers)
+	}
+}
+
+// TestMergeConfigBlocksLeavesNoUnknowns is the guard that matters most: after
+// merging, no config block may still carry an unknown attribute, whatever the
+// API returned.
+func TestMergeConfigBlocksLeavesNoUnknowns(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	prior := LoadBalancerProfileModel{
+		ConfigHttp: ConfigHttpValue{
+			RedirectAddress: types.StringUnknown(),
+			XForwardedFor:   types.StringUnknown(),
+			RequestBodySize: types.Int64Unknown(),
+			state:           attr.ValueStateKnown,
+		},
+		ConfigFastTcp:             NewConfigFastTcpValueNull(),
+		ConfigFastUdp:             NewConfigFastUdpValueNull(),
+		ConfigCookiePersistence:   NewConfigCookiePersistenceValueNull(),
+		ConfigSourceIpPersistence: NewConfigSourceIpPersistenceValueNull(),
+		ConfigGenericPersistence:  NewConfigGenericPersistenceValueNull(),
+		ConfigClientSsl:           NewConfigClientSslValueNull(),
+		ConfigServerSsl:           NewConfigServerSslValueNull(),
+	}
+
+	var state LoadBalancerProfileModel
+
+	mergeConfigBlocks(ctx, &state, prior, nil)
+
+	obj, diags := state.ConfigHttp.ToObjectValue(ctx)
+	if diags.HasError() {
+		t.Fatalf("ToObjectValue: %v", diags)
+	}
+
+	for name, v := range obj.Attributes() {
+		if v.IsUnknown() {
+			t.Errorf("config_http.%s is still unknown after merge", name)
+		}
+	}
+
+	// Blocks the practitioner did not set must remain null.
+	if !state.ConfigClientSsl.IsNull() || !state.ConfigCookiePersistence.IsNull() {
+		t.Error("unset config blocks should remain null")
+	}
+}

--- a/morpheus/framework/resources/loadbalancerprofile/sweep/sweep.go
+++ b/morpheus/framework/resources/loadbalancerprofile/sweep/sweep.go
@@ -33,7 +33,8 @@ func init() {
 			*http.Response,
 			error,
 		) {
-			lbResp, hresp, err := client.LoadBalancersAPI.ListLoadBalancers(ctx).Execute()
+			lbResp, hresp, err := client.LoadBalancersAPI.ListLoadBalancers(ctx).
+				Max(testsweep.ListPageSize).Execute()
 			if err != nil {
 				return nil, hresp, err
 			}
@@ -47,7 +48,8 @@ func init() {
 				}
 
 				profileResp, _, err := client.LoadBalancersAPI.
-					ListLoadBalancerProfiles(ctx, *lbID).Execute()
+					ListLoadBalancerProfiles(ctx, *lbID).
+					Max(testsweep.ListPageSize).Execute()
 				if err != nil || profileResp == nil {
 					continue
 				}

--- a/morpheus/framework/resources/loadbalancervirtualserver/sweep/sweep.go
+++ b/morpheus/framework/resources/loadbalancervirtualserver/sweep/sweep.go
@@ -33,7 +33,8 @@ func init() {
 			*http.Response,
 			error,
 		) {
-			lbResp, lbHresp, lbErr := client.LoadBalancersAPI.ListLoadBalancers(ctx).Execute()
+			lbResp, lbHresp, lbErr := client.LoadBalancersAPI.ListLoadBalancers(ctx).
+				Max(testsweep.ListPageSize).Execute()
 			if lbErr != nil || lbResp == nil {
 				return nil, lbHresp, lbErr
 			}
@@ -47,7 +48,8 @@ func init() {
 				}
 
 				vsResp, _, vsErr := client.LoadBalancersAPI.
-					ListLoadBalancerVirtualServers(ctx, *lbID).Execute()
+					ListLoadBalancerVirtualServers(ctx, *lbID).
+					Max(testsweep.ListPageSize).Execute()
 				if vsErr != nil || vsResp == nil {
 					continue
 				}

--- a/morpheus/framework/resources/networkrouter/sweep/sweep.go
+++ b/morpheus/framework/resources/networkrouter/sweep/sweep.go
@@ -27,6 +27,10 @@ func init() {
 			*http.Response,
 			error,
 		) {
+			// NOTE: the generated SDK exposes no max/offset builders for this
+			// endpoint, so the API's default page size applies and only the
+			// first page of routers is swept. Paginating needs the OpenAPI
+			// spec to declare the query parameters first.
 			resp, hresp, err := client.NetworksAPI.GetNetworkRouters(ctx).Execute()
 			if resp == nil {
 				return nil, hresp, err
@@ -58,12 +62,18 @@ func init() {
 
 			return hresp, err
 		},
-	testsweep.WithDependencies[sdk.GetNetworkRouters200ResponseNetworkRoutersInner](
-		"hpe_morpheus_network_router_route",
-		"hpe_morpheus_network_router_firewall_rule",
-		"hpe_morpheus_network_router_firewall_rule_group",
-		"hpe_morpheus_network_router_bgp_neighbor",
-		"hpe_morpheus_network_router_nat",
-	),
+		testsweep.WithDependencies[sdk.GetNetworkRouters200ResponseNetworkRoutersInner](
+			"hpe_morpheus_network_router_route",
+			"hpe_morpheus_network_router_firewall_rule",
+			"hpe_morpheus_network_router_firewall_rule_group",
+			"hpe_morpheus_network_router_bgp_neighbor",
+			"hpe_morpheus_network_router_nat",
+			// Load balancer tests attach an NSX-T lb-service to a per-test tier-1
+			// gateway. NSX-T refuses to delete a tier-1 that is still referenced by
+			// an lb-service ("cannot be deleted as either it has children or it is
+			// being referenced by other objects"), so load balancers must go first
+			// or the router sweep leaves both behind.
+			"hpe_morpheus_load_balancer",
+		),
 	)
 }

--- a/morpheus/framework/resources/networkrouter/sweep_import.go
+++ b/morpheus/framework/resources/networkrouter/sweep_import.go
@@ -5,6 +5,7 @@
 package networkrouter
 
 import (
+	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/loadbalancer/sweep"
 	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouter/sweep"
 	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouterbgpneighbor/sweep"
 	_ "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouterfirewallrule/sweep"

--- a/morpheus/framework/resources/networkrouterbgpneighbor/read.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/read.go
@@ -58,6 +58,14 @@ func getNetworkRouterBgpNeighborAsState(
 
 	if neighbor.Description.IsSet() {
 		state.Description = convert.StrToType(neighbor.Description.Get())
+	} else if !plan.Description.IsUnknown() {
+		// The API accepts description on create/update but never returns it, so
+		// preserve the configured (or prior) value. Without this a configured
+		// description is nulled out and the apply fails with "Provider produced
+		// inconsistent result after apply". The IsUnknown guard matters because
+		// description is Optional+Computed: an unset value arrives unknown in
+		// the plan and must never be copied into state.
+		state.Description = plan.Description
 	} else {
 		state.Description = types.StringNull()
 	}

--- a/morpheus/testhelpers/sweep/sweep.go
+++ b/morpheus/testhelpers/sweep/sweep.go
@@ -29,6 +29,16 @@ const EnvSweepPrefix = "TF_ACC_SWEEP_PREFIX"
 // which name resources after their Go test function (TestAccMorpheus*).
 const defaultTestResourcePrefix = "TestAccMorpheus"
 
+// ListPageSize is the page size sweepers should request when listing
+// resources.
+//
+// The Morpheus API applies a default of 25 records when the max query
+// parameter is omitted. A sweeper that lists without it therefore only ever
+// sees the first 25 resources, silently leaving older leaked resources on the
+// appliance and letting the leak grow without bound. Pass this to the list
+// call's Max builder, e.g. ListLoadBalancers(ctx).Max(ListPageSize).
+const ListPageSize int64 = 10000
+
 // TestResourcePrefix identifies acceptance test resources eligible for sweeping.
 // It is overridable via EnvSweepPrefix for targeted cleanup; unset or blank
 // keeps the default so a normal sweep still matches test-created resources.


### PR DESCRIPTION
Fixes two independent classes of load balancer test failure: sweepers that could
not keep up with leaked NSX-T resources, and resources that returned state
inconsistent with the plan.

---

# 1. Sweepers leaked NSX-T load balancer services

Acceptance tests leaked NSX-T load balancer services until the edge node ran out
of capacity. In one run, 10 of 27 `POST /api/load-balancers` attempts failed
before the suite had created anything — the edge node was already full when the
run started:

```
Errors validating path=[/infra/lb-services/1b5a6427-…].
There is no available capacity on edge node …/edge-nodes/1 to deploy a SMALL
load balancer service … the existed load balancer services on the edge node are
/infra/lb-services/d633f22b-…(SMALL), /infra/lb-services/63754663-…(SMALL), … (10+)
```

The `hpe_morpheus_load_balancer` sweeper already existed and was correctly
registered — it just could not keep up, for four independent reasons.

### 1.1 Lists were capped at 25 records

`ListLoadBalancers(ctx).Execute()` was called with no `Max`. When the `max` query
parameter is omitted the API applies a default of **25**, so the sweeper only ever
saw the first 25 load balancers (and, in the child sweepers, the first 25 children
of each). Anything older was invisible and could never be reclaimed, so the leak
only ever grew. Confirmed against a live appliance:

```json
{ "meta": { "offset": 0, "max": 25, "size": 1, "total": 1 } }
```

Fixed across all 9 list calls in the 5 `loadbalancer*` sweepers via a new shared
`testsweep.ListPageSize` constant, rather than scattering a magic number.

### 1.2 Load balancers were deleted before their children

`WithDependencies` listed only `monitor` and `virtual_server`, omitting `pool` and
`profile`. NSX-T refuses to delete an lb-service that still has children attached.
Both are now declared.

### 1.3 Tier-1 gateways were stranded

Each NSX-T load balancer test creates a per-test tier-1 gateway. The
`network_router` sweeper had no ordering relative to load balancers, so NSX-T
rejected the delete and both objects were left behind:

```
network router 2502 DELETE failed: 400 (Bad Request): {"msg":"The object
path=[/infra/tier-1s/50cd2ad5-…] cannot be deleted as either it has children or
it is being referenced by other objects path=[/infra/lb-services/35f2e021-…]"}
```

`hpe_morpheus_network_router` now depends on `hpe_morpheus_load_balancer`.

### 1.4 One failing sweeper aborted the whole run

`make sweep` did not pass `-sweep-allow-failures`. Sweepers execute in map
iteration order, so a single failure aborted the run and left every
not-yet-executed sweeper's resources on the appliance.

---

# 2. Post-apply contract violations

Three resources returned state that did not match the plan, so applies failed with
`Provider produced inconsistent result after apply` or `Provider returned invalid
result object after apply`. This accounted for 9 failing acceptance tests.

### 2.1 `load_balancer_monitor` — configured values nulled out

```
.receive_data: was cty.StringVal(""), but now null.
.data_length:  was cty.NumberIntVal(0), but now null.
```

Both attributes are sent on create, but the API does not echo them back: an empty
`receive_data` reads back as `null`, and `data_length` is only round-tripped for
ICMP monitors (these tests use an HTTP monitor). The response mapper therefore
turned a configured value into `null`.

Added `preserveUnreturnedFields`, called from create, update and read alongside
the existing `monitor_type` fixup. Unknown prior values are deliberately left
alone so they resolve from the API response rather than leaking into state.

### 2.2 `load_balancer_profile` — unknown values leaked into state

```
After the apply operation, the provider still indicated an unknown value for
  …config_client_ssl.supported_ssl_ciphers / .supported_ssl_protocols
  …config_cookie_persistence.cookie_path / .max_cookie_age / .max_idle_time
  …config_http.redirect_address / .request_body_size / .x_forwarded_for
```

The `config_*` block was copied verbatim from the plan. Every nested
`Optional+Computed` attribute the configuration omits is **unknown** in the plan,
and those unknowns were written straight into state.

Rebuilding the block from the API response was not an option either — that
overwrites configured values with the API's own defaults (for example
`x_forwarded_for` defaults to `INSERT` server-side), which is the very reason the
previous code copied the plan wholesale.

The fix merges per attribute: a configured (known) value always wins, and only
unknown attributes are resolved from the API response, falling back to null.
This satisfies both constraints, and computed attributes now correctly reflect the
server-side value. Applied to all eight config variants, not just the three that
were failing.

### 2.3 `network_router_bgp_neighbor` — configured description nulled out

```
.description: was cty.StringVal("TestAcc…"), but now null.
```

The API accepts `description` on create and update but never returns it, so the
mapper unconditionally nulled it. Now preserved from plan/prior state, guarded on
`IsUnknown` so an unset `Optional+Computed` description cannot leak an unknown
into state.

---

# Testing

The target appliance is not reachable from the development environment, so these
changes are covered by unit tests and will be exercised against a live appliance
separately.

- **New unit tests** (5 groups, 16 cases) covering the preserve/merge semantics:
  configured values win, unknowns resolve from the API response, absent values
  fall back to null, null blocks stay null, and no unknown ever survives a merge.
- **The tests were verified to actually catch the bug.** Temporarily reverting the
  merge to the previous blanket copy makes `TestMergeConfigBlocksLeavesNoUnknowns`
  fail with:
  ```
  config_http.request_body_size is still unknown after merge
  config_http.redirect_address is still unknown after merge
  config_http.x_forwarded_for is still unknown after merge
  ```
  — precisely three of the eight attributes reported by the failing acceptance
  tests.
- Sweeper ordering was verified against a live appliance: `profile`, `pool`,
  `monitor` and `virtual_server` all now execute **before**
  `hpe_morpheus_load_balancer`.
- `go build`, `go vet` (with and without the `sweep` build tag), `make lint`
  (0 issues) and `make unit-tests` all pass.

# Notes for reviewers

- **`GetNetworkRouters` cannot be paginated.** The generated SDK exposes no
  `Max`/`Offset` builders for that endpoint, so the router sweeper is still limited
  to the API default page size. An explicit `NOTE` comment marks this rather than
  leaving it silently broken; lifting it needs the query parameters declared in the
  API spec first.
- **All 57 sweepers share the same 25-record cap.** Only the load balancer and
  router sweepers are fixed here to keep this reviewable. The rest is a worthwhile
  follow-up.
- The sweeper change is **preventive**: the appliance had already been cleaned up
  by the time the fix was exercised, so it stops the leak recurring rather than
  performing the reclaim itself.
- No schema or codegen changes — the contract fixes are all in state mapping.
