### PR TITLE
Fix acceptance test failures across load balancer, network and integration resources

### DIFF
--- a/docs/resources/morpheus_load_balancer_monitor.md
+++ b/docs/resources/morpheus_load_balancer_monitor.md
@@ -140,3 +140,5 @@ Load balancer monitors can be imported using the composite ID `loadBalancerId.mo
 ```shell
 terraform import hpe_morpheus_load_balancer_monitor.example 42.101
 ```
+
+~> The API accepts `receive_data` and `data_length` on create and update but never returns them (`receive_data` is stored encrypted, and `data_length` is only round-tripped for ICMP monitors). They therefore cannot be populated on import and will be null in the imported state. Set them in your configuration and apply to reconcile.

--- a/docs/resources/morpheus_network_router_bgp_neighbor.md
+++ b/docs/resources/morpheus_network_router_bgp_neighbor.md
@@ -19,6 +19,7 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "example" {
   weight      = 100
   keep_alive  = 60
   hold_down   = 180
+  hop_limit   = 2
 }
 ```
 

--- a/docs/resources/morpheus_network_router_firewall_rule.md
+++ b/docs/resources/morpheus_network_router_firewall_rule.md
@@ -11,8 +11,16 @@ description: |-
 ## Example Usage
 
 ```terraform
+# Firewall rules attach to a rule group on the router. Look the group up and
+# use its external_id as the rule's parent_id.
+data "hpe_morpheus_network_router_firewall_rule_group" "example" {
+  router_id = 1
+  name      = "Example Firewall Rule Group"
+}
+
 resource "hpe_morpheus_network_router_firewall_rule" "example" {
   router_id = 1
+  parent_id = data.hpe_morpheus_network_router_firewall_rule_group.example.external_id
   name      = "Example Firewall Rule"
   policy    = "accept"
   enabled   = true

--- a/examples/resources/morpheus_network_router_bgp_neighbor/resource.tf
+++ b/examples/resources/morpheus_network_router_bgp_neighbor/resource.tf
@@ -6,4 +6,5 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "example" {
   weight      = 100
   keep_alive  = 60
   hold_down   = 180
+  hop_limit   = 2
 }

--- a/examples/resources/morpheus_network_router_firewall_rule/example.tf
+++ b/examples/resources/morpheus_network_router_firewall_rule/example.tf
@@ -1,5 +1,13 @@
+# Firewall rules attach to a rule group on the router. Look the group up and
+# use its external_id as the rule's parent_id.
+data "hpe_morpheus_network_router_firewall_rule_group" "example" {
+  router_id = 1
+  name      = "Example Firewall Rule Group"
+}
+
 resource "hpe_morpheus_network_router_firewall_rule" "example" {
   router_id = 1
+  parent_id = data.hpe_morpheus_network_router_firewall_rule_group.example.external_id
   name      = "Example Firewall Rule"
   policy    = "accept"
   enabled   = true

--- a/morpheus/framework/datasources/loadbalancermonitor/datasource_test.go
+++ b/morpheus/framework/datasources/loadbalancermonitor/datasource_test.go
@@ -120,9 +120,13 @@ func TestAccMorpheusLoadBalancerMonitorDataSourceByNameOk(t *testing.T) {
 		t.Fatalf("failed to render monitor config: %s", err)
 	}
 
+	// The name is a literal, so nothing links the data source to the monitor
+	// resource. Without an explicit dependency Terraform reads the data source
+	// before the monitor exists and the name lookup returns no results.
 	dataSourceConfig, err := datasourcemonitor.RenderLoadBalancerMonitorDataSourceByNameConfig(t, map[string]string{
 		"LoadBalancerId": "hpe_morpheus_load_balancer.lb.id",
 		"Name":           monitorName,
+		"DependsOn":      "hpe_morpheus_load_balancer_monitor.nsxt",
 	})
 	if err != nil {
 		t.Fatalf("failed to render data source config: %s", err)

--- a/morpheus/framework/datasources/loadbalancermonitor/example-name.tf.tmpl
+++ b/morpheus/framework/datasources/loadbalancermonitor/example-name.tf.tmpl
@@ -1,4 +1,8 @@
 data "hpe_morpheus_load_balancer_monitor" "example" {
   load_balancer_id = {{.LoadBalancerId}}
   name             = "{{.Name}}"
+{{- if .DependsOn}}
+
+  depends_on = [{{.DependsOn}}]
+{{- end}}
 }

--- a/morpheus/framework/datasources/loadbalancermonitor/example.go
+++ b/morpheus/framework/datasources/loadbalancermonitor/example.go
@@ -22,14 +22,7 @@ func RenderLoadBalancerMonitorDataSourceByIDConfig(t *testing.T, overrides map[s
 		"Id":             "99",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -54,14 +47,7 @@ func RenderLoadBalancerMonitorDataSourceByNameConfig(t *testing.T, overrides map
 		"Name":           "HTTP Monitor",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/morpheus/framework/datasources/loadbalancerprofile/datasource_acc_test.go
+++ b/morpheus/framework/datasources/loadbalancerprofile/datasource_acc_test.go
@@ -191,7 +191,7 @@ resource "hpe_morpheus_load_balancer_profile" "http" {
   load_balancer_id = hpe_morpheus_load_balancer.lb.id
   name             = %q
   service_type     = "LBHttpProfile"
-  config_http {
+  config_http = {
     https_redirect = true
   }
 }

--- a/morpheus/framework/datasources/loadbalancervirtualserver/datasource_test.go
+++ b/morpheus/framework/datasources/loadbalancervirtualserver/datasource_test.go
@@ -134,9 +134,13 @@ func TestAccMorpheusLoadBalancerVirtualServerDataSourceByNameOk(t *testing.T) {
 		t.Fatalf("failed to render vs config: %s", err)
 	}
 
+	// vip_name is a literal, so nothing links the data source to the virtual
+	// server resource. Without an explicit dependency Terraform reads the data
+	// source before the virtual server exists and the lookup returns nothing.
 	dsConfig, err := datasourcevs.RenderLoadBalancerVirtualServerDataSourceByNameConfig(t, map[string]string{
 		"LoadBalancerId": "hpe_morpheus_load_balancer.lb.id",
 		"VipName":        vipName,
+		"DependsOn":      "hpe_morpheus_load_balancer_virtual_server.nsxt_minimal",
 	})
 	if err != nil {
 		t.Fatalf("failed to render data source config: %s", err)

--- a/morpheus/framework/datasources/loadbalancervirtualserver/example-name.tf.tmpl
+++ b/morpheus/framework/datasources/loadbalancervirtualserver/example-name.tf.tmpl
@@ -1,4 +1,8 @@
 data "hpe_morpheus_load_balancer_virtual_server" "example" {
   load_balancer_id = {{.LoadBalancerId}}
   vip_name         = "{{.VipName}}"
+{{- if .DependsOn}}
+
+  depends_on = [{{.DependsOn}}]
+{{- end}}
 }

--- a/morpheus/framework/datasources/loadbalancervirtualserver/example.go
+++ b/morpheus/framework/datasources/loadbalancervirtualserver/example.go
@@ -22,14 +22,7 @@ func RenderLoadBalancerVirtualServerDataSourceByIDConfig(t *testing.T, overrides
 		"Id":             "99",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -54,14 +47,7 @@ func RenderLoadBalancerVirtualServerDataSourceByNameConfig(t *testing.T, overrid
 		"VipName":        "my-web-vs",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/morpheus/framework/datasources/networkedgecluster/datasource_test.go
+++ b/morpheus/framework/datasources/networkedgecluster/datasource_test.go
@@ -26,6 +26,14 @@ func TestAccMorpheusNetworkEdgeClusterByID(t *testing.T) {
 
 	capabilities.MustHaveOrSkip(t, capabilities.NSXT)
 
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" {
+		t.Skip("TF_ACC_NETWORK_SERVER_ID not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
+
+	if os.Getenv("TF_ACC_EDGE_CLUSTER_ID") == "" {
+		t.Skip("TF_ACC_EDGE_CLUSTER_ID not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
+
 	t.Parallel()
 
 	if testing.Short() {
@@ -65,6 +73,14 @@ func TestAccMorpheusNetworkEdgeClusterByName(t *testing.T) {
 
 	capabilities.MustHaveOrSkip(t, capabilities.NSXT)
 
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" {
+		t.Skip("TF_ACC_NETWORK_SERVER_ID not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
+
+	if os.Getenv("TF_ACC_EDGE_CLUSTER_NAME") == "" {
+		t.Skip("TF_ACC_EDGE_CLUSTER_NAME not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
+
 	t.Parallel()
 
 	if testing.Short() {
@@ -103,6 +119,10 @@ func TestAccMorpheusNetworkEdgeClusterNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	capabilities.MustHaveOrSkip(t, capabilities.NSXT)
+
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" {
+		t.Skip("TF_ACC_NETWORK_SERVER_ID not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
 
 	t.Parallel()
 

--- a/morpheus/framework/datasources/networkedgecluster/networkedgecluster_example.go
+++ b/morpheus/framework/datasources/networkedgecluster/networkedgecluster_example.go
@@ -22,14 +22,7 @@ func RenderNetworkEdgeClusterDataSourceByIDConfig(t *testing.T, overrides map[st
 		"Id":              "99",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -54,14 +47,7 @@ func RenderNetworkEdgeClusterDataSourceByNameConfig(t *testing.T, overrides map[
 		"Name":            "edge-cluster-01",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/morpheus/framework/datasources/networkrouterfirewallrule/datasource_test.go
+++ b/morpheus/framework/datasources/networkrouterfirewallrule/datasource_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/HPE/terraform-provider-hpe/morpheus/framework/datasources/networkrouterfirewallrule"
-	networkrouterresource "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouter"
 	firewallruleresource "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouterfirewallrule"
+	firewallrulegroupresource "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouterfirewallrulegroup"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/capabilities"
 	"github.com/HPE/terraform-provider-hpe/provider/adapter"
@@ -34,21 +34,42 @@ provider "hpe" {
 }
 `
 
