### PR TITLE
Capitalize the docs subcategory as "Morpheus"

### DIFF
--- a/docs/data-sources/morpheus_ansible_tower_inventory.md
+++ b/docs/data-sources/morpheus_ansible_tower_inventory.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_ansible_tower_inventory Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus ansible tower inventory data source.
 ---

--- a/docs/data-sources/morpheus_ansible_tower_job_template.md
+++ b/docs/data-sources/morpheus_ansible_tower_job_template.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_ansible_tower_job_template Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus ansible tower job template data source.
 ---

--- a/docs/data-sources/morpheus_backup.md
+++ b/docs/data-sources/morpheus_backup.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_backup Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus backup.
 ---

--- a/docs/data-sources/morpheus_backup_host.md
+++ b/docs/data-sources/morpheus_backup_host.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_backup_host Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus host backup.
 ---

--- a/docs/data-sources/morpheus_backup_instance.md
+++ b/docs/data-sources/morpheus_backup_instance.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_backup_instance Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus instance backup.
 ---

--- a/docs/data-sources/morpheus_backup_job.md
+++ b/docs/data-sources/morpheus_backup_job.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_backup_job Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_backup_type.md
+++ b/docs/data-sources/morpheus_backup_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_backup_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus backup type.
 ---

--- a/docs/data-sources/morpheus_blueprint.md
+++ b/docs/data-sources/morpheus_blueprint.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_blueprint Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus blueprint data source.
 ---

--- a/docs/data-sources/morpheus_budget.md
+++ b/docs/data-sources/morpheus_budget.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_budget Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus budget data source.
 ---

--- a/docs/data-sources/morpheus_catalog_item_type.md
+++ b/docs/data-sources/morpheus_catalog_item_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_catalog_item_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus user group data source.
 ---

--- a/docs/data-sources/morpheus_certificate.md
+++ b/docs/data-sources/morpheus_certificate.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_certificate Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_cloud.md
+++ b/docs/data-sources/morpheus_cloud.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cloud Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_cloud_folder.md
+++ b/docs/data-sources/morpheus_cloud_folder.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cloud_folder Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus Cloud Folder data source.
 ---

--- a/docs/data-sources/morpheus_cloud_type.md
+++ b/docs/data-sources/morpheus_cloud_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cloud_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cloud type data source.
 ---

--- a/docs/data-sources/morpheus_clouds.md
+++ b/docs/data-sources/morpheus_clouds.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_clouds Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus clouds data source.
 ---

--- a/docs/data-sources/morpheus_cluster.md
+++ b/docs/data-sources/morpheus_cluster.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_cluster_affinity_group.md
+++ b/docs/data-sources/morpheus_cluster_affinity_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_affinity_group Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_cluster_layout.md
+++ b/docs/data-sources/morpheus_cluster_layout.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_layout Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_cluster_namespace.md
+++ b/docs/data-sources/morpheus_cluster_namespace.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_namespace Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_cluster_type.md
+++ b/docs/data-sources/morpheus_cluster_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cluster type source.
 ---

--- a/docs/data-sources/morpheus_contact.md
+++ b/docs/data-sources/morpheus_contact.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_contact Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus contact data source.
 ---

--- a/docs/data-sources/morpheus_container_script.md
+++ b/docs/data-sources/morpheus_container_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_container_script Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_credential.md
+++ b/docs/data-sources/morpheus_credential.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_credential Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus credential data source.
 ---

--- a/docs/data-sources/morpheus_cypher_secret.md
+++ b/docs/data-sources/morpheus_cypher_secret.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cypher_secret Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cypher secret data source.
 ---

--- a/docs/data-sources/morpheus_datastore.md
+++ b/docs/data-sources/morpheus_datastore.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_datastore Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_datastore_types.md
+++ b/docs/data-sources/morpheus_datastore_types.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_datastore_types Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves a list of Morpheus datastore types, optionally filtered using one or more filter blocks.
 ---

--- a/docs/data-sources/morpheus_datastores.md
+++ b/docs/data-sources/morpheus_datastores.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_datastores Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves a list of Morpheus datastores, optionally filtered using one or more filter blocks.
 ---

--- a/docs/data-sources/morpheus_deployment.md
+++ b/docs/data-sources/morpheus_deployment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_deployment Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_environment.md
+++ b/docs/data-sources/morpheus_environment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_environment Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_environments.md
+++ b/docs/data-sources/morpheus_environments.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_environments Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus environments data source.
 ---

--- a/docs/data-sources/morpheus_execute_schedule.md
+++ b/docs/data-sources/morpheus_execute_schedule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_execute_schedule Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus execute schedule data source.
 ---

--- a/docs/data-sources/morpheus_file_template.md
+++ b/docs/data-sources/morpheus_file_template.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_file_template Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus file template data source.
 ---

--- a/docs/data-sources/morpheus_group.md
+++ b/docs/data-sources/morpheus_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_group Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_groups.md
+++ b/docs/data-sources/morpheus_groups.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_groups Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus groups data source.
 ---

--- a/docs/data-sources/morpheus_image.md
+++ b/docs/data-sources/morpheus_image.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_image Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_images.md
+++ b/docs/data-sources/morpheus_images.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_images Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus virtual images data source.
 ---

--- a/docs/data-sources/morpheus_instance.md
+++ b/docs/data-sources/morpheus_instance.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_instance_snapshot.md
+++ b/docs/data-sources/morpheus_instance_snapshot.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance_snapshot Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_instance_type.md
+++ b/docs/data-sources/morpheus_instance_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus instance type data source.
 ---

--- a/docs/data-sources/morpheus_instance_type_layout.md
+++ b/docs/data-sources/morpheus_instance_type_layout.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance_type_layout Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_integration.md
+++ b/docs/data-sources/morpheus_integration.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus integration data source.
 ---

--- a/docs/data-sources/morpheus_integration_git.md
+++ b/docs/data-sources/morpheus_integration_git.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_git Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus git integration data source.
 ---

--- a/docs/data-sources/morpheus_job.md
+++ b/docs/data-sources/morpheus_job.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_job Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus job data source.
 ---

--- a/docs/data-sources/morpheus_key_pair.md
+++ b/docs/data-sources/morpheus_key_pair.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_key_pair Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus key pair data source.
 ---

--- a/docs/data-sources/morpheus_load_balancer.md
+++ b/docs/data-sources/morpheus_load_balancer.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_load_balancer_monitor.md
+++ b/docs/data-sources/morpheus_load_balancer_monitor.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer_monitor Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus load balancer health check monitor.
 ---

--- a/docs/data-sources/morpheus_load_balancer_pool.md
+++ b/docs/data-sources/morpheus_load_balancer_pool.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer_pool Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus load balancer pool.
 ---

--- a/docs/data-sources/morpheus_load_balancer_profile.md
+++ b/docs/data-sources/morpheus_load_balancer_profile.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer_profile Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus load balancer profile.
 ---

--- a/docs/data-sources/morpheus_load_balancer_virtual_server.md
+++ b/docs/data-sources/morpheus_load_balancer_virtual_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer_virtual_server Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus load balancer virtual server.
 ---

--- a/docs/data-sources/morpheus_monitoring_alert.md
+++ b/docs/data-sources/morpheus_monitoring_alert.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_monitoring_alert Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_monitoring_check.md
+++ b/docs/data-sources/morpheus_monitoring_check.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_monitoring_check Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_monitoring_check_type.md
+++ b/docs/data-sources/morpheus_monitoring_check_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_monitoring_check_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_monitoring_group.md
+++ b/docs/data-sources/morpheus_monitoring_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_monitoring_group Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network.md
+++ b/docs/data-sources/morpheus_network.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_dhcp_server.md
+++ b/docs/data-sources/morpheus_network_dhcp_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_dhcp_server Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_domain.md
+++ b/docs/data-sources/morpheus_network_domain.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_domain Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Network Domain data source. This can be used to reference an existing Network Domain by name or id.
 ---

--- a/docs/data-sources/morpheus_network_edge_cluster.md
+++ b/docs/data-sources/morpheus_network_edge_cluster.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_edge_cluster Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus network edge cluster from a network server that supports them (e.g. NSX-T, VCD).
 ---

--- a/docs/data-sources/morpheus_network_firewall_rule.md
+++ b/docs/data-sources/morpheus_network_firewall_rule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_firewall_rule Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_firewall_rule_group.md
+++ b/docs/data-sources/morpheus_network_firewall_rule_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_firewall_rule_group Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a network firewall rule group data source.
 ---

--- a/docs/data-sources/morpheus_network_group.md
+++ b/docs/data-sources/morpheus_network_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_group Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus network group data source.
 ---

