### PR TITLE
fix(cluster tests): report skipped tests as skipped, not passed

### DIFF
--- a/morpheus/framework/resources/cluster/cluster_test.go
+++ b/morpheus/framework/resources/cluster/cluster_test.go
@@ -27,15 +27,13 @@ func TestMain(m *testing.M) {
 
 // Tests that our HVM example file template used for docs is a valid config
 func TestAccMorpheusClusterResourceHVMExampleOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
 	capabilities.MustHaveOrSkip(t, capabilities.All)
 
 	if skip.SkipByDefault(t) {
-		t.Log("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
-
-		return
+		t.Skip("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
 	}
-
-	defer testhelpers.RecordResult(t)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -213,15 +211,13 @@ data "hpe_morpheus_service_plan" "test" {
 
 // Tests that our generic example file template used for docs is a valid config
 func TestAccMorpheusClusterResourceGenericExampleOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
 	capabilities.MustHaveOrSkip(t, capabilities.All)
 
 	if skip.SkipByDefault(t) {
-		t.Log("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
-
-		return
+		t.Skip("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
 	}
-
-	defer testhelpers.RecordResult(t)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -386,15 +382,13 @@ data "hpe_morpheus_service_plan" "test" {
 }
 
 func TestAccMorpheusClusterResourceHVMUpdateOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
 	capabilities.MustHaveOrSkip(t, capabilities.All)
 
 	if skip.SkipByDefault(t) {
-		t.Log("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
-
-		return
+		t.Skip("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
 	}
-
-	defer testhelpers.RecordResult(t)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")
@@ -573,15 +567,13 @@ resource "hpe_morpheus_cluster" "test" {
 }
 
 func TestAccMorpheusClusterResourceGenericUpdateOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
 	capabilities.MustHaveOrSkip(t, capabilities.All)
 
 	if skip.SkipByDefault(t) {
-		t.Log("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
-
-		return
+		t.Skip("Skipping test not opted in via RUN_SKIPPED_BY_DEFAULT")
 	}
-
-	defer testhelpers.RecordResult(t)
 
 	if testing.Short() {
 		t.Skip("Skipping slow test in short mode")


### PR DESCRIPTION
## Summary

The four `TestAccMorpheusClusterResource*` tests are gated behind
`RUN_SKIPPED_BY_DEFAULT`. The gate logged a message and then did a bare
`return` — but a test that returns normally **passes**, so `go test -json`
emitted `"Action":"pass"` with `"Elapsed":0` for tests that never executed.

This replaces the bare `return` with `t.Skip(...)` in all four tests, and
hoists `defer testhelpers.RecordResult(t)` above `capabilities.MustHaveOrSkip`
so skips are actually recorded (`RecordResult` already handles `t.Skipped()`).

## Why it matters

1. **It corrupts the nightly results baseline.** The run recorded these tests
   as passing when they never ran, so any comparison against that baseline
   starts from a false premise.
2. **It fabricates flake evidence.** A `["pass","fail"]` pair is the standard
   signal for "intermittent, deprioritise". During triage of this run it caused
   three of four independent analyses to misclassify two deterministic failures
   as flakes; the correct reading was only recovered by cross-checking raw
   `go test` events.
3. **Genuinely skipped runs were not recorded either**, because the `defer` sat
   after the gate.

## Scope

Confirmed narrow: exactly 4 tests suite-wide had this defect, all in this file.
The other 220 skips in the run already use a real `t.Skip()`.

## Triage

Phase B of triage run `2026-07-30_06-30-00-testacc` (RC-3).

**Verification — this is not a GREEN run-level result.** The run-level
acceptance verdict is **RED**
(`TRIAGE-VERIFY-VERDICT: RED | fixed=0 still_failing=2`), caused **solely by
RC-1, a separate environmental fault** (clusters stuck at `provisioning` for
55m+) that no code change can repair and that this PR does not address.

The acceptance suite was **deliberately not re-run** — a rerun proves nothing
against a stuck appliance.

This phase is proven by its own gate instead:

- `go vet` and `go build` clean
- With `RUN_SKIPPED_BY_DEFAULT` unset, all 4 tests now emit `skip` and 0 emit
  `pass` (previously `pass` at 0.00s)

Automated review: PASS (gaps=0, violations=0, warnings=1).

## Merge order

Merge order across this triage run is **A → B → C**. This is **B**, and is
intended to merge **after the Phase A PR**.

## Follow-ups

1. **Follow-up (out of scope here):** `morpheus/testhelpers/skip/skip.go` still
   carries the doc comment *"Callers should return early when true. The test
   will not be marked as skipped."* — now precisely the wrong advice, and
   arguably what invited this bug. Left out of scope deliberately (different
   file and package); worth a one-line follow-up so the defect is not
   reintroduced by the next test written against that helper.
2. **Note for CI:** the skip assertion is environment-sensitive.
   `capabilities.MustHaveOrSkip` runs before the `SkipByDefault` gate, so if
   `TF_ACC_CAPABILITIES` is unset all four tests skip at the capability gate
   and the assertion would show 4 skips while proving nothing. Pin
   `TF_ACC_CAPABILITIES=all` if this assertion is ever promoted into CI.
