### PR TITLE
test(cluster): raise provisioning timeouts to 55m and TEST_TIMEOUT to 240m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,13 @@ SWEEP_RUN_ARGS = $(if $(filter all,$(SWEEP)),,-sweep-run=$(SWEEP))
 # resource run several such tests in parallel (with multi-step update tests
 # provisioning twice), so the default needs generous headroom. Override per run,
 # e.g. `make test TEST_TIMEOUT=180m`.
-TEST_TIMEOUT ?= 120m
+#
+# The cluster package is the binding constraint: it runs four tests
+# sequentially, each provisioning a three-worker cluster with an explicit 55m
+# create timeout, so its worst case is 4 x 55m = 220m. At the previous 120m the
+# package was killed before its own tests could time out, which replaced the
+# per-test diagnostics with a bare `panic: test timed out`.
+TEST_TIMEOUT ?= 240m
 
 build:
 	go build

--- a/docs/resources/morpheus_cluster.md
+++ b/docs/resources/morpheus_cluster.md
@@ -25,6 +25,13 @@ resource "hpe_morpheus_cluster" "example_hvm" {
   group_id    = 1
   layout_id   = 2
 
+  # Cluster provisioning builds every worker node, so it can comfortably run
+  # past the 45m default on a busy or lower-spec appliance. Raise this if
+  # creation is timing out while the cluster is still reported "provisioning".
+  timeouts = {
+    create = "55m"
+  }
+
   labels = [
     "terraform",
     "example",
@@ -95,6 +102,13 @@ resource "hpe_morpheus_cluster" "example_generic_hvm" {
   group_id          = 1
   layout_id         = 2
   cluster_type_code = "mvm-cluster"
+
+  # Cluster provisioning builds every worker node, so it can comfortably run
+  # past the 45m default on a busy or lower-spec appliance. Raise this if
+  # creation is timing out while the cluster is still reported "provisioning".
+  timeouts = {
+    create = "55m"
+  }
 
   labels = [
     "terraform",

--- a/examples/resources/morpheus_cluster/example_generic_hvm.tf
+++ b/examples/resources/morpheus_cluster/example_generic_hvm.tf
@@ -6,6 +6,13 @@ resource "hpe_morpheus_cluster" "example_generic_hvm" {
   layout_id         = 2
   cluster_type_code = "mvm-cluster"
 
+  # Cluster provisioning builds every worker node, so it can comfortably run
+  # past the 45m default on a busy or lower-spec appliance. Raise this if
+  # creation is timing out while the cluster is still reported "provisioning".
+  timeouts = {
+    create = "55m"
+  }
+
   labels = [
     "terraform",
     "example",

--- a/examples/resources/morpheus_cluster/example_hvm.tf
+++ b/examples/resources/morpheus_cluster/example_hvm.tf
@@ -5,6 +5,13 @@ resource "hpe_morpheus_cluster" "example_hvm" {
   group_id    = 1
   layout_id   = 2
 
+  # Cluster provisioning builds every worker node, so it can comfortably run
+  # past the 45m default on a busy or lower-spec appliance. Raise this if
+  # creation is timing out while the cluster is still reported "provisioning".
+  timeouts = {
+    create = "55m"
+  }
+
   labels = [
     "terraform",
     "example",

--- a/morpheus/framework/resources/cluster/cluster_test.go
+++ b/morpheus/framework/resources/cluster/cluster_test.go
@@ -463,6 +463,15 @@ data "hpe_morpheus_service_plan" "test" {
 	}
 `
 
+	// Cluster provisioning builds every worker node and can outrun the 45m
+	// default on a busy appliance. Shared by the create and update configs so
+	// the final PlanOnly step does not see a diff on this attribute.
+	timeoutsConfig := `
+	timeouts = {
+		create = "55m"
+	}
+`
+
 	createConfig := providerConfig + dataSourcesConfig + `
 resource "hpe_morpheus_cluster" "test" {
 	name        = "` + name + `"
@@ -481,7 +490,7 @@ resource "hpe_morpheus_cluster" "test" {
 		power_policy      = "balanced"
 	}
 
-` + serverConfig + `
+` + serverConfig + timeoutsConfig + `
 }
 `
 
@@ -507,7 +516,7 @@ resource "hpe_morpheus_cluster" "test" {
 		vcpu_placement_mode = "auto"
 	}
 
-` + serverConfig + `
+` + serverConfig + timeoutsConfig + `
 }
 `
 
@@ -650,6 +659,15 @@ data "hpe_morpheus_service_plan" "test" {
 	}
 `
 
+	// Cluster provisioning builds every worker node and can outrun the 45m
+	// default on a busy appliance. Shared by the create and update configs so
+	// the final PlanOnly step does not see a diff on this attribute.
+	timeoutsConfig := `
+	timeouts = {
+		create = "55m"
+	}
+`
+
 	createConfig := providerConfig + dataSourcesConfig + `
 resource "hpe_morpheus_cluster" "test" {
 	name              = "` + name + `"
@@ -668,7 +686,7 @@ resource "hpe_morpheus_cluster" "test" {
 		powerPolicy          = "balanced"
 	}
 
-` + serverConfig + `
+` + serverConfig + timeoutsConfig + `
 }
 `
 
@@ -691,7 +709,7 @@ resource "hpe_morpheus_cluster" "test" {
 		vcpuPlacementMode    = "auto"
 	}
 
-` + serverConfig + `
+` + serverConfig + timeoutsConfig + `
 }
 `
 

--- a/morpheus/framework/resources/cluster/example_generic_hvm.tf.tmpl
+++ b/morpheus/framework/resources/cluster/example_generic_hvm.tf.tmpl
@@ -6,6 +6,13 @@ resource "hpe_morpheus_cluster" "example_generic_hvm" {
   layout_id         = {{.LayoutId}}
   cluster_type_code = "{{.ClusterTypeCode}}"
 
+  # Cluster provisioning builds every worker node, so it can comfortably run
+  # past the 45m default on a busy or lower-spec appliance. Raise this if
+  # creation is timing out while the cluster is still reported "provisioning".
+  timeouts = {
+    create = "55m"
+  }
+
   labels = [
     "{{.Label1}}",
     "{{.Label2}}",

--- a/morpheus/framework/resources/cluster/example_hvm.tf.tmpl
+++ b/morpheus/framework/resources/cluster/example_hvm.tf.tmpl
@@ -5,6 +5,13 @@ resource "hpe_morpheus_cluster" "example_hvm" {
   group_id          = {{.GroupId}}
   layout_id         = {{.LayoutId}}
 
+  # Cluster provisioning builds every worker node, so it can comfortably run
+  # past the 45m default on a busy or lower-spec appliance. Raise this if
+  # creation is timing out while the cluster is still reported "provisioning".
+  timeouts = {
+    create = "55m"
+  }
+
   labels = [
     "{{.Label1}}",
     "{{.Label2}}",


### PR DESCRIPTION
## This is a mitigation, not a fix

**It does not make the failing cluster tests pass, and is not expected to.**

Both cluster example tests fail because the clusters are created correctly —
three workers each — and then sit at `status: provisioning` /
`provisionComplete: false` until the provider's 45-minute create deadline
expires. The provider's polling loop is **correct**: it waits, observes the
terminal condition, and reports it accurately. There is no code defect here.
The stall is an environmental/appliance fault.

A rerun at the new 55m timeout **already proved a longer deadline does not
help** — the clusters sat at `provisioning` for the full 55m02s and 55m03s
before failing exactly as before. This is a *stuck* provision, not a *slow*
one, so no timeout value will turn these tests green.

What this change does is stop the **harness** being the limiting factor, so
the real failure becomes legible instead of being masked by a package-level
kill.

## Changes

- `timeouts = { create = "55m" }` added to both cluster example templates and
  to all four cluster tests' HCL.
- `TEST_TIMEOUT` raised 120m → 240m (worst case 4 × 55m = 220m). Previously
  the package was killed before its own tests could time out, replacing the
  per-test diagnostics with a bare `panic: test timed out`.
- `docs/resources/morpheus_cluster.md` and the two
  `examples/resources/morpheus_cluster/*.tf` files are regenerated `make docs`
  output, included so they stay in sync with the templates.

> **Note on the 240m figure.** The Makefile comment justifies it as
> "4 × 55m worst case", which holds only while the cluster package's four
> tests run **sequentially**. If that package gains parallelism or a fifth
> test, this number needs revisiting.

## Verification

The acceptance suite was **deliberately not re-run** for this PR: it takes
~111 minutes and would prove nothing against a stuck appliance.

The run-level verdict remains **RED**
(`TRIAGE-VERIFY-VERDICT: RED | fixed=0 still_failing=2`), entirely due to the
provisioning stall this PR mitigates and cannot fix.

| test | before | after |
|---|---|---|
| `TestAccMorpheusClusterResourceHVMExampleOk` | fail | fail (unchanged — stuck provision) |
| `TestAccMorpheusClusterResourceGenericExampleOk` | fail | fail (unchanged — stuck provision) |

This phase's own gate did pass:

- `make docs` run; only the three cluster artefacts changed.
- **Idempotency verified** — two consecutive `make docs` passes produced
  byte-identical diffs (sha256 `eef8e86c…909a`).
- `go build` and `go vet` clean; the cluster package compiles.
- Automated review: **PASS** (gaps=0, violations=0, warnings=0). The reviewer
  confirmed the `timeouts = { … }` *attribute* syntax is correct — the
  plugin-framework schema uses `timeouts.AttributesAll(ctx)`, making it an
  Object attribute rather than an SDKv2-style block.

**This PR stays a draft.** It is not a proven fix.

## Follow-up

No story is filed for this root cause. It is an appliance fault, so a ticket
could never be closed by this team and would sit in the backlog as permanent
noise. What it actually needs is appliance-side investigation into HVM cluster
provisioning throughput and capacity.

For context only, a related-but-different precedent: MORPH-14165 (HKS HVM
cluster provisioning settling to `warning`).

## Merge order

This is phase **C of three and must merge last: A → B → C**, because it
carries the generated artefacts. B and C both touch `cluster_test.go`, but in
regions ~60 lines apart; a three-way merge dry-run of C onto B auto-merges
cleanly with zero conflicts.