--- a/docs/data-sources/morpheus_network_pool.md
+++ b/docs/data-sources/morpheus_network_pool.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_pool Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_pool_server.md
+++ b/docs/data-sources/morpheus_network_pool_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_pool_server Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_pool_server_type.md
+++ b/docs/data-sources/morpheus_network_pool_server_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_pool_server_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_router.md
+++ b/docs/data-sources/morpheus_network_router.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_router_bgp_neighbor.md
+++ b/docs/data-sources/morpheus_network_router_bgp_neighbor.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_bgp_neighbor Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_router_firewall_rule.md
+++ b/docs/data-sources/morpheus_network_router_firewall_rule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_firewall_rule Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_router_firewall_rule_groups.md
+++ b/docs/data-sources/morpheus_network_router_firewall_rule_groups.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_firewall_rule_groups Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves the list of firewall rule groups for a specified network router.
 ---

--- a/docs/data-sources/morpheus_network_router_nat.md
+++ b/docs/data-sources/morpheus_network_router_nat.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_nat Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_router_route.md
+++ b/docs/data-sources/morpheus_network_router_route.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_route Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_router_type.md
+++ b/docs/data-sources/morpheus_network_router_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_server.md
+++ b/docs/data-sources/morpheus_network_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_server Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_network_subnet.md
+++ b/docs/data-sources/morpheus_network_subnet.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_subnet Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus network subnet data source.
 ---

--- a/docs/data-sources/morpheus_network_transport_zone.md
+++ b/docs/data-sources/morpheus_network_transport_zone.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_transport_zone Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus network transport zone from a network server that supports them (e.g. NSX-T, VCD).
 ---

--- a/docs/data-sources/morpheus_network_type.md
+++ b/docs/data-sources/morpheus_network_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_networks.md
+++ b/docs/data-sources/morpheus_networks.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_networks Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus networks data source.
 ---

--- a/docs/data-sources/morpheus_node_type.md
+++ b/docs/data-sources/morpheus_node_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_node_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus node type data source.
 ---

--- a/docs/data-sources/morpheus_option_list.md
+++ b/docs/data-sources/morpheus_option_list.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_list Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus option list data source.
 ---

--- a/docs/data-sources/morpheus_option_type.md
+++ b/docs/data-sources/morpheus_option_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus option type data source.
 ---

--- a/docs/data-sources/morpheus_os_type.md
+++ b/docs/data-sources/morpheus_os_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_os_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_os_type_image.md
+++ b/docs/data-sources/morpheus_os_type_image.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_os_type_image Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_policies.md
+++ b/docs/data-sources/morpheus_policies.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_policies Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus policies data source.
 ---

--- a/docs/data-sources/morpheus_policy.md
+++ b/docs/data-sources/morpheus_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_policy Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_power_schedule.md
+++ b/docs/data-sources/morpheus_power_schedule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_power_schedule Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus power schedule data source.
 ---

--- a/docs/data-sources/morpheus_price.md
+++ b/docs/data-sources/morpheus_price.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_price Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   The Price data source allows details of a Price to be retrieved by its name.
 ---

--- a/docs/data-sources/morpheus_price_set.md
+++ b/docs/data-sources/morpheus_price_set.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_price_set Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   The Price Set data source allows details of a Price Set to be retrieved by its name.
 ---

--- a/docs/data-sources/morpheus_provision_type.md
+++ b/docs/data-sources/morpheus_provision_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_provision_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus provision type data source.
 ---

--- a/docs/data-sources/morpheus_provisioning_license.md
+++ b/docs/data-sources/morpheus_provisioning_license.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_provisioning_license Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_resource_pool.md
+++ b/docs/data-sources/morpheus_resource_pool.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_resource_pool Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus resource pool data source.
 ---

--- a/docs/data-sources/morpheus_role.md
+++ b/docs/data-sources/morpheus_role.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_role Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_script_template.md
+++ b/docs/data-sources/morpheus_script_template.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_script_template Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus script template data source.
 ---

--- a/docs/data-sources/morpheus_security_group.md
+++ b/docs/data-sources/morpheus_security_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_security_group Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves information about a single Morpheus security group by id or name.
 ---

--- a/docs/data-sources/morpheus_security_group_rule.md
+++ b/docs/data-sources/morpheus_security_group_rule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_security_group_rule Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_security_groups.md
+++ b/docs/data-sources/morpheus_security_groups.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_security_groups Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves a list of Morpheus security groups, optionally filtered using one or more filter blocks.
 ---

--- a/docs/data-sources/morpheus_security_package.md
+++ b/docs/data-sources/morpheus_security_package.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_security_package Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus security package data source.
 ---

--- a/docs/data-sources/morpheus_service_plan.md
+++ b/docs/data-sources/morpheus_service_plan.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_service_plan Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_servicenow_workflow.md
+++ b/docs/data-sources/morpheus_servicenow_workflow.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_servicenow_workflow Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus ServiceNow workflow data source.
 ---

--- a/docs/data-sources/morpheus_spec_template.md
+++ b/docs/data-sources/morpheus_spec_template.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_spec_template Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus spec template data source.
 ---

--- a/docs/data-sources/morpheus_storage_bucket.md
+++ b/docs/data-sources/morpheus_storage_bucket.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_bucket Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus storage bucket data source.
 ---

--- a/docs/data-sources/morpheus_storage_server.md
+++ b/docs/data-sources/morpheus_storage_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_server Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves information about a single Morpheus storage server by id or name.
 ---

--- a/docs/data-sources/morpheus_storage_servers.md
+++ b/docs/data-sources/morpheus_storage_servers.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_servers Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves a list of Morpheus storage servers, optionally filtered using one or more filter blocks.
 ---

--- a/docs/data-sources/morpheus_storage_volume.md
+++ b/docs/data-sources/morpheus_storage_volume.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_volume Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves information about a single Morpheus storage volume by id or name.
 ---

--- a/docs/data-sources/morpheus_storage_volume_type.md
+++ b/docs/data-sources/morpheus_storage_volume_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_volume_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus storage volume type data source.
 ---

--- a/docs/data-sources/morpheus_storage_volumes.md
+++ b/docs/data-sources/morpheus_storage_volumes.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_volumes Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Retrieves a list of Morpheus storage volumes, optionally filtered using one or more filter blocks.
 ---

--- a/docs/data-sources/morpheus_subnet_type.md
+++ b/docs/data-sources/morpheus_subnet_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_subnet_type Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_task.md
+++ b/docs/data-sources/morpheus_task.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus task data source.
 ---

--- a/docs/data-sources/morpheus_tasks.md
+++ b/docs/data-sources/morpheus_tasks.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_tasks Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus tasks data source.
 ---

--- a/docs/data-sources/morpheus_tenant.md
+++ b/docs/data-sources/morpheus_tenant.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_tenant Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus tenant data source.
 ---

--- a/docs/data-sources/morpheus_tenants.md
+++ b/docs/data-sources/morpheus_tenants.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_tenants Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus tenants data source.
 ---

--- a/docs/data-sources/morpheus_user.md
+++ b/docs/data-sources/morpheus_user.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_user Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_user_group.md
+++ b/docs/data-sources/morpheus_user_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_user_group Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus user group data source.
 ---

--- a/docs/data-sources/morpheus_user_groups.md
+++ b/docs/data-sources/morpheus_user_groups.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_user_groups Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus user groups data source.
 ---

--- a/docs/data-sources/morpheus_vdi_app.md
+++ b/docs/data-sources/morpheus_vdi_app.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_vdi_app Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_vdi_gateway.md
+++ b/docs/data-sources/morpheus_vdi_gateway.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_vdi_gateway Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/data-sources/morpheus_vdi_pool.md
+++ b/docs/data-sources/morpheus_vdi_pool.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_vdi_pool Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus user group data source.
 ---

--- a/docs/data-sources/morpheus_vro_workflow.md
+++ b/docs/data-sources/morpheus_vro_workflow.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_vro_workflow Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus vRO workflow data source.
 ---

--- a/docs/data-sources/morpheus_workflow.md
+++ b/docs/data-sources/morpheus_workflow.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_workflow Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus workflow data source.
 ---

--- a/docs/resources/morpheus_app_blueprint_arm.md
+++ b/docs/resources/morpheus_app_blueprint_arm.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_app_blueprint_arm Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus arm app blueprint resource
 ---

--- a/docs/resources/morpheus_app_blueprint_cloud_formation.md
+++ b/docs/resources/morpheus_app_blueprint_cloud_formation.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_app_blueprint_cloud_formation Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cloud formation app blueprint resource
 ---

--- a/docs/resources/morpheus_app_blueprint_helm.md
+++ b/docs/resources/morpheus_app_blueprint_helm.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_app_blueprint_helm Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus helm app blueprint resource
 ---

