### PR TITLE
Capitalize the docs subcategory for network_router_firewall_rule_group

### DIFF
--- a/docs/data-sources/morpheus_network_router_firewall_rule_group.md
+++ b/docs/data-sources/morpheus_network_router_firewall_rule_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_firewall_rule_group Data Source - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Provides a network router firewall rule group data source.
 ---

--- a/docs/resources/morpheus_network_router_firewall_rule_group.md
+++ b/docs/resources/morpheus_network_router_firewall_rule_group.md
@@ -1,6 +1,6 @@
 ---
 page_title: "hpe_morpheus_network_router_firewall_rule_group Resource - terraform-provider-hpe"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
   Manages an NSX-T gateway firewall policy group in Morpheus. Gateway firewall
   policies are attached to a specific Tier-0 or Tier-1 router and control

--- a/templates/data-sources/morpheus_network_router_firewall_rule_group.md.tmpl
+++ b/templates/data-sources/morpheus_network_router_firewall_rule_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: {{ $arr := split .Name "_" }}"{{ index $arr 1 }}"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/morpheus_network_router_firewall_rule_group.md.tmpl
+++ b/templates/resources/morpheus_network_router_firewall_rule_group.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "morpheus"
+subcategory: "Morpheus"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---


### PR DESCRIPTION
Completes the subcategory capitalisation on this line.

The `network_router_firewall_rule_group` resource and data source were added here after the subcategory change was made on the 1.6 line, so the merge from that line did not cover them. They were the only two pages still carrying the old form, and they carried two different old forms:

- the resource hardcoded the lower-case value
- the data source still used the earlier derived expression, `{{ $arr := split .Name "_" }}"{{ index $arr 1 }}"`

## Why it matters

The Terraform Registry groups pages by the exact subcategory string. Left alone, these two pages would have appeared under a separate `morpheus` heading, away from the other 264.

## Result

```
266  subcategory: "Morpheus"
  3  subcategory: "Migration"   (guides)
  1  subcategory: ""            (index)
```

No page is left on the old value.

## Verification

- Four files, four lines: the two templates and their two generated pages. Nothing else is touched.
- Checked that no changed line in `docs/` is anything other than a `subcategory` line.
- `make docs` is idempotent — re-running produces an identical tree, so the docs check stays green.
- `go build ./...` is clean. Documentation only; no schema or provider behaviour changes.