### PR TITLE
MORPH-14683: Keep instance disks backed by a storage server datastore

### DIFF
--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -1210,6 +1210,28 @@ func getVolumes(
 	// instance's host — which are not part of the instance's provisioned disks.
 	apiVolumes = removeExternalStorageVolumes(apiVolumes)
 
+	// Filtering must never remove every volume while the configuration declares
+	// some. convert.ToListType maps an empty slice to a null list, so silently
+	// continuing would write `volumes = null` into state and surface as an
+	// opaque "Provider produced inconsistent result after apply" rather than a
+	// usable error. Fail loudly instead.
+	if len(apiVolumes) == 0 && len(plan.Volumes.Elements()) > 0 {
+		diags.AddError(
+			"no instance volumes left after filtering",
+			fmt.Sprintf(
+				"instance %d returned %d volume(s), but none were recognised as "+
+					"belonging to the instance, while the configuration declares %d. "+
+					"This is a provider bug: the instance's volumes would be written "+
+					"to state as null.",
+				instanceIDValue(instance),
+				len(serverVolumes),
+				len(plan.Volumes.Elements()),
+			),
+		)
+
+		return basetypes.NewListNull(VolumesValue{}.Type(ctx)), diags
+	}
+
 	// Import
 	if plan.Name.IsNull() || plan.Name.IsUnknown() {
 		nonRaidVolumes := removeRaidDisks(apiVolumes)
@@ -1395,25 +1417,55 @@ func reorderVolumes(
 	return orderedVolumes
 }
 
-// removeExternalStorageVolumes drops storage-server (SAN) volumes from the list.
-// A volume that belongs to a storage server — e.g. an Alletra MP BMaaS LUN
-// created by hpe_morpheus_storage_volume and exported to this instance's host —
-// is added to the compute server's volume collection as a side effect of that
-// export (see updateVolumeAttachment in the Alletra MP plugin). Such volumes are
-// not part of the instance's provisioned disks, so including them here would
-// cause spurious drift on this resource's volumes (and the resize-on-count-change
-// update path could try to detach them). Provisioned VM/metal disks are managed
-// via a datastore/zone and carry no storageServer, so this only excludes
-// externally-managed array LUNs.
+// removeExternalStorageVolumes drops externally-attached storage-server (SAN)
+// volumes from the list. A volume that belongs to a storage server — e.g. an
+// Alletra MP BMaaS LUN created by hpe_morpheus_storage_volume and exported to
+// this instance's host — is added to the compute server's volume collection as a
+// side effect of that export (see updateVolumeAttachment in the Alletra MP
+// plugin). Such volumes are not part of the instance's provisioned disks, so
+// including them here would cause spurious drift on this resource's volumes (and
+// the resize-on-count-change update path could try to detach them).
+//
+// A storageServer reference alone does not make a volume external. When a disk
+// is provisioned onto a datastore that is itself backed by a storage server
+// (e.g. an Alletra MP datastore), Morpheus copies the datastore's storage server
+// onto the instance's own disk — assignVolumeDatastore sets volume.datastore and
+// volume.storageServer together, and the eject path clears both together. Those
+// disks are the instance's own and must be kept; excluding them emptied the
+// volume list and wrote a null `volumes` into state.
+//
+// A volume is therefore only treated as externally attached when it comes from a
+// storage server *and* was not provisioned through a datastore. The root volume
+// is never excluded.
 func removeExternalStorageVolumes(
 	apiVolumes []sdk.InstanceContainerServerVolume1,
 ) []sdk.InstanceContainerServerVolume1 {
-	return slices.DeleteFunc(
-		apiVolumes,
-		func(v sdk.InstanceContainerServerVolume1) bool {
-			return v.StorageServer != nil
-		},
-	)
+	return slices.DeleteFunc(apiVolumes, isExternallyAttachedVolume)
+}
+
+// isExternallyAttachedVolume reports whether a volume was attached to this
+// instance's host by something other than the instance's own provisioning —
+// i.e. an array LUN exported to the host rather than a disk provisioned for
+// this instance.
+func isExternallyAttachedVolume(v sdk.InstanceContainerServerVolume1) bool {
+	// Not from a storage server: an ordinary provisioned disk.
+	if v.StorageServer == nil {
+		return false
+	}
+
+	// The instance's own boot disk is never externally attached, regardless of
+	// the storage backing it.
+	if v.RootVolume != nil && *v.RootVolume {
+		return false
+	}
+
+	// Provisioned through a datastore, so the storageServer was inherited from
+	// that datastore rather than indicating an external export.
+	if v.DatastoreId != nil {
+		return false
+	}
+
+	return true
 }
 
 // removeRaidDisks removes any RAID disks from the list of volumes

--- a/morpheus/framework/resources/instance/instance_read_internal_test.go
+++ b/morpheus/framework/resources/instance/instance_read_internal_test.go
@@ -199,6 +199,118 @@ func TestUnitRemoveExternalStorageVolumes(t *testing.T) {
 	}
 }
 
+// TestUnitIsExternallyAttachedVolume verifies which volumes are treated as
+// externally attached to the instance's host.
+//
+// A storageServer reference alone is not sufficient: when a disk is provisioned
+// onto a datastore that is itself backed by a storage server (e.g. an Alletra MP
+// datastore), Morpheus copies the datastore's storage server onto the instance's
+// own disk (assignVolumeDatastore sets volume.datastore and volume.storageServer
+// together). Excluding those disks emptied the volume list and wrote a null
+// `volumes` into state, surfacing as "Provider produced inconsistent result
+// after apply: .volumes ... but now null".
+func TestUnitIsExternallyAttachedVolume(t *testing.T) {
+	t.Parallel()
+
+	storageServer := &sdk.InstanceContainerServerVolumeStorageServer1{}
+
+	tests := []struct {
+		name   string
+		volume sdk.InstanceContainerServerVolume1
+		want   bool
+	}{
+		{
+			name:   "ordinary provisioned disk",
+			volume: sdk.InstanceContainerServerVolume1{Id: sdk.PtrInt64(1), Name: sdk.PtrString("data")},
+			want:   false,
+		},
+		{
+			name: "externally attached array LUN",
+			volume: sdk.InstanceContainerServerVolume1{
+				Id:            sdk.PtrInt64(2),
+				Name:          sdk.PtrString("alletra-bmaas-lun"),
+				StorageServer: storageServer,
+			},
+			want: true,
+		},
+		{
+			name: "root volume on a storage-server-backed datastore",
+			volume: sdk.InstanceContainerServerVolume1{
+				Id:            sdk.PtrInt64(3),
+				Name:          sdk.PtrString("root"),
+				RootVolume:    sdk.PtrBool(true),
+				DatastoreId:   sdk.PtrInt64(406),
+				StorageServer: storageServer,
+			},
+			want: false,
+		},
+		{
+			name: "data volume on a storage-server-backed datastore",
+			volume: sdk.InstanceContainerServerVolume1{
+				Id:            sdk.PtrInt64(4),
+				Name:          sdk.PtrString("data"),
+				DatastoreId:   sdk.PtrInt64(406),
+				StorageServer: storageServer,
+			},
+			want: false,
+		},
+		{
+			name: "root volume from a storage server with no datastore",
+			volume: sdk.InstanceContainerServerVolume1{
+				Id:            sdk.PtrInt64(5),
+				Name:          sdk.PtrString("root"),
+				RootVolume:    sdk.PtrBool(true),
+				StorageServer: storageServer,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isExternallyAttachedVolume(tt.volume); got != tt.want {
+				t.Errorf("isExternallyAttachedVolume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnitRemoveExternalStorageVolumesKeepsDatastoreBackedDisks verifies the
+// reported failure case: an instance whose disks are provisioned on a
+// storage-server-backed datastore keeps those disks, while an array LUN exported
+// to the same host is still excluded.
+func TestUnitRemoveExternalStorageVolumesKeepsDatastoreBackedDisks(t *testing.T) {
+	t.Parallel()
+
+	storageServer := &sdk.InstanceContainerServerVolumeStorageServer1{}
+
+	volumes := []sdk.InstanceContainerServerVolume1{
+		{
+			Id:            sdk.PtrInt64(1),
+			Name:          sdk.PtrString("root"),
+			RootVolume:    sdk.PtrBool(true),
+			DatastoreId:   sdk.PtrInt64(406),
+			StorageServer: storageServer,
+		},
+		{
+			Id:            sdk.PtrInt64(2),
+			Name:          sdk.PtrString("alletra-bmaas-lun"),
+			StorageServer: storageServer,
+		},
+	}
+
+	got := removeExternalStorageVolumes(volumes)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 volume after filtering, got %d", len(got))
+	}
+	if got[0].Id == nil || *got[0].Id != 1 {
+		t.Errorf("expected the instance's root disk (id 1) to be retained, got %v", got[0].Id)
+	}
+}
+
 // TestUnitBoolFromConfig verifies the defensive coercion of untyped instance config
 // values (native bool or the string encodings Morpheus may use) that back the
 // config_bmaas.enforce_raid_boot_volume attribute, including the fallback to the


### PR DESCRIPTION
Fixes a regression that breaks `hpe_morpheus_instance` whenever its disks are provisioned onto a datastore that is backed by a storage server, such as an Alletra MP datastore.

## Symptom

```
Error: Provider produced inconsistent result after apply

When applying changes to hpe_morpheus_instance.test, provider produced an
unexpected new value: .volumes: was cty.ListVal([...]), but now null.
```

## Cause

Instance volumes were filtered out whenever they carried a `storageServer` reference. That reference does not by itself make a volume external: when a disk is provisioned onto a datastore that is backed by a storage server, the API copies the datastore's storage server onto the instance's own disk, setting the datastore and the storage server together, and clearing them together when the disk is detached.

The instance's own disks were therefore discarded, the volume list was emptied, and an empty slice converts to a **null** list rather than an empty one — so `volumes` was written to state as null while the plan held a populated list.

## Scope

The read path is shared by create, update, refresh and import, so an affected instance fails to create, and on refresh has its volumes nulled in state. A subsequent plan then sees configured volumes against a null state value.

Instances on ordinary datastores are unaffected, as those volumes carry no storage server.

## Fix

A volume is now only treated as externally attached when it comes from a storage server **and** was not provisioned through a datastore. The root volume is never excluded.

Externally attached array LUNs — created by `hpe_morpheus_storage_volume` and exported to the instance's host — are still filtered, exactly as before. That behaviour was deliberate and is preserved; the existing unit test covering it is unchanged and still passes.

Also fails loudly rather than writing null volumes into state if filtering ever removes every volume while the configuration declares some, so a similar problem surfaces as a clear error instead of an opaque inconsistent-result failure.

## Tests

- Existing `TestUnitRemoveExternalStorageVolumes` unchanged and passing, confirming externally attached LUNs are still excluded.
- New table-driven `TestUnitIsExternallyAttachedVolume` covering ordinary disks, an externally attached LUN, root and data volumes on a storage-server-backed datastore, and a root volume from a storage server with no datastore.
- New `TestUnitRemoveExternalStorageVolumesKeepsDatastoreBackedDisks` reproducing the reported case.

## Targeting

Raised against `dev-1.6` because 1.6.0 is due to ship imminently and the regression is not in any released version — the newest tag is v1.5.0. The same fix is prepared for the 1.7 line and will follow.

## Notes

An acceptance test that provisions an instance whose root volume sits on a storage-server-backed datastore would have caught this and is worth adding; there is currently no coverage for that configuration.