--- a/docs/resources/morpheus_app_blueprint_kubernetes.md
+++ b/docs/resources/morpheus_app_blueprint_kubernetes.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_app_blueprint_kubernetes Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus kubernetes app blueprint resource
 ---

--- a/docs/resources/morpheus_app_blueprint_terraform.md
+++ b/docs/resources/morpheus_app_blueprint_terraform.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_app_blueprint_terraform Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus terraform app blueprint resource
 ---

--- a/docs/resources/morpheus_backup_host.md
+++ b/docs/resources/morpheus_backup_host.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_backup_host Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Backup resource for Hosts.
 ---

--- a/docs/resources/morpheus_backup_instance.md
+++ b/docs/resources/morpheus_backup_instance.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_backup_instance Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Backup resource for Instances.
 ---

--- a/docs/resources/morpheus_backup_job.md
+++ b/docs/resources/morpheus_backup_job.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_backup_job Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Backup Job resource.
 ---

--- a/docs/resources/morpheus_boot_script.md
+++ b/docs/resources/morpheus_boot_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_boot_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus boot script resource
 ---

--- a/docs/resources/morpheus_budget.md
+++ b/docs/resources/morpheus_budget.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_budget Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Budget resource.
 ---

--- a/docs/resources/morpheus_catalog_item_app_blueprint.md
+++ b/docs/resources/morpheus_catalog_item_app_blueprint.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_catalog_item_app_blueprint Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus App Blueprint catalog item resource
 ---

--- a/docs/resources/morpheus_catalog_item_instance.md
+++ b/docs/resources/morpheus_catalog_item_instance.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_catalog_item_instance Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus instance catalog item resource
 ---

--- a/docs/resources/morpheus_catalog_item_workflow.md
+++ b/docs/resources/morpheus_catalog_item_workflow.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_catalog_item_workflow Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus workflow catalog item resource
 ---

--- a/docs/resources/morpheus_certificate.md
+++ b/docs/resources/morpheus_certificate.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_certificate Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Certificate resource.
 ---

--- a/docs/resources/morpheus_cloud.md
+++ b/docs/resources/morpheus_cloud.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cloud Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_cluster.md
+++ b/docs/resources/morpheus_cluster.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_cluster_affinity_group.md
+++ b/docs/resources/morpheus_cluster_affinity_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_affinity_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Cluster Affinity Group resource.
 ---

--- a/docs/resources/morpheus_cluster_hks_hvm.md
+++ b/docs/resources/morpheus_cluster_hks_hvm.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_hks_hvm Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a HPE Kubernetes Service (HKS) cluster on a HVM cloud
 ---

--- a/docs/resources/morpheus_cluster_hks_vsphere.md
+++ b/docs/resources/morpheus_cluster_hks_vsphere.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_hks_vsphere Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a HPE Kubernetes Service (HKS) cluster on VMware vSphere cloud
 ---

--- a/docs/resources/morpheus_cluster_layout.md
+++ b/docs/resources/morpheus_cluster_layout.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_layout Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cluster layout resource
 ---

--- a/docs/resources/morpheus_cluster_namespace.md
+++ b/docs/resources/morpheus_cluster_namespace.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_namespace Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Cluster Namespace resource.
 ---

--- a/docs/resources/morpheus_cluster_package.md
+++ b/docs/resources/morpheus_cluster_package.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cluster_package Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cluster package resource.
 ---

--- a/docs/resources/morpheus_contact.md
+++ b/docs/resources/morpheus_contact.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_contact Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus contact resource.
 ---

--- a/docs/resources/morpheus_container_script.md
+++ b/docs/resources/morpheus_container_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_container_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Library Container Script resource.
 ---

--- a/docs/resources/morpheus_credential.md
+++ b/docs/resources/morpheus_credential.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_credential Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus credential resource.
 ---

--- a/docs/resources/morpheus_cypher_secret.md
+++ b/docs/resources/morpheus_cypher_secret.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cypher_secret Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cypher secret resource.
 ---

--- a/docs/resources/morpheus_cypher_tfvars.md
+++ b/docs/resources/morpheus_cypher_tfvars.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_cypher_tfvars Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cypher tfvars secret resource.
 ---

--- a/docs/resources/morpheus_datastore.md
+++ b/docs/resources/morpheus_datastore.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_datastore Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_deployment.md
+++ b/docs/resources/morpheus_deployment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_deployment Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Deployment resource.
 ---

--- a/docs/resources/morpheus_environment.md
+++ b/docs/resources/morpheus_environment.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_environment Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus environment resource
 ---

--- a/docs/resources/morpheus_execute_schedule.md
+++ b/docs/resources/morpheus_execute_schedule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_execute_schedule Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides an execution schedule resource
 ---

--- a/docs/resources/morpheus_file_template.md
+++ b/docs/resources/morpheus_file_template.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_file_template Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus file template resource
 ---

--- a/docs/resources/morpheus_form.md
+++ b/docs/resources/morpheus_form.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_form Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus form resource
 ---

--- a/docs/resources/morpheus_group.md
+++ b/docs/resources/morpheus_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_identity_source_active_directory.md
+++ b/docs/resources/morpheus_identity_source_active_directory.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_identity_source_active_directory Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides an active directory identity source resource
 ---

--- a/docs/resources/morpheus_identity_source_saml.md
+++ b/docs/resources/morpheus_identity_source_saml.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_identity_source_saml Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a saml identity source resource
 ---

--- a/docs/resources/morpheus_image.md
+++ b/docs/resources/morpheus_image.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_image Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_instance_clone.md
+++ b/docs/resources/morpheus_instance_clone.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance_clone Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Clones an instance in HPE Morpheus from a source instance, copying its disk contents.
 ---

--- a/docs/resources/morpheus_instance_power_state.md
+++ b/docs/resources/morpheus_instance_power_state.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance_power_state Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages the power state of an existing Morpheus instance. This resource does not create or destroy instances — it only transitions them between running, stopped, and suspended states.
 ---

--- a/docs/resources/morpheus_instance_snapshot.md
+++ b/docs/resources/morpheus_instance_snapshot.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance_snapshot Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages an instance snapshot in HPE Morpheus.
 ---

--- a/docs/resources/morpheus_instance_type.md
+++ b/docs/resources/morpheus_instance_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance_type Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus instance type resource
 ---

--- a/docs/resources/morpheus_instance_type_layout.md
+++ b/docs/resources/morpheus_instance_type_layout.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_instance_type_layout Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus instance layout resource
 ---

--- a/docs/resources/morpheus_integration_ansible.md
+++ b/docs/resources/morpheus_integration_ansible.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_ansible Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides an ansible integration resource
 ---

--- a/docs/resources/morpheus_integration_ansible_tower.md
+++ b/docs/resources/morpheus_integration_ansible_tower.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_ansible_tower Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides an Ansible Tower integration resource
 ---

--- a/docs/resources/morpheus_integration_chef.md
+++ b/docs/resources/morpheus_integration_chef.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_chef Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Chef integration resource
 ---

--- a/docs/resources/morpheus_integration_docker_registry.md
+++ b/docs/resources/morpheus_integration_docker_registry.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_docker_registry Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Docker registry integration resource
 ---

--- a/docs/resources/morpheus_integration_git.md
+++ b/docs/resources/morpheus_integration_git.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_git Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a git integration resource
 ---

--- a/docs/resources/morpheus_integration_puppet.md
+++ b/docs/resources/morpheus_integration_puppet.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_puppet Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a puppet integration resource
 ---

--- a/docs/resources/morpheus_integration_servicenow.md
+++ b/docs/resources/morpheus_integration_servicenow.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_servicenow Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a ServiceNow integration resource
 ---

--- a/docs/resources/morpheus_integration_vro.md
+++ b/docs/resources/morpheus_integration_vro.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_integration_vro Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a vRealize Orchestrator integration resource
 ---

--- a/docs/resources/morpheus_ip_pool_ipv4.md
+++ b/docs/resources/morpheus_ip_pool_ipv4.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_ip_pool_ipv4 Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus IPv4 ip pool resource
 ---

--- a/docs/resources/morpheus_job_task.md
+++ b/docs/resources/morpheus_job_task.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_job_task Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a task job resource
 ---

--- a/docs/resources/morpheus_job_workflow.md
+++ b/docs/resources/morpheus_job_workflow.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_job_workflow Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a workflow job resource
 ---

--- a/docs/resources/morpheus_key_pair.md
+++ b/docs/resources/morpheus_key_pair.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_key_pair Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus key pair resource.
 ---

--- a/docs/resources/morpheus_license.md
+++ b/docs/resources/morpheus_license.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_license Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus license resource.
 ---

