### PR TITLE
fix: handle string-encoded noAgent in getNoAgent

### DIFF
--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -913,14 +913,12 @@ func getNestedVirtualization(
 	id int64,
 	apiConfig *apiConfigType,
 ) (*string, diag.Diagnostics) {
-	var diags diag.Diagnostics
+	// nestedVirtualization is optional: hpegl never sets it, so Morpheus omits
+	// it from the GET response entirely (IsSet() == false).  Treat absence as
+	// nil rather than an error — the caller passes nil to convert.StrToType
+	// which produces a null value, valid for this Optional+Computed attribute.
 	if !apiConfig.NestedVirtualization.IsSet() {
-		diags.AddError(
-			"populate instance resource",
-			fmt.Sprintf("instance %d GET failed to get config nestedVirtualization", id),
-		)
-
-		return nil, diags
+		return nil, nil
 	}
 
 	return apiConfig.NestedVirtualization.Get(), nil

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -876,17 +876,37 @@ func getNoAgent(
 ) (*bool, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	noAgent := apiConfig.NoAgent
-	if noAgent == nil || noAgent.Bool == nil {
+	if noAgent == nil {
 		diags.AddError(
 			"populate instance resource",
 			fmt.Sprintf("instance %d GET failed to get config noAgent", id),
 		)
 
 		return nil, diags
-
 	}
 
-	return noAgent.Bool, nil
+	// Normal path: Morpheus returned noAgent as a JSON boolean.
+	if noAgent.Bool != nil {
+		return noAgent.Bool, diags
+	}
+
+	// Legacy-string path: some providers (e.g. hpegl) send noAgent as the
+	// string "true"/"false" to the Morpheus API, which stores and returns it
+	// as a JSON string rather than a boolean.  Parse it so that instances
+	// created by hpegl can be read without error.
+	if noAgent.String != nil {
+		b, err := strconv.ParseBool(*noAgent.String)
+		if err == nil {
+			return &b, diags
+		}
+	}
+
+	diags.AddError(
+		"populate instance resource",
+		fmt.Sprintf("instance %d GET failed to get config noAgent", id),
+	)
+
+	return nil, diags
 }
 
 func getNestedVirtualization(


### PR DESCRIPTION
**Fix 1: handle string-encoded noAgent in getNoAgent**
Morpheus stores noAgent as the string "true"/"false" when it was written by the hpegl provider that serialises booleans via strconv.FormatBool before sending them to the API.  

The generated SDK model GetInstance200ResponseInstanceConfigNoAgent has two fields: Bool *bool and String *string.  The previous getNoAgent implementation only checked Bool, so instances created by hpegl triggered the error `"instance N GET failed to get config noAgent"` on every read.

Fall back to strconv.ParseBool(*noAgent.String) when Bool is nil, so both the boolean and string-encoded variants are handled.  The error path is preserved for the case where neither field is set.

**Fix 2: treat absent nestedVirtualization as optional on read, not an error**
hpegl never sets nestedVirtualization when provisioning VMware/HVM
instances, so Morpheus omits the field from GET responses entirely.
IsSet() on the NullableString returns false in this case, and the
previous code treated that as an error:
```
  instance N GET failed to get config nestedVirtualization
```
nestedVirtualization is Optional+Computed with Default "off" in the
schema, so absence is legitimate.  Return nil, nil (no error) when the
field is not set, mirroring the kvmHostId pattern already in the same
file.  convert.StrToType(nil) produces a null basetypes.StringValue,
which is valid for an optional/computed attribute.  The default is
applied at plan time, not read time, so no persistent diff is produced.

The unused 'var diags diag.Diagnostics' declaration is also removed.