-// routerFixture renders a self-contained NSX-T network router.
+// routerFixture renders an NSX-T Tier-1 gateway router labelled
+// hpe_morpheus_network_router.fw_tier1, plus a firewall rule group on it
+// labelled hpe_morpheus_network_router_firewall_rule_group.example.
+//
+// parent_id is Required and RequiresReplace: NSX-T rejects a rule without a
+// parent group. Gateway firewall rule groups attach to the router's gateway
+// policy, which does not require an edge cluster or tier-0 connection -- a
+// simple dhcpLocal Tier-1 is sufficient. This mirrors the fixture used by the
+// firewall rule group resource/data source tests.
+//
+// QA constants: group_id 3, network_integration_id 5.
 func routerFixture(t *testing.T, name string) string {
 	t.Helper()
 
-	cfg, err := networkrouterresource.RenderNetworkRouterGenericConfig(t, map[string]string{
-		"Name":                 name + "-router",
-		"TypeId":               "9",
-		"GroupId":              "3",
-		"NetworkIntegrationId": "5",
-	})
+	routerConfig := `
+resource "hpe_morpheus_network_router" "fw_tier1" {
+  name                   = "` + name + `-tier1"
+  group_id               = 3
+  network_integration_id = 5
+
+  config_nsxt_gateway_tier1 = {
+    ip_management_type = "dhcpLocal"
+  }
+}
+`
+
+	groupConfig, err := firewallrulegroupresource.RenderNetworkRouterFirewallRuleGroupConfig(
+		t, map[string]string{
+			"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
+			"Name":     name + "-group",
+		})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return cfg
+	return routerConfig + groupConfig
 }
 
 func TestAccMorpheusFindNetworkRouterFirewallRuleByName(t *testing.T) {
@@ -68,7 +89,7 @@ func TestAccMorpheusFindNetworkRouterFirewallRuleByName(t *testing.T) {
 	routerConfig := routerFixture(t, name)
 
 	resourceConfig, err := firewallruleresource.RenderNetworkRouterFirewallRuleConfig(t, map[string]string{
-		"RouterId": "hpe_morpheus_network_router.example.id",
+		"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
 		"Name":     name,
 	})
 	if err != nil {
@@ -78,7 +99,7 @@ func TestAccMorpheusFindNetworkRouterFirewallRuleByName(t *testing.T) {
 	dataSourceConfig := `
 data "hpe_morpheus_network_router_firewall_rule" "example" {
   name       = "` + name + `"
-  router_id  = hpe_morpheus_network_router.example.id
+  router_id  = hpe_morpheus_network_router.fw_tier1.id
   depends_on = [hpe_morpheus_network_router_firewall_rule.example]
 }
 `
@@ -113,7 +134,7 @@ func TestAccMorpheusFindNetworkRouterFirewallRuleById(t *testing.T) {
 	routerConfig := routerFixture(t, name)
 
 	resourceConfig, err := firewallruleresource.RenderNetworkRouterFirewallRuleConfig(t, map[string]string{
-		"RouterId": "hpe_morpheus_network_router.example.id",
+		"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
 		"Name":     name,
 	})
 	if err != nil {
@@ -122,7 +143,7 @@ func TestAccMorpheusFindNetworkRouterFirewallRuleById(t *testing.T) {
 
 	dataSourceConfig, err := networkrouterfirewallrule.RenderFirewallRuleByIdConfig(t, map[string]string{
 		"Id":       "hpe_morpheus_network_router_firewall_rule.example.id",
-		"RouterId": "hpe_morpheus_network_router.example.id",
+		"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +181,7 @@ func TestAccMorpheusFindNetworkRouterFirewallRuleNotFound(t *testing.T) {
 	dataSourceConfig := `
 data "hpe_morpheus_network_router_firewall_rule" "example" {
   name      = "nonexistent-firewall-rule-name-that-should-not-exist"
-  router_id = hpe_morpheus_network_router.example.id
+  router_id = hpe_morpheus_network_router.fw_tier1.id
 }
 `
 

--- a/morpheus/framework/datasources/networkrouterfirewallrulegroups/datasource_test.go
+++ b/morpheus/framework/datasources/networkrouterfirewallrulegroups/datasource_test.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/HPE/terraform-provider-hpe/morpheus/framework/datasources/networkrouterfirewallrulegroups"
+	firewallrulegroupresource "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouterfirewallrulegroup"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/capabilities"
 	"github.com/HPE/terraform-provider-hpe/provider/adapter"
@@ -37,17 +39,47 @@ func TestAccMorpheusNetworkRouterFirewallRuleGroupsBasic(t *testing.T) {
 
 	providerConfig := testhelpers.ProviderBlock()
 
+	name := acctest.RandomWithPrefix(t.Name())
+
+	// The data source config below references the router, so it must be part of
+	// the same configuration -- rendering only the data source left the
+	// reference dangling ("Reference to undeclared resource"). A rule group is
+	// created alongside it so rule_groups is actually populated rather than
+	// asserting against an empty list.
+	//
+	// Gateway firewall rule groups attach to the router's gateway policy, which
+	// does not require an edge cluster or tier-0 connection -- a simple
+	// dhcpLocal Tier-1 is sufficient. QA constants: group_id 3,
+	// network_integration_id 5.
+	routerConfig := `
+resource "hpe_morpheus_network_router" "fw_tier1" {
+  name                   = "` + name + `-tier1"
+  group_id               = 3
+  network_integration_id = 5
+
+  config_nsxt_gateway_tier1 = {
+    ip_management_type = "dhcpLocal"
+  }
+}
+`
+
+	groupConfig, err := firewallrulegroupresource.RenderNetworkRouterFirewallRuleGroupConfig(
+		t, map[string]string{
+			"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
+			"Name":     name + "-group",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	dataSourceConfig, err := networkrouterfirewallrulegroups.RenderConfig(t, map[string]string{
-		"RouterId": "hpe_morpheus_network_router.example.id",
+		"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Use a minimal router fixture. In environments where a suitable NSX-T
-	// router with firewall rule groups is pre-provisioned, override the
-	// RouterId to point to that router directly.
-	config := providerConfig + dataSourceConfig
+	config := providerConfig + routerConfig + groupConfig + dataSourceConfig
 
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(

--- a/morpheus/framework/datasources/networktransportzone/datasource_test.go
+++ b/morpheus/framework/datasources/networktransportzone/datasource_test.go
@@ -26,6 +26,14 @@ func TestAccMorpheusNetworkTransportZoneByID(t *testing.T) {
 
 	capabilities.MustHaveOrSkip(t, capabilities.NSXT)
 
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" {
+		t.Skip("TF_ACC_NETWORK_SERVER_ID not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
+
+	if os.Getenv("TF_ACC_TRANSPORT_ZONE_ID") == "" {
+		t.Skip("TF_ACC_TRANSPORT_ZONE_ID not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
+
 	t.Parallel()
 
 	if testing.Short() {
@@ -65,6 +73,14 @@ func TestAccMorpheusNetworkTransportZoneByName(t *testing.T) {
 
 	capabilities.MustHaveOrSkip(t, capabilities.NSXT)
 
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" {
+		t.Skip("TF_ACC_NETWORK_SERVER_ID not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
+
+	if os.Getenv("TF_ACC_TRANSPORT_ZONE_NAME") == "" {
+		t.Skip("TF_ACC_TRANSPORT_ZONE_NAME not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
+
 	t.Parallel()
 
 	if testing.Short() {
@@ -103,6 +119,10 @@ func TestAccMorpheusNetworkTransportZoneNotFound(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
 	capabilities.MustHaveOrSkip(t, capabilities.NSXT)
+
+	if os.Getenv("TF_ACC_NETWORK_SERVER_ID") == "" {
+		t.Skip("TF_ACC_NETWORK_SERVER_ID not set; skipping test requiring a pre-provisioned NSX-T fixture")
+	}
 
 	t.Parallel()
 

--- a/morpheus/framework/datasources/networktransportzone/networktransportzone_example.go
+++ b/morpheus/framework/datasources/networktransportzone/networktransportzone_example.go
@@ -22,14 +22,7 @@ func RenderNetworkTransportZoneDataSourceByIDConfig(t *testing.T, overrides map[
 		"Id":              "99",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -54,14 +47,7 @@ func RenderNetworkTransportZoneDataSourceByNameConfig(t *testing.T, overrides ma
 		"Name":            "overlay-tz-01",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/morpheus/framework/resources/loadbalancermonitor/resource_test.go
+++ b/morpheus/framework/resources/loadbalancermonitor/resource_test.go
@@ -92,11 +92,19 @@ func TestAccMorpheusLoadBalancerMonitorResourceNsxtExampleOk(t *testing.T) {
 				PlanOnly:           false,
 			},
 			{
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ResourceName:            resourceName,
-				ImportStateVerifyIgnore: []string{"monitor_password_wo_version", "config"},
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ResourceName:      resourceName,
+				ImportStateVerifyIgnore: []string{
+					"monitor_password_wo_version",
+					"config",
+					// The API accepts these on create/update but never
+					// returns them, so an imported resource cannot know
+					// them. See preserveUnreturnedFields in resource_read.go.
+					"receive_data",
+					"data_length",
+				},
 			},
 		},
 	})

--- a/morpheus/framework/resources/loadbalancerprofile/config.go
+++ b/morpheus/framework/resources/loadbalancerprofile/config.go
@@ -14,14 +14,28 @@ import (
 	"github.com/HPE/terraform-provider-hpe/utils/convert"
 )
 
+// Supported service_type values. These mirror the OneOf validator on the
+// service_type attribute and select which config_* block, SDK config variant
+// and tag list apply to a profile.
+const (
+	serviceTypeHTTP                = "LBHttpProfile"
+	serviceTypeFastTCP             = "LBFastTcpProfile"
+	serviceTypeFastUDP             = "LBFastUdpProfile"
+	serviceTypeCookiePersistence   = "LBCookiePersistenceProfile"
+	serviceTypeSourceIPPersistence = "LBSourceIpPersistenceProfile"
+	serviceTypeGenericPersistence  = "LBGenericPersistenceProfile"
+	serviceTypeClientSSL           = "LBClientSslProfile"
+	serviceTypeServerSSL           = "LBServerSslProfile"
+)
+
 // profileTypeForServiceType returns the profileType API value for a given serviceType.
 func profileTypeForServiceType(serviceType string) string {
 	switch serviceType {
-	case "LBHttpProfile", "LBFastTcpProfile", "LBFastUdpProfile":
+	case serviceTypeHTTP, serviceTypeFastTCP, serviceTypeFastUDP:
 		return "application-profile"
-	case "LBCookiePersistenceProfile", "LBSourceIpPersistenceProfile", "LBGenericPersistenceProfile":
+	case serviceTypeCookiePersistence, serviceTypeSourceIPPersistence, serviceTypeGenericPersistence:
 		return "persistence-profile"
-	case "LBClientSslProfile", "LBServerSslProfile":
+	case serviceTypeClientSSL, serviceTypeServerSSL:
 		return "ssl-profile"
 	default:
 		return ""
@@ -41,7 +55,7 @@ func buildCreateConfig(
 	cfg := &sdk.CreateLoadBalancerProfileRequestLoadBalancerProfileConfig{}
 
 	switch serviceType {
-	case "LBHttpProfile":
+	case serviceTypeHTTP:
 		variant := &sdk.HTTPLoadBalancerProfileConfig1{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -62,7 +76,7 @@ func buildCreateConfig(
 		}
 		cfg.HTTPLoadBalancerProfileConfig1 = variant
 
-	case "LBFastTcpProfile":
+	case serviceTypeFastTCP:
 		variant := &sdk.FastTCPLoadBalancerProfileConfig1{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -75,7 +89,7 @@ func buildCreateConfig(
 		}
 		cfg.FastTCPLoadBalancerProfileConfig1 = variant
 
-	case "LBFastUdpProfile":
+	case serviceTypeFastUDP:
 		variant := &sdk.FastUDPLoadBalancerProfileConfig1{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -87,7 +101,7 @@ func buildCreateConfig(
 		}
 		cfg.FastUDPLoadBalancerProfileConfig1 = variant
 
-	case "LBCookiePersistenceProfile":
+	case serviceTypeCookiePersistence:
 		variant := &sdk.CookiePersistenceLoadBalancerProfileConfig1{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -109,7 +123,7 @@ func buildCreateConfig(
 		}
 		cfg.CookiePersistenceLoadBalancerProfileConfig1 = variant
 
-	case "LBSourceIpPersistenceProfile":
+	case serviceTypeSourceIPPersistence:
 		variant := &sdk.SourceIPPersistenceLoadBalancerProfileConfig1{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -123,7 +137,7 @@ func buildCreateConfig(
 		}
 		cfg.SourceIPPersistenceLoadBalancerProfileConfig1 = variant
 
-	case "LBGenericPersistenceProfile":
+	case serviceTypeGenericPersistence:
 		variant := &sdk.GenericPersistenceLoadBalancerProfileConfig1{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -136,7 +150,7 @@ func buildCreateConfig(
 		}
 		cfg.GenericPersistenceLoadBalancerProfileConfig1 = variant
 
-	case "LBClientSslProfile":
+	case serviceTypeClientSSL:
 		variant := &sdk.ClientSSLLoadBalancerProfileConfig1{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -162,7 +176,7 @@ func buildCreateConfig(
 		}
 		cfg.ClientSSLLoadBalancerProfileConfig1 = variant
 
-	case "LBServerSslProfile":
+	case serviceTypeServerSSL:
 		variant := &sdk.ServerSSLLoadBalancerProfileConfig1{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -203,7 +217,7 @@ func buildUpdateConfig(
 	cfg := &sdk.UpdateLoadBalancerProfileRequestLoadBalancerProfileConfig{}
 
 	switch serviceType {
-	case "LBHttpProfile":
+	case serviceTypeHTTP:
 		variant := &sdk.HTTPLoadBalancerProfileConfig4{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -224,7 +238,7 @@ func buildUpdateConfig(
 		}
 		cfg.HTTPLoadBalancerProfileConfig4 = variant
 
-	case "LBFastTcpProfile":
+	case serviceTypeFastTCP:
 		variant := &sdk.FastTCPLoadBalancerProfileConfig4{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -237,7 +251,7 @@ func buildUpdateConfig(
 		}
 		cfg.FastTCPLoadBalancerProfileConfig4 = variant
 
-	case "LBFastUdpProfile":
+	case serviceTypeFastUDP:
 		variant := &sdk.FastUDPLoadBalancerProfileConfig4{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -249,7 +263,7 @@ func buildUpdateConfig(
 		}
 		cfg.FastUDPLoadBalancerProfileConfig4 = variant
 
-	case "LBCookiePersistenceProfile":
+	case serviceTypeCookiePersistence:
 		variant := &sdk.CookiePersistenceLoadBalancerProfileConfig4{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -271,7 +285,7 @@ func buildUpdateConfig(
 		}
 		cfg.CookiePersistenceLoadBalancerProfileConfig4 = variant
 
-	case "LBSourceIpPersistenceProfile":
+	case serviceTypeSourceIPPersistence:
 		variant := &sdk.SourceIPPersistenceLoadBalancerProfileConfig4{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -285,7 +299,7 @@ func buildUpdateConfig(
 		}
 		cfg.SourceIPPersistenceLoadBalancerProfileConfig4 = variant
 
-	case "LBGenericPersistenceProfile":
+	case serviceTypeGenericPersistence:
 		variant := &sdk.GenericPersistenceLoadBalancerProfileConfig4{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -298,7 +312,7 @@ func buildUpdateConfig(
 		}
 		cfg.GenericPersistenceLoadBalancerProfileConfig4 = variant
 
-	case "LBClientSslProfile":
+	case serviceTypeClientSSL:
 		variant := &sdk.ClientSSLLoadBalancerProfileConfig4{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -324,7 +338,7 @@ func buildUpdateConfig(
 		}
 		cfg.ClientSSLLoadBalancerProfileConfig4 = variant
 
-	case "LBServerSslProfile":
+	case serviceTypeServerSSL:
 		variant := &sdk.ServerSSLLoadBalancerProfileConfig4{
 			ProfileType: sdk.PtrString(profileType),
 		}
@@ -354,8 +368,15 @@ func buildUpdateConfig(
 
 // readTagsFromConfig extracts tags from the read response config and returns them
 // as a Terraform Set, preserving user-specified name casing from the plan/state.
+//
+// Like reconstructConfigBlockFromResponse, the variant is selected by
+// serviceType rather than by which union pointer the SDK left non-nil: the
+// config schema has no discriminator, so several anyOf variants are populated
+// from the same payload and dispatching on order would read another variant's
+// tag list.
 func readTagsFromConfig(
 	ctx context.Context,
+	serviceType string,
 	cfg *sdk.GetLoadBalancerProfile200ResponseLoadBalancerProfileConfig,
 	priorTags types.Set,
 ) types.Set {
@@ -371,62 +392,45 @@ func readTagsFromConfig(
 
 	var apiTags []tagPair
 
-	switch {
-	case cfg.HTTPLoadBalancerProfileConfig3 != nil:
-		for _, t := range cfg.HTTPLoadBalancerProfileConfig3.Tags {
-			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
-			})
+	addTags := func(n int, at func(int) (*string, *string)) {
+		for i := range n {
+			name, value := at(i)
+			apiTags = append(apiTags, tagPair{name: ptrStr(name), value: ptrStr(value)})
 		}
-	case cfg.FastTCPLoadBalancerProfileConfig3 != nil:
-		for _, t := range cfg.FastTCPLoadBalancerProfileConfig3.Tags {
-			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
-			})
+	}
+
+	switch serviceType {
+	case serviceTypeHTTP:
+		if v := cfg.HTTPLoadBalancerProfileConfig3; v != nil {
+			addTags(len(v.Tags), func(i int) (*string, *string) { return v.Tags[i].Name, v.Tags[i].Value })
 		}
-	case cfg.FastUDPLoadBalancerProfileConfig3 != nil:
-		for _, t := range cfg.FastUDPLoadBalancerProfileConfig3.Tags {
-			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
-			})
+	case serviceTypeFastTCP:
+		if v := cfg.FastTCPLoadBalancerProfileConfig3; v != nil {
+			addTags(len(v.Tags), func(i int) (*string, *string) { return v.Tags[i].Name, v.Tags[i].Value })
 		}
-	case cfg.CookiePersistenceLoadBalancerProfileConfig3 != nil:
-		for _, t := range cfg.CookiePersistenceLoadBalancerProfileConfig3.Tags {
-			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
-			})
+	case serviceTypeFastUDP:
+		if v := cfg.FastUDPLoadBalancerProfileConfig3; v != nil {
+			addTags(len(v.Tags), func(i int) (*string, *string) { return v.Tags[i].Name, v.Tags[i].Value })
 		}
-	case cfg.SourceIPPersistenceLoadBalancerProfileConfig3 != nil:
-		for _, t := range cfg.SourceIPPersistenceLoadBalancerProfileConfig3.Tags {
-			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
-			})
+	case serviceTypeCookiePersistence:
+		if v := cfg.CookiePersistenceLoadBalancerProfileConfig3; v != nil {
+			addTags(len(v.Tags), func(i int) (*string, *string) { return v.Tags[i].Name, v.Tags[i].Value })
 		}
-	case cfg.GenericPersistenceLoadBalancerProfileConfig3 != nil:
-		for _, t := range cfg.GenericPersistenceLoadBalancerProfileConfig3.Tags {
-			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
-			})
+	case serviceTypeSourceIPPersistence:
+		if v := cfg.SourceIPPersistenceLoadBalancerProfileConfig3; v != nil {
+			addTags(len(v.Tags), func(i int) (*string, *string) { return v.Tags[i].Name, v.Tags[i].Value })
 		}
-	case cfg.ClientSSLLoadBalancerProfileConfig3 != nil:
-		for _, t := range cfg.ClientSSLLoadBalancerProfileConfig3.Tags {
-			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
-			})
+	case serviceTypeGenericPersistence:
+		if v := cfg.GenericPersistenceLoadBalancerProfileConfig3; v != nil {
+			addTags(len(v.Tags), func(i int) (*string, *string) { return v.Tags[i].Name, v.Tags[i].Value })
 		}
-	case cfg.ServerSSLLoadBalancerProfileConfig3 != nil:
-		for _, t := range cfg.ServerSSLLoadBalancerProfileConfig3.Tags {
-			apiTags = append(apiTags, tagPair{
-				name:  ptrStr(t.Name),
-				value: ptrStr(t.Value),
-			})
+	case serviceTypeClientSSL:
+		if v := cfg.ClientSSLLoadBalancerProfileConfig3; v != nil {
+			addTags(len(v.Tags), func(i int) (*string, *string) { return v.Tags[i].Name, v.Tags[i].Value })
+		}
+	case serviceTypeServerSSL:
+		if v := cfg.ServerSSLLoadBalancerProfileConfig3; v != nil {
+			addTags(len(v.Tags), func(i int) (*string, *string) { return v.Tags[i].Name, v.Tags[i].Value })
 		}
 	}
 

--- a/morpheus/framework/resources/loadbalancerprofile/read.go
+++ b/morpheus/framework/resources/loadbalancerprofile/read.go
@@ -170,8 +170,12 @@ func getLoadBalancerProfileAsState(
 
 	state.LoadBalancer = lb
 
+	// serviceType selects which config variant and tag list apply. It is read
+	// straight from the API response, so it is available on import too.
+	serviceType := state.ServiceType.ValueString()
+
 	// Tags: read from config response
-	state.Tags = readTagsFromConfig(ctx, p.Config, prior.Tags)
+	state.Tags = readTagsFromConfig(ctx, serviceType, p.Config, prior.Tags)
 
 	// Config blocks: preserve every value the practitioner configured, while
 	// resolving any attribute that arrived unknown from the API response.
@@ -189,7 +193,7 @@ func getLoadBalancerProfileAsState(
 	// id and load_balancer_id). Reconstruct the active block from the API
 	// response so the imported resource is complete and produces a clean plan.
 	if allConfigBlocksNull(prior) {
-		reconstructConfigBlockFromResponse(ctx, &state, p.Config)
+		reconstructConfigBlockFromResponse(ctx, &state, serviceType, p.Config)
 	}
 
 	return state, diags

--- a/morpheus/framework/resources/loadbalancerprofile/read_config.go
+++ b/morpheus/framework/resources/loadbalancerprofile/read_config.go
@@ -39,40 +39,60 @@ func allConfigBlocksNull(m LoadBalancerProfileModel) bool {
 // is no prior config and no plan to be consistent with, so reconstructing the
 // block yields a complete, usable imported resource.
 //
+// Selection is driven by serviceType, never by which union variant the SDK
+// left non-nil. The config schema has no discriminator, so the SDK's
+// UnmarshalMapstructure decodes the same payload into every anyOf variant and
+// keeps each one that is not entirely empty. A single shared field is enough
+// to make a variant survive -- ntlmAuthentication, for example, appears in the
+// generic NSX-T config blob, so the HTTP variant is non-nil for every profile
+// type. Dispatching on variant order would therefore reconstruct config_http
+// for a fast-TCP profile.
+//
 // Tags are not handled here; the caller reconstructs the single top-level tags
 // set from the response separately.
 func reconstructConfigBlockFromResponse(
 	ctx context.Context,
 	state *LoadBalancerProfileModel,
+	serviceType string,
 	cfg *sdk.GetLoadBalancerProfile200ResponseLoadBalancerProfileConfig,
 ) {
 	if cfg == nil {
 		return
 	}
 
-	switch {
-	case cfg.HTTPLoadBalancerProfileConfig3 != nil:
-		state.ConfigHttp = httpConfigFromResponse(ctx, cfg.HTTPLoadBalancerProfileConfig3)
-	case cfg.FastTCPLoadBalancerProfileConfig3 != nil:
-		state.ConfigFastTcp = fastTCPConfigFromResponse(cfg.FastTCPLoadBalancerProfileConfig3)
-	case cfg.FastUDPLoadBalancerProfileConfig3 != nil:
-		state.ConfigFastUdp = fastUDPConfigFromResponse(cfg.FastUDPLoadBalancerProfileConfig3)
-	case cfg.CookiePersistenceLoadBalancerProfileConfig3 != nil:
-		state.ConfigCookiePersistence = cookiePersistenceConfigFromResponse(
-			cfg.CookiePersistenceLoadBalancerProfileConfig3,
-		)
-	case cfg.SourceIPPersistenceLoadBalancerProfileConfig3 != nil:
-		state.ConfigSourceIpPersistence = sourceIPPersistenceConfigFromResponse(
-			cfg.SourceIPPersistenceLoadBalancerProfileConfig3,
-		)
-	case cfg.GenericPersistenceLoadBalancerProfileConfig3 != nil:
-		state.ConfigGenericPersistence = genericPersistenceConfigFromResponse(
-			cfg.GenericPersistenceLoadBalancerProfileConfig3,
-		)
-	case cfg.ClientSSLLoadBalancerProfileConfig3 != nil:
-		state.ConfigClientSsl = clientSSLConfigFromResponse(cfg.ClientSSLLoadBalancerProfileConfig3)
-	case cfg.ServerSSLLoadBalancerProfileConfig3 != nil:
-		state.ConfigServerSsl = serverSSLConfigFromResponse(cfg.ServerSSLLoadBalancerProfileConfig3)
+	switch serviceType {
+	case serviceTypeHTTP:
+		if v := cfg.HTTPLoadBalancerProfileConfig3; v != nil {
+			state.ConfigHttp = httpConfigFromResponse(ctx, v)
+		}
+	case serviceTypeFastTCP:
+		if v := cfg.FastTCPLoadBalancerProfileConfig3; v != nil {
+			state.ConfigFastTcp = fastTCPConfigFromResponse(v)
+		}
+	case serviceTypeFastUDP:
+		if v := cfg.FastUDPLoadBalancerProfileConfig3; v != nil {
+			state.ConfigFastUdp = fastUDPConfigFromResponse(v)
+		}
+	case serviceTypeCookiePersistence:
+		if v := cfg.CookiePersistenceLoadBalancerProfileConfig3; v != nil {
+			state.ConfigCookiePersistence = cookiePersistenceConfigFromResponse(v)
+		}
+	case serviceTypeSourceIPPersistence:
+		if v := cfg.SourceIPPersistenceLoadBalancerProfileConfig3; v != nil {
+			state.ConfigSourceIpPersistence = sourceIPPersistenceConfigFromResponse(v)
+		}
+	case serviceTypeGenericPersistence:
+		if v := cfg.GenericPersistenceLoadBalancerProfileConfig3; v != nil {
+			state.ConfigGenericPersistence = genericPersistenceConfigFromResponse(v)
+		}
+	case serviceTypeClientSSL:
+		if v := cfg.ClientSSLLoadBalancerProfileConfig3; v != nil {
+			state.ConfigClientSsl = clientSSLConfigFromResponse(v)
+		}
+	case serviceTypeServerSSL:
+		if v := cfg.ServerSSLLoadBalancerProfileConfig3; v != nil {
+			state.ConfigServerSsl = serverSSLConfigFromResponse(v)
+		}
 	}
 }
 

--- a/morpheus/framework/resources/loadbalancerprofile/read_config_unit_test.go
+++ b/morpheus/framework/resources/loadbalancerprofile/read_config_unit_test.go
@@ -240,3 +240,189 @@ func TestMergeConfigBlocksLeavesNoUnknowns(t *testing.T) {
 		t.Error("unset config blocks should remain null")
 	}
 }
+
+// allVariantsPopulated mirrors what the SDK actually hands the provider.
+//
+// The load balancer profile config schema has no discriminator, so
+// UnmarshalMapstructure decodes the same JSON blob into every anyOf variant and
+// keeps each one that is not entirely empty. A single shared field is enough to
+// make a variant survive, so in practice several variants -- always including
+// HTTP, because the generic NSX-T config blob carries ntlmAuthentication -- are
+// non-nil regardless of the profile's actual service type.
+func allVariantsPopulated() *sdk.GetLoadBalancerProfile200ResponseLoadBalancerProfileConfig {
+	return &sdk.GetLoadBalancerProfile200ResponseLoadBalancerProfileConfig{
+		HTTPLoadBalancerProfileConfig3: &sdk.HTTPLoadBalancerProfileConfig3{
+			NtlmAuthentication: sdk.PtrBool(false),
+			RedirectAddress:    sdk.PtrString("http-variant"),
+			Tags:               []sdk.LoadBalancerProfileTag24{{Name: sdk.PtrString("from"), Value: sdk.PtrString("http")}},
+		},
+		FastTCPLoadBalancerProfileConfig3: &sdk.FastTCPLoadBalancerProfileConfig3{
+			HaFlowMirroring: sdk.PtrBool(true),
+			Tags:            []sdk.LoadBalancerProfileTag25{{Name: sdk.PtrString("from"), Value: sdk.PtrString("fast_tcp")}},
+		},
+		FastUDPLoadBalancerProfileConfig3: &sdk.FastUDPLoadBalancerProfileConfig3{
+			HaFlowMirroring: sdk.PtrBool(true),
+			Tags:            []sdk.LoadBalancerProfileTag26{{Name: sdk.PtrString("from"), Value: sdk.PtrString("fast_udp")}},
+		},
+		CookiePersistenceLoadBalancerProfileConfig3: &sdk.CookiePersistenceLoadBalancerProfileConfig3{
+			CookieName: sdk.PtrString("cookie-variant"),
+			Tags:       []sdk.LoadBalancerProfileTag27{{Name: sdk.PtrString("from"), Value: sdk.PtrString("cookie_persistence")}},
+		},
+		SourceIPPersistenceLoadBalancerProfileConfig3: &sdk.SourceIPPersistenceLoadBalancerProfileConfig3{
+			PurgeEntries: sdk.PtrBool(true),
+			Tags:         []sdk.LoadBalancerProfileTag28{{Name: sdk.PtrString("from"), Value: sdk.PtrString("source_ip_persistence")}},
+		},
+		GenericPersistenceLoadBalancerProfileConfig3: &sdk.GenericPersistenceLoadBalancerProfileConfig3{
+			SharePersistence: sdk.PtrBool(true),
+			Tags:             []sdk.LoadBalancerProfileTag29{{Name: sdk.PtrString("from"), Value: sdk.PtrString("generic_persistence")}},
+		},
+		ClientSSLLoadBalancerProfileConfig3: &sdk.ClientSSLLoadBalancerProfileConfig3{
+			SslSuite: sdk.PtrString("client-ssl-variant"),
+			Tags:     []sdk.LoadBalancerProfileTag30{{Name: sdk.PtrString("from"), Value: sdk.PtrString("client_ssl")}},
+		},
+		ServerSSLLoadBalancerProfileConfig3: &sdk.ServerSSLLoadBalancerProfileConfig3{
+			SslSuite: sdk.PtrString("server-ssl-variant"),
+			Tags:     []sdk.LoadBalancerProfileTag31{{Name: sdk.PtrString("from"), Value: sdk.PtrString("server_ssl")}},
+		},
+	}
+}
+
+// configBlockIsNull reports whether the named config_* block is null.
+func configBlockIsNull(m LoadBalancerProfileModel, block string) bool {
+	switch block {
+	case "config_http":
+		return m.ConfigHttp.IsNull()
+	case "config_fast_tcp":
+		return m.ConfigFastTcp.IsNull()
+	case "config_fast_udp":
+		return m.ConfigFastUdp.IsNull()
+	case "config_cookie_persistence":
+		return m.ConfigCookiePersistence.IsNull()
+	case "config_source_ip_persistence":
+		return m.ConfigSourceIpPersistence.IsNull()
+	case "config_generic_persistence":
+		return m.ConfigGenericPersistence.IsNull()
+	case "config_client_ssl":
+		return m.ConfigClientSsl.IsNull()
+	case "config_server_ssl":
+		return m.ConfigServerSsl.IsNull()
+	default:
+		return true
+	}
+}
+
+var allConfigBlockNames = []string{
+	"config_http",
+	"config_fast_tcp",
+	"config_fast_udp",
+	"config_cookie_persistence",
+	"config_source_ip_persistence",
+	"config_generic_persistence",
+	"config_client_ssl",
+	"config_server_ssl",
+}
+
+// TestReconstructConfigBlockFromResponseSelectsByServiceType is the regression
+// guard for the import bug: reconstruction dispatched on which SDK union
+// pointer happened to be non-nil, and HTTP was checked first, so importing any
+// non-HTTP profile also materialised config_http. ImportStateVerify then failed
+// with extra attributes ("config_http.%": "9").
+func TestReconstructConfigBlockFromResponseSelectsByServiceType(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	for serviceType, want := range map[string]string{
+		serviceTypeHTTP:                "config_http",
+		serviceTypeFastTCP:             "config_fast_tcp",
+		serviceTypeFastUDP:             "config_fast_udp",
+		serviceTypeCookiePersistence:   "config_cookie_persistence",
+		serviceTypeSourceIPPersistence: "config_source_ip_persistence",
+		serviceTypeGenericPersistence:  "config_generic_persistence",
+		serviceTypeClientSSL:           "config_client_ssl",
+		serviceTypeServerSSL:           "config_server_ssl",
+	} {
+		t.Run(serviceType, func(t *testing.T) {
+			t.Parallel()
+
+			// A freshly imported model: every config block is null.
+			var state LoadBalancerProfileModel
+			if !allConfigBlocksNull(state) {
+				t.Fatal("precondition: a zero-value model must have no config block set")
+			}
+
+			reconstructConfigBlockFromResponse(ctx, &state, serviceType, allVariantsPopulated())
+
+			if configBlockIsNull(state, want) {
+				t.Errorf("%s was not reconstructed for service_type %q", want, serviceType)
+			}
+
+			for _, name := range allConfigBlockNames {
+				if name == want {
+					continue
+				}
+
+				if !configBlockIsNull(state, name) {
+					t.Errorf("%s was populated for service_type %q; only %s may be set",
+						name, serviceType, want)
+				}
+			}
+		})
+	}
+}
+
+// TestReadTagsFromConfigSelectsByServiceType guards the same dispatch bug in
+// the tag reader, which would otherwise return another variant's tag list.
+func TestReadTagsFromConfigSelectsByServiceType(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	for serviceType, want := range map[string]string{
+		serviceTypeHTTP:                "http",
+		serviceTypeFastTCP:             "fast_tcp",
+		serviceTypeFastUDP:             "fast_udp",
+		serviceTypeCookiePersistence:   "cookie_persistence",
+		serviceTypeSourceIPPersistence: "source_ip_persistence",
+		serviceTypeGenericPersistence:  "generic_persistence",
+		serviceTypeClientSSL:           "client_ssl",
+		serviceTypeServerSSL:           "server_ssl",
+	} {
+		t.Run(serviceType, func(t *testing.T) {
+			t.Parallel()
+
+			got := readTagsFromConfig(
+				ctx, serviceType, allVariantsPopulated(), types.SetNull(TagsValue{}.Type(ctx)),
+			)
+
+			var tags []TagsValue
+			if diags := got.ElementsAs(ctx, &tags, false); diags.HasError() {
+				t.Fatalf("ElementsAs: %v", diags)
+			}
+
+			if len(tags) != 1 {
+				t.Fatalf("got %d tags, want 1", len(tags))
+			}
+
+			if v := tags[0].Value.ValueString(); v != want {
+				t.Errorf("read tags from the %q variant, want %q", v, want)
+			}
+		})
+	}
+}
+
+// TestReconstructConfigBlockFromResponseUnknownServiceType ensures an
+// unrecognised service_type is inert rather than defaulting to a variant.
+func TestReconstructConfigBlockFromResponseUnknownServiceType(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var state LoadBalancerProfileModel
+
+	reconstructConfigBlockFromResponse(ctx, &state, "LBSomethingElseProfile", allVariantsPopulated())
+
+	if !allConfigBlocksNull(state) {
+		t.Error("an unrecognised service_type must not populate any config block")
+	}
+}

--- a/morpheus/framework/resources/loadbalancerprofile/validators.go
+++ b/morpheus/framework/resources/loadbalancerprofile/validators.go
@@ -14,21 +14,21 @@ import (
 // a given serviceType, or "" if the serviceType is not recognised.
 func blockForServiceType(serviceType string) string {
 	switch serviceType {
-	case "LBHttpProfile":
+	case serviceTypeHTTP:
 		return "config_http"
-	case "LBFastTcpProfile":
+	case serviceTypeFastTCP:
 		return "config_fast_tcp"
-	case "LBFastUdpProfile":
+	case serviceTypeFastUDP:
 		return "config_fast_udp"
-	case "LBCookiePersistenceProfile":
+	case serviceTypeCookiePersistence:
 		return "config_cookie_persistence"
-	case "LBSourceIpPersistenceProfile":
+	case serviceTypeSourceIPPersistence:
 		return "config_source_ip_persistence"
-	case "LBGenericPersistenceProfile":
+	case serviceTypeGenericPersistence:
 		return "config_generic_persistence"
-	case "LBClientSslProfile":
+	case serviceTypeClientSSL:
 		return "config_client_ssl"
-	case "LBServerSslProfile":
+	case serviceTypeServerSSL:
 		return "config_server_ssl"
 	default:
 		return ""

--- a/morpheus/framework/resources/networkrouterbgpneighbor/bfd.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/bfd.go
@@ -1,0 +1,43 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package networkrouterbgpneighbor
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Platform defaults for the BFD timers.
+//
+// These mirror the defaults the Morpheus UI applies when creating an NSX-T BGP
+// neighbour, which it always sends with the request.
+const (
+	defaultBfdIntervalMs = 1000
+	defaultBfdMultiple   = 3
+)
+
+// bfdTimers resolves the bfd_interval and bfd_multiple values to send.
+//
+// Both attributes are Optional+Computed with no schema default, so omitting
+// them from the configuration leaves them unknown and they were previously not
+// sent at all. The API always forwards a BFD object to NSX-T and does not drop
+// unset members on create, so omitting them produces
+//
+//	"bfd": {"enabled": false, "interval": null, "multiple": null}
+//
+// which NSX-T rejects during body validation with the opaque
+// "General error has occurred." -- masking any real semantic error underneath.
+// Creating a neighbour through the UI never hits this, because the UI defaults
+// are always sent, so the provider sends them too.
+func bfdTimers(interval, multiple types.Int64) (intervalOut, multipleOut *int64) {
+	i := int64(defaultBfdIntervalMs)
+	if !interval.IsNull() && !interval.IsUnknown() {
+		i = interval.ValueInt64()
+	}
+
+	m := int64(defaultBfdMultiple)
+	if !multiple.IsNull() && !multiple.IsUnknown() {
+		m = multiple.ValueInt64()
+	}
+
+	return &i, &m
+}

--- a/morpheus/framework/resources/networkrouterbgpneighbor/bfd_unit_test.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/bfd_unit_test.go
@@ -1,0 +1,70 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package networkrouterbgpneighbor
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestBfdTimers guards the create failure where NSX-T rejected the body with
+// the opaque "General error has occurred.".
+//
+// bfd_interval and bfd_multiple are Optional+Computed with no schema default,
+// so omitting them left them unknown and they were not sent. Morpheus builds
+// the outbound NSX-T bfd object unconditionally and does not strip nulls on
+// create, producing "bfd":{"enabled":false,"interval":null,"multiple":null}.
+func TestBfdTimers(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		interval, multiple         types.Int64
+		wantInterval, wantMultiple int64
+	}{
+		"omitted from configuration (unknown)": {
+			interval:     types.Int64Unknown(),
+			multiple:     types.Int64Unknown(),
+			wantInterval: defaultBfdIntervalMs,
+			wantMultiple: defaultBfdMultiple,
+		},
+		"null": {
+			interval:     types.Int64Null(),
+			multiple:     types.Int64Null(),
+			wantInterval: defaultBfdIntervalMs,
+			wantMultiple: defaultBfdMultiple,
+		},
+		"configured values win": {
+			interval:     types.Int64Value(500),
+			multiple:     types.Int64Value(5),
+			wantInterval: 500,
+			wantMultiple: 5,
+		},
+		"partially configured": {
+			interval:     types.Int64Value(300),
+			multiple:     types.Int64Unknown(),
+			wantInterval: 300,
+			wantMultiple: defaultBfdMultiple,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			interval, multiple := bfdTimers(tc.interval, tc.multiple)
+
+			if interval == nil || multiple == nil {
+				t.Fatal("BFD timers must always be sent, never nil")
+			}
+
+			if *interval != tc.wantInterval {
+				t.Errorf("bfd_interval = %d, want %d", *interval, tc.wantInterval)
+			}
+
+			if *multiple != tc.wantMultiple {
+				t.Errorf("bfd_multiple = %d, want %d", *multiple, tc.wantMultiple)
+			}
+		})
+	}
+}

--- a/morpheus/framework/resources/networkrouterbgpneighbor/create.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/create.go
@@ -108,13 +108,9 @@ func (r *Resource) Create(
 		neighbor.BfdEnabled = &bfdVal
 	}
 
-	if !plan.BfdInterval.IsNull() && !plan.BfdInterval.IsUnknown() {
-		neighbor.BfdInterval = plan.BfdInterval.ValueInt64Pointer()
-	}
-
-	if !plan.BfdMultiple.IsNull() && !plan.BfdMultiple.IsUnknown() {
-		neighbor.BfdMultiple = plan.BfdMultiple.ValueInt64Pointer()
-	}
+	// Always send the BFD timers: Morpheus emits the NSX-T bfd object
+	// unconditionally and does not strip nulls on create. See bfd.go.
+	neighbor.BfdInterval, neighbor.BfdMultiple = bfdTimers(plan.BfdInterval, plan.BfdMultiple)
 
 	if !plan.AllowAsIn.IsNull() && !plan.AllowAsIn.IsUnknown() {
 		allowVal := sdk.CreateNetworkRouterBgpNeighborRequestNetworkRouterBgpNeighborAllowAsIn{}

--- a/morpheus/framework/resources/networkrouterbgpneighbor/example.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/example.go
@@ -1,6 +1,6 @@
 // (C) Copyright 2026 Hewlett Packard Enterprise Development LP
 
-//go:generate ../../../../bin/render -out examples/resources/morpheus_network_router_bgp_neighbor/resource.tf example.tf.tmpl RouterId "42" IpAddress "10.0.0.1" Description "Example BGP neighbor" RemoteAs "65001" Weight "100" KeepAlive "60" HoldDown "180"
+//go:generate ../../../../bin/render -out examples/resources/morpheus_network_router_bgp_neighbor/resource.tf example.tf.tmpl RouterId "42" IpAddress "10.0.0.1" Description "Example BGP neighbor" RemoteAs "65001" Weight "100" KeepAlive "60" HoldDown "180" HopLimit "2"
 
 package networkrouterbgpneighbor
 
@@ -24,16 +24,12 @@ func RenderBgpNeighborConfig(t *testing.T, overrides map[string]string) (string,
 		"Weight":      "60",
 		"KeepAlive":   "60",
 		"HoldDown":    "180",
+		// NSX-T only allows a single-hop neighbor (the schema default of 1)
+		// when the neighbor address shares a subnet with the source address.
+		"HopLimit": "2",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/morpheus/framework/resources/networkrouterbgpneighbor/example.tf.tmpl
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/example.tf.tmpl
@@ -6,6 +6,7 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "example" {
   weight               = {{.Weight}}
   keep_alive           = {{.KeepAlive}}
   hold_down            = {{.HoldDown}}
+  hop_limit            = {{.HopLimit}}
 {{- if .SourceAddresses}}
 
   config_nsxt = {

--- a/morpheus/framework/resources/networkrouterbgpneighbor/resource_test.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/resource_test.go
@@ -37,6 +37,18 @@ const existingTier0RouterID = "28"
 // "BGP neighbor source address is mandatory for EBGP Multihop."
 const bgpNeighborSourceAddress = "10.100.10.1"
 
+// bgpNeighborHopLimit is why every fixture below sets hop_limit explicitly.
+//
+// The schema default is 1, which NSX-T treats as single-hop and then requires
+// the neighbor address to share a subnet with the source address:
+//
+//	BGPNeighborConfig with max hop limit of 1, the neighbor address
+//	<ip> must be on the same subnet as the source address 10.100.10.1.
+//
+// The fixtures deliberately use unrelated neighbor subnets, so they must
+// declare themselves multihop.
+const bgpNeighborHopLimit = "2"
+
 func TestAccMorpheusNetworkRouterBgpNeighborResourceExampleOk(t *testing.T) {
 	defer testhelpers.RecordResult(t)
 
@@ -109,6 +121,7 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "test" {
   weight      = 60
   keep_alive  = 60
   hold_down   = 180
+  hop_limit   = ` + bgpNeighborHopLimit + `
 
   config_nsxt = {
     source_addresses = ["` + bgpNeighborSourceAddress + `"]
@@ -292,6 +305,7 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "update_test" {
   weight      = 60
   keep_alive  = 60
   hold_down   = 180
+  hop_limit   = ` + bgpNeighborHopLimit + `
 
   config_nsxt = {
     source_addresses = ["` + bgpNeighborSourceAddress + `"]
@@ -313,7 +327,7 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "update_test" {
   bfd_multiple = 3
   allow_as_in  = true
   hop_limit    = 3
-  restart_mode = "GRACEFUL_RESTART"
+  restart_mode = "GR_AND_HELPER"
 
   config_nsxt = {
     source_addresses = ["` + bgpNeighborSourceAddress + `"]
@@ -385,7 +399,7 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "update_test" {
 					),
 					resource.TestCheckResourceAttr(
 						"hpe_morpheus_network_router_bgp_neighbor.update_test",
-						"restart_mode", "GRACEFUL_RESTART",
+						"restart_mode", "GR_AND_HELPER",
 					),
 				),
 			},
@@ -415,6 +429,7 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "import_test" {
   ip_address  = "` + ipAddress + `"
   description = "` + name + `"
   remote_as   = "65001"
+  hop_limit   = ` + bgpNeighborHopLimit + `
 
   config_nsxt = {
     source_addresses = ["` + bgpNeighborSourceAddress + `"]
@@ -473,6 +488,7 @@ resource "hpe_morpheus_network_router_bgp_neighbor" "nsxt_test" {
   ip_address  = "` + ipAddress + `"
   description = "` + name + `"
   remote_as   = "65010"
+  hop_limit   = ` + bgpNeighborHopLimit + `
 
   config_nsxt = {
     source_addresses = ["` + bgpNeighborSourceAddress + `"]
@@ -517,6 +533,14 @@ func TestAccMorpheusNetworkRouterBgpNeighborResourceWithNsxvConfig(t *testing.T)
 	defer testhelpers.RecordResult(t)
 
 	capabilities.MustHaveOrSkip(t, capabilities.NSXV)
+
+	// The config below declares a required root variable with no default, so
+	// without a value Terraform fails the plan with "No value for required
+	// variable" before the provider is ever exercised.
+	nsxvRouterID := os.Getenv("TF_VAR_nsxv_router_id")
+	if nsxvRouterID == "" {
+		t.Skip("TF_VAR_nsxv_router_id not set; skipping test requiring a pre-existing NSX-V router")
+	}
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")

--- a/morpheus/framework/resources/networkrouterbgpneighbor/update.go
+++ b/morpheus/framework/resources/networkrouterbgpneighbor/update.go
@@ -110,13 +110,8 @@ func (r *Resource) Update(
 		neighbor.BfdEnabled = &bfdVal
 	}
 
-	if !plan.BfdInterval.IsNull() && !plan.BfdInterval.IsUnknown() {
-		neighbor.BfdInterval = plan.BfdInterval.ValueInt64Pointer()
-	}
-
-	if !plan.BfdMultiple.IsNull() && !plan.BfdMultiple.IsUnknown() {
-		neighbor.BfdMultiple = plan.BfdMultiple.ValueInt64Pointer()
-	}
+	// Always send the BFD timers, for the same reason as create. See bfd.go.
+	neighbor.BfdInterval, neighbor.BfdMultiple = bfdTimers(plan.BfdInterval, plan.BfdMultiple)
 
 	if !plan.AllowAsIn.IsNull() && !plan.AllowAsIn.IsUnknown() {
 		allowVal := sdk.UpdateNetworkRouterBgpNeighborRequestNetworkRouterBgpNeighborAllowAsIn{}

--- a/morpheus/framework/resources/networkrouterfirewallrule/example.go
+++ b/morpheus/framework/resources/networkrouterfirewallrule/example.go
@@ -11,26 +11,27 @@ import (
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 )
 
-//go:generate ../../../../bin/render -out examples/resources/morpheus_network_router_firewall_rule/example.tf example.tf.tmpl RouterId "1" Name "Example Firewall Rule" Policy "accept" Enabled "true"
+//go:generate ../../../../bin/render -out examples/resources/morpheus_network_router_firewall_rule/example.tf example.tf.tmpl RouterId "1" ParentGroupName "Example Firewall Rule Group" ParentId "data.hpe_morpheus_network_router_firewall_rule_group.example.external_id" Name "Example Firewall Rule" Policy "accept" Enabled "true"
 
 func RenderNetworkRouterFirewallRuleConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
 
 	defaults := map[string]string{
 		"RouterId": "1",
+		// parent_id is an expression, not a literal. The published example
+		// (see the go:generate directive above) resolves it through the
+		// hpe_morpheus_network_router_firewall_rule_group data source, which is
+		// how a practitioner attaches a rule to a group that already exists.
+		// Acceptance tests create their own group, so they reference that
+		// resource directly and leave ParentGroupName unset, which omits the
+		// data source block entirely.
+		"ParentId": "hpe_morpheus_network_router_firewall_rule_group.example.external_id",
 		"Name":     "Example Firewall Rule",
 		"Policy":   "accept",
 		"Enabled":  "true",
 	}
 
-	for key, value := range overrides {
-		defaults[key] = value
-	}
-
-	var args []string
-	for key, value := range defaults {
-		args = append(args, key, value)
-	}
+	args := testhelpers.RenderArgs(testhelpers.MergeOverrides(defaults, overrides))
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/morpheus/framework/resources/networkrouterfirewallrule/example.tf.tmpl
+++ b/morpheus/framework/resources/networkrouterfirewallrule/example.tf.tmpl
@@ -1,5 +1,15 @@
+{{- if .ParentGroupName -}}
+# Firewall rules attach to a rule group on the router. Look the group up and
+# use its external_id as the rule's parent_id.
+data "hpe_morpheus_network_router_firewall_rule_group" "example" {
+  router_id = {{.RouterId}}
+  name      = "{{.ParentGroupName}}"
+}
+
+{{ end -}}
 resource "hpe_morpheus_network_router_firewall_rule" "example" {
   router_id = {{.RouterId}}
+  parent_id = {{.ParentId}}
   name      = "{{.Name}}"
   policy    = "{{.Policy}}"
   enabled   = {{.Enabled}}

--- a/morpheus/framework/resources/networkrouterfirewallrule/resource_test.go
+++ b/morpheus/framework/resources/networkrouterfirewallrule/resource_test.go
@@ -10,12 +10,50 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouter"
 	"github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouterfirewallrule"
+	firewallrulegroupresource "github.com/HPE/terraform-provider-hpe/morpheus/framework/resources/networkrouterfirewallrulegroup"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
 	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/capabilities"
 	"github.com/HPE/terraform-provider-hpe/provider/adapter"
 )
+
+// firewallRuleFixture renders a per-test NSX-T Tier-1 gateway router labelled
+// hpe_morpheus_network_router.fw_tier1, plus a firewall rule group on it
+// labelled hpe_morpheus_network_router_firewall_rule_group.example.
+//
+// parent_id is Required and RequiresReplace: NSX-T rejects a rule without a
+// parent group. Gateway firewall rule groups attach to the router's gateway
+// policy, which does not require an edge cluster or tier-0 connection -- a
+// simple dhcpLocal Tier-1 is sufficient. This mirrors the fixture used by the
+// firewall rule group resource/data source tests.
+//
+// QA constants: group_id 3, network_integration_id 5.
+func firewallRuleFixture(t *testing.T, name string) string {
+	t.Helper()
+
+	routerConfig := `
+resource "hpe_morpheus_network_router" "fw_tier1" {
+  name                   = "` + name + `-tier1"
+  group_id               = 3
+  network_integration_id = 5
+
+  config_nsxt_gateway_tier1 = {
+    ip_management_type = "dhcpLocal"
+  }
+}
+`
+
+	groupConfig, err := firewallrulegroupresource.RenderNetworkRouterFirewallRuleGroupConfig(
+		t, map[string]string{
+			"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
+			"Name":     name + "-group",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return routerConfig + groupConfig
+}
 
 func TestMain(m *testing.M) {
 	code := testhelpers.TestMain(m)
@@ -38,18 +76,10 @@ func TestAccMorpheusNetworkRouterFirewallRuleResourceExampleOk(t *testing.T) {
 	name := acctest.RandomWithPrefix(t.Name())
 	resourceName := "hpe_morpheus_network_router_firewall_rule.example"
 
-	routerConfig, err := networkrouter.RenderNetworkRouterGenericConfig(t, map[string]string{
-		"Name":                 name + "-router",
-		"TypeId":               "9",
-		"GroupId":              "3",
-		"NetworkIntegrationId": "5",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	routerConfig := firewallRuleFixture(t, name)
 
 	resourceConfig, err := networkrouterfirewallrule.RenderNetworkRouterFirewallRuleConfig(t, map[string]string{
-		"RouterId": "hpe_morpheus_network_router.example.id",
+		"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
 		"Name":     name,
 	})
 	if err != nil {
@@ -57,7 +87,7 @@ func TestAccMorpheusNetworkRouterFirewallRuleResourceExampleOk(t *testing.T) {
 	}
 
 	checks := resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckResourceAttrPair(resourceName, "router_id", "hpe_morpheus_network_router.example", "id"),
+		resource.TestCheckResourceAttrPair(resourceName, "router_id", "hpe_morpheus_network_router.fw_tier1", "id"),
 		resource.TestCheckResourceAttr(resourceName, "name", name),
 		resource.TestCheckResourceAttr(resourceName, "policy", "accept"),
 		resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -108,18 +138,10 @@ func TestAccMorpheusNetworkRouterFirewallRuleResourceUpdateOk(t *testing.T) {
 	name := acctest.RandomWithPrefix(t.Name())
 	resourceName := "hpe_morpheus_network_router_firewall_rule.example"
 
-	routerConfig, err := networkrouter.RenderNetworkRouterGenericConfig(t, map[string]string{
-		"Name":                 name + "-router",
-		"TypeId":               "9",
-		"GroupId":              "3",
-		"NetworkIntegrationId": "5",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	routerConfig := firewallRuleFixture(t, name)
 
 	createConfig, err := networkrouterfirewallrule.RenderNetworkRouterFirewallRuleConfig(t, map[string]string{
-		"RouterId": "hpe_morpheus_network_router.example.id",
+		"RouterId": "hpe_morpheus_network_router.fw_tier1.id",
 		"Name":     name,
 	})
 	if err != nil {
@@ -128,7 +150,8 @@ func TestAccMorpheusNetworkRouterFirewallRuleResourceUpdateOk(t *testing.T) {
 
 	updateConfig := `
 resource "hpe_morpheus_network_router_firewall_rule" "example" {
-  router_id = hpe_morpheus_network_router.example.id
+  router_id = hpe_morpheus_network_router.fw_tier1.id
+  parent_id = hpe_morpheus_network_router_firewall_rule_group.example.external_id
   name      = "` + name + `"
   policy    = "deny"
   enabled   = false
@@ -136,14 +159,14 @@ resource "hpe_morpheus_network_router_firewall_rule" "example" {
 `
 
 	createChecks := resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckResourceAttrPair(resourceName, "router_id", "hpe_morpheus_network_router.example", "id"),
+		resource.TestCheckResourceAttrPair(resourceName, "router_id", "hpe_morpheus_network_router.fw_tier1", "id"),
 		resource.TestCheckResourceAttr(resourceName, "name", name),
 		resource.TestCheckResourceAttr(resourceName, "policy", "accept"),
 		resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 	)
 
 	updateChecks := resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckResourceAttrPair(resourceName, "router_id", "hpe_morpheus_network_router.example", "id"),
+		resource.TestCheckResourceAttrPair(resourceName, "router_id", "hpe_morpheus_network_router.fw_tier1", "id"),
 		resource.TestCheckResourceAttr(resourceName, "name", name),
 		resource.TestCheckResourceAttr(resourceName, "policy", "deny"),
 		resource.TestCheckResourceAttr(resourceName, "enabled", "false"),

--- a/morpheus/framework/resources/storagebucket/resource.go
+++ b/morpheus/framework/resources/storagebucket/resource.go
@@ -42,6 +42,45 @@ func (r *storageBucketResource) Schema(ctx context.Context, _ resource.SchemaReq
 	resp.Schema = StorageBucketResourceSchema(ctx)
 }
 
+// bucketConfigFields resolves the credential/endpoint values that belong under
+// the request's nested config object.
+//
+// The API reads these only from the nested config object; values sent at the
+// top level of the request body are silently discarded.
+func bucketConfigFields(endpoint, accessKey, secretKey types.String) (ak, sk, ep *string) {
+	if !accessKey.IsNull() && !accessKey.IsUnknown() {
+		ak = accessKey.ValueStringPointer()
+	}
+
+	if !secretKey.IsNull() && !secretKey.IsUnknown() {
+		sk = secretKey.ValueStringPointer()
+	}
+
+	if !endpoint.IsNull() && !endpoint.IsUnknown() {
+		ep = endpoint.ValueStringPointer()
+	}
+
+	return ak, sk, ep
+}
+
+// addBucketConfig builds the create request's config object.
+//
+// The oneOf wrapper is a non-pointer field that is always serialised, and its
+// generated MarshalJSON returns (nil, nil) when no variant is set -- which
+// encoding/json rejects with "unexpected end of JSON input". A variant must
+// therefore always be selected, even when every field inside it is empty.
+func addBucketConfig(endpoint, accessKey, secretKey types.String) sdk.AddStorageBucketsRequestStorageBucketConfig {
+	ak, sk, ep := bucketConfigFields(endpoint, accessKey, secretKey)
+
+	return sdk.AddStorageBucketsRequestStorageBucketConfig{
+		AddStorageBucketsRequestStorageBucketConfigOneOf: &sdk.AddStorageBucketsRequestStorageBucketConfigOneOf{
+			AccessKey: ak,
+			SecretKey: sk,
+			Endpoint:  ep,
+		},
+	}
+}
+
 func (r *storageBucketResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	client, err := r.NewClient(ctx)
 	if err != nil {
@@ -56,9 +95,18 @@ func (r *storageBucketResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	// access_key and secret_key are write-only, so their values are only
+	// available from config -- they are always null in the plan.
+	var config StorageBucketModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	body := sdk.AddStorageBucketsRequestStorageBucket{
 		Name:         plan.Name.ValueString(),
 		ProviderType: plan.ProviderType.ValueString(),
+		Config:       addBucketConfig(plan.Endpoint, config.AccessKey, config.SecretKey),
 	}
 	if !plan.BucketName.IsNull() {
 		body.BucketName = plan.BucketName.ValueString()
@@ -70,19 +118,6 @@ func (r *storageBucketResource) Create(ctx context.Context, req resource.CreateR
 		body.RetentionPolicyDays = plan.RetentionDays.ValueInt64Pointer()
 		retType := "delete"
 		body.RetentionPolicyType = &retType
-	}
-	if !plan.Endpoint.IsNull() || !plan.AccessKey.IsNull() || !plan.SecretKey.IsNull() {
-		// These are typically passed via config; set as additional properties
-		body.AdditionalProperties = map[string]interface{}{}
-		if !plan.Endpoint.IsNull() {
-			body.AdditionalProperties["endpoint"] = plan.Endpoint.ValueString()
-		}
-		if !plan.AccessKey.IsNull() {
-			body.AdditionalProperties["accessKey"] = plan.AccessKey.ValueString()
-		}
-		if !plan.SecretKey.IsNull() {
-			body.AdditionalProperties["secretKey"] = plan.SecretKey.ValueString()
-		}
 	}
 
 	result, httpResp, err := client.StorageAPI.AddStorageBuckets(ctx).
@@ -179,11 +214,28 @@ func (r *storageBucketResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	// access_key and secret_key are write-only, so their values are only
+	// available from config -- they are always null in the plan.
+	var config StorageBucketModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	id := plan.Id.ValueInt64()
+
+	accessKey, secretKey, endpoint := bucketConfigFields(plan.Endpoint, config.AccessKey, config.SecretKey)
 
 	body := sdk.UpdateStorageBucketsRequestStorageBucket{
 		Name:         plan.Name.ValueStringPointer(),
 		ProviderType: plan.ProviderType.ValueStringPointer(),
+		Config: &sdk.UpdateStorageBucketsRequestStorageBucketConfig{
+			UpdateStorageBucketsRequestStorageBucketConfigOneOf: &sdk.UpdateStorageBucketsRequestStorageBucketConfigOneOf{
+				AccessKey: accessKey,
+				SecretKey: secretKey,
+				Endpoint:  endpoint,
+			},
+		},
 	}
 	if !plan.BucketName.IsNull() {
 		body.BucketName = plan.BucketName.ValueStringPointer()
@@ -195,18 +247,6 @@ func (r *storageBucketResource) Update(ctx context.Context, req resource.UpdateR
 		body.RetentionPolicyDays = plan.RetentionDays.ValueInt64Pointer()
 		retType := "delete"
 		body.RetentionPolicyType = &retType
-	}
-	if !plan.Endpoint.IsNull() || !plan.AccessKey.IsNull() || !plan.SecretKey.IsNull() {
-		body.AdditionalProperties = map[string]interface{}{}
-		if !plan.Endpoint.IsNull() {
-			body.AdditionalProperties["endpoint"] = plan.Endpoint.ValueString()
-		}
-		if !plan.AccessKey.IsNull() {
-			body.AdditionalProperties["accessKey"] = plan.AccessKey.ValueString()
-		}
-		if !plan.SecretKey.IsNull() {
-			body.AdditionalProperties["secretKey"] = plan.SecretKey.ValueString()
-		}
 	}
 
 	_, httpResp, err := client.StorageAPI.UpdateStorageBuckets(ctx, id).

--- a/morpheus/framework/resources/storagebucket/resource_unit_test.go
+++ b/morpheus/framework/resources/storagebucket/resource_unit_test.go
@@ -1,0 +1,120 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package storagebucket
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
+)
+
+// TestAddBucketConfigAlwaysMarshals guards the create failure reported as
+//
+//	json: error calling MarshalJSON for type
+//	sdk.AddStorageBucketsRequestStorageBucketConfig: unexpected end of JSON input
+//
+// storageBucket.config is a non-pointer oneOf wrapper that ToMap always
+// serialises, and the generated MarshalJSON returns (nil, nil) when no variant
+// is set, which encoding/json rejects. A variant must therefore be selected
+// even when the practitioner supplied no credentials at all.
+func TestAddBucketConfigAlwaysMarshals(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		endpoint, accessKey, secretKey types.String
+		wantConfig                     map[string]any
+	}{
+		"no credentials configured": {
+			endpoint:   types.StringNull(),
+			accessKey:  types.StringNull(),
+			secretKey:  types.StringNull(),
+			wantConfig: map[string]any{},
+		},
+		"unknown values are omitted": {
+			endpoint:   types.StringUnknown(),
+			accessKey:  types.StringUnknown(),
+			secretKey:  types.StringUnknown(),
+			wantConfig: map[string]any{},
+		},
+		"credentials are nested under config": {
+			endpoint:  types.StringValue("https://s3.example.com"),
+			accessKey: types.StringValue("AKIAEXAMPLE"),
+			secretKey: types.StringValue("s3cr3t"),
+			wantConfig: map[string]any{
+				"endpoint":  "https://s3.example.com",
+				"accessKey": "AKIAEXAMPLE",
+				"secretKey": "s3cr3t",
+			},
+		},
+		"endpoint only": {
+			endpoint:   types.StringValue("https://s3.example.com"),
+			accessKey:  types.StringNull(),
+			secretKey:  types.StringNull(),
+			wantConfig: map[string]any{"endpoint": "https://s3.example.com"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			body := sdk.AddStorageBucketsRequestStorageBucket{
+				Name:         "example",
+				ProviderType: "s3",
+				Config:       addBucketConfig(tc.endpoint, tc.accessKey, tc.secretKey),
+			}
+
+			raw, err := json.Marshal(sdk.AddStorageBucketsRequest{StorageBucket: body})
+			if err != nil {
+				t.Fatalf("marshalling the create request failed: %v", err)
+			}
+
+			var got struct {
+				StorageBucket struct {
+					Name         string         `json:"name"`
+					ProviderType string         `json:"providerType"`
+					Config       map[string]any `json:"config"`
+				} `json:"storageBucket"`
+			}
+
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Fatalf("unmarshalling the create request failed: %v", err)
+			}
+
+			if got.StorageBucket.Config == nil {
+				t.Fatal("config must always be an object, never null")
+			}
+
+			if len(got.StorageBucket.Config) != len(tc.wantConfig) {
+				t.Fatalf("config = %v, want %v", got.StorageBucket.Config, tc.wantConfig)
+			}
+
+			for k, want := range tc.wantConfig {
+				if got.StorageBucket.Config[k] != want {
+					t.Errorf("config[%q] = %v, want %v", k, got.StorageBucket.Config[k], want)
+				}
+			}
+
+			// Credentials must not leak to the top level: Morpheus binds the
+			// bucket with config excluded, so anything there is discarded.
+			var top map[string]any
+			if err := json.Unmarshal(raw, &top); err != nil {
+				t.Fatalf("unmarshalling the create request failed: %v", err)
+			}
+
+			bucket, ok := top["storageBucket"].(map[string]any)
+			if !ok {
+				t.Fatal("storageBucket missing from the request body")
+			}
+
+			for _, k := range []string{"accessKey", "secretKey", "endpoint"} {
+				if _, found := bucket[k]; found {
+					t.Errorf("%q was sent at the top level; it belongs under config", k)
+				}
+			}
+		})
+	}
+}

--- a/morpheus/sdkv2/resources/integration/integration_chef.go
+++ b/morpheus/sdkv2/resources/integration/integration_chef.go
@@ -367,12 +367,15 @@ func resourceIntegrationChefRead(ctx context.Context, d *schema.ResourceData, me
 
 	if integration.Credential.ID == 0 {
 		d.Set("username", integration.Config.ChefUser)
-		d.Set("private_key", integration.Config.UserKeyHash)
 	} else {
 		d.Set("credential_id", integration.Credential.ID)
 	}
 
-	d.Set("organization_validator_key", integration.Config.OrgKeyHash)
+	// private_key and organization_validator_key are write-only: the API
+	// returns only a salted hash (userKeyHash / orgKeyHash) that cannot be
+	// reproduced from the configured PEM, so reading it back would overwrite
+	// state with a value that never matches the configuration. Leave the
+	// values already held in state.
 
 	// databags
 	/* AWAITING API SUPPORT

--- a/morpheus/sdkv2/resources/integration/integration_vro.go
+++ b/morpheus/sdkv2/resources/integration/integration_vro.go
@@ -138,13 +138,6 @@ func ResourceIntegrationVRO() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The tenant of the account used to connect to vRO (required for non-aria auth types)",
 				Optional:    true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					h := sha256.New()
-					h.Write([]byte(new))
-					sha256Hash := hex.EncodeToString(h.Sum(nil))
-
-					return strings.EqualFold(old, sha256Hash)
-				},
 			},
 			"auth_id": {
 				Type:        schema.TypeString,
@@ -340,8 +333,13 @@ func resourceIntegrationVRORead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("enabled", integration.Enabled)
 	d.Set("url", integration.URL)
 	d.Set("username", integration.Username)
-	d.Set("password", integration.PasswordHash)
-	d.Set("tenant", integration.TokenHash)
+	// password is write-only: the API returns only a salted hash
+	// (passwordHash) that cannot be reproduced from the configured plaintext.
+	//
+	// tenant is sent as the service token, and the API likewise returns only
+	// tokenHash. Reading that back stored a 64-character hash in a
+	// non-sensitive attribute, so a plan showed the tenant changing from e.g.
+	// "vsphere.local" to a hash. Leave both as configured.
 	// d.Set("auth_type", integration.Config)
 
 	return diags
@@ -414,7 +412,7 @@ func resourceIntegrationVROUpdate(ctx context.Context, d *schema.ResourceData, m
 	} else {
 		return diag.FromErr(helpers.TypeAssertFailError("tenant", d.Get("tenant")))
 	}
-	integration["token"] = tenant
+	integration["serviceToken"] = tenant
 
 	req := &morpheus.Request{
 		Body: map[string]any{

--- a/morpheus/sdkv2/resources/task/resource_task_chef_bootstrap.go
+++ b/morpheus/sdkv2/resources/task/resource_task_chef_bootstrap.go
@@ -380,7 +380,10 @@ func resourceTaskChefBootstrapRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("chef_server_id", serverId)
 	d.Set("environment", chefBootstrapTask.TaskOptions.ChefEnv)
 	d.Set("run_list", chefBootstrapTask.TaskOptions.ChefRunList)
-	d.Set("data_bag_key", chefBootstrapTask.TaskOptions.ChefDataKeyHash)
+	// data_bag_key is write-only: the API returns only a salted hash
+	// (chefDataKeyHash) that cannot be reproduced from the configured key, so
+	// reading it back left state holding a value the configuration can never
+	// match and every subsequent plan showed a change. Leave it as configured.
 	d.Set("data_bag_key_path", chefBootstrapTask.TaskOptions.ChefDataKeyPath)
 	d.Set("node_name", chefBootstrapTask.TaskOptions.ChefNodeName)
 	d.Set("node_attributes", chefBootstrapTask.TaskOptions.ChefAttributes)

--- a/morpheus/testhelpers/examples.go
+++ b/morpheus/testhelpers/examples.go
@@ -39,6 +39,43 @@ func RenderExample(t *testing.T, name string, args ...string) (string, error) {
 	return example, nil
 }
 
+// MergeOverrides applies overrides on top of defaults, ignoring any override
+// whose value is empty.
+//
+// Test fixtures routinely build overrides straight from os.Getenv. Assigning
+// unconditionally lets an unset variable replace a working default with "",
+// which the template then renders as nothing -- turning `network_server_id = 1`
+// into `network_server_id = `, an HCL parse error that reads as a provider bug.
+// Skipping empty overrides keeps the default in play; a test that genuinely
+// requires the variable should check it and t.Skip explicitly.
+func MergeOverrides(defaults, overrides map[string]string) map[string]string {
+	merged := make(map[string]string, len(defaults))
+	for key, value := range defaults {
+		merged[key] = value
+	}
+
+	for key, value := range overrides {
+		if value == "" {
+			continue
+		}
+
+		merged[key] = value
+	}
+
+	return merged
+}
+
+// RenderArgs flattens a map into the "Key" "value" argument pairs that
+// RenderExample and WriteExample expect.
+func RenderArgs(values map[string]string) []string {
+	args := make([]string, 0, len(values)*2)
+	for key, value := range values {
+		args = append(args, key, value)
+	}
+
+	return args
+}
+
 func WriteExample(name string, args ...string) {
 	text, err := renderExample(name, args...)
 	if err != nil {

--- a/templates/resources/morpheus_load_balancer_monitor.md.tmpl
+++ b/templates/resources/morpheus_load_balancer_monitor.md.tmpl
@@ -52,3 +52,5 @@ Load balancer monitors can be imported using the composite ID `loadBalancerId.mo
 ```shell
 terraform import hpe_morpheus_load_balancer_monitor.example 42.101
 ```
+
+~> The API accepts `receive_data` and `data_length` on create and update but never returns them (`receive_data` is stored encrypted, and `data_length` is only round-tripped for ICMP monitors). They therefore cannot be populated on import and will be null in the imported state. Set them in your configuration and apply to reconcile.


### PR DESCRIPTION
Addresses 35 of the 71 acceptance test failures in the 2026-07-29 run.

## Provider defects

- **Load balancer profile** — the config block was selected by response shape rather than `service_type`. The config schema has no discriminator, so the SDK decodes the same payload into every `anyOf` variant and keeps any that is not empty; `ntlmAuthentication` appears in the generic NSX-T blob, so the HTTP variant was always present. Every non-HTTP profile therefore reconstructed `config_http` on import and read another variant's tags. Both paths now switch on `service_type`.
- **Storage bucket** — create always failed with `unexpected end of JSON input`, because the `config` oneOf is always serialised but marshals to nothing when no variant is set. Fixing it exposed two silent bugs in the same path: credentials were sent at the top level of the body, where the API discards them, and the write-only `access_key`/`secret_key` were read from the plan, where write-only attributes are always null.
- **BGP neighbour** — create failed with `General error has occurred.` whenever `bfd_interval`/`bfd_multiple` were omitted. They were not sent, and the API forwards a BFD object to NSX-T without dropping unset members, so NSX-T rejected the body during validation and masked the real error underneath. The provider now always sends them, using the same defaults the UI applies.
- **Integrations and tasks** — Chef, vRO and the Chef bootstrap task wrote server-side secret hashes into state, causing permanent diffs. The vRO `tenant` is not a secret but was stored as a hash; that read-back and the `DiffSuppressFunc` masking it are both removed. The vRO update path also sent the tenant under a different key than create.

## Test fixtures

Several suites failed before reaching the provider at all. The most common cause was fixtures building overrides from `os.Getenv` and assigning unconditionally, so an unset variable replaced a working default with `""` and the template rendered invalid HCL. `testhelpers.MergeOverrides` now ignores empty overrides, and tests that genuinely need a pre-provisioned fixture skip explicitly.

Firewall rule tests never supplied the required `parent_id`. They now build an NSX-T Tier-1 gateway and their own rule group and reference it directly, matching the fixture already used by the passing rule group suites, so they are self-contained and need no new environment variable. The published example demonstrates the documented lookup through the `hpe_morpheus_network_router_firewall_rule_group` data source instead of a placeholder id.

Also fixed: `config_http` written as a block where the schema is an attribute; a data source test referencing a router it never rendered and asserting against an always-empty list; a required variable declared with no value, failing the plan before the provider ran; `hop_limit` and `restart_mode` values the API rejects; and two by-name data sources read before the resource they looked up existed.

## Verification

`go build`, `make lint` (0 issues), `make unit-tests`, and all `morpheus/...` packages pass without `TF_ACC`. `make docs` is idempotent. New unit tests cover profile variant selection, the storage bucket request body, and the BFD defaults; the profile test was confirmed to fail against the previous behaviour before the fix was applied.

Acceptance tests run against a firewalled appliance rather than in CI, so they are not part of the automated checks on this PR; they are exercised manually.

## Not included

Two failures need an API specification change plus an SDK regeneration and are deliberately out of scope here: load balancer profile `tags` key names, and `network.pool` being sent as a bare integer where an object is expected. The remaining failures in the run are missing appliance fixture data rather than code defects.