--- a/docs/resources/morpheus_load_balancer.md
+++ b/docs/resources/morpheus_load_balancer.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_load_balancer_monitor.md
+++ b/docs/resources/morpheus_load_balancer_monitor.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer_monitor Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus load balancer health check monitor.
 ---

--- a/docs/resources/morpheus_load_balancer_pool.md
+++ b/docs/resources/morpheus_load_balancer_pool.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer_pool Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus load balancer pool.
 ---

--- a/docs/resources/morpheus_load_balancer_profile.md
+++ b/docs/resources/morpheus_load_balancer_profile.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer_profile Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus load balancer profile.
 ---

--- a/docs/resources/morpheus_load_balancer_virtual_server.md
+++ b/docs/resources/morpheus_load_balancer_virtual_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_load_balancer_virtual_server Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus load balancer virtual server (VIP). A virtual server defines a frontend listener on a load balancer, including the VIP address, port, and protocol.
 ---

--- a/docs/resources/morpheus_monitoring_alert.md
+++ b/docs/resources/morpheus_monitoring_alert.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_monitoring_alert Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Monitoring Alert resource.
 ---

--- a/docs/resources/morpheus_monitoring_check.md
+++ b/docs/resources/morpheus_monitoring_check.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_monitoring_check Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Monitoring Check resource.
 ---

--- a/docs/resources/morpheus_monitoring_group.md
+++ b/docs/resources/morpheus_monitoring_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_monitoring_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Monitoring Group (Check Group) resource.
 ---

--- a/docs/resources/morpheus_network.md
+++ b/docs/resources/morpheus_network.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_network_dhcp_server.md
+++ b/docs/resources/morpheus_network_dhcp_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_dhcp_server Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_network_domain.md
+++ b/docs/resources/morpheus_network_domain.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_domain Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus network domain resource.
 ---

--- a/docs/resources/morpheus_network_firewall_rule.md
+++ b/docs/resources/morpheus_network_firewall_rule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_firewall_rule Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_network_firewall_rule_group.md
+++ b/docs/resources/morpheus_network_firewall_rule_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_firewall_rule_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a network firewall rule group resource in Morpheus.
 ---

--- a/docs/resources/morpheus_network_group.md
+++ b/docs/resources/morpheus_network_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Network Group resource.
 ---

--- a/docs/resources/morpheus_network_pool.md
+++ b/docs/resources/morpheus_network_pool.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_pool Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Network Pool resource.
 ---

--- a/docs/resources/morpheus_network_pool_server.md
+++ b/docs/resources/morpheus_network_pool_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_pool_server Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Network Pool Server (IPAM integration) resource.
 ---

--- a/docs/resources/morpheus_network_router.md
+++ b/docs/resources/morpheus_network_router.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_network_router_bgp_neighbor.md
+++ b/docs/resources/morpheus_network_router_bgp_neighbor.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_bgp_neighbor Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_network_router_firewall_rule.md
+++ b/docs/resources/morpheus_network_router_firewall_rule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_firewall_rule Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_network_router_nat.md
+++ b/docs/resources/morpheus_network_router_nat.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_nat Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_network_router_route.md
+++ b/docs/resources/morpheus_network_router_route.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_route Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_node_type.md
+++ b/docs/resources/morpheus_node_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_node_type Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus node type resource
 ---

--- a/docs/resources/morpheus_option_list.md
+++ b/docs/resources/morpheus_option_list.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_list Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Library Option Type List resource.
 ---

--- a/docs/resources/morpheus_option_list_api.md
+++ b/docs/resources/morpheus_option_list_api.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_list_api Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus api option list resource.
 ---

--- a/docs/resources/morpheus_option_list_manual.md
+++ b/docs/resources/morpheus_option_list_manual.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_list_manual Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus manual option list resource.
 ---

--- a/docs/resources/morpheus_option_list_rest.md
+++ b/docs/resources/morpheus_option_list_rest.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_list_rest Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus REST option list resource.
 ---

--- a/docs/resources/morpheus_option_type_checkbox.md
+++ b/docs/resources/morpheus_option_type_checkbox.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_checkbox Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus checkbox option type resource
 ---

--- a/docs/resources/morpheus_option_type_hidden.md
+++ b/docs/resources/morpheus_option_type_hidden.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_hidden Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus hidden option type resource
 ---

--- a/docs/resources/morpheus_option_type_number.md
+++ b/docs/resources/morpheus_option_type_number.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_number Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus number option type resource
 ---

--- a/docs/resources/morpheus_option_type_password.md
+++ b/docs/resources/morpheus_option_type_password.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_password Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus password option type resource
 ---

--- a/docs/resources/morpheus_option_type_radio_list.md
+++ b/docs/resources/morpheus_option_type_radio_list.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_radio_list Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus radio list option type resource
 ---

--- a/docs/resources/morpheus_option_type_select_list.md
+++ b/docs/resources/morpheus_option_type_select_list.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_select_list Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus select list option type resource
 ---

--- a/docs/resources/morpheus_option_type_text.md
+++ b/docs/resources/morpheus_option_type_text.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_text Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus text option type resource
 ---

--- a/docs/resources/morpheus_option_type_textarea.md
+++ b/docs/resources/morpheus_option_type_textarea.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_textarea Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus textarea option type resource
 ---

--- a/docs/resources/morpheus_option_type_typeahead.md
+++ b/docs/resources/morpheus_option_type_typeahead.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_option_type_typeahead Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus typeahead option type resource
 ---

--- a/docs/resources/morpheus_os_type.md
+++ b/docs/resources/morpheus_os_type.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_os_type Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_os_type_image.md
+++ b/docs/resources/morpheus_os_type_image.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_os_type_image Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_policy.md
+++ b/docs/resources/morpheus_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_policy Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_power_schedule.md
+++ b/docs/resources/morpheus_power_schedule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_power_schedule Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Power Schedule resource.
 ---

--- a/docs/resources/morpheus_preseed_script.md
+++ b/docs/resources/morpheus_preseed_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_preseed_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus preseed script resource
 ---

--- a/docs/resources/morpheus_price.md
+++ b/docs/resources/morpheus_price.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_price Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a price resource
 ---

--- a/docs/resources/morpheus_price_set.md
+++ b/docs/resources/morpheus_price_set.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_price_set Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a price set resource
 ---

--- a/docs/resources/morpheus_provisioning_license.md
+++ b/docs/resources/morpheus_provisioning_license.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_provisioning_license Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Provisioning License resource.
 ---

--- a/docs/resources/morpheus_resource_pool_group.md
+++ b/docs/resources/morpheus_resource_pool_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_resource_pool_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus resource pool group resource
 ---

--- a/docs/resources/morpheus_role.md
+++ b/docs/resources/morpheus_role.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_role Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_scale_threshold.md
+++ b/docs/resources/morpheus_scale_threshold.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_scale_threshold Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus scale threshold resource.
 ---

--- a/docs/resources/morpheus_script_template.md
+++ b/docs/resources/morpheus_script_template.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_script_template Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus script template resource
 ---

--- a/docs/resources/morpheus_security_group.md
+++ b/docs/resources/morpheus_security_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_security_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Security Group resource.
 ---

--- a/docs/resources/morpheus_security_group_rule.md
+++ b/docs/resources/morpheus_security_group_rule.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_security_group_rule Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Security Group Rule resource.
 ---

--- a/docs/resources/morpheus_security_package.md
+++ b/docs/resources/morpheus_security_package.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_security_package Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus security package resource
 ---

--- a/docs/resources/morpheus_service_plan.md
+++ b/docs/resources/morpheus_service_plan.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_service_plan Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_setting_appliance.md
+++ b/docs/resources/morpheus_setting_appliance.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_setting_appliance Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus appliance setting resource.
 ---

--- a/docs/resources/morpheus_setting_backup.md
+++ b/docs/resources/morpheus_setting_backup.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_setting_backup Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus backup setting resource.
 ---

--- a/docs/resources/morpheus_setting_guidance.md
+++ b/docs/resources/morpheus_setting_guidance.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_setting_guidance Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus guidance setting resource.
 ---

--- a/docs/resources/morpheus_setting_monitoring.md
+++ b/docs/resources/morpheus_setting_monitoring.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_setting_monitoring Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus monitoring setting resource.
 ---

--- a/docs/resources/morpheus_setting_provisioning.md
+++ b/docs/resources/morpheus_setting_provisioning.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_setting_provisioning Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus provisioning setting resource.
 ---

--- a/docs/resources/morpheus_setting_whitelabel.md
+++ b/docs/resources/morpheus_setting_whitelabel.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_setting_whitelabel Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages Morpheus Whitelabel Settings. This is a singleton resource — only one instance should exist. On destroy, all whitelabel settings will be reset to their zero values.
 ---

