### PR TITLE
hpegl to hpe migration fixes: instanceclone and network_router

### DIFF
--- a/morpheus/framework/resources/instanceclone/read.go
+++ b/morpheus/framework/resources/instanceclone/read.go
@@ -254,9 +254,7 @@ func mergeVolumesFromAPI(
 			StorageProfile:       preferKnownString(pv[i].StorageProfile, api.StorageProfile),
 		}
 
-		objVal, d := vol.ToObjectValue(ctx)
-		diags.Append(d...)
-		values = append(values, objVal)
+		values = append(values, vol)
 	}
 
 	listVal, d := types.ListValue(VolumesValue{}.Type(ctx), values)
@@ -273,9 +271,7 @@ func mapVolumeObjs(
 
 	values := make([]attr.Value, 0, len(apiVolumes))
 	for _, v := range apiVolumes {
-		objVal, d := volumeValueFromAPI(v).ToObjectValue(ctx)
-		diags.Append(d...)
-		values = append(values, objVal)
+		values = append(values, volumeValueFromAPI(v))
 	}
 
 	return values, diags
@@ -307,9 +303,7 @@ func mergeVolumesForRead(
 			vol.SizeId = prior[i].SizeId
 		}
 
-		objVal, d := vol.ToObjectValue(ctx)
-		diags.Append(d...)
-		values = append(values, objVal)
+		values = append(values, vol)
 	}
 
 	listVal, d := types.ListValue(VolumesValue{}.Type(ctx), values)
@@ -350,9 +344,7 @@ func mergeInterfacesForRead(
 		diags.Append(cd...)
 		ni.ChildVirtualNetworks = children
 
-		objVal, od := ni.ToObjectValue(ctx)
-		diags.Append(od...)
-		values = append(values, objVal)
+		values = append(values, ni)
 	}
 
 	listVal, d := types.ListValue(NetworkInterfacesValue{}.Type(ctx), values)
@@ -387,9 +379,7 @@ func mergeChildInterfacesForRead(
 			c.MacAddress = prior[i].MacAddress
 		}
 
-		objVal, d := c.ToObjectValue(ctx)
-		diags.Append(d...)
-		values = append(values, objVal)
+		values = append(values, c)
 	}
 
 	listVal, d := types.ListValue(ChildVirtualNetworksValue{}.Type(ctx), values)
@@ -506,9 +496,7 @@ func childInterfacesFromAPI(
 
 	values := make([]attr.Value, 0, len(apiChildren))
 	for _, child := range apiChildren {
-		objVal, d := childInterfaceValueFromAPI(child).ToObjectValue(ctx)
-		diags.Append(d...)
-		values = append(values, objVal)
+		values = append(values, childInterfaceValueFromAPI(child))
 	}
 
 	listVal, d := types.ListValue(ChildVirtualNetworksValue{}.Type(ctx), values)
@@ -532,9 +520,7 @@ func mergeInterfacesFromAPI(
 		for _, iface := range apiInterfaces {
 			ni, d := interfaceValueFromAPI(ctx, iface)
 			diags.Append(d...)
-			objVal, od := ni.ToObjectValue(ctx)
-			diags.Append(od...)
-			values = append(values, objVal)
+			values = append(values, ni)
 		}
 		listVal, d := types.ListValue(NetworkInterfacesValue{}.Type(ctx), values)
 		diags.Append(d...)
@@ -583,9 +569,7 @@ func mergeInterfacesFromAPI(
 			ChildVirtualNetworks:   children,
 		}
 
-		objVal, od := ni.ToObjectValue(ctx)
-		diags.Append(od...)
-		values = append(values, objVal)
+		values = append(values, ni)
 	}
 
 	listVal, d := types.ListValue(NetworkInterfacesValue{}.Type(ctx), values)
@@ -640,9 +624,7 @@ func mergeChildInterfacesFromAPI(
 			NetworkInterfaceTypeId: preferKnownInt64(pc[i].NetworkInterfaceTypeId, api.NetworkInterfaceTypeId),
 		}
 
-		objVal, d := c.ToObjectValue(ctx)
-		diags.Append(d...)
-		values = append(values, objVal)
+		values = append(values, c)
 	}
 
 	listVal, d := types.ListValue(ChildVirtualNetworksValue{}.Type(ctx), values)

--- a/morpheus/framework/resources/networkrouter/config_import.go
+++ b/morpheus/framework/resources/networkrouter/config_import.go
@@ -45,14 +45,23 @@ func configInt64(m map[string]interface{}, key string) types.Int64 {
 	return types.Int64Null()
 }
 
-// configBoolOnOff reads an NSX-T checkbox config value using convert.StringToBool
-// ("on"/"off" -> true/false). The typed schema fields are computed with a false
-// default, so an absent/null/unrecognized value maps to false (not null) to keep
-// import equivalent to a freshly-applied resource.
+// configBoolOnOff reads an NSX-T checkbox config value. The Morpheus API stores
+// and returns route-advertisement flags as native JSON booleans (true/false) —
+// not "on"/"off" strings — because setConfigProperty encodes Groovy Boolean
+// values directly via encodeAsJSON(). String "on"/"off" is retained as a fallback
+// for any legacy values that may have been stored differently.
+// The typed schema fields are computed with a false default, so an absent/null/
+// unrecognized value maps to false (not null) to keep import equivalent to a
+// freshly-applied resource.
 func configBoolOnOff(ctx context.Context, m map[string]interface{}, key string) types.Bool {
 	if v, ok := m[key]; ok && v != nil {
-		if s, ok := v.(string); ok {
-			if b := convert.StringToBool(ctx, s); !b.IsNull() {
+		switch val := v.(type) {
+		case bool:
+			// Native JSON boolean — what the Morpheus API returns for TIER1_* flags.
+			return types.BoolValue(val)
+		case string:
+			// Legacy "on"/"off" string fallback.
+			if b := convert.StringToBool(ctx, val); !b.IsNull() {
 				return b
 			}
 		}


### PR DESCRIPTION
instanceclone/read.go: Stops incorrectly converting custom struct values to Object values (.ToObjectValue(ctx)) before appending them to ListValue elements. The custom structs already implement attr.Value, so appending them directly fixes type-matching panics.

networkrouter/config_import.go: Fixes a bug where Morpheus API flags were being returned as native JSON booleans (true/false), but the import function was only looking for "on"/"off" strings. It now properly supports both.