### PR TITLE
MORPH-14919: Stop unrelated computed attributes churning the instance plan

### DIFF
--- a/morpheus/framework/resources/instance/example.tf.tmpl
+++ b/morpheus/framework/resources/instance/example.tf.tmpl
@@ -20,6 +20,12 @@ resource "hpe_morpheus_instance" "example" {
 {{- if .UserGroup}}
   user_group = {{.UserGroup}}
 {{- end}}
+{{- if .MaxMemory}}
+
+  service_plan_options = {
+    max_memory = {{.MaxMemory}}
+  }
+{{- end}}
   network_interfaces = [
     {
       network_id = {{.NetworkId}}
@@ -37,6 +43,7 @@ resource "hpe_morpheus_instance" "example" {
       storage_profile = "{{.StorageProfile}}"
 {{- end}}
     },
+{{- if not .SingleVolume}}
     {
       root_volume     = false
       name            = "data"
@@ -44,6 +51,7 @@ resource "hpe_morpheus_instance" "example" {
       storage_type_id = 1
       datastore_id    = {{.DatastoreId}}
     }
+{{- end}}
   ]
 
   tags = [{{if .MultipleTags}}

--- a/morpheus/framework/resources/instance/instance_example.go
+++ b/morpheus/framework/resources/instance/instance_example.go
@@ -36,6 +36,10 @@ func RenderInstanceConfig(t *testing.T, overrides map[string]string) (string, er
 		"MultipleTags":    "",
 		"UserGroup":       "",
 		"StorageProfile":  "",
+		// MaxMemory renders a service_plan_options block, for resize coverage.
+		"MaxMemory": "",
+		// SingleVolume omits the non-root volume, for volume add/remove coverage.
+		"SingleVolume": "",
 	}
 
 	for key, value := range overrides {

--- a/morpheus/framework/resources/instance/instance_plan_modifiers.go
+++ b/morpheus/framework/resources/instance/instance_plan_modifiers.go
@@ -5,17 +5,11 @@ package instance
 import (
 	"context"
 	"errors"
+	"slices"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
-
-// errUnexpectedPathValue is returned when walking an attribute path yields
-// something other than a value, which should not happen for a well-formed plan
-// or state.
-var errUnexpectedPathValue = errors.New("unexpected type at attribute path")
 
 // The plugin framework marks every computed attribute that is null in the
 // configuration as unknown whenever the planned state differs from the prior
@@ -28,52 +22,78 @@ var errUnexpectedPathValue = errors.New("unexpected type at attribute path")
 // changing service_plan_options.max_memory also churns connection_info, labels,
 // and every computed field of network_interfaces and volumes.
 //
-// A blanket UseStateForUnknown is not safe here. Update re-reads the instance
-// from the API and writes whatever it returns into state, so pinning an
-// attribute the API legitimately changes during the update would produce
-// "Provider produced inconsistent result after apply" — a hard failure, worse
-// than a noisy plan. Two cases matter in practice:
+// Restoring values has to be done narrowly. Update re-reads the instance from
+// the API and writes what it returns into state, so a planned value that the
+// read path then overrides produces "Provider produced inconsistent result
+// after apply" — a hard failure, worse than a noisy plan. Two rules keep this
+// safe:
 //
-//   - connection_info holds the instance's addresses. A resize that cannot be
-//     performed hot stops and restarts the instance, and the address can change
-//     as a direct result.
-//   - Interface and volume identity can change when those collections are
-//     themselves reconfigured.
+//  1. Only attributes whose value is stable and API-assigned are restored:
+//     interface and volume identity. Attributes such as volume storage_profile
+//     are excluded, because the post-apply read prefers the API value whenever
+//     the planned value is null or unknown (see instance_read.go), so pinning
+//     them from prior state can contradict what apply returns.
+//  2. A value is only ever filled in where the plan says unknown, and only from
+//     a prior-state value that is itself known and non-null. A null is never
+//     pinned, so restoring cannot turn "unknown, resolve later" into an
+//     assertion the read path will contradict.
 //
-// So each group is restored from prior state only when nothing that could
-// affect it has changed, and the whole collection is restored at once. Restoring
-// per element would be positional, and would pin values from the wrong element
-// if interfaces or volumes were added, removed or reordered.
+// Each group is additionally gated on its own triggers: if the practitioner
+// changed the collection, nothing in it is restored, because the API may assign
+// new identities and a positional restore could pin the previous element's
+// values onto a different one.
 
-// restoreRule describes one group of computed attributes that can be taken from
-// prior state, and the attributes whose modification would invalidate it.
+// errUnexpectedPathValue is returned when walking an attribute path yields
+// something other than a value, which should not happen for a well-formed plan
+// or state.
+var errUnexpectedPathValue = errors.New("unexpected type at attribute path")
+
+// restoreRule describes attributes that can be taken from prior state, and the
+// attributes whose modification would invalidate them.
 type restoreRule struct {
-	// attribute is the attribute restored from prior state.
+	// attribute is the root attribute this rule applies to.
 	attribute string
 
-	// triggers are the attributes that, if changed by the practitioner, mean
-	// the restored value can no longer be trusted. An attribute is normally
-	// its own trigger.
+	// fields, when non-empty, restricts the rule to those nested attributes of
+	// each element of the collection. When empty the root attribute value itself
+	// is restored.
+	fields []string
+
+	// triggers are the attributes that, if changed by the practitioner, mean the
+	// restored values can no longer be trusted. An attribute is normally its own
+	// trigger.
 	triggers []string
 }
 
-// restoreRules lists the computed attributes that can be recovered from prior
-// state, together with what invalidates them.
+// restoreRules lists what may be recovered from prior state.
+//
+// Only identity attributes are listed for the nested collections. Attributes
+// that the post-apply read sources from the API — volume storage_profile and
+// controller_mount_point, interface ip_address — are deliberately absent.
 var restoreRules = []restoreRule{
-	// Interface identity (id, name, primary_interface, ...) is stable unless the
-	// interfaces themselves are reconfigured. Note that on appliances from 8.1.2
-	// a network change is applied in place rather than forcing replacement, and
-	// the API may recreate interfaces, so network_interfaces must gate itself.
-	{attribute: "network_interfaces", triggers: []string{"network_interfaces"}},
+	// Interface identity is stable unless the interfaces are reconfigured. Note
+	// that from 8.1.2 a network change is applied in place rather than forcing
+	// replacement, and the API may recreate interfaces, so network_interfaces
+	// gates itself.
+	{
+		attribute: "network_interfaces",
+		fields:    []string{"id", "name", "primary_interface"},
+		triggers:  []string{"network_interfaces"},
+	},
 
-	// Volume identity is stable unless the volumes themselves are reconfigured.
-	{attribute: "volumes", triggers: []string{"volumes"}},
+	// Volume identity is stable unless the volumes are reconfigured.
+	{
+		attribute: "volumes",
+		fields:    []string{"id"},
+		triggers:  []string{"volumes"},
+	},
 
-	// Labels only change when the practitioner changes them.
+	// Labels are a flat collection with no nested attributes, and only change
+	// when the practitioner changes them.
 	{attribute: "labels", triggers: []string{"labels"}},
 
 	// Addresses can change whenever the instance is reconfigured or restarted,
-	// so anything that drives an infrastructure operation invalidates them.
+	// so anything driving an infrastructure operation invalidates them.
 	{
 		attribute: "connection_info",
 		triggers: []string{
@@ -101,13 +121,115 @@ func restoreUnchangedComputedAttributes(
 		return
 	}
 
+	applicable := make([]restoreRule, 0, len(restoreRules))
+
 	for _, rule := range restoreRules {
 		if anyAttributeChanged(req.Plan.Raw, req.State.Raw, rule.triggers) {
 			continue
 		}
 
-		restoreAttributeFromState(ctx, req, resp, rule.attribute)
+		applicable = append(applicable, rule)
 	}
+
+	if len(applicable) == 0 {
+		return
+	}
+
+	restored, err := restoreFromState(resp.Plan.Raw, req.State.Raw, applicable)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error restoring planned values",
+			"An unexpected error occurred while restoring unchanged computed "+
+				"attributes into the plan. This is always a problem with the "+
+				"provider. Please report the following to the provider "+
+				"developer:\n\n"+err.Error(),
+		)
+
+		return
+	}
+
+	resp.Plan.Raw = restored
+}
+
+// restoreFromState fills unknown values in plan from prior state, for the paths
+// covered by the supplied rules.
+//
+// Only unknown planned values are filled, and only from state values that are
+// known, non-null and of the same type. Anything else is left as planned, so a
+// value the read path will supply is never pre-empted.
+func restoreFromState(
+	plan, state tftypes.Value,
+	rules []restoreRule,
+) (tftypes.Value, error) {
+	return tftypes.Transform(
+		plan,
+		func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
+			if v.IsKnown() || !matchesAnyRestoreRule(p, rules) {
+				return v, nil
+			}
+
+			stateValue, err := valueAtPath(state, p)
+			if err != nil {
+				// No counterpart in prior state — for example a newly added
+				// element. Leave it unknown.
+				return v, nil
+			}
+
+			if !stateValue.IsKnown() || stateValue.IsNull() {
+				return v, nil
+			}
+
+			if !stateValue.Type().Equal(v.Type()) {
+				return v, nil
+			}
+
+			return stateValue, nil
+		},
+	)
+}
+
+// matchesAnyRestoreRule reports whether path is covered by one of the rules.
+func matchesAnyRestoreRule(p *tftypes.AttributePath, rules []restoreRule) bool {
+	return slices.ContainsFunc(rules, func(r restoreRule) bool {
+		return matchesRestoreRule(p, r)
+	})
+}
+
+// matchesRestoreRule reports whether path is covered by a single rule.
+//
+// For a rule without fields the path must be the root attribute itself. For a
+// rule with fields the path must address one of those fields within an element
+// of the collection, e.g. volumes[0].id.
+func matchesRestoreRule(p *tftypes.AttributePath, r restoreRule) bool {
+	steps := p.Steps()
+	if len(steps) == 0 {
+		return false
+	}
+
+	root, ok := steps[0].(tftypes.AttributeName)
+	if !ok || string(root) != r.attribute {
+		return false
+	}
+
+	if len(r.fields) == 0 {
+		return len(steps) == 1
+	}
+
+	// collection[index].field
+	if len(steps) != 3 {
+		return false
+	}
+
+	if _, ok := steps[1].(tftypes.ElementKeyInt); !ok {
+		return false
+	}
+
+	leaf, ok := steps[2].(tftypes.AttributeName)
+	if !ok {
+		return false
+	}
+
+	return slices.Contains(r.fields, string(leaf))
 }
 
 // anyAttributeChanged reports whether the practitioner changed any of the named
@@ -194,33 +316,4 @@ func valueAtPath(val tftypes.Value, p *tftypes.AttributePath) (tftypes.Value, er
 	}
 
 	return value, nil
-}
-
-// restoreAttributeFromState copies one attribute from prior state into the plan.
-func restoreAttributeFromState(
-	ctx context.Context,
-	req resource.ModifyPlanRequest,
-	resp *resource.ModifyPlanResponse,
-	attribute string,
-) {
-	p := path.Root(attribute)
-
-	// These attributes are all collections; read them as their concrete types so
-	// the framework performs the conversion.
-	switch attribute {
-	case "labels":
-		var value types.Set
-		if diags := req.State.GetAttribute(ctx, p, &value); diags.HasError() {
-			return
-		}
-
-		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, p, value)...)
-	default:
-		var value types.List
-		if diags := req.State.GetAttribute(ctx, p, &value); diags.HasError() {
-			return
-		}
-
-		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, p, value)...)
-	}
 }