--- a/docs/resources/morpheus_spec_template_arm.md
+++ b/docs/resources/morpheus_spec_template_arm.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_spec_template_arm Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus ARM spec template resource
 ---

--- a/docs/resources/morpheus_spec_template_cloud_formation.md
+++ b/docs/resources/morpheus_spec_template_cloud_formation.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_spec_template_cloud_formation Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus cloud formation spec template resource
 ---

--- a/docs/resources/morpheus_spec_template_helm.md
+++ b/docs/resources/morpheus_spec_template_helm.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_spec_template_helm Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus helm spec template resource
 ---

--- a/docs/resources/morpheus_spec_template_kubernetes.md
+++ b/docs/resources/morpheus_spec_template_kubernetes.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_spec_template_kubernetes Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus kubernetes spec template resource
 ---

--- a/docs/resources/morpheus_spec_template_terraform.md
+++ b/docs/resources/morpheus_spec_template_terraform.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_spec_template_terraform Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus terraform spec template resource
 ---

--- a/docs/resources/morpheus_storage_bucket.md
+++ b/docs/resources/morpheus_storage_bucket.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_bucket Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Storage Bucket resource.
 ---

--- a/docs/resources/morpheus_storage_server.md
+++ b/docs/resources/morpheus_storage_server.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_server Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Storage Server resource.
 ---

--- a/docs/resources/morpheus_storage_volume.md
+++ b/docs/resources/morpheus_storage_volume.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_storage_volume Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Storage Volume resource.
 ---

--- a/docs/resources/morpheus_subnet.md
+++ b/docs/resources/morpheus_subnet.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_subnet Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus Subnet resource.
 ---

--- a/docs/resources/morpheus_task.md
+++ b/docs/resources/morpheus_task.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_task_ansible_playbook.md
+++ b/docs/resources/morpheus_task_ansible_playbook.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_ansible_playbook Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus ansible playbook task resource
 ---

--- a/docs/resources/morpheus_task_ansible_tower.md
+++ b/docs/resources/morpheus_task_ansible_tower.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_ansible_tower Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus Ansible Tower task resource
 ---

--- a/docs/resources/morpheus_task_chef_bootstrap.md
+++ b/docs/resources/morpheus_task_chef_bootstrap.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_chef_bootstrap Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus chef bootstrap task resource
 ---

--- a/docs/resources/morpheus_task_email.md
+++ b/docs/resources/morpheus_task_email.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_email Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus email task resource
 ---

--- a/docs/resources/morpheus_task_groovy_script.md
+++ b/docs/resources/morpheus_task_groovy_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_groovy_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus groovy script task resource
 ---

--- a/docs/resources/morpheus_task_javascript.md
+++ b/docs/resources/morpheus_task_javascript.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_javascript Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus javascript task resource
 ---

--- a/docs/resources/morpheus_task_library_script.md
+++ b/docs/resources/morpheus_task_library_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_library_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus library script task resource
 ---

--- a/docs/resources/morpheus_task_library_template.md
+++ b/docs/resources/morpheus_task_library_template.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_library_template Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus library template task resource
 ---

--- a/docs/resources/morpheus_task_nested_workflow.md
+++ b/docs/resources/morpheus_task_nested_workflow.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_nested_workflow Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus nested workflow task resource
 ---

--- a/docs/resources/morpheus_task_powershell_script.md
+++ b/docs/resources/morpheus_task_powershell_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_powershell_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus powershell script task resource
 ---

--- a/docs/resources/morpheus_task_python_script.md
+++ b/docs/resources/morpheus_task_python_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_python_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus python script task resource
 ---

--- a/docs/resources/morpheus_task_restart.md
+++ b/docs/resources/morpheus_task_restart.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_restart Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus restart task resource
 ---

--- a/docs/resources/morpheus_task_ruby_script.md
+++ b/docs/resources/morpheus_task_ruby_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_ruby_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus ruby script task resource
 ---

--- a/docs/resources/morpheus_task_shell_script.md
+++ b/docs/resources/morpheus_task_shell_script.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_shell_script Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus shell script task resource
 ---

--- a/docs/resources/morpheus_task_vro.md
+++ b/docs/resources/morpheus_task_vro.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_vro Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus vRealize Orchestrator (vRO) task resource
 ---

--- a/docs/resources/morpheus_task_write_attributes.md
+++ b/docs/resources/morpheus_task_write_attributes.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_task_write_attributes Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus write attributes task resource
 ---

--- a/docs/resources/morpheus_tenant.md
+++ b/docs/resources/morpheus_tenant.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_tenant Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus tenant resource.
 ---

--- a/docs/resources/morpheus_user.md
+++ b/docs/resources/morpheus_user.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_user Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   
 ---

--- a/docs/resources/morpheus_user_group.md
+++ b/docs/resources/morpheus_user_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_user_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus user group resource
 ---

--- a/docs/resources/morpheus_vdi_app.md
+++ b/docs/resources/morpheus_vdi_app.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_vdi_app Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus VDI App resource.
 ---

--- a/docs/resources/morpheus_vdi_gateway.md
+++ b/docs/resources/morpheus_vdi_gateway.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_vdi_gateway Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus VDI Gateway resource.
 ---

--- a/docs/resources/morpheus_vdi_pool.md
+++ b/docs/resources/morpheus_vdi_pool.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_vdi_pool Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus VDI Pool resource.
 ---

--- a/docs/resources/morpheus_wiki_page.md
+++ b/docs/resources/morpheus_wiki_page.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_wiki_page Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus wiki page resource
 ---

--- a/docs/resources/morpheus_workflow_operational.md
+++ b/docs/resources/morpheus_workflow_operational.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_workflow_operational Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus operational workflow resource.
 ---

--- a/docs/resources/morpheus_workflow_provisioning.md
+++ b/docs/resources/morpheus_workflow_provisioning.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_workflow_provisioning Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a Morpheus provisioning workflow resource.
 ---

--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -1,6 +1,18 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+{{ $s := index (split .Name "_") 1 -}}
+{{ $label := title $s -}}
+{{ $table := `
+morpheus=Morpheus
+opsramp=OpsRamp
+` -}}
+{{ range $e := split $table "\n" -}}
+  {{ $kv := split $e "=" -}}
+  {{ if and (eq (len $kv) 2) (eq (index $kv 0) $s) -}}
+    {{ $label = index $kv 1 -}}
+  {{ end -}}
+{{ end -}}
+subcategory: "{{ $label }}"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_ansible_tower_inventory.md.tmpl
+++ b/templates/data-sources/morpheus_ansible_tower_inventory.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_ansible_tower_job_template.md.tmpl
+++ b/templates/data-sources/morpheus_ansible_tower_job_template.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_backup.md.tmpl
+++ b/templates/data-sources/morpheus_backup.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus backup.
 ---

--- a/templates/data-sources/morpheus_backup_host.md.tmpl
+++ b/templates/data-sources/morpheus_backup_host.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus host backup.
 ---

--- a/templates/data-sources/morpheus_backup_instance.md.tmpl
+++ b/templates/data-sources/morpheus_backup_instance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus instance backup.
 ---

--- a/templates/data-sources/morpheus_backup_job.md.tmpl
+++ b/templates/data-sources/morpheus_backup_job.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_backup_type.md.tmpl
+++ b/templates/data-sources/morpheus_backup_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus backup type.
 ---

--- a/templates/data-sources/morpheus_blueprint.md.tmpl
+++ b/templates/data-sources/morpheus_blueprint.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_budget.md.tmpl
+++ b/templates/data-sources/morpheus_budget.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_catalog_item_type.md.tmpl
+++ b/templates/data-sources/morpheus_catalog_item_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_certificate.md.tmpl
+++ b/templates/data-sources/morpheus_certificate.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cloud.md.tmpl
+++ b/templates/data-sources/morpheus_cloud.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cloud_folder.md.tmpl
+++ b/templates/data-sources/morpheus_cloud_folder.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cloud_type.md.tmpl
+++ b/templates/data-sources/morpheus_cloud_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_clouds.md.tmpl
+++ b/templates/data-sources/morpheus_clouds.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cluster.md.tmpl
+++ b/templates/data-sources/morpheus_cluster.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cluster_affinity_group.md.tmpl
+++ b/templates/data-sources/morpheus_cluster_affinity_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cluster_layout.md.tmpl
+++ b/templates/data-sources/morpheus_cluster_layout.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cluster_namespace.md.tmpl
+++ b/templates/data-sources/morpheus_cluster_namespace.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cluster_type.md.tmpl
+++ b/templates/data-sources/morpheus_cluster_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_contact.md.tmpl
+++ b/templates/data-sources/morpheus_contact.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_container_script.md.tmpl
+++ b/templates/data-sources/morpheus_container_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_credential.md.tmpl
+++ b/templates/data-sources/morpheus_credential.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_cypher_secret.md.tmpl
+++ b/templates/data-sources/morpheus_cypher_secret.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_datastore.md.tmpl
+++ b/templates/data-sources/morpheus_datastore.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_datastore_types.md.tmpl
+++ b/templates/data-sources/morpheus_datastore_types.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_datastores.md.tmpl
+++ b/templates/data-sources/morpheus_datastores.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_deployment.md.tmpl
+++ b/templates/data-sources/morpheus_deployment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_environment.md.tmpl
+++ b/templates/data-sources/morpheus_environment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_environments.md.tmpl
+++ b/templates/data-sources/morpheus_environments.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_execute_schedule.md.tmpl
+++ b/templates/data-sources/morpheus_execute_schedule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_file_template.md.tmpl
+++ b/templates/data-sources/morpheus_file_template.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_group.md.tmpl
+++ b/templates/data-sources/morpheus_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_groups.md.tmpl
+++ b/templates/data-sources/morpheus_groups.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_image.md.tmpl
+++ b/templates/data-sources/morpheus_image.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_images.md.tmpl
+++ b/templates/data-sources/morpheus_images.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_instance.md.tmpl
+++ b/templates/data-sources/morpheus_instance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_instance_snapshot.md.tmpl
+++ b/templates/data-sources/morpheus_instance_snapshot.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_instance_type.md.tmpl
+++ b/templates/data-sources/morpheus_instance_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_instance_type_layout.md.tmpl
+++ b/templates/data-sources/morpheus_instance_type_layout.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_integration.md.tmpl
+++ b/templates/data-sources/morpheus_integration.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_integration_git.md.tmpl
+++ b/templates/data-sources/morpheus_integration_git.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_job.md.tmpl
+++ b/templates/data-sources/morpheus_job.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_key_pair.md.tmpl
+++ b/templates/data-sources/morpheus_key_pair.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_load_balancer.md.tmpl
+++ b/templates/data-sources/morpheus_load_balancer.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_load_balancer_monitor.md.tmpl
+++ b/templates/data-sources/morpheus_load_balancer_monitor.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus load balancer health check monitor.
 ---

--- a/templates/data-sources/morpheus_load_balancer_pool.md.tmpl
+++ b/templates/data-sources/morpheus_load_balancer_pool.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus load balancer pool.
 ---

--- a/templates/data-sources/morpheus_load_balancer_profile.md.tmpl
+++ b/templates/data-sources/morpheus_load_balancer_profile.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus load balancer profile.
 ---

--- a/templates/data-sources/morpheus_load_balancer_virtual_server.md.tmpl
+++ b/templates/data-sources/morpheus_load_balancer_virtual_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus load balancer virtual server.
 ---

--- a/templates/data-sources/morpheus_monitoring_alert.md.tmpl
+++ b/templates/data-sources/morpheus_monitoring_alert.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_monitoring_check.md.tmpl
+++ b/templates/data-sources/morpheus_monitoring_check.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_monitoring_check_type.md.tmpl
+++ b/templates/data-sources/morpheus_monitoring_check_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_monitoring_group.md.tmpl
+++ b/templates/data-sources/morpheus_monitoring_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network.md.tmpl
+++ b/templates/data-sources/morpheus_network.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_dhcp_server.md.tmpl
+++ b/templates/data-sources/morpheus_network_dhcp_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_domain.md.tmpl
+++ b/templates/data-sources/morpheus_network_domain.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Provides a Network Domain data source. This can be used to reference an existing Network Domain by name or id.
 ---

--- a/templates/data-sources/morpheus_network_edge_cluster.md.tmpl
+++ b/templates/data-sources/morpheus_network_edge_cluster.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus network edge cluster from a network server that supports them (e.g. NSX-T, VCD).
 ---

--- a/templates/data-sources/morpheus_network_firewall_rule.md.tmpl
+++ b/templates/data-sources/morpheus_network_firewall_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_firewall_rule_group.md.tmpl
+++ b/templates/data-sources/morpheus_network_firewall_rule_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_group.md.tmpl
+++ b/templates/data-sources/morpheus_network_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_pool.md.tmpl
+++ b/templates/data-sources/morpheus_network_pool.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_pool_server.md.tmpl
+++ b/templates/data-sources/morpheus_network_pool_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_pool_server_type.md.tmpl
+++ b/templates/data-sources/morpheus_network_pool_server_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_router.md.tmpl
+++ b/templates/data-sources/morpheus_network_router.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_router_firewall_rule.md.tmpl
+++ b/templates/data-sources/morpheus_network_router_firewall_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_router_firewall_rule_groups.md.tmpl
+++ b/templates/data-sources/morpheus_network_router_firewall_rule_groups.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_router_nat.md.tmpl
+++ b/templates/data-sources/morpheus_network_router_nat.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_router_route.md.tmpl
+++ b/templates/data-sources/morpheus_network_router_route.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_router_type.md.tmpl
+++ b/templates/data-sources/morpheus_network_router_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_server.md.tmpl
+++ b/templates/data-sources/morpheus_network_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_subnet.md.tmpl
+++ b/templates/data-sources/morpheus_network_subnet.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_network_transport_zone.md.tmpl
+++ b/templates/data-sources/morpheus_network_transport_zone.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Reads a Morpheus network transport zone from a network server that supports them (e.g. NSX-T, VCD).
 ---

