### PR TITLE
Triage: Give the two cluster example tests a 70m provisioning budget

### DIFF
--- a/morpheus/framework/resources/cluster/cluster_test.go
+++ b/morpheus/framework/resources/cluster/cluster_test.go
@@ -96,6 +96,16 @@ data "hpe_morpheus_service_plan" "test" {
 		t.Fatal(err)
 	}
 
+	// Test-only provisioning budget. The published example template is left
+	// untouched; the timeouts attribute must sit inside the resource block, so
+	// it is injected into the rendered config rather than concatenated.
+	resourceConfig = testhelpers.InjectResourceAttrs(t, resourceConfig,
+		"hpe_morpheus_cluster", "example_hvm",
+		`  timeouts = {
+    create = "70m"
+    delete = "30m"
+  }`)
+
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(
 			"hpe_morpheus_cluster.example_hvm",
@@ -279,6 +289,14 @@ data "hpe_morpheus_service_plan" "test" {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Test-only provisioning budget. See the note on the HVM example above.
+	resourceConfig = testhelpers.InjectResourceAttrs(t, resourceConfig,
+		"hpe_morpheus_cluster", "example_generic_hvm",
+		`  timeouts = {
+    create = "70m"
+    delete = "30m"
+  }`)
 
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(

--- a/morpheus/testhelpers/examples.go
+++ b/morpheus/testhelpers/examples.go
@@ -39,6 +39,20 @@ func RenderExample(t *testing.T, name string, args ...string) (string, error) {
 	return example, nil
 }
 
+// InjectResourceAttrs inserts raw HCL immediately after the opening brace of the
+// named resource block. It fails the test if the block is absent, so a template
+// rename can never silently drop the injected attributes.
+func InjectResourceAttrs(t *testing.T, config, resourceType, resourceName, hcl string) string {
+	t.Helper()
+
+	anchor := fmt.Sprintf("resource %q %q {", resourceType, resourceName)
+	if !strings.Contains(config, anchor) {
+		t.Fatalf("resource block %s.%s not found in rendered config", resourceType, resourceName)
+	}
+
+	return strings.Replace(config, anchor, anchor+"\n"+hcl, 1)
+}
+
 // MergeOverrides applies overrides on top of defaults, ignoring any override
 // whose value is empty.
 //


### PR DESCRIPTION
Test-infrastructure only — no product code changes.

## Problem

`TestAccMorpheusClusterResourceHVMExampleOk` and
`TestAccMorpheusClusterResourceGenericExampleOk` inherit the 45m default create
timeout and fail with it expiring while the cluster is still provisioning.

## Change

Raise the budget for these two tests only, to 70m create / 30m delete.

`timeouts` is declared via `timeouts.AttributesAll(ctx)` (`schema_gen.go:459`), so
the HCL is an *attribute* that must sit inside the resource block and cannot be
concatenated onto the rendered config. The example templates double as the
published doc examples and are deliberately left untouched, so a new
`testhelpers.InjectResourceAttrs` helper splices the attribute in after the
resource block's opening brace. It calls `t.Fatalf` when the named block is
absent, so a template rename can never silently restore the 45m default — that
guard is the load-bearing part.

## Budget

70m create + 30m delete = 100m against `TEST_TIMEOUT ?= 120m`, leaving 20m
margin. 90m create would exceed the budget once the 45m delete default is added,
converting a clean test failure into a binary-level `panic: test timed out`.

## Tests

Verified against a live appliance (2026-08-06, 14:04–16:24Z). The pass criterion
is that the wait runs ~70m rather than ~45m, proving the injection took effect —
independently of whether the test itself passes.

| test | elapsed | budget |
|---|---|---|
| `TestAccMorpheusClusterResourceHVMExampleOk` | 4202.86s (70.05m) | injected 70m |
| `TestAccMorpheusClusterResourceGenericExampleOk` | 4202.74s (70.05m) | injected 70m |

Against 2702.34s / 2702.38s (45.04m) before the change, and 2703.29s (45.05m) in
a control run without the injection. Both anchors matched — neither `t.Fatalf`
fired. Criterion met, no regressions.

## Notes

**This is a mitigation, not a fix, and stays in draft.** Both tests still fail at
the new 70m deadline, and a live probe on 2026-08-07 established why. The
clusters are **stuck, not slow**: 511 polls showed `provisionComplete: false`
throughout, with all three worker records present in every one — the earlier
"1 of 3 workers" reading was an artefact of a truncated grep window.

The layout these tests use provisions with `provisionType: Manual`, and the
manual provision service implements no provisioning at all (`startServer`
returns `supported: false`). Morpheus never builds the hosts or installs their
agents, so provisioning parks at the `provisionFinalize` process step awaiting
an agent check-in that can never arrive: `provisionResources` completes in under
a second, `provisionFinalize` then runs indefinitely, and the workers report
`agentInstalled: false` with `agentVersion` and `lastAgentUpdate` null. Nothing
errors, so no failure is raised and `statusMessage` stays null; the
postProvision scripts that convert the base image into a hypervisor are never
reached.

It is therefore established, not merely indicated, that **no timeout value can
make these tests pass** — 45m, 55m and 70m all behaved identically because the
wait is for an event that never occurs. The question for review is whether to
keep this change at all, given the real fix is appliance-side.

**Held pending an environment fix.** Parked at the developer's direction until
agent installation on the three worker hosts is resolved.

**Open question.** The nightly runner is not in this repo and shards one test per
`go test` invocation; the `-timeout` it passes is unknown beyond "> 45m". If that
is below ~100m, this change could convert a clean diagnostic into a
`panic: test timed out`. Worth confirming before this reaches a nightly.

**Prior art.** Draft PR #1322 raised timeouts to 55m and was closed unmerged on
2026-08-04 without comment. This deliberately differs: 70m rather than 55m, and
test-only — #1322 also changed the example templates, `examples/`, `docs/` and
the Makefile. Please don't reopen or rebase onto #1322's branch.