--- a/morpheus/framework/resources/instance/instance_plan_modifiers.go
+++ b/morpheus/framework/resources/instance/instance_plan_modifiers.go
@@ -1,0 +1,226 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package instance
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// errUnexpectedPathValue is returned when walking an attribute path yields
+// something other than a value, which should not happen for a well-formed plan
+// or state.
+var errUnexpectedPathValue = errors.New("unexpected type at attribute path")
+
+// The plugin framework marks every computed attribute that is null in the
+// configuration as unknown whenever the planned state differs from the prior
+// state (MarkComputedNilsAsUnknown in server_planresourcechange.go). That is
+// deliberate — the framework's own comment notes that later plan modifier passes
+// are expected to put known values back — but it means a change to one attribute
+// makes every unrelated computed attribute show as "(known after apply)".
+//
+// On this resource that produces a large, unreviewable diff for a small edit:
+// changing service_plan_options.max_memory also churns connection_info, labels,
+// and every computed field of network_interfaces and volumes.
+//
+// A blanket UseStateForUnknown is not safe here. Update re-reads the instance
+// from the API and writes whatever it returns into state, so pinning an
+// attribute the API legitimately changes during the update would produce
+// "Provider produced inconsistent result after apply" — a hard failure, worse
+// than a noisy plan. Two cases matter in practice:
+//
+//   - connection_info holds the instance's addresses. A resize that cannot be
+//     performed hot stops and restarts the instance, and the address can change
+//     as a direct result.
+//   - Interface and volume identity can change when those collections are
+//     themselves reconfigured.
+//
+// So each group is restored from prior state only when nothing that could
+// affect it has changed, and the whole collection is restored at once. Restoring
+// per element would be positional, and would pin values from the wrong element
+// if interfaces or volumes were added, removed or reordered.
+
+// restoreRule describes one group of computed attributes that can be taken from
+// prior state, and the attributes whose modification would invalidate it.
+type restoreRule struct {
+	// attribute is the attribute restored from prior state.
+	attribute string
+
+	// triggers are the attributes that, if changed by the practitioner, mean
+	// the restored value can no longer be trusted. An attribute is normally
+	// its own trigger.
+	triggers []string
+}
+
+// restoreRules lists the computed attributes that can be recovered from prior
+// state, together with what invalidates them.
+var restoreRules = []restoreRule{
+	// Interface identity (id, name, primary_interface, ...) is stable unless the
+	// interfaces themselves are reconfigured. Note that on appliances from 8.1.2
+	// a network change is applied in place rather than forcing replacement, and
+	// the API may recreate interfaces, so network_interfaces must gate itself.
+	{attribute: "network_interfaces", triggers: []string{"network_interfaces"}},
+
+	// Volume identity is stable unless the volumes themselves are reconfigured.
+	{attribute: "volumes", triggers: []string{"volumes"}},
+
+	// Labels only change when the practitioner changes them.
+	{attribute: "labels", triggers: []string{"labels"}},
+
+	// Addresses can change whenever the instance is reconfigured or restarted,
+	// so anything that drives an infrastructure operation invalidates them.
+	{
+		attribute: "connection_info",
+		triggers: []string{
+			"service_plan_options",
+			"network_interfaces",
+			"volumes",
+			"config",
+			"plan_id",
+			"layout_id",
+		},
+	},
+}
+
+// restoreUnchangedComputedAttributes puts prior state values back into the plan
+// for computed attributes whose triggering configuration has not been modified,
+// so that an unrelated edit does not show them as "(known after apply)".
+func restoreUnchangedComputedAttributes(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	// Only applies to updates: on create there is no prior state to restore
+	// from, and on destroy there is no plan to modify.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	for _, rule := range restoreRules {
+		if anyAttributeChanged(req.Plan.Raw, req.State.Raw, rule.triggers) {
+			continue
+		}
+
+		restoreAttributeFromState(ctx, req, resp, rule.attribute)
+	}
+}
+
+// anyAttributeChanged reports whether the practitioner changed any of the named
+// attributes.
+func anyAttributeChanged(plan, state tftypes.Value, attributes []string) bool {
+	for _, name := range attributes {
+		if attributeChanged(plan, state, name) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// attributeChanged reports whether the named attribute differs between the plan
+// and prior state, ignoring values the framework marked unknown.
+//
+// Unknown values carry no intent: they are what the framework substituted for
+// computed attributes, not something the practitioner asked for. They are
+// therefore filled from prior state before comparing, so that only values the
+// practitioner actually set are considered.
+func attributeChanged(plan, state tftypes.Value, attribute string) bool {
+	p := tftypes.NewAttributePath().WithAttributeName(attribute)
+
+	planValue, err := valueAtPath(plan, p)
+	if err != nil {
+		return true
+	}
+
+	stateValue, err := valueAtPath(state, p)
+	if err != nil {
+		return true
+	}
+
+	filled, err := fillUnknownsFromState(planValue, stateValue)
+	if err != nil {
+		return true
+	}
+
+	return !filled.Equal(stateValue)
+}
+
+// fillUnknownsFromState replaces every unknown value in plan with the value at
+// the same path in state. Values with no counterpart in state — for example a
+// newly added list element — are left unknown, so the comparison still reports a
+// difference.
+func fillUnknownsFromState(plan, state tftypes.Value) (tftypes.Value, error) {
+	return tftypes.Transform(
+		plan,
+		func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
+			if v.IsKnown() {
+				return v, nil
+			}
+
+			stateValue, err := valueAtPath(state, p)
+			if err != nil {
+				return v, nil
+			}
+
+			if !stateValue.Type().Equal(v.Type()) {
+				return v, nil
+			}
+
+			return stateValue, nil
+		},
+	)
+}
+
+// valueAtPath returns the value at path within val.
+func valueAtPath(val tftypes.Value, p *tftypes.AttributePath) (tftypes.Value, error) {
+	// A path relative to the value itself resolves to the value.
+	if len(p.Steps()) == 0 {
+		return val, nil
+	}
+
+	raw, _, err := tftypes.WalkAttributePath(val, p)
+	if err != nil {
+		return tftypes.Value{}, err
+	}
+
+	value, ok := raw.(tftypes.Value)
+	if !ok {
+		return tftypes.Value{}, errUnexpectedPathValue
+	}
+
+	return value, nil
+}
+
+// restoreAttributeFromState copies one attribute from prior state into the plan.
+func restoreAttributeFromState(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+	attribute string,
+) {
+	p := path.Root(attribute)
+
+	// These attributes are all collections; read them as their concrete types so
+	// the framework performs the conversion.
+	switch attribute {
+	case "labels":
+		var value types.Set
+		if diags := req.State.GetAttribute(ctx, p, &value); diags.HasError() {
+			return
+		}
+
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, p, value)...)
+	default:
+		var value types.List
+		if diags := req.State.GetAttribute(ctx, p, &value); diags.HasError() {
+			return
+		}
+
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, p, value)...)
+	}
+}