--- a/templates/data-sources/morpheus_network_type.md.tmpl
+++ b/templates/data-sources/morpheus_network_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_networks.md.tmpl
+++ b/templates/data-sources/morpheus_networks.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_node_type.md.tmpl
+++ b/templates/data-sources/morpheus_node_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_option_list.md.tmpl
+++ b/templates/data-sources/morpheus_option_list.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_option_type.md.tmpl
+++ b/templates/data-sources/morpheus_option_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_os_type.md.tmpl
+++ b/templates/data-sources/morpheus_os_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_os_type_image.md.tmpl
+++ b/templates/data-sources/morpheus_os_type_image.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_policies.md.tmpl
+++ b/templates/data-sources/morpheus_policies.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_policy.md.tmpl
+++ b/templates/data-sources/morpheus_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_power_schedule.md.tmpl
+++ b/templates/data-sources/morpheus_power_schedule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_price.md.tmpl
+++ b/templates/data-sources/morpheus_price.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_price_set.md.tmpl
+++ b/templates/data-sources/morpheus_price_set.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_provision_type.md.tmpl
+++ b/templates/data-sources/morpheus_provision_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_provisioning_license.md.tmpl
+++ b/templates/data-sources/morpheus_provisioning_license.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_resource_pool.md.tmpl
+++ b/templates/data-sources/morpheus_resource_pool.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_role.md.tmpl
+++ b/templates/data-sources/morpheus_role.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_script_template.md.tmpl
+++ b/templates/data-sources/morpheus_script_template.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_security_group.md.tmpl
+++ b/templates/data-sources/morpheus_security_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_security_group_rule.md.tmpl
+++ b/templates/data-sources/morpheus_security_group_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_security_groups.md.tmpl
+++ b/templates/data-sources/morpheus_security_groups.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_security_package.md.tmpl
+++ b/templates/data-sources/morpheus_security_package.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_service_plan.md.tmpl
+++ b/templates/data-sources/morpheus_service_plan.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_servicenow_workflow.md.tmpl
+++ b/templates/data-sources/morpheus_servicenow_workflow.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_spec_template.md.tmpl
+++ b/templates/data-sources/morpheus_spec_template.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_storage_bucket.md.tmpl
+++ b/templates/data-sources/morpheus_storage_bucket.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_storage_server.md.tmpl
+++ b/templates/data-sources/morpheus_storage_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_storage_servers.md.tmpl
+++ b/templates/data-sources/morpheus_storage_servers.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_storage_volume.md.tmpl
+++ b/templates/data-sources/morpheus_storage_volume.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_storage_volume_type.md.tmpl
+++ b/templates/data-sources/morpheus_storage_volume_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_storage_volumes.md.tmpl
+++ b/templates/data-sources/morpheus_storage_volumes.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_subnet_type.md.tmpl
+++ b/templates/data-sources/morpheus_subnet_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_task.md.tmpl
+++ b/templates/data-sources/morpheus_task.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_tasks.md.tmpl
+++ b/templates/data-sources/morpheus_tasks.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_tenant.md.tmpl
+++ b/templates/data-sources/morpheus_tenant.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_tenants.md.tmpl
+++ b/templates/data-sources/morpheus_tenants.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_user.md.tmpl
+++ b/templates/data-sources/morpheus_user.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_user_group.md.tmpl
+++ b/templates/data-sources/morpheus_user_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_user_groups.md.tmpl
+++ b/templates/data-sources/morpheus_user_groups.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_vdi_app.md.tmpl
+++ b/templates/data-sources/morpheus_vdi_app.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_vdi_gateway.md.tmpl
+++ b/templates/data-sources/morpheus_vdi_gateway.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_vdi_pool.md.tmpl
+++ b/templates/data-sources/morpheus_vdi_pool.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_vro_workflow.md.tmpl
+++ b/templates/data-sources/morpheus_vro_workflow.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/data-sources/morpheus_workflow.md.tmpl
+++ b/templates/data-sources/morpheus_workflow.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -1,6 +1,18 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+{{ $s := index (split .Name "_") 1 -}}
+{{ $label := title $s -}}
+{{ $table := `
+morpheus=Morpheus
+opsramp=OpsRamp
+` -}}
+{{ range $e := split $table "\n" -}}
+  {{ $kv := split $e "=" -}}
+  {{ if and (eq (len $kv) 2) (eq (index $kv 0) $s) -}}
+    {{ $label = index $kv 1 -}}
+  {{ end -}}
+{{ end -}}
+subcategory: "{{ $label }}"
 description: |-
 {{ $lines := split .Description "\n" }}{{ index $lines 0 | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_app_blueprint_arm.md.tmpl
+++ b/templates/resources/morpheus_app_blueprint_arm.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_app_blueprint_cloud_formation.md.tmpl
+++ b/templates/resources/morpheus_app_blueprint_cloud_formation.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_app_blueprint_helm.md.tmpl
+++ b/templates/resources/morpheus_app_blueprint_helm.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_app_blueprint_kubernetes.md.tmpl
+++ b/templates/resources/morpheus_app_blueprint_kubernetes.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_app_blueprint_terraform.md.tmpl
+++ b/templates/resources/morpheus_app_blueprint_terraform.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_backup_host.md.tmpl
+++ b/templates/resources/morpheus_backup_host.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_backup_instance.md.tmpl
+++ b/templates/resources/morpheus_backup_instance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_backup_job.md.tmpl
+++ b/templates/resources/morpheus_backup_job.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_boot_script.md.tmpl
+++ b/templates/resources/morpheus_boot_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_budget.md.tmpl
+++ b/templates/resources/morpheus_budget.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_catalog_item_app_blueprint.md.tmpl
+++ b/templates/resources/morpheus_catalog_item_app_blueprint.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_catalog_item_instance.md.tmpl
+++ b/templates/resources/morpheus_catalog_item_instance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_catalog_item_workflow.md.tmpl
+++ b/templates/resources/morpheus_catalog_item_workflow.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_certificate.md.tmpl
+++ b/templates/resources/morpheus_certificate.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cloud.md.tmpl
+++ b/templates/resources/morpheus_cloud.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cluster.md.tmpl
+++ b/templates/resources/morpheus_cluster.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cluster_affinity_group.md.tmpl
+++ b/templates/resources/morpheus_cluster_affinity_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cluster_hks_vsphere.md.tmpl
+++ b/templates/resources/morpheus_cluster_hks_vsphere.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cluster_layout.md.tmpl
+++ b/templates/resources/morpheus_cluster_layout.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cluster_namespace.md.tmpl
+++ b/templates/resources/morpheus_cluster_namespace.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cluster_package.md.tmpl
+++ b/templates/resources/morpheus_cluster_package.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_contact.md.tmpl
+++ b/templates/resources/morpheus_contact.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_container_script.md.tmpl
+++ b/templates/resources/morpheus_container_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_credential.md.tmpl
+++ b/templates/resources/morpheus_credential.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cypher_secret.md.tmpl
+++ b/templates/resources/morpheus_cypher_secret.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_cypher_tfvars.md.tmpl
+++ b/templates/resources/morpheus_cypher_tfvars.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_datastore.md.tmpl
+++ b/templates/resources/morpheus_datastore.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_deployment.md.tmpl
+++ b/templates/resources/morpheus_deployment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_environment.md.tmpl
+++ b/templates/resources/morpheus_environment.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_execute_schedule.md.tmpl
+++ b/templates/resources/morpheus_execute_schedule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_file_template.md.tmpl
+++ b/templates/resources/morpheus_file_template.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_form.md.tmpl
+++ b/templates/resources/morpheus_form.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_group.md.tmpl
+++ b/templates/resources/morpheus_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_identity_source_active_directory.md.tmpl
+++ b/templates/resources/morpheus_identity_source_active_directory.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_identity_source_saml.md.tmpl
+++ b/templates/resources/morpheus_identity_source_saml.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_image.md.tmpl
+++ b/templates/resources/morpheus_image.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_instance.md.tmpl
+++ b/templates/resources/morpheus_instance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_instance_clone.md.tmpl
+++ b/templates/resources/morpheus_instance_clone.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_instance_power_state.md.tmpl
+++ b/templates/resources/morpheus_instance_power_state.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_instance_snapshot.md.tmpl
+++ b/templates/resources/morpheus_instance_snapshot.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_instance_type.md.tmpl
+++ b/templates/resources/morpheus_instance_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_instance_type_layout.md.tmpl
+++ b/templates/resources/morpheus_instance_type_layout.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_integration_ansible.md.tmpl
+++ b/templates/resources/morpheus_integration_ansible.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_integration_ansible_tower.md.tmpl
+++ b/templates/resources/morpheus_integration_ansible_tower.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_integration_chef.md.tmpl
+++ b/templates/resources/morpheus_integration_chef.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_integration_docker_registry.md.tmpl
+++ b/templates/resources/morpheus_integration_docker_registry.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_integration_git.md.tmpl
+++ b/templates/resources/morpheus_integration_git.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_integration_puppet.md.tmpl
+++ b/templates/resources/morpheus_integration_puppet.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_integration_servicenow.md.tmpl
+++ b/templates/resources/morpheus_integration_servicenow.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_integration_vro.md.tmpl
+++ b/templates/resources/morpheus_integration_vro.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_ip_pool_ipv4.md.tmpl
+++ b/templates/resources/morpheus_ip_pool_ipv4.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_job_task.md.tmpl
+++ b/templates/resources/morpheus_job_task.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_job_workflow.md.tmpl
+++ b/templates/resources/morpheus_job_workflow.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_license.md.tmpl
+++ b/templates/resources/morpheus_license.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_load_balancer.md.tmpl
+++ b/templates/resources/morpheus_load_balancer.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_load_balancer_monitor.md.tmpl
+++ b/templates/resources/morpheus_load_balancer_monitor.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus load balancer health check monitor.
 ---

--- a/templates/resources/morpheus_load_balancer_pool.md.tmpl
+++ b/templates/resources/morpheus_load_balancer_pool.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus load balancer pool.
 ---

--- a/templates/resources/morpheus_load_balancer_profile.md.tmpl
+++ b/templates/resources/morpheus_load_balancer_profile.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus load balancer profile.
 ---

--- a/templates/resources/morpheus_load_balancer_virtual_server.md.tmpl
+++ b/templates/resources/morpheus_load_balancer_virtual_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
   Manages a Morpheus load balancer virtual server (VIP). A virtual server defines a frontend listener on a load balancer, including the VIP address, port, and protocol.
 ---

--- a/templates/resources/morpheus_monitoring_alert.md.tmpl
+++ b/templates/resources/morpheus_monitoring_alert.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_monitoring_check.md.tmpl
+++ b/templates/resources/morpheus_monitoring_check.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_monitoring_group.md.tmpl
+++ b/templates/resources/morpheus_monitoring_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network.md.tmpl
+++ b/templates/resources/morpheus_network.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_dhcp_server.md.tmpl
+++ b/templates/resources/morpheus_network_dhcp_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_domain.md.tmpl
+++ b/templates/resources/morpheus_network_domain.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_firewall_rule.md.tmpl
+++ b/templates/resources/morpheus_network_firewall_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_firewall_rule_group.md.tmpl
+++ b/templates/resources/morpheus_network_firewall_rule_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_group.md.tmpl
+++ b/templates/resources/morpheus_network_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_pool.md.tmpl
+++ b/templates/resources/morpheus_network_pool.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_pool_server.md.tmpl
+++ b/templates/resources/morpheus_network_pool_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_router.md.tmpl
+++ b/templates/resources/morpheus_network_router.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_router_bgp_neighbor.md.tmpl
+++ b/templates/resources/morpheus_network_router_bgp_neighbor.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_router_firewall_rule.md.tmpl
+++ b/templates/resources/morpheus_network_router_firewall_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_router_nat.md.tmpl
+++ b/templates/resources/morpheus_network_router_nat.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_router_route.md.tmpl
+++ b/templates/resources/morpheus_network_router_route.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_node_type.md.tmpl
+++ b/templates/resources/morpheus_node_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_list.md.tmpl
+++ b/templates/resources/morpheus_option_list.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_list_api.md.tmpl
+++ b/templates/resources/morpheus_option_list_api.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_list_manual.md.tmpl
+++ b/templates/resources/morpheus_option_list_manual.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_list_rest.md.tmpl
+++ b/templates/resources/morpheus_option_list_rest.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_checkbox.md.tmpl
+++ b/templates/resources/morpheus_option_type_checkbox.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_hidden.md.tmpl
+++ b/templates/resources/morpheus_option_type_hidden.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_number.md.tmpl
+++ b/templates/resources/morpheus_option_type_number.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_password.md.tmpl
+++ b/templates/resources/morpheus_option_type_password.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_radio_list.md.tmpl
+++ b/templates/resources/morpheus_option_type_radio_list.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_select_list.md.tmpl
+++ b/templates/resources/morpheus_option_type_select_list.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_text.md.tmpl
+++ b/templates/resources/morpheus_option_type_text.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_textarea.md.tmpl
+++ b/templates/resources/morpheus_option_type_textarea.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_option_type_typeahead.md.tmpl
+++ b/templates/resources/morpheus_option_type_typeahead.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_os_type.md.tmpl
+++ b/templates/resources/morpheus_os_type.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_os_type_image.md.tmpl
+++ b/templates/resources/morpheus_os_type_image.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_policy.md.tmpl
+++ b/templates/resources/morpheus_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_power_schedule.md.tmpl
+++ b/templates/resources/morpheus_power_schedule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_preseed_script.md.tmpl
+++ b/templates/resources/morpheus_preseed_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_price.md.tmpl
+++ b/templates/resources/morpheus_price.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_price_set.md.tmpl
+++ b/templates/resources/morpheus_price_set.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_provisioning_license.md.tmpl
+++ b/templates/resources/morpheus_provisioning_license.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_resource_pool_group.md.tmpl
+++ b/templates/resources/morpheus_resource_pool_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_role.md.tmpl
+++ b/templates/resources/morpheus_role.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_scale_threshold.md.tmpl
+++ b/templates/resources/morpheus_scale_threshold.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_script_template.md.tmpl
+++ b/templates/resources/morpheus_script_template.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_security_group.md.tmpl
+++ b/templates/resources/morpheus_security_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_security_group_rule.md.tmpl
+++ b/templates/resources/morpheus_security_group_rule.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_security_package.md.tmpl
+++ b/templates/resources/morpheus_security_package.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_service_plan.md.tmpl
+++ b/templates/resources/morpheus_service_plan.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ $lines := split .Description "\n" }}{{ index $lines 0 | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_setting_appliance.md.tmpl
+++ b/templates/resources/morpheus_setting_appliance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_setting_backup.md.tmpl
+++ b/templates/resources/morpheus_setting_backup.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_setting_guidance.md.tmpl
+++ b/templates/resources/morpheus_setting_guidance.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_setting_monitoring.md.tmpl
+++ b/templates/resources/morpheus_setting_monitoring.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_setting_provisioning.md.tmpl
+++ b/templates/resources/morpheus_setting_provisioning.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_setting_whitelabel.md.tmpl
+++ b/templates/resources/morpheus_setting_whitelabel.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_spec_template_arm.md.tmpl
+++ b/templates/resources/morpheus_spec_template_arm.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_spec_template_cloud_formation.md.tmpl
+++ b/templates/resources/morpheus_spec_template_cloud_formation.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_spec_template_helm.md.tmpl
+++ b/templates/resources/morpheus_spec_template_helm.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_spec_template_kubernetes.md.tmpl
+++ b/templates/resources/morpheus_spec_template_kubernetes.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_spec_template_terraform.md.tmpl
+++ b/templates/resources/morpheus_spec_template_terraform.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_storage_bucket.md.tmpl
+++ b/templates/resources/morpheus_storage_bucket.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_storage_server.md.tmpl
+++ b/templates/resources/morpheus_storage_server.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_storage_volume.md.tmpl
+++ b/templates/resources/morpheus_storage_volume.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_subnet.md.tmpl
+++ b/templates/resources/morpheus_subnet.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task.md.tmpl
+++ b/templates/resources/morpheus_task.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_ansible_playbook.md.tmpl
+++ b/templates/resources/morpheus_task_ansible_playbook.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_ansible_tower.md.tmpl
+++ b/templates/resources/morpheus_task_ansible_tower.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_chef_bootstrap.md.tmpl
+++ b/templates/resources/morpheus_task_chef_bootstrap.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_email.md.tmpl
+++ b/templates/resources/morpheus_task_email.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_groovy_script.md.tmpl
+++ b/templates/resources/morpheus_task_groovy_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_javascript.md.tmpl
+++ b/templates/resources/morpheus_task_javascript.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_library_script.md.tmpl
+++ b/templates/resources/morpheus_task_library_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_library_template.md.tmpl
+++ b/templates/resources/morpheus_task_library_template.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_nested_workflow.md.tmpl
+++ b/templates/resources/morpheus_task_nested_workflow.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_powershell_script.md.tmpl
+++ b/templates/resources/morpheus_task_powershell_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_python_script.md.tmpl
+++ b/templates/resources/morpheus_task_python_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_restart.md.tmpl
+++ b/templates/resources/morpheus_task_restart.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_ruby_script.md.tmpl
+++ b/templates/resources/morpheus_task_ruby_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_shell_script.md.tmpl
+++ b/templates/resources/morpheus_task_shell_script.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_vro.md.tmpl
+++ b/templates/resources/morpheus_task_vro.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_task_write_attributes.md.tmpl
+++ b/templates/resources/morpheus_task_write_attributes.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_tenant.md.tmpl
+++ b/templates/resources/morpheus_tenant.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_user.md.tmpl
+++ b/templates/resources/morpheus_user.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_user_group.md.tmpl
+++ b/templates/resources/morpheus_user_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_vdi_app.md.tmpl
+++ b/templates/resources/morpheus_vdi_app.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_vdi_gateway.md.tmpl
+++ b/templates/resources/morpheus_vdi_gateway.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_vdi_pool.md.tmpl
+++ b/templates/resources/morpheus_vdi_pool.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_wiki_page.md.tmpl
+++ b/templates/resources/morpheus_wiki_page.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_workflow_operational.md.tmpl
+++ b/templates/resources/morpheus_workflow_operational.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_workflow_provisioning.md.tmpl
+++ b/templates/resources/morpheus_workflow_provisioning.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---


### PR DESCRIPTION
Product management asked for the documentation `subcategory` to be presented as **"Morpheus"** rather than `"morpheus"` (and **"OpsRamp"** rather than `"opsramp"` for future OpsRamp resources).

## What changed

**Fallback templates** (`templates/resources.md.tmpl`, `templates/data-sources.md.tmpl`) now resolve the subcategory through a small product-name lookup table, so future products only need one new line:

```gotemplate
{{ $table := `
morpheus=Morpheus
opsramp=OpsRamp
` -}}
```

Anything not listed falls back to title case. This matters because `title` alone cannot produce internal capitalization — it would yield `Opsramp`, not `OpsRamp`.

**Per-resource and per-data-source templates** (261 files) hardcode `subcategory: "Morpheus"`, since each of those templates belongs to exactly one product.

**Docs regenerated** — 264 pages now read `subcategory: "Morpheus"`.

## Why every template changes at once

The Terraform Registry groups pages by the *exact* subcategory string. Mixing `"morpheus"` and `"Morpheus"` would split the navigation into two separate groups, so this is intentionally all-or-nothing.

## Verification

- `make docs` on the base branch produces **zero** drift beforehand, so the entire diff is attributable to this change.
- Only `subcategory` lines changed in the 264 regenerated pages — verified with a line-level diff guard.
- `make docs` is idempotent (identical tree hash on re-run), so the docs check stays green.
- The three pages that use the fallback templates (`morpheus_cluster_hks_hvm`, `morpheus_key_pair`, `morpheus_network_router_bgp_neighbor`) render `"Morpheus"` via the table, which exercises the new logic.
- `go build ./...` and `golangci-lint` are clean. No Go, schema, or provider behaviour changes — documentation only.

## Note

The `opsramp` row is forward-looking: there are no OpsRamp resources in the provider yet, so that entry is not exercised by current output.