--- a/morpheus/framework/resources/instance/instance_plan_modifiers_internal_test.go
+++ b/morpheus/framework/resources/instance/instance_plan_modifiers_internal_test.go
@@ -176,3 +176,123 @@ func TestUnitFillUnknownsFromStateLeavesUnmatchedUnknown(t *testing.T) {
 		t.Error("filled plan equals state, want a difference for the added element")
 	}
 }
+
+// TestUnitMatchesRestoreRule verifies which attribute paths a rule covers.
+//
+// A rule without fields covers only the root attribute. A rule with fields
+// covers those fields within a collection element, and nothing else — in
+// particular it must not match sibling attributes that the post-apply read
+// sources from the API.
+func TestUnitMatchesRestoreRule(t *testing.T) {
+	t.Parallel()
+
+	volumes := restoreRule{attribute: "volumes", fields: []string{"id"}}
+	labels := restoreRule{attribute: "labels"}
+
+	root := func(n string) *tftypes.AttributePath {
+		return tftypes.NewAttributePath().WithAttributeName(n)
+	}
+	elem := func(n string, i int, f string) *tftypes.AttributePath {
+		return tftypes.NewAttributePath().WithAttributeName(n).WithElementKeyInt(i).WithAttributeName(f)
+	}
+
+	tests := []struct {
+		name string
+		path *tftypes.AttributePath
+		rule restoreRule
+		want bool
+	}{
+		{"volume id covered", elem("volumes", 0, "id"), volumes, true},
+		{"volume id at higher index covered", elem("volumes", 3, "id"), volumes, true},
+		{"volume storage_profile NOT covered", elem("volumes", 0, "storage_profile"), volumes, false},
+		{"volume controller_mount_point NOT covered", elem("volumes", 0, "controller_mount_point"), volumes, false},
+		{"volumes root NOT covered when fields set", root("volumes"), volumes, false},
+		{"different collection not covered", elem("network_interfaces", 0, "id"), volumes, false},
+		{"labels root covered", root("labels"), labels, true},
+		{"labels element not covered", elem("labels", 0, "id"), labels, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := matchesRestoreRule(tt.path, tt.rule); got != tt.want {
+				t.Errorf("matchesRestoreRule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnitRestoreFromStateNeverPinsNull is the regression test for the failure
+// this design exists to avoid.
+//
+// Volume storage_profile is null in prior state on a post-apply read, but the
+// API supplies a value. Pinning the null produced "Provider produced
+// inconsistent result after apply: .volumes[0].storage_profile: was null, but
+// now cty.StringVal(...)". The restore must leave such values unknown: both
+// because storage_profile is not a covered field, and because a null is never
+// pinned even where it is covered.
+func TestUnitRestoreFromStateNeverPinsNull(t *testing.T) {
+	t.Parallel()
+
+	planVolumes := volumes(volume(unknownNum(), unknownString()))
+	stateVolumes := volumes(volume(num(671), tftypes.NewValue(tftypes.String, nil)))
+
+	plan := resourceValue(planVolumes)
+	state := resourceValue(stateVolumes)
+
+	// "name" stands in for a value the read path sources from the API: it is
+	// null in prior state, so it must not be pinned.
+	rules := []restoreRule{{attribute: "volumes", fields: []string{"id", "name"}}}
+
+	got, err := restoreFromState(plan, state, rules)
+	if err != nil {
+		t.Fatalf("restoreFromState() error = %v", err)
+	}
+
+	idPath := tftypes.NewAttributePath().WithAttributeName("volumes").WithElementKeyInt(0).WithAttributeName("id")
+	namePath := tftypes.NewAttributePath().WithAttributeName("volumes").WithElementKeyInt(0).WithAttributeName("name")
+
+	gotID, err := valueAtPath(got, idPath)
+	if err != nil {
+		t.Fatalf("id path: %v", err)
+	}
+	if !gotID.Equal(num(671)) {
+		t.Errorf("id = %v, want it restored to 671", gotID)
+	}
+
+	gotName, err := valueAtPath(got, namePath)
+	if err != nil {
+		t.Fatalf("name path: %v", err)
+	}
+	if gotName.IsKnown() {
+		t.Errorf("name = %v, want it left unknown rather than pinned to null", gotName)
+	}
+}
+
+// TestUnitRestoreFromStateLeavesUncoveredAttributesAlone verifies that an
+// attribute outside the rule's fields is untouched even when prior state holds a
+// perfectly good value for it.
+func TestUnitRestoreFromStateLeavesUncoveredAttributesAlone(t *testing.T) {
+	t.Parallel()
+
+	plan := resourceValue(volumes(volume(unknownNum(), unknownString())))
+	state := resourceValue(volumes(volume(num(671), str("kvm-cache-none"))))
+
+	rules := []restoreRule{{attribute: "volumes", fields: []string{"id"}}}
+
+	got, err := restoreFromState(plan, state, rules)
+	if err != nil {
+		t.Fatalf("restoreFromState() error = %v", err)
+	}
+
+	namePath := tftypes.NewAttributePath().WithAttributeName("volumes").WithElementKeyInt(0).WithAttributeName("name")
+	gotName, err := valueAtPath(got, namePath)
+	if err != nil {
+		t.Fatalf("name path: %v", err)
+	}
+
+	if gotName.IsKnown() {
+		t.Errorf("uncovered attribute = %v, want it left unknown", gotName)
+	}
+}

--- a/morpheus/framework/resources/instance/instance_plan_modifiers_internal_test.go
+++ b/morpheus/framework/resources/instance/instance_plan_modifiers_internal_test.go
@@ -1,0 +1,178 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// volumeElementType mirrors the shape of a single volumes element closely enough
+// to exercise the comparison logic: an identity attribute the API supplies, and
+// an attribute the practitioner sets.
+var volumeElementType = tftypes.Object{
+	AttributeTypes: map[string]tftypes.Type{
+		"id":   tftypes.Number,
+		"name": tftypes.String,
+	},
+}
+
+var volumesListType = tftypes.List{ElementType: volumeElementType}
+
+// resourceValue wraps a volumes list in an object, as it appears in the plan and
+// state of a resource.
+func resourceValue(volumes tftypes.Value) tftypes.Value {
+	return tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{"volumes": volumesListType},
+		},
+		map[string]tftypes.Value{"volumes": volumes},
+	)
+}
+
+func volume(id, name tftypes.Value) tftypes.Value {
+	return tftypes.NewValue(
+		volumeElementType,
+		map[string]tftypes.Value{"id": id, "name": name},
+	)
+}
+
+func volumes(elements ...tftypes.Value) tftypes.Value {
+	return tftypes.NewValue(volumesListType, elements)
+}
+
+func num(i int64) tftypes.Value    { return tftypes.NewValue(tftypes.Number, i) }
+func str(s string) tftypes.Value   { return tftypes.NewValue(tftypes.String, s) }
+func unknownNum() tftypes.Value    { return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue) }
+func unknownString() tftypes.Value { return tftypes.NewValue(tftypes.String, tftypes.UnknownValue) }
+
+// TestUnitAttributeChanged verifies that only changes the practitioner actually
+// made count as a change.
+//
+// The framework marks computed attributes as unknown whenever anything on the
+// resource changes, so an unknown value carries no intent and must not be
+// treated as a modification. A value the practitioner set, a change in the
+// number of elements, or a newly added element must all be treated as changes.
+func TestUnitAttributeChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		plan  tftypes.Value
+		state tftypes.Value
+		want  bool
+	}{
+		{
+			name:  "identical",
+			plan:  resourceValue(volumes(volume(num(671), str("root")))),
+			state: resourceValue(volumes(volume(num(671), str("root")))),
+			want:  false,
+		},
+		{
+			name: "only computed attributes unknown",
+			// What the framework produces on an unrelated edit: identity is
+			// unknown, the practitioner's value is untouched.
+			plan:  resourceValue(volumes(volume(unknownNum(), str("root")))),
+			state: resourceValue(volumes(volume(num(671), str("root")))),
+			want:  false,
+		},
+		{
+			name:  "practitioner changed a value",
+			plan:  resourceValue(volumes(volume(unknownNum(), str("data")))),
+			state: resourceValue(volumes(volume(num(671), str("root")))),
+			want:  true,
+		},
+		{
+			name: "element added",
+			plan: resourceValue(volumes(
+				volume(unknownNum(), str("root")),
+				volume(unknownNum(), unknownString()),
+			)),
+			state: resourceValue(volumes(volume(num(671), str("root")))),
+			want:  true,
+		},
+		{
+			name:  "element removed",
+			plan:  resourceValue(volumes(volume(unknownNum(), str("root")))),
+			state: resourceValue(volumes(volume(num(671), str("root")), volume(num(672), str("data")))),
+			want:  true,
+		},
+		{
+			name: "elements reordered",
+			plan: resourceValue(volumes(
+				volume(unknownNum(), str("data")),
+				volume(unknownNum(), str("root")),
+			)),
+			state: resourceValue(volumes(
+				volume(num(671), str("root")),
+				volume(num(672), str("data")),
+			)),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := attributeChanged(tt.plan, tt.state, "volumes"); got != tt.want {
+				t.Errorf("attributeChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnitAttributeChangedMissingAttribute verifies that an attribute which
+// cannot be resolved is reported as changed, so that the caller leaves the plan
+// alone rather than restoring a value it cannot verify.
+func TestUnitAttributeChangedMissingAttribute(t *testing.T) {
+	t.Parallel()
+
+	plan := resourceValue(volumes(volume(num(1), str("root"))))
+	state := resourceValue(volumes(volume(num(1), str("root"))))
+
+	if !attributeChanged(plan, state, "does_not_exist") {
+		t.Error("attributeChanged() = false for an unresolvable attribute, want true")
+	}
+}
+
+// TestUnitFillUnknownsFromState verifies that unknown values are taken from
+// prior state, and that a value with no counterpart in state is left unknown so
+// the subsequent comparison still reports a difference.
+func TestUnitFillUnknownsFromState(t *testing.T) {
+	t.Parallel()
+
+	plan := volumes(volume(unknownNum(), str("root")))
+	state := volumes(volume(num(671), str("root")))
+
+	filled, err := fillUnknownsFromState(plan, state)
+	if err != nil {
+		t.Fatalf("fillUnknownsFromState() error = %v", err)
+	}
+
+	if !filled.Equal(state) {
+		t.Errorf("filled plan = %v, want it to equal state %v", filled, state)
+	}
+}
+
+// TestUnitFillUnknownsFromStateLeavesUnmatchedUnknown verifies that an unknown
+// with no counterpart in prior state stays unknown.
+func TestUnitFillUnknownsFromStateLeavesUnmatchedUnknown(t *testing.T) {
+	t.Parallel()
+
+	plan := volumes(
+		volume(unknownNum(), str("root")),
+		volume(unknownNum(), str("data")),
+	)
+	state := volumes(volume(num(671), str("root")))
+
+	filled, err := fillUnknownsFromState(plan, state)
+	if err != nil {
+		t.Fatalf("fillUnknownsFromState() error = %v", err)
+	}
+
+	if filled.Equal(state) {
+		t.Error("filled plan equals state, want a difference for the added element")
+	}
+}

--- a/morpheus/framework/resources/instance/resource.go
+++ b/morpheus/framework/resources/instance/resource.go
@@ -74,6 +74,15 @@ func (g *Resource) ModifyPlan(
 		return
 	}
 
+	// Put prior state back into the plan for computed attributes whose
+	// triggering configuration has not changed, so that an unrelated edit does
+	// not show them as "(known after apply)". Done before the checks below,
+	// which return early when the appliance version cannot be determined.
+	restoreUnchangedComputedAttributes(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var plan, state InstanceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)

--- a/morpheus/framework/resources/instance/resource_plan_stability_test.go
+++ b/morpheus/framework/resources/instance/resource_plan_stability_test.go
@@ -1,0 +1,260 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package instance_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/instance"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/capabilities"
+	"github.com/HPE/terraform-provider-hpe/provider/adapter"
+)
+
+// These tests cover the plan stability of hpe_morpheus_instance across in-place
+// updates.
+//
+// The plugin framework marks every computed attribute that is null in the
+// configuration as unknown whenever anything on the resource changes, so without
+// a plan modifier pass a small edit shows unrelated attributes as "(known after
+// apply)". The resource restores those values from prior state, but only when
+// nothing that could affect them has changed — pinning a value the API
+// legitimately changes during an update would raise "Provider produced
+// inconsistent result after apply", which is a worse failure than a noisy plan.
+//
+// Each test therefore asserts one half of that contract:
+//
+//   - a metadata-only edit restores the computed values, so the plan stays
+//     reviewable;
+//   - an edit that reconfigures a collection leaves that collection's computed
+//     values unknown, and the apply still succeeds.
+
+const instanceResourceName = "hpe_morpheus_instance.example"
+
+// TestAccMorpheusInstanceResourceTagUpdateDoesNotChurnPlan verifies that editing
+// only tags does not show unrelated computed attributes as "(known after
+// apply)".
+//
+// This is the regression test for the reported behaviour: changing one
+// attribute churned connection_info, labels and every computed field of
+// network_interfaces and volumes, producing a diff too large to review.
+//
+// Interface and volume identity are asserted because they are populated by the
+// API on create and are stable across an unrelated edit, so a known value in the
+// plan proves the restore happened.
+func TestAccMorpheusInstanceResourceTagUpdateDoesNotChurnPlan(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	capabilities.MustHaveOrSkip(t, capabilities.All)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	config, err := instance.RenderInstanceConfig(t, map[string]string{"Name": name})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	taggedConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name":         name,
+		"MultipleTags": "true",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + config,
+			},
+			{
+				Config: providerConfig + taggedConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							instanceResourceName, plancheck.ResourceActionUpdate,
+						),
+						// Restored from prior state rather than left unknown.
+						plancheck.ExpectKnownValue(
+							instanceResourceName,
+							tfjsonpath.New("volumes").AtSliceIndex(0).AtMapKey("id"),
+							knownvalue.NotNull(),
+						),
+						plancheck.ExpectKnownValue(
+							instanceResourceName,
+							tfjsonpath.New("network_interfaces").AtSliceIndex(0).AtMapKey("id"),
+							knownvalue.NotNull(),
+						),
+						plancheck.ExpectKnownValue(
+							instanceResourceName,
+							tfjsonpath.New("network_interfaces").AtSliceIndex(0).AtMapKey("name"),
+							knownvalue.NotNull(),
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(instanceResourceName, "tags.#", "5"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMorpheusInstanceResourceResizeKeepsInterfaceAndVolumeIdentity verifies
+// that resizing an instance does not churn interface and volume identity, and
+// that the resize still applies cleanly.
+//
+// This is the scenario reported from the field: a memory change also showed
+// interface and volume attributes as "(known after apply)". Addresses are
+// deliberately not asserted as known — a resize that cannot be performed hot
+// restarts the instance, so connection_info can legitimately change and is left
+// unknown by design.
+//
+// The apply completing is itself part of the assertion: if identity were pinned
+// while the API changed it, the step would fail with "Provider produced
+// inconsistent result after apply".
+func TestAccMorpheusInstanceResourceResizeKeepsInterfaceAndVolumeIdentity(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	capabilities.MustHaveOrSkip(t, capabilities.All)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	config, err := instance.RenderInstanceConfig(t, map[string]string{"Name": name})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resizedConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name":      name,
+		"MaxMemory": "2048",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + config,
+			},
+			{
+				Config: providerConfig + resizedConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							instanceResourceName, plancheck.ResourceActionUpdate,
+						),
+						plancheck.ExpectKnownValue(
+							instanceResourceName,
+							tfjsonpath.New("volumes").AtSliceIndex(0).AtMapKey("id"),
+							knownvalue.NotNull(),
+						),
+						plancheck.ExpectKnownValue(
+							instanceResourceName,
+							tfjsonpath.New("network_interfaces").AtSliceIndex(0).AtMapKey("id"),
+							knownvalue.NotNull(),
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						instanceResourceName, "service_plan_options.max_memory", "2048",
+					),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMorpheusInstanceResourceVolumeAddLeavesVolumeIdentityUnknown verifies
+// the other half of the contract: when the volumes themselves are reconfigured,
+// volume identity is *not* restored from prior state.
+//
+// Restoring it would be wrong twice over. The API may assign a new id, and
+// because these are list elements a positional restore could pin the previous
+// element's values onto a different volume. Either would surface as "Provider
+// produced inconsistent result after apply", so the value is deliberately left
+// unknown and the apply must still succeed.
+func TestAccMorpheusInstanceResourceVolumeAddLeavesVolumeIdentityUnknown(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	capabilities.MustHaveOrSkip(t, capabilities.All)
+
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	t.Parallel()
+
+	providerConfig := testhelpers.ProviderBlock()
+	name := acctest.RandomWithPrefix(t.Name())
+
+	singleVolumeConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name":         name,
+		"SingleVolume": "true",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	twoVolumeConfig, err := instance.RenderInstanceConfig(t, map[string]string{
+		"Name": name,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + singleVolumeConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(instanceResourceName, "volumes.#", "1"),
+				),
+			},
+			{
+				Config: providerConfig + twoVolumeConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							instanceResourceName, plancheck.ResourceActionUpdate,
+						),
+						// The volumes were reconfigured, so identity must not be
+						// taken from prior state.
+						plancheck.ExpectUnknownValue(
+							instanceResourceName,
+							tfjsonpath.New("volumes").AtSliceIndex(1).AtMapKey("id"),
+						),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(instanceResourceName, "volumes.#", "2"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Changing one attribute of an `hpe_morpheus_instance` — for example `service_plan_options.max_memory` — also showed `connection_info`, `labels`, and every computed field of `network_interfaces` and `volumes` as `(known after apply)`, even though none of them changed. A small edit produced a diff too large to review, which is a blocker for using the resource in production: you cannot safely approve an apply whose plan contains changes you did not ask for.

## Cause

The plugin framework marks every computed attribute that is null in the configuration as unknown whenever the planned state differs from the prior state (`MarkComputedNilsAsUnknown`). That is deliberate — the framework's own comment notes that later plan modifier passes are expected to put known values back — but this resource had no such pass, so everything surfaced as unknown.

The values themselves are stable: comparing two plans taken either side of a real resize apply, the interface id, interface name, `primary_interface`, volume id and `connection_info` were all identical before and after.

## Why not UseStateForUnknown

A blanket `UseStateForUnknown` would not be safe. Update re-reads the instance from the API and writes whatever it returns into state, so pinning an attribute the API legitimately changes during the update would raise `Provider produced inconsistent result after apply` — a hard failure, and a worse outcome than a noisy plan. Two cases matter:

- `connection_info` holds the instance addresses. A resize that cannot be performed hot stops and restarts the instance, so the address can change as a direct result of the update.
- Interface and volume identity can change when those collections are themselves reconfigured. Note that from 8.1.2 a network change is applied in place rather than forcing replacement, and the API may recreate interfaces.

Applying it per nested attribute would also be positional, and would pin values from the wrong element when interfaces or volumes are added, removed or reordered.

## Approach

A conditional restore in the resource-level `ModifyPlan`, which runs after the framework has marked attributes unknown and can therefore correct the plan. Two rules keep it safe:

1. **Only stable, API-assigned identity attributes are restored** — interface `id`, `name` and `primary_interface`, and volume `id`. Attributes the post-apply read sources from the API, such as volume `storage_profile` and `controller_mount_point`, are deliberately excluded.
2. **A value is only filled where the plan says unknown, and only from a prior-state value that is itself known and non-null.** A null is never pinned.

Each group is additionally gated on its own triggers:

| Group | Restored unless this changed |
|---|---|
| `network_interfaces` identity | `network_interfaces` |
| `volumes` identity | `volumes` |
| `labels` | `labels` |
| `connection_info` | `service_plan_options`, `network_interfaces`, `volumes`, `config`, `plan_id`, `layout_id` |

Deciding whether something changed ignores values the framework marked unknown, since those carry no practitioner intent: unknowns are filled from prior state and the result compared with prior state. Anything that cannot be resolved — a newly added element, an attribute missing from state — is treated as a change, so the plan is left alone rather than restoring a value that cannot be verified.

Restoring per attribute rather than per collection is safe against positional aliasing because each group stays gated on its triggers, and a path with no counterpart in prior state is left unknown.

Placed in hand-written code rather than the generated schema so it survives regeneration.

## Why not restore whole collections

An earlier iteration of this change restored each collection wholesale. That is not safe, and acceptance testing caught it.

Volume `storage_profile` is null in prior state after a create or update, because the post-apply read prefers the planned value only when that value is known and non-null, and otherwise takes the API value. Restoring the whole collection therefore placed a **known null** into the plan, which apply then contradicted:

```
Error: Provider produced inconsistent result after apply
  .volumes[0].storage_profile: was null, but now cty.StringVal("kvm-cache-none")
```

That is the same failure class this change exists to avoid. It was intermittent — roughly one run in three — because whether prior state holds the null or the real value depends on whether a refresh ran first.

Rule 2 above makes that failure impossible by construction rather than by exclusion list: since a null is never pinned, no restored value can contradict what the read path supplies.

## Result

- Metadata-only edits (tags, labels, name, description, instance_context) now plan cleanly.
- A memory resize drops from eleven churning lines to one: `connection_info` deliberately stays unknown, because it genuinely can change.

## Tests

**Unit tests** over the comparison and restore logic, which are pure and need no appliance:

- `TestUnitAttributeChanged` — identical values, computed-only unknowns (must not count as a change), a practitioner edit, and element added / removed / reordered.
- `TestUnitAttributeChangedMissingAttribute` — an unresolvable attribute is reported as changed, so the plan is left alone.
- `TestUnitFillUnknownsFromState` and `TestUnitFillUnknownsFromStateLeavesUnmatchedUnknown` — unknowns are taken from prior state, and an unknown with no counterpart stays unknown.
- `TestUnitMatchesRestoreRule` — asserts that `storage_profile` and `controller_mount_point` are **not** covered by the volume rule.
- `TestUnitRestoreFromStateNeverPinsNull` — the regression test for the failure above: a null in prior state is left unknown rather than pinned.
- `TestUnitRestoreFromStateLeavesUncoveredAttributesAlone` — an attribute outside the rule's fields is untouched even when prior state holds a good value.

**Acceptance tests** covering both halves of the contract — that values are restored when they should be, and deliberately left unknown when they should not be:

- `TestAccMorpheusInstanceResourceTagUpdateDoesNotChurnPlan` — a metadata-only edit restores interface and volume identity, so the plan stays reviewable.
- `TestAccMorpheusInstanceResourceResizeKeepsInterfaceAndVolumeIdentity` — the same on a service plan change. Addresses are deliberately not asserted, since a resize that cannot be performed hot restarts the instance and the address can legitimately change.
- `TestAccMorpheusInstanceResourceVolumeAddLeavesVolumeIdentityUnknown` — reconfiguring the volumes leaves volume identity unknown, so a positional restore cannot pin the previous element's values onto a different volume.

## Verification

Run against a live Morpheus appliance. Because the earlier failure was intermittent, the suite was run **five consecutive times** rather than once:

| Runs | Tests | Result |
|---|---|---|
| 5 | 15 | all pass, no `inconsistent result` errors |

Provider trace logging confirms a real lifecycle rather than a short-circuit: an instance is provisioned with an assigned address, then created, read, updated and deleted.

To confirm the acceptance tests are genuine regression guards rather than assertions that would pass either way, the plan modifier was temporarily disabled and the tag test re-run. It fails, on exactly the attributes this change addresses:

```
Step 2/2 error: Pre-apply plan check(s) failed:
    path not found: specified key id not found in map at volumes.0.id
    path not found: specified key id not found in map at network_interfaces.0.id
    path not found: specified key name not found in map at network_interfaces.0.name
```

Unknown values are omitted from the plan JSON entirely, which is why the keys are absent. So the tests pass with this change and fail without it.

Five clean runs is strong evidence rather than proof; the unit tests are the firmer guarantee, since they pin the invariant instead of sampling it.

## Notes

One gap remains: an in-place network change is not covered, because it needs a second valid network id, which is environment-specific. That is the case where the gating matters most for `network_interfaces`, since from 8.1.2 a network change is applied in place rather than forcing replacement, and the API may recreate interfaces. Worth adding once a second network is available in the test environment.
