### PR TITLE
Replace server_uuids with a single server_uuid, and allow it on nodes (MORPH-15552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # v2.0.0 Release Notes (Unreleased)
 
-## Breaking Changes
+## Deprecations
 
-- `hpe_morpheus_instance` — The `server_uuids` attribute (Set of String) has been removed and replaced by `server_uuid` (String). Configurations that set `server_uuids` must change to the singular form with a single value. The new attribute assigns a UUID to the single server the instance provisions; use `hpe_morpheus_instance_node` for scaled nodes.
+- `hpe_morpheus_instance` — The `server_uuids` attribute is deprecated in favour of `server_uuid` (String). Both remain functional; `server_uuids` will be removed in a future major version. Existing configurations using `server_uuids` continue to work but should migrate to `server_uuid`. Use `hpe_morpheus_instance_node` for scaled nodes.
 
 ## Enhancements
 
 - `hpe_morpheus_instance` — Added computed `container_id` attribute identifying the container provisioned by the instance.
-- `hpe_morpheus_instance_node` — Added optional `server_uuid` attribute to assign a UUID to the node's server at create time.
+- `hpe_morpheus_instance_node` — Added optional `server_uuid` attribute to assign a UUID to the node's underlying compute server at create time.
+- `hpe_morpheus_instance_node` — The computed `uuid` attribute is renamed `container_uuid`, so that it is distinguishable from `server_uuid`. This attribute has not appeared in a release, so no published configuration is affected.
 
 # v1.6.0 Release Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v2.0.0 Release Notes (Unreleased)
+
+## Breaking Changes
+
+- `hpe_morpheus_instance` — The `server_uuids` attribute (Set of String) has been removed and replaced by `server_uuid` (String). Configurations that set `server_uuids` must change to the singular form with a single value. The new attribute assigns a UUID to the single server the instance provisions; use `hpe_morpheus_instance_node` for scaled nodes.
+
+## Enhancements
+
+- `hpe_morpheus_instance` — Added computed `container_id` attribute identifying the container provisioned by the instance.
+- `hpe_morpheus_instance_node` — Added optional `server_uuid` attribute to assign a UUID to the node's server at create time.
+
 # v1.6.0 Release Notes
 
 In this release (v1.6.0) we have added the following resources:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-# v2.0.0 Release Notes (Unreleased)
-
-## Deprecations
-
-- `hpe_morpheus_instance` — The `server_uuids` attribute is deprecated in favour of `server_uuid` (String). Both remain functional; `server_uuids` will be removed in a future major version. Existing configurations using `server_uuids` continue to work but should migrate to `server_uuid`. Use `hpe_morpheus_instance_node` for scaled nodes.
-
-## Enhancements
-
-- `hpe_morpheus_instance` — Added computed `container_id` attribute identifying the container provisioned by the instance.
-- `hpe_morpheus_instance_node` — Added optional `server_uuid` attribute to assign a UUID to the node's underlying compute server at create time.
-- `hpe_morpheus_instance_node` — The computed `uuid` attribute is renamed `container_uuid`, so that it is distinguishable from `server_uuid`. This attribute has not appeared in a release, so no published configuration is affected.
-
 # v1.6.0 Release Notes
 
 In this release (v1.6.0) we have added the following resources:

--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -355,10 +355,9 @@ resource "hpe_morpheus_instance" "example" {
   host_name        = "webserver01"
   # labels are organization keywords assigned to the instance.
   labels = ["terraform", "webserver"]
-  # server_uuids optionally assigns specific UUIDs to the servers provisioned for
-  # this instance (bring-your-own-UUID). Set at provision time only; changing it
-  # forces replacement. When omitted, Morpheus generates the UUIDs.
-  # server_uuids = ["550e8400-e29b-41d4-a716-446655440000"]
+  # server_uuid optionally assigns a UUID to the single server provisioned for
+  # this instance. Use hpe_morpheus_instance_node for scaled nodes.
+  # server_uuid = "550e8400-e29b-41d4-a716-446655440000"
   cloud_id         = data.hpe_morpheus_cloud.vmware_cloud.id
   layout_id        = data.hpe_morpheus_instance_type_layout.vmware.id
   instance_type_id = 9
@@ -918,17 +917,14 @@ hostname, so changing it forces replacement.
 - `ports` (Attributes Set) The ports parameter is for port configuration.
 
 The layout may have default ports, which are defined in node types, that are always configured. This parameter will be for additional custom ports to be opened. (see [below for nested schema](#nestedatt--ports))
-- `server_uuids` (Set of String) Optional UUIDs to assign to the servers provisioned for this instance.
-Supply at most one value. The API assigns UUIDs by position, but this
-attribute is a set and Terraform sets are unordered, so with more than
-one value it is not defined which UUID reaches which server. An
-instance provisions a single server in practice (layout_size is one),
-so one value is all that is used; scaling is done with
-hpe_morpheus_instance_node. A UUID already in use by another server is
-silently ignored by the API, which assigns a generated one instead;
-the provider detects that after create and fails the apply. Set at
-provision time only; changing it forces replacement. When not set,
-Morpheus generates the UUIDs and they are read back here.
+- `server_uuid` (String) UUID to assign to the single server provisioned for this instance.
+Morpheus assigns UUIDs strictly by position; an instance provisions
+exactly one server (layout_size is always 1), so this is the only UUID
+that takes effect. Use hpe_morpheus_instance_node to set UUIDs on
+scaled nodes. A UUID already in use by another server is silently
+ignored by the API, which assigns a generated one instead; the provider
+detects that after create and fails the apply. Set at provision time
+only; changing it forces replacement.
 - `service_plan_options` (Attributes) Custom options for selected service plan - the supported options depend on the service plan selected (see [below for nested schema](#nestedatt--service_plan_options))
 - `tags` (Attributes Set) Metadata tags, Array of objects having a name and value. (see [below for nested schema](#nestedatt--tags))
 - `task_set_id` (Number) The Workflow ID to execute.
@@ -947,6 +943,9 @@ consumes the remaining budget of the create or update timeout.
 ### Read-Only
 
 - `connection_info` (List of String) List of IP addresses to use when connecting to instance
+- `container_id` (Number) The container ID of the single container provisioned by this instance.
+Populated at create time and preserved across reads. Used internally to
+scope the server_uuid read-back to the owned container only.
 - `id` (Number) The ID of this resource.
 - `status` (String) The status of the instance (e.g. running, stopped, failed, unknown). The provider
 refreshes this on read, so an out-of-band deletion of the underlying VM - which Morpheus

--- a/docs/resources/morpheus_instance.md
+++ b/docs/resources/morpheus_instance.md
@@ -925,6 +925,19 @@ scaled nodes. A UUID already in use by another server is silently
 ignored by the API, which assigns a generated one instead; the provider
 detects that after create and fails the apply. Set at provision time
 only; changing it forces replacement.
+- `server_uuids` (Set of String, Deprecated) Deprecated: use server_uuid instead. This attribute will be removed in
+a future major version.
+Optional UUIDs to assign to the servers provisioned for this instance.
+Supply at most one value. The API assigns UUIDs by position, but this
+attribute is a set and Terraform sets are unordered, so with more than
+one value it is not defined which UUID reaches which server. An
+instance provisions a single server in practice (layout_size is one),
+so one value is all that is used; scaling is done with
+hpe_morpheus_instance_node. A UUID already in use by another server is
+silently ignored by the API, which assigns a generated one instead;
+the provider detects that after create and fails the apply. Set at
+provision time only; changing it forces replacement. When not set,
+Morpheus generates the UUIDs and they are read back here.
 - `service_plan_options` (Attributes) Custom options for selected service plan - the supported options depend on the service plan selected (see [below for nested schema](#nestedatt--service_plan_options))
 - `tags` (Attributes Set) Metadata tags, Array of objects having a name and value. (see [below for nested schema](#nestedatt--tags))
 - `task_set_id` (Number) The Workflow ID to execute.

--- a/docs/resources/morpheus_instance_node.md
+++ b/docs/resources/morpheus_instance_node.md
@@ -59,6 +59,7 @@ resource "hpe_morpheus_instance_node" "ha" {
 - `pre_provisioned` (Boolean) Attach an existing server instead of provisioning a new one.
 - `resource_pool_id` (Number) The resource pool where the node will be placed. Only honoured for HPE bare-metal instances; omit for all other instance types.
 - `selected_server_id` (Number) The ID of the pre-provisioned server. Required when `pre_provisioned` is set.
+- `server_uuid` (String) UUID to assign to the node's server. Sent as a single-element `serverUUIDs` list in the add-node action envelope. A UUID already in use by another server is silently ignored by the API; the provider detects this after create and fails the apply. Changing it forces replacement.
 - `ssh_host` (String) SSH host for the pre-provisioned server.
 - `ssh_key_pair_id` (Number) The ID of the SSH key pair for the pre-provisioned server.
 - `ssh_password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) SSH password for the pre-provisioned server. Write-only.

--- a/docs/resources/morpheus_instance_node.md
+++ b/docs/resources/morpheus_instance_node.md
@@ -59,7 +59,7 @@ resource "hpe_morpheus_instance_node" "ha" {
 - `pre_provisioned` (Boolean) Attach an existing server instead of provisioning a new one.
 - `resource_pool_id` (Number) The resource pool where the node will be placed. Only honoured for HPE bare-metal instances; omit for all other instance types.
 - `selected_server_id` (Number) The ID of the pre-provisioned server. Required when `pre_provisioned` is set.
-- `server_uuid` (String) UUID to assign to the node's server. Sent as a single-element `serverUUIDs` list in the add-node action envelope. A UUID already in use by another server is silently ignored by the API; the provider detects this after create and fails the apply. Changing it forces replacement.
+- `server_uuid` (String) UUID to assign to the node's underlying compute server, distinct from `container_uuid` which is the container's own identifier. Sent as a single-element `serverUUIDs` list in the add-node action envelope. A UUID already in use by another server is silently ignored by the API; the provider detects this after create and fails the apply. Changing it forces replacement.
 - `ssh_host` (String) SSH host for the pre-provisioned server.
 - `ssh_key_pair_id` (Number) The ID of the SSH key pair for the pre-provisioned server.
 - `ssh_password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) SSH password for the pre-provisioned server. Write-only.
@@ -70,6 +70,7 @@ resource "hpe_morpheus_instance_node" "ha" {
 ### Read-Only
 
 - `container_id` (Number) The container ID of the added node. Same value as `id`.
+- `container_uuid` (String) The UUID of the node container, assigned by the appliance.
 - `external_fqdn` (String) The external fully-qualified domain name of the node.
 - `hostname` (String) The hostname of the node container.
 - `id` (Number) The container ID of the added node. Holds the same value as `container_id`; exists to satisfy the framework's taint-on-error path.
@@ -79,7 +80,6 @@ resource "hpe_morpheus_instance_node" "ha" {
 - `name` (String) The name of the node container, assigned by the appliance.
 - `server_id` (Number) The compute server ID of the added node.
 - `server_resource_pool_id` (Number) The resource pool the node's server currently belongs to. For bare-metal instances this is the pool the server was drawn from. For virtual instances it reflects the hypervisor pool. Compare with `resource_pool_id` (the placement requested at create time, bare-metal only) to detect drift.
-- `uuid` (String) The UUID of the node container, assigned by the appliance.
 
 <a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/morpheus/framework/resources/instance/example_vmware.tf
+++ b/morpheus/framework/resources/instance/example_vmware.tf
@@ -20,10 +20,9 @@ resource "hpe_morpheus_instance" "example" {
   host_name        = "webserver01"
   # labels are organization keywords assigned to the instance.
   labels = ["terraform", "webserver"]
-  # server_uuids optionally assigns specific UUIDs to the servers provisioned for
-  # this instance (bring-your-own-UUID). Set at provision time only; changing it
-  # forces replacement. When omitted, Morpheus generates the UUIDs.
-  # server_uuids = ["550e8400-e29b-41d4-a716-446655440000"]
+  # server_uuid optionally assigns a UUID to the single server provisioned for
+  # this instance. Use hpe_morpheus_instance_node for scaled nodes.
+  # server_uuid = "550e8400-e29b-41d4-a716-446655440000"
   cloud_id         = data.hpe_morpheus_cloud.vmware_cloud.id
   layout_id        = data.hpe_morpheus_instance_type_layout.vmware.id
   instance_type_id = 9

--- a/morpheus/framework/resources/instance/example_vmware.tf.tmpl
+++ b/morpheus/framework/resources/instance/example_vmware.tf.tmpl
@@ -20,10 +20,9 @@ resource "hpe_morpheus_instance" "example" {
   host_name        = "webserver01"
   # labels are organization keywords assigned to the instance.
   labels = ["terraform", "webserver"]
-  # server_uuids optionally assigns specific UUIDs to the servers provisioned for
-  # this instance (bring-your-own-UUID). Set at provision time only; changing it
-  # forces replacement. When omitted, Morpheus generates the UUIDs.
-  # server_uuids = ["550e8400-e29b-41d4-a716-446655440000"]
+  # server_uuid optionally assigns a UUID to the single server provisioned for
+  # this instance. Use hpe_morpheus_instance_node for scaled nodes.
+  # server_uuid = "550e8400-e29b-41d4-a716-446655440000"
   cloud_id         = data.hpe_morpheus_cloud.vmware_cloud.id
   layout_id        = data.hpe_morpheus_instance_type_layout.vmware.id
   instance_type_id = {{.InstanceType}}

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -367,15 +366,10 @@ func (g *Resource) Create(
 		reqInstance.Labels = labels
 	}
 
-	// server_uuids - optional bring-your-own UUIDs for the provisioned servers.
+	// server_uuid - optional bring-your-own UUID for the single provisioned server.
 	// Create-time only (RequiresReplace); read back from containerDetails.server.uuid.
-	if !plan.ServerUuids.IsNull() && !plan.ServerUuids.IsUnknown() {
-		var serverUUIDs []string
-		resp.Diagnostics.Append(plan.ServerUuids.ElementsAs(ctx, &serverUUIDs, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		reqInstance.ServerUUIDs = serverUUIDs
+	if !plan.ServerUuid.IsNull() && !plan.ServerUuid.IsUnknown() {
+		reqInstance.ServerUUIDs = []string{plan.ServerUuid.ValueString()}
 	}
 
 	// group_id
@@ -651,13 +645,12 @@ func (g *Resource) Create(
 		}
 	}
 
-	// Validate that requested server UUIDs were actually applied. Morpheus
-	// silently drops a UUID that is already in use by another server and
-	// silently discards excess UUIDs beyond the number of servers provisioned.
-	// Both cases leave the instance in a state that does not match the config,
+	// Validate that the requested server UUID was actually applied. Morpheus
+	// silently drops a UUID that is already in use by another server.
+	// This leaves the instance in a state that does not match the config,
 	// so we fail the apply and taint the resource for replacement.
-	if !plan.ServerUuids.IsNull() && !plan.ServerUuids.IsUnknown() {
-		if d := validateServerUUIDs(ctx, client, instanceId, plan); d.HasError() {
+	if !plan.ServerUuid.IsNull() && !plan.ServerUuid.IsUnknown() {
+		if d := validateServerUUID(ctx, client, instanceId, plan.ServerUuid.ValueString()); d.HasError() {
 			resp.Diagnostics.Append(d...)
 			taintResourceState(instanceId)
 
@@ -731,29 +724,16 @@ func getInstanceTypeCode(
 	return instanceType.InstanceType.Code, diags
 }
 
-// validateServerUUIDs compares the UUIDs the user requested in server_uuids
-// against the UUIDs actually assigned to the instance's servers (read from
-// containerDetails[].server.uuid). Any requested UUID not present among the
-// assigned ones indicates a silent failure: Morpheus either dropped a duplicate
-// UUID that was already in use by another server, or ignored an excess UUID
-// beyond the number of servers provisioned by the instance.
-func validateServerUUIDs(
+// validateServerUUID checks whether the requested UUID was actually applied to
+// the instance's server. Morpheus silently drops a UUID that is already in use
+// by another server, assigning a generated one instead.
+func validateServerUUID(
 	ctx context.Context,
 	client *sdk.APIClient,
 	instanceID int64,
-	plan InstanceModel,
+	requestedUUID string,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
-
-	var requestedUUIDs []string
-	diags.Append(plan.ServerUuids.ElementsAs(ctx, &requestedUUIDs, false)...)
-	if diags.HasError() {
-		return diags
-	}
-
-	if len(requestedUUIDs) == 0 {
-		return diags
-	}
 
 	assigned, d := assignedServerUUIDs(ctx, client, instanceID)
 	diags.Append(d...)
@@ -761,7 +741,33 @@ func validateServerUUIDs(
 		return diags
 	}
 
-	diags.Append(checkServerUUIDs(requestedUUIDs, assigned, instanceID)...)
+	diags.Append(validateServerUUIDLogic(requestedUUID, assigned, instanceID)...)
+
+	return diags
+}
+
+// validateServerUUIDLogic is the pure-logic core: checks whether requestedUUID
+// is present in assigned. Returns an error diagnostic if not.
+func validateServerUUIDLogic(
+	requestedUUID string,
+	assigned map[string]struct{},
+	instanceID int64,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if _, ok := assigned[requestedUUID]; !ok {
+		diags.AddError(
+			"server_uuid not applied",
+			fmt.Sprintf(
+				"Instance %d was created successfully but Morpheus silently ignored "+
+					"the requested server UUID %q. This happens when the UUID is already "+
+					"in use by another server. The instance has been created and marked "+
+					"for replacement.",
+				instanceID,
+				requestedUUID,
+			),
+		)
+	}
 
 	return diags
 }
@@ -803,39 +809,4 @@ func assignedServerUUIDs(
 	}
 
 	return assigned, diags
-}
-
-// checkServerUUIDs is the pure-logic core of the server UUID post-create
-// validation. It compares requested UUIDs against assigned ones and returns an
-// error diagnostic naming every UUID that was not applied.
-func checkServerUUIDs(
-	requested []string,
-	assigned map[string]struct{},
-	instanceID int64,
-) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	var missing []string
-	for _, uuid := range requested {
-		if _, ok := assigned[uuid]; !ok {
-			missing = append(missing, uuid)
-		}
-	}
-
-	if len(missing) > 0 {
-		diags.AddError(
-			"server_uuids not applied",
-			fmt.Sprintf(
-				"Instance %d was created successfully but Morpheus silently ignored "+
-					"the following requested server UUID(s): [%s]. This happens when a "+
-					"UUID is already in use by another server, or when more UUIDs are "+
-					"supplied than servers provisioned by the instance. The instance has "+
-					"been created and marked for replacement.",
-				instanceID,
-				strings.Join(missing, ", "),
-			),
-		)
-	}
-
-	return diags
 }

--- a/morpheus/framework/resources/instance/instance_create.go
+++ b/morpheus/framework/resources/instance/instance_create.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -372,6 +373,17 @@ func (g *Resource) Create(
 		reqInstance.ServerUUIDs = []string{plan.ServerUuid.ValueString()}
 	}
 
+	// server_uuids (deprecated) - optional bring-your-own UUIDs for the provisioned servers.
+	// Create-time only (RequiresReplace); read back from containerDetails.server.uuid.
+	if !plan.ServerUuids.IsNull() && !plan.ServerUuids.IsUnknown() {
+		var serverUUIDs []string
+		resp.Diagnostics.Append(plan.ServerUuids.ElementsAs(ctx, &serverUUIDs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		reqInstance.ServerUUIDs = serverUUIDs
+	}
+
 	// group_id
 	reqInstance.Instance.Site = sdk.AddInstanceRequestInstanceSite{
 		Id: plan.GroupId.ValueInt64(),
@@ -658,6 +670,16 @@ func (g *Resource) Create(
 		}
 	}
 
+	// Validate server_uuids (deprecated path) if set.
+	if !plan.ServerUuids.IsNull() && !plan.ServerUuids.IsUnknown() {
+		if d := validateServerUUIDs(ctx, client, instanceId, plan); d.HasError() {
+			resp.Diagnostics.Append(d...)
+			taintResourceState(instanceId)
+
+			return
+		}
+	}
+
 	// Read the instance state
 	state, found, d := getInstanceAsState(ctx, instanceId, client, plan, false)
 	if d.HasError() || !found {
@@ -809,4 +831,74 @@ func assignedServerUUIDs(
 	}
 
 	return assigned, diags
+}
+
+// validateServerUUIDs compares the UUIDs the user requested in server_uuids
+// against the UUIDs actually assigned to the instance's servers (read from
+// containerDetails[].server.uuid). Any requested UUID not present among the
+// assigned ones indicates a silent failure: Morpheus either dropped a duplicate
+// UUID that was already in use by another server, or ignored an excess UUID
+// beyond the number of servers provisioned by the instance.
+func validateServerUUIDs(
+	ctx context.Context,
+	client *sdk.APIClient,
+	instanceID int64,
+	plan InstanceModel,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	var requestedUUIDs []string
+	diags.Append(plan.ServerUuids.ElementsAs(ctx, &requestedUUIDs, false)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	if len(requestedUUIDs) == 0 {
+		return diags
+	}
+
+	assigned, d := assignedServerUUIDs(ctx, client, instanceID)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	diags.Append(checkServerUUIDs(requestedUUIDs, assigned, instanceID)...)
+
+	return diags
+}
+
+// checkServerUUIDs is the pure-logic core of the server UUID post-create
+// validation. It compares requested UUIDs against assigned ones and returns an
+// error diagnostic naming every UUID that was not applied.
+func checkServerUUIDs(
+	requested []string,
+	assigned map[string]struct{},
+	instanceID int64,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	var missing []string
+	for _, uuid := range requested {
+		if _, ok := assigned[uuid]; !ok {
+			missing = append(missing, uuid)
+		}
+	}
+
+	if len(missing) > 0 {
+		diags.AddError(
+			"server_uuids not applied",
+			fmt.Sprintf(
+				"Instance %d was created successfully but Morpheus silently ignored "+
+					"the following requested server UUID(s): [%s]. This happens when a "+
+					"UUID is already in use by another server, or when more UUIDs are "+
+					"supplied than servers provisioned by the instance. The instance has "+
+					"been created and marked for replacement.",
+				instanceID,
+				strings.Join(missing, ", "),
+			),
+		)
+	}
+
+	return diags
 }

--- a/morpheus/framework/resources/instance/instance_create_internal_test.go
+++ b/morpheus/framework/resources/instance/instance_create_internal_test.go
@@ -138,3 +138,79 @@ func TestUnitServerUUIDNotApplied(t *testing.T) {
 		t.Errorf("expected error to name 'uuid-missing', got: %s", detail)
 	}
 }
+
+// TestUnitCheckServerUUIDsAllPresent verifies that when all requested UUIDs
+// are found among the assigned ones, no diagnostic is emitted.
+func TestUnitCheckServerUUIDsAllPresent(t *testing.T) {
+	t.Parallel()
+
+	requested := []string{"uuid-a", "uuid-b"}
+	assigned := map[string]struct{}{
+		"uuid-a": {},
+		"uuid-b": {},
+		"uuid-c": {}, // extra assigned UUID (from another container) is fine
+	}
+
+	diags := checkServerUUIDs(requested, assigned, 42)
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics, got: %v", diags)
+	}
+}
+
+// TestUnitCheckServerUUIDsOneMissing verifies that a requested UUID not found
+// among the assigned ones produces an error diagnostic naming that UUID.
+func TestUnitCheckServerUUIDsOneMissing(t *testing.T) {
+	t.Parallel()
+
+	requested := []string{"uuid-a", "uuid-missing"}
+	assigned := map[string]struct{}{
+		"uuid-a":     {},
+		"uuid-other": {},
+	}
+
+	diags := checkServerUUIDs(requested, assigned, 99)
+	if !diags.HasError() {
+		t.Fatal("expected an error diagnostic when a UUID is missing")
+	}
+
+	detail := diags.Errors()[0].Detail()
+	if !strings.Contains(detail, "uuid-missing") {
+		t.Errorf("expected error to name 'uuid-missing', got: %s", detail)
+	}
+	if strings.Contains(detail, "uuid-a") {
+		t.Errorf("error should not name 'uuid-a' which was applied, got: %s", detail)
+	}
+}
+
+// TestUnitCheckServerUUIDsExcessRequested verifies that requesting more UUIDs
+// than servers provisioned produces an error for the excess UUIDs.
+func TestUnitCheckServerUUIDsExcessRequested(t *testing.T) {
+	t.Parallel()
+
+	// Only one server was provisioned (layout_size=1), but two UUIDs requested.
+	requested := []string{"uuid-a", "uuid-excess"}
+	assigned := map[string]struct{}{
+		"uuid-a": {},
+	}
+
+	diags := checkServerUUIDs(requested, assigned, 10)
+	if !diags.HasError() {
+		t.Fatal("expected an error diagnostic for excess UUIDs")
+	}
+
+	detail := diags.Errors()[0].Detail()
+	if !strings.Contains(detail, "uuid-excess") {
+		t.Errorf("expected error to name 'uuid-excess', got: %s", detail)
+	}
+}
+
+// TestUnitCheckServerUUIDsEmptyRequested verifies that an empty requested list
+// produces no diagnostics (edge case: set is non-null but empty).
+func TestUnitCheckServerUUIDsEmptyRequested(t *testing.T) {
+	t.Parallel()
+
+	diags := checkServerUUIDs(nil, map[string]struct{}{"uuid-a": {}}, 1)
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics for empty requested list, got: %v", diags)
+	}
+}

--- a/morpheus/framework/resources/instance/instance_create_internal_test.go
+++ b/morpheus/framework/resources/instance/instance_create_internal_test.go
@@ -103,36 +103,32 @@ func TestUnitCreateStatusSetsDisjoint(t *testing.T) {
 	}
 }
 
-// TestUnitCheckServerUUIDsAllPresent verifies that when all requested UUIDs
-// are found among the assigned ones, no diagnostic is emitted.
-func TestUnitCheckServerUUIDsAllPresent(t *testing.T) {
+// TestUnitServerUUIDApplied verifies no diagnostic when the requested UUID
+// is found among the assigned ones.
+func TestUnitServerUUIDApplied(t *testing.T) {
 	t.Parallel()
 
-	requested := []string{"uuid-a", "uuid-b"}
 	assigned := map[string]struct{}{
-		"uuid-a": {},
-		"uuid-b": {},
-		"uuid-c": {}, // extra assigned UUID (from another container) is fine
+		"uuid-a":     {},
+		"uuid-extra": {},
 	}
 
-	diags := checkServerUUIDs(requested, assigned, 42)
+	diags := validateServerUUIDLogic("uuid-a", assigned, 42)
 	if diags.HasError() {
 		t.Fatalf("expected no diagnostics, got: %v", diags)
 	}
 }
 
-// TestUnitCheckServerUUIDsOneMissing verifies that a requested UUID not found
-// among the assigned ones produces an error diagnostic naming that UUID.
-func TestUnitCheckServerUUIDsOneMissing(t *testing.T) {
+// TestUnitServerUUIDNotApplied verifies that a requested UUID not found
+// produces an error diagnostic naming that UUID.
+func TestUnitServerUUIDNotApplied(t *testing.T) {
 	t.Parallel()
 
-	requested := []string{"uuid-a", "uuid-missing"}
 	assigned := map[string]struct{}{
-		"uuid-a":     {},
 		"uuid-other": {},
 	}
 
-	diags := checkServerUUIDs(requested, assigned, 99)
+	diags := validateServerUUIDLogic("uuid-missing", assigned, 99)
 	if !diags.HasError() {
 		t.Fatal("expected an error diagnostic when a UUID is missing")
 	}
@@ -140,41 +136,5 @@ func TestUnitCheckServerUUIDsOneMissing(t *testing.T) {
 	detail := diags.Errors()[0].Detail()
 	if !strings.Contains(detail, "uuid-missing") {
 		t.Errorf("expected error to name 'uuid-missing', got: %s", detail)
-	}
-	if strings.Contains(detail, "uuid-a") {
-		t.Errorf("error should not name 'uuid-a' which was applied, got: %s", detail)
-	}
-}
-
-// TestUnitCheckServerUUIDsExcessRequested verifies that requesting more UUIDs
-// than servers provisioned produces an error for the excess UUIDs.
-func TestUnitCheckServerUUIDsExcessRequested(t *testing.T) {
-	t.Parallel()
-
-	// Only one server was provisioned (layout_size=1), but two UUIDs requested.
-	requested := []string{"uuid-a", "uuid-excess"}
-	assigned := map[string]struct{}{
-		"uuid-a": {},
-	}
-
-	diags := checkServerUUIDs(requested, assigned, 10)
-	if !diags.HasError() {
-		t.Fatal("expected an error diagnostic for excess UUIDs")
-	}
-
-	detail := diags.Errors()[0].Detail()
-	if !strings.Contains(detail, "uuid-excess") {
-		t.Errorf("expected error to name 'uuid-excess', got: %s", detail)
-	}
-}
-
-// TestUnitCheckServerUUIDsEmptyRequested verifies that an empty requested list
-// produces no diagnostics (edge case: set is non-null but empty).
-func TestUnitCheckServerUUIDsEmptyRequested(t *testing.T) {
-	t.Parallel()
-
-	diags := checkServerUUIDs(nil, map[string]struct{}{"uuid-a": {}}, 1)
-	if diags.HasError() {
-		t.Fatalf("expected no diagnostics for empty requested list, got: %v", diags)
 	}
 }

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -328,6 +328,18 @@ func getInstanceAsState(
 	// containers outside this resource's lifecycle, and reading their UUIDs
 	// would change the value after scaling and force replacement.
 	state.ServerUuid = readServerUUIDFromOwnedContainer(instance.ContainerDetails, state.ContainerId)
+
+	// server_uuids (deprecated) - RequiresReplace, create-only input. Preserve the incoming
+	// value when the user set it (the API assigns exactly those UUIDs to the
+	// servers, so preserving avoids any read-back mismatch). Otherwise read the
+	// auto-generated UUIDs back from containerDetails[].server.uuid so the
+	// Computed value is known after apply. It is an unordered set because Morpheus
+	// does not guarantee containerDetails ordering matches the supplied order.
+	if !plan.ServerUuids.IsNull() && !plan.ServerUuids.IsUnknown() {
+		state.ServerUuids = plan.ServerUuids
+	} else {
+		state.ServerUuids = serverUUIDsFromContainerDetails(instance.ContainerDetails)
+	}
 	// wait_for_ip_address is provider-only; preserve from plan.
 	//
 	// Fall back to the schema default when the incoming value is null rather
@@ -1168,6 +1180,21 @@ func getInstanceEnvVars(
 	}
 
 	return resp.Envs, diags
+}
+
+// serverUUIDsFromContainerDetails builds the server_uuids set from
+// instance.containerDetails[].server.uuid, skipping containers with no server or
+// no uuid. Returns a null set when no UUIDs are present. server_uuids is an
+// unordered set because Morpheus does not guarantee containerDetails ordering.
+func serverUUIDsFromContainerDetails(containers []sdk.InstanceContainer2) types.Set {
+	uuids := make([]string, 0, len(containers))
+	for _, cont := range containers {
+		if cont.Server != nil && cont.Server.Uuid != nil {
+			uuids = append(uuids, *cont.Server.Uuid)
+		}
+	}
+
+	return convert.StrSliceToSet(uuids)
 }
 
 // readServerUUIDFromOwnedContainer reads the server UUID only from the container

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -311,17 +311,23 @@ func getInstanceAsState(
 	// response (empty -> null).
 	state.Labels = convert.StrSliceToSet(instance.Labels)
 
-	// server_uuids - RequiresReplace, create-only input. Preserve the incoming
-	// value when the user set it (the API assigns exactly those UUIDs to the
-	// servers, so preserving avoids any read-back mismatch). Otherwise read the
-	// auto-generated UUIDs back from containerDetails[].server.uuid so the
-	// Computed value is known after apply. It is an unordered set because Morpheus
-	// does not guarantee containerDetails ordering matches the supplied order.
-	if !plan.ServerUuids.IsNull() && !plan.ServerUuids.IsUnknown() {
-		state.ServerUuids = plan.ServerUuids
+	// container_id - Computed, UseStateForUnknown. Populated at create from the
+	// single container the instance provisions. Preserved across reads; if the
+	// recorded container is no longer present the stored value is kept (the
+	// instance still exists; a missing container is a different condition).
+	if !plan.ContainerId.IsNull() && !plan.ContainerId.IsUnknown() {
+		state.ContainerId = plan.ContainerId
+	} else if len(instance.ContainerDetails) > 0 && instance.ContainerDetails[0].Id != nil {
+		state.ContainerId = convert.Int64ToType(instance.ContainerDetails[0].Id)
 	} else {
-		state.ServerUuids = serverUUIDsFromContainerDetails(instance.ContainerDetails)
+		state.ContainerId = types.Int64Null()
 	}
+
+	// server_uuid - read back ONLY from the container matching container_id.
+	// Never reconcile from all containers: hpe_morpheus_instance_node adds
+	// containers outside this resource's lifecycle, and reading their UUIDs
+	// would change the value after scaling and force replacement.
+	state.ServerUuid = readServerUUIDFromOwnedContainer(instance.ContainerDetails, state.ContainerId)
 	// wait_for_ip_address is provider-only; preserve from plan.
 	//
 	// Fall back to the schema default when the incoming value is null rather
@@ -1164,19 +1170,31 @@ func getInstanceEnvVars(
 	return resp.Envs, diags
 }
 
-// serverUUIDsFromContainerDetails builds the server_uuids set from
-// instance.containerDetails[].server.uuid, skipping containers with no server or
-// no uuid. Returns a null set when no UUIDs are present. server_uuids is an
-// unordered set because Morpheus does not guarantee containerDetails ordering.
-func serverUUIDsFromContainerDetails(containers []sdk.InstanceContainer2) types.Set {
-	uuids := make([]string, 0, len(containers))
+// readServerUUIDFromOwnedContainer reads the server UUID only from the container
+// matching containerID. Returns null if the container is not found or has no
+// server UUID. This scoping prevents scaling (adding containers via
+// hpe_morpheus_instance_node) from changing the value and triggering replacement.
+func readServerUUIDFromOwnedContainer(
+	containers []sdk.InstanceContainer2,
+	containerID types.Int64,
+) types.String {
+	if containerID.IsNull() || containerID.IsUnknown() {
+		return types.StringNull()
+	}
+
+	target := containerID.ValueInt64()
 	for _, cont := range containers {
-		if cont.Server != nil && cont.Server.Uuid != nil {
-			uuids = append(uuids, *cont.Server.Uuid)
+		if cont.Id != nil && *cont.Id == target {
+			if cont.Server != nil && cont.Server.Uuid != nil {
+				return types.StringValue(*cont.Server.Uuid)
+			}
+
+			return types.StringNull()
 		}
 	}
 
-	return convert.StrSliceToSet(uuids)
+	// Container not present — return null rather than erroring.
+	return types.StringNull()
 }
 
 // getVolumes builds the volumes list from instance.containerDetails.server.volumes

--- a/morpheus/framework/resources/instance/instance_read_internal_test.go
+++ b/morpheus/framework/resources/instance/instance_read_internal_test.go
@@ -521,3 +521,86 @@ func TestUnitContainerIdPreservedWhenAbsent(t *testing.T) {
 		t.Errorf("expected null server_uuid when container absent, got %q", uuid.ValueString())
 	}
 }
+
+// TestUnitServerUUIDsFromContainerDetails verifies that serverUUIDsFromContainerDetails
+// builds the correct set from containerDetails[].server.uuid.
+func TestUnitServerUUIDsFromContainerDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		containers []sdk.InstanceContainer2
+		wantNull   bool
+		wantUUIDs  []string
+	}{
+		{
+			name: "single container with UUID",
+			containers: []sdk.InstanceContainer2{
+				{Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-a")}},
+			},
+			wantUUIDs: []string{"uuid-a"},
+		},
+		{
+			name: "multiple containers with UUIDs",
+			containers: []sdk.InstanceContainer2{
+				{Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-a")}},
+				{Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-b")}},
+			},
+			wantUUIDs: []string{"uuid-a", "uuid-b"},
+		},
+		{
+			name: "container with no server",
+			containers: []sdk.InstanceContainer2{
+				{Server: nil},
+			},
+			wantNull: true,
+		},
+		{
+			name: "container with server but no UUID",
+			containers: []sdk.InstanceContainer2{
+				{Server: &sdk.InstanceContainerServer2{Uuid: nil}},
+			},
+			wantNull: true,
+		},
+		{
+			name:       "empty containers",
+			containers: nil,
+			wantNull:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := serverUUIDsFromContainerDetails(tt.containers)
+			if tt.wantNull {
+				if !got.IsNull() {
+					t.Errorf("expected null set, got %v", got)
+				}
+
+				return
+			}
+
+			ctx := context.Background()
+			var uuids []string
+			if d := got.ElementsAs(ctx, &uuids, false); d.HasError() {
+				t.Fatalf("ElementsAs failed: %v", d)
+			}
+
+			if len(uuids) != len(tt.wantUUIDs) {
+				t.Fatalf("got %d UUIDs, want %d", len(uuids), len(tt.wantUUIDs))
+			}
+
+			// Sets are unordered, so check that all expected UUIDs are present.
+			uuidSet := make(map[string]struct{}, len(uuids))
+			for _, u := range uuids {
+				uuidSet[u] = struct{}{}
+			}
+			for _, want := range tt.wantUUIDs {
+				if _, ok := uuidSet[want]; !ok {
+					t.Errorf("expected UUID %q not found in result %v", want, uuids)
+				}
+			}
+		})
+	}
+}

--- a/morpheus/framework/resources/instance/instance_read_internal_test.go
+++ b/morpheus/framework/resources/instance/instance_read_internal_test.go
@@ -4,12 +4,12 @@ package instance
 
 import (
 	"context"
-	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
+	"github.com/HPE/terraform-provider-hpe/utils/convert"
 )
 
 // TestUnitGetChildNetworksReadsSubnetID verifies that getChildNetworks reads subnet_id
@@ -94,73 +94,75 @@ func TestUnitGetChildNetworksNoSubnet(t *testing.T) {
 	}
 }
 
-// TestUnitServerUUIDsFromContainerDetails verifies server_uuids is read back
-// from containerDetails[].server.uuid (MORPH-12963), skipping containers with no
-// server or no uuid, and yielding a null set when none are present. server_uuids
-// is an unordered set, so values are compared order-insensitively.
-func TestUnitServerUUIDsFromContainerDetails(t *testing.T) {
+// TestUnitReadServerUUIDFromOwnedContainer verifies that server_uuid is read
+// back only from the container matching container_id, and that extra containers
+// (added by hpe_morpheus_instance_node) do not change the value.
+func TestUnitReadServerUUIDFromOwnedContainer(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
 	tests := []struct {
-		name       string
-		containers []sdk.InstanceContainer2
-		wantNull   bool
-		want       []string
+		name        string
+		containers  []sdk.InstanceContainer2
+		containerID types.Int64
+		want        string
+		wantNull    bool
 	}{
 		{
-			name: "collects server uuids",
+			name: "reads from owned container",
 			containers: []sdk.InstanceContainer2{
-				{Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-1")}},
-				{Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-2")}},
+				{Id: sdk.PtrInt64(100), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("owned-uuid")}},
+				{Id: sdk.PtrInt64(200), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("node-uuid")}},
 			},
-			want: []string{"uuid-1", "uuid-2"},
+			containerID: types.Int64Value(100),
+			want:        "owned-uuid",
 		},
 		{
-			name: "nil server skipped",
+			name: "ignores other containers - scaling regression guard",
 			containers: []sdk.InstanceContainer2{
-				{Server: nil},
-				{Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-2")}},
+				{Id: sdk.PtrInt64(100), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("owned-uuid")}},
+				{Id: sdk.PtrInt64(200), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("different-uuid")}},
+				{Id: sdk.PtrInt64(300), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("third-uuid")}},
 			},
-			want: []string{"uuid-2"},
+			containerID: types.Int64Value(100),
+			want:        "owned-uuid",
 		},
 		{
-			name: "nil uuid skipped -> null",
+			name: "container not found returns null",
 			containers: []sdk.InstanceContainer2{
-				{Server: &sdk.InstanceContainerServer2{Uuid: nil}},
+				{Id: sdk.PtrInt64(200), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-2")}},
 			},
-			wantNull: true,
+			containerID: types.Int64Value(999),
+			wantNull:    true,
 		},
-		{name: "empty containers -> null", containers: nil, wantNull: true},
+		{
+			name:        "null container_id returns null",
+			containers:  []sdk.InstanceContainer2{{Id: sdk.PtrInt64(1), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("x")}}},
+			containerID: types.Int64Null(),
+			wantNull:    true,
+		},
+		{
+			name: "server with no uuid returns null",
+			containers: []sdk.InstanceContainer2{
+				{Id: sdk.PtrInt64(100), Server: &sdk.InstanceContainerServer2{Uuid: nil}},
+			},
+			containerID: types.Int64Value(100),
+			wantNull:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := serverUUIDsFromContainerDetails(tt.containers)
+			got := readServerUUIDFromOwnedContainer(tt.containers, tt.containerID)
 			if tt.wantNull {
 				if !got.IsNull() {
-					t.Errorf("expected null set, got %v", got)
+					t.Errorf("expected null, got %v", got)
 				}
 
 				return
 			}
-			var uuids []string
-			if d := got.ElementsAs(ctx, &uuids, false); d.HasError() {
-				t.Fatalf("ElementsAs returned diagnostics: %v", d)
-			}
-			// server_uuids is an unordered set: compare order-insensitively.
-			sort.Strings(uuids)
-			want := append([]string(nil), tt.want...)
-			sort.Strings(want)
-			if len(uuids) != len(want) {
-				t.Fatalf("got %d uuids %v, want %d %v", len(uuids), uuids, len(want), want)
-			}
-			for i := range uuids {
-				if uuids[i] != want[i] {
-					t.Errorf("uuid[%d] = %q, want %q", i, uuids[i], want[i])
-				}
+			if got.ValueString() != tt.want {
+				t.Errorf("got %q, want %q", got.ValueString(), tt.want)
 			}
 		})
 	}
@@ -445,53 +447,77 @@ func TestUnitNumberToInt64(t *testing.T) {
 	}
 }
 
-// TestUnitServerUUIDsReadPreservesPlan is a regression guard for the volatility
-// trap described in MORPH-12804: when server_uuids is set in config, the read
-// must preserve the plan value, NOT read back from containerDetails. If it read
-// back, adding a container via hpe_morpheus_instance_node would grow the set,
-// differ from config, and — because the attribute is RequiresReplace — trigger
-// destruction and recreation of the instance.
-func TestUnitServerUUIDsReadPreservesPlan(t *testing.T) {
+// TestUnitContainerIdPreservedAcrossReads verifies that container_id is
+// preserved from the plan when already set (UseStateForUnknown), and populated
+// from the first container when null (import/create).
+func TestUnitContainerIdPreservedAcrossReads(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
-	// Simulate: plan has one UUID, but the instance now has two containers
-	// (one added by instance_node). The read must still return the plan's
-	// single UUID, not the two from containerDetails.
-	planUUID := "plan-uuid-1"
-	planSet, d := types.SetValueFrom(ctx, types.StringType, []string{planUUID})
-	if d.HasError() {
-		t.Fatalf("SetValueFrom: %v", d)
-	}
-
 	containers := []sdk.InstanceContainer2{
-		{Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString(planUUID)}},
-		{Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("node-added-uuid")}},
+		{Id: sdk.PtrInt64(100), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-a")}},
+		{Id: sdk.PtrInt64(200), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-b")}},
 	}
 
-	// When plan.ServerUuids is set, the read preserves it.
+	// Case 1: plan has container_id set => preserved
 	plan := InstanceModel{}
-	plan.ServerUuids = planSet
+	plan.ContainerId = types.Int64Value(100)
 
-	// Inline the logic from getInstanceAsState lines 320-324
 	var state InstanceModel
-	if !plan.ServerUuids.IsNull() && !plan.ServerUuids.IsUnknown() {
-		state.ServerUuids = plan.ServerUuids
-	} else {
-		state.ServerUuids = serverUUIDsFromContainerDetails(containers)
+	if !plan.ContainerId.IsNull() && !plan.ContainerId.IsUnknown() {
+		state.ContainerId = plan.ContainerId
+	} else if len(containers) > 0 && containers[0].Id != nil {
+		state.ContainerId = convert.Int64ToType(containers[0].Id)
 	}
 
-	var stateUUIDs []string
-	if dd := state.ServerUuids.ElementsAs(ctx, &stateUUIDs, false); dd.HasError() {
-		t.Fatalf("ElementsAs: %v", dd)
+	if state.ContainerId.ValueInt64() != 100 {
+		t.Errorf("expected container_id=100, got %d", state.ContainerId.ValueInt64())
 	}
 
-	if len(stateUUIDs) != 1 {
-		t.Fatalf("expected 1 UUID in state, got %d: %v", len(stateUUIDs), stateUUIDs)
+	// Case 2: plan container_id is null => populated from first container
+	plan2 := InstanceModel{}
+	plan2.ContainerId = types.Int64Null()
+
+	var state2 InstanceModel
+	if !plan2.ContainerId.IsNull() && !plan2.ContainerId.IsUnknown() {
+		state2.ContainerId = plan2.ContainerId
+	} else if len(containers) > 0 && containers[0].Id != nil {
+		state2.ContainerId = convert.Int64ToType(containers[0].Id)
 	}
 
-	if stateUUIDs[0] != planUUID {
-		t.Errorf("state UUID = %q, want %q", stateUUIDs[0], planUUID)
+	if state2.ContainerId.ValueInt64() != 100 {
+		t.Errorf("expected container_id=100 from first container, got %d", state2.ContainerId.ValueInt64())
+	}
+}
+
+// TestUnitContainerIdPreservedWhenAbsent verifies that when the recorded
+// container is no longer present in the instance, the stored container_id is
+// kept rather than being nulled or erroring.
+func TestUnitContainerIdPreservedWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	// The recorded container (100) is gone; only 200 exists.
+	containers := []sdk.InstanceContainer2{
+		{Id: sdk.PtrInt64(200), Server: &sdk.InstanceContainerServer2{Uuid: sdk.PtrString("uuid-b")}},
+	}
+
+	plan := InstanceModel{}
+	plan.ContainerId = types.Int64Value(100)
+
+	// The logic preserves plan when non-null (UseStateForUnknown behaviour)
+	var state InstanceModel
+	if !plan.ContainerId.IsNull() && !plan.ContainerId.IsUnknown() {
+		state.ContainerId = plan.ContainerId
+	} else if len(containers) > 0 && containers[0].Id != nil {
+		state.ContainerId = convert.Int64ToType(containers[0].Id)
+	}
+
+	if state.ContainerId.ValueInt64() != 100 {
+		t.Errorf("expected container_id=100 preserved, got %d", state.ContainerId.ValueInt64())
+	}
+
+	// server_uuid should be null since container 100 is not found
+	uuid := readServerUUIDFromOwnedContainer(containers, state.ContainerId)
+	if !uuid.IsNull() {
+		t.Errorf("expected null server_uuid when container absent, got %q", uuid.ValueString())
 	}
 }

--- a/morpheus/framework/resources/instance/resource.go
+++ b/morpheus/framework/resources/instance/resource.go
@@ -21,9 +21,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &Resource{}
-	_ resource.ResourceWithImportState = &Resource{}
-	_ resource.ResourceWithModifyPlan  = &Resource{}
+	_ resource.Resource                     = &Resource{}
+	_ resource.ResourceWithImportState      = &Resource{}
+	_ resource.ResourceWithModifyPlan       = &Resource{}
+	_ resource.ResourceWithConfigValidators = &Resource{}
 )
 
 func NewResource() resource.Resource {
@@ -167,4 +168,50 @@ func (m *morpheusConstraint) checkForAttributeUpdate(
 		fmt.Sprintf("Morpheus version must be %s to allow %s updates without instance replacement",
 			m.constraint, m.mnemonic),
 	)
+}
+
+// ConfigValidators implements resource.ResourceWithConfigValidators.
+// server_uuid and server_uuids are mutually exclusive.
+func (g *Resource) ConfigValidators(
+	_ context.Context,
+) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		serverUUIDConflictValidator{},
+	}
+}
+
+// serverUUIDConflictValidator rejects configs that set both server_uuid and
+// server_uuids. Only one may be used at a time.
+type serverUUIDConflictValidator struct{}
+
+func (v serverUUIDConflictValidator) Description(_ context.Context) string {
+	return "server_uuid and server_uuids are mutually exclusive"
+}
+
+func (v serverUUIDConflictValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v serverUUIDConflictValidator) ValidateResource(
+	ctx context.Context,
+	req resource.ValidateConfigRequest,
+	resp *resource.ValidateConfigResponse,
+) {
+	var config InstanceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	uuidSet := !config.ServerUuid.IsNull() && !config.ServerUuid.IsUnknown()
+	uuidsSet := !config.ServerUuids.IsNull() && !config.ServerUuids.IsUnknown()
+
+	if uuidSet && uuidsSet {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("server_uuid"),
+			"Conflicting attributes",
+			"server_uuid and server_uuids are mutually exclusive. "+
+				"Use server_uuid (server_uuids is deprecated and will be removed in a future major version).",
+		)
+	}
 }

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -719,6 +719,18 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"server_uuids": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				Description:         "Deprecated: use server_uuid instead. This attribute will be removed in\na future major version.\nOptional UUIDs to assign to the servers provisioned for this instance.\nSupply at most one value. The API assigns UUIDs by position, but this\nattribute is a set and Terraform sets are unordered, so with more than\none value it is not defined which UUID reaches which server. An\ninstance provisions a single server in practice (layout_size is one),\nso one value is all that is used; scaling is done with\nhpe_morpheus_instance_node. A UUID already in use by another server is\nsilently ignored by the API, which assigns a generated one instead;\nthe provider detects that after create and fails the apply. Set at\nprovision time only; changing it forces replacement. When not set,\nMorpheus generates the UUIDs and they are read back here.",
+				MarkdownDescription: "Deprecated: use server_uuid instead. This attribute will be removed in\na future major version.\nOptional UUIDs to assign to the servers provisioned for this instance.\nSupply at most one value. The API assigns UUIDs by position, but this\nattribute is a set and Terraform sets are unordered, so with more than\none value it is not defined which UUID reaches which server. An\ninstance provisions a single server in practice (layout_size is one),\nso one value is all that is used; scaling is done with\nhpe_morpheus_instance_node. A UUID already in use by another server is\nsilently ignored by the API, which assigns a generated one instead;\nthe provider detects that after create and fails the apply. Set at\nprovision time only; changing it forces replacement. When not set,\nMorpheus generates the UUIDs and they are read back here.",
+				DeprecationMessage:  "Deprecated: use server_uuid instead. server_uuids is retained for backward compatibility and will be removed in a future major version.",
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+					setplanmodifier.RequiresReplace(),
+				},
+			},
 			"service_plan_options": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"cores_per_socket": schema.Int64Attribute{
@@ -912,6 +924,7 @@ type InstanceModel struct {
 	PlanId             types.Int64             `tfsdk:"plan_id"`
 	Ports              types.Set               `tfsdk:"ports"`
 	ServerUuid         types.String            `tfsdk:"server_uuid"`
+	ServerUuids        types.Set               `tfsdk:"server_uuids"`
 	ServicePlanOptions ServicePlanOptionsValue `tfsdk:"service_plan_options"`
 	Status             types.String            `tfsdk:"status"`
 	Tags               types.Set               `tfsdk:"tags"`

--- a/morpheus/framework/resources/instance/schema_gen.go
+++ b/morpheus/framework/resources/instance/schema_gen.go
@@ -371,6 +371,14 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "List of IP addresses to use when connecting to instance",
 				MarkdownDescription: "List of IP addresses to use when connecting to instance",
 			},
+			"container_id": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "The container ID of the single container provisioned by this instance.\nPopulated at create time and preserved across reads. Used internally to\nscope the server_uuid read-back to the owned container only.",
+				MarkdownDescription: "The container ID of the single container provisioned by this instance.\nPopulated at create time and preserved across reads. Used internally to\nscope the server_uuid read-back to the owned container only.",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
 			"description": schema.StringAttribute{
 				Optional:            true,
 				Description:         "A description of the instance.",
@@ -701,15 +709,14 @@ func InstanceResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The ports parameter is for port configuration.\n\nThe layout may have default ports, which are defined in node types, that are always configured. This parameter will be for additional custom ports to be opened.\n",
 				MarkdownDescription: "The ports parameter is for port configuration.\n\nThe layout may have default ports, which are defined in node types, that are always configured. This parameter will be for additional custom ports to be opened.\n",
 			},
-			"server_uuids": schema.SetAttribute{
-				ElementType:         types.StringType,
+			"server_uuid": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Optional UUIDs to assign to the servers provisioned for this instance.\nSupply at most one value. The API assigns UUIDs by position, but this\nattribute is a set and Terraform sets are unordered, so with more than\none value it is not defined which UUID reaches which server. An\ninstance provisions a single server in practice (layout_size is one),\nso one value is all that is used; scaling is done with\nhpe_morpheus_instance_node. A UUID already in use by another server is\nsilently ignored by the API, which assigns a generated one instead;\nthe provider detects that after create and fails the apply. Set at\nprovision time only; changing it forces replacement. When not set,\nMorpheus generates the UUIDs and they are read back here.",
-				MarkdownDescription: "Optional UUIDs to assign to the servers provisioned for this instance.\nSupply at most one value. The API assigns UUIDs by position, but this\nattribute is a set and Terraform sets are unordered, so with more than\none value it is not defined which UUID reaches which server. An\ninstance provisions a single server in practice (layout_size is one),\nso one value is all that is used; scaling is done with\nhpe_morpheus_instance_node. A UUID already in use by another server is\nsilently ignored by the API, which assigns a generated one instead;\nthe provider detects that after create and fails the apply. Set at\nprovision time only; changing it forces replacement. When not set,\nMorpheus generates the UUIDs and they are read back here.",
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.UseStateForUnknown(),
-					setplanmodifier.RequiresReplace(),
+				Description:         "UUID to assign to the single server provisioned for this instance.\nMorpheus assigns UUIDs strictly by position; an instance provisions\nexactly one server (layout_size is always 1), so this is the only UUID\nthat takes effect. Use hpe_morpheus_instance_node to set UUIDs on\nscaled nodes. A UUID already in use by another server is silently\nignored by the API, which assigns a generated one instead; the provider\ndetects that after create and fails the apply. Set at provision time\nonly; changing it forces replacement.",
+				MarkdownDescription: "UUID to assign to the single server provisioned for this instance.\nMorpheus assigns UUIDs strictly by position; an instance provisions\nexactly one server (layout_size is always 1), so this is the only UUID\nthat takes effect. Use hpe_morpheus_instance_node to set UUIDs on\nscaled nodes. A UUID already in use by another server is silently\nignored by the API, which assigns a generated one instead; the provider\ndetects that after create and fails the apply. Set at provision time\nonly; changing it forces replacement.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"service_plan_options": schema.SingleNestedAttribute{
@@ -888,6 +895,7 @@ type InstanceModel struct {
 	ConfigHvm          ConfigHvmValue          `tfsdk:"config_hvm"`
 	ConfigVmware       ConfigVmwareValue       `tfsdk:"config_vmware"`
 	ConnectionInfo     types.List              `tfsdk:"connection_info"`
+	ContainerId        types.Int64             `tfsdk:"container_id"`
 	Description        types.String            `tfsdk:"description"`
 	Evars              types.Set               `tfsdk:"evars"`
 	GroupId            types.Int64             `tfsdk:"group_id"`
@@ -903,7 +911,7 @@ type InstanceModel struct {
 	NetworkInterfaces  types.List              `tfsdk:"network_interfaces"`
 	PlanId             types.Int64             `tfsdk:"plan_id"`
 	Ports              types.Set               `tfsdk:"ports"`
-	ServerUuids        types.Set               `tfsdk:"server_uuids"`
+	ServerUuid         types.String            `tfsdk:"server_uuid"`
 	ServicePlanOptions ServicePlanOptionsValue `tfsdk:"service_plan_options"`
 	Status             types.String            `tfsdk:"status"`
 	Tags               types.Set               `tfsdk:"tags"`

--- a/morpheus/framework/resources/instancenode/create.go
+++ b/morpheus/framework/resources/instancenode/create.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -202,20 +203,10 @@ func (r *Resource) Create(
 
 	// Step 5b: Validate that the requested server UUID was applied.
 	if !plan.ServerUUID.IsNull() && !plan.ServerUUID.IsUnknown() {
-		actualUUID := resolveNodeServerUUID(ctx, client, instanceID, containerID)
-		requestedUUID := plan.ServerUUID.ValueString()
-		if actualUUID != requestedUUID {
-			resp.Diagnostics.AddError(
-				"server_uuid not applied",
-				fmt.Sprintf(
-					"Instance %d node (container %d) was added but Morpheus silently "+
-						"ignored the requested server UUID %q. The server was assigned "+
-						"UUID %q instead. This happens when the UUID is already in use "+
-						"by another server.",
-					instanceID, containerID, requestedUUID, actualUUID,
-				),
-			)
-
+		uuidDiags := validateNodeServerUUID(ctx, client, instanceID, containerID,
+			plan.ServerUUID.ValueString())
+		resp.Diagnostics.Append(uuidDiags...)
+		if resp.Diagnostics.HasError() {
 			cleanup.TaintResourceState(ctx, cleanup.TaintResourceStateConfig{
 				ResourceType: "instance_node",
 				ResourceID:   containerID,
@@ -555,29 +546,93 @@ func extractContainerIDFromResults(results any, instanceID int64) (int64, error)
 	}
 }
 
-// resolveNodeServerUUID reads the instance and returns the server UUID for
-// the container matching containerID. Returns empty string if not found.
-func resolveNodeServerUUID(
+// validateNodeServerUUID reads the instance and checks whether the requested
+// UUID was actually applied to the node's server. Returns diagnostics that
+// distinguish three failure modes: API read failure, container not found in
+// the response, and UUID mismatch (silently ignored by Morpheus).
+func validateNodeServerUUID(
 	ctx context.Context,
 	client *sdk.APIClient,
 	instanceID int64,
 	containerID int64,
-) string {
-	getResp, _, err := client.InstancesAPI.GetInstance(ctx, instanceID).Execute()
-	if err != nil || getResp == nil || getResp.Instance == nil {
-		return ""
+	requestedUUID string,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	getResp, hresp, err := client.InstancesAPI.GetInstance(ctx, instanceID).Execute()
+	if err != nil {
+		diags.AddError(
+			"failed to read instance for server UUID validation",
+			fmt.Sprintf("instance %d container %d: could not confirm whether the "+
+				"requested server UUID %q was applied: %s",
+				instanceID, containerID, requestedUUID, errfmt.ErrMsg(err, hresp)),
+		)
+
+		return diags
 	}
 
-	for i := range getResp.Instance.ContainerDetails {
-		cd := &getResp.Instance.ContainerDetails[i]
-		if cd.Id != nil && *cd.Id == containerID {
-			if cd.Server != nil && cd.Server.Uuid != nil {
-				return *cd.Server.Uuid
-			}
+	if getResp == nil || getResp.Instance == nil {
+		diags.AddError(
+			"failed to read instance for server UUID validation",
+			fmt.Sprintf("instance %d: GET returned nil instance", instanceID),
+		)
 
-			return ""
+		return diags
+	}
+
+	return resolveAndValidateNodeUUID(
+		getResp.Instance.ContainerDetails, instanceID, containerID, requestedUUID,
+	)
+}
+
+// resolveAndValidateNodeUUID decides whether the requested server UUID was
+// applied, given the containers already read from the instance.
+//
+// It is separated from the API call so the decision can be tested directly.
+// validateNodeServerUUID must delegate to it rather than repeating the checks:
+// a second copy would let the tested logic and the executed logic drift apart,
+// and the tests would keep passing while the real path was wrong.
+func resolveAndValidateNodeUUID(
+	details []sdk.InstanceContainer2,
+	instanceID int64,
+	containerID int64,
+	requestedUUID string,
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	for i := range details {
+		cd := &details[i]
+		if cd.Id == nil || *cd.Id != containerID {
+			continue
 		}
+
+		var actualUUID string
+		if cd.Server != nil && cd.Server.Uuid != nil {
+			actualUUID = *cd.Server.Uuid
+		}
+
+		if actualUUID != requestedUUID {
+			diags.AddError(
+				"server_uuid not applied",
+				fmt.Sprintf(
+					"Instance %d node (container %d) was added but Morpheus "+
+						"silently ignored the requested server UUID %q. The "+
+						"server was assigned UUID %q instead. This happens "+
+						"when the UUID is already in use by another server.",
+					instanceID, containerID, requestedUUID, actualUUID,
+				),
+			)
+		}
+
+		return diags
 	}
 
-	return ""
+	diags.AddError(
+		"container not found during server UUID validation",
+		fmt.Sprintf("instance %d container %d: the container was not found in the "+
+			"instance response; the server UUID could not be validated",
+			instanceID, containerID),
+	)
+
+	return diags
 }

--- a/morpheus/framework/resources/instancenode/create.go
+++ b/morpheus/framework/resources/instancenode/create.go
@@ -200,6 +200,33 @@ func (r *Resource) Create(
 		return
 	}
 
+	// Step 5b: Validate that the requested server UUID was applied.
+	if !plan.ServerUUID.IsNull() && !plan.ServerUUID.IsUnknown() {
+		actualUUID := resolveNodeServerUUID(ctx, client, instanceID, containerID)
+		requestedUUID := plan.ServerUUID.ValueString()
+		if actualUUID != requestedUUID {
+			resp.Diagnostics.AddError(
+				"server_uuid not applied",
+				fmt.Sprintf(
+					"Instance %d node (container %d) was added but Morpheus silently "+
+						"ignored the requested server UUID %q. The server was assigned "+
+						"UUID %q instead. This happens when the UUID is already in use "+
+						"by another server.",
+					instanceID, containerID, requestedUUID, actualUUID,
+				),
+			)
+
+			cleanup.TaintResourceState(ctx, cleanup.TaintResourceStateConfig{
+				ResourceType: "instance_node",
+				ResourceID:   containerID,
+				StateWriter:  &resp.State,
+				Diagnostics:  &resp.Diagnostics,
+			})
+
+			return
+		}
+	}
+
 	// Step 6: Optionally wait for IP address.
 	if plan.WaitForIPAddress.ValueBool() {
 		ip, warned, waitErr := containerip.Wait(
@@ -316,6 +343,12 @@ func buildAddNodeEnvelope(plan *instanceNodeModel, actionCode string) map[string
 				"id": plan.SshKeyPairID.ValueInt64(),
 			}
 		}
+	}
+
+	// server_uuid: include as a single-element serverUUIDs list when set.
+	// When unset, omit the key entirely - never send null or empty list.
+	if !plan.ServerUUID.IsNull() && !plan.ServerUUID.IsUnknown() {
+		env["serverUUIDs"] = []string{plan.ServerUUID.ValueString()}
 	}
 
 	return env
@@ -520,4 +553,31 @@ func extractContainerIDFromResults(results any, instanceID int64) (int64, error)
 	default:
 		return 0, fmt.Errorf("container id has unexpected type: %T", idVal)
 	}
+}
+
+// resolveNodeServerUUID reads the instance and returns the server UUID for
+// the container matching containerID. Returns empty string if not found.
+func resolveNodeServerUUID(
+	ctx context.Context,
+	client *sdk.APIClient,
+	instanceID int64,
+	containerID int64,
+) string {
+	getResp, _, err := client.InstancesAPI.GetInstance(ctx, instanceID).Execute()
+	if err != nil || getResp == nil || getResp.Instance == nil {
+		return ""
+	}
+
+	for i := range getResp.Instance.ContainerDetails {
+		cd := &getResp.Instance.ContainerDetails[i]
+		if cd.Id != nil && *cd.Id == containerID {
+			if cd.Server != nil && cd.Server.Uuid != nil {
+				return *cd.Server.Uuid
+			}
+
+			return ""
+		}
+	}
+
+	return ""
 }

--- a/morpheus/framework/resources/instancenode/create_test.go
+++ b/morpheus/framework/resources/instancenode/create_test.go
@@ -459,3 +459,140 @@ func TestUnitResolveNodeServerUUID_Found(t *testing.T) {
 		t.Errorf("expected serverUUIDs=[my-uuid], got %v", uuids)
 	}
 }
+
+// TestUnitValidateNodeServerUUID_APIReadFailure verifies that an API error
+// produces a diagnostic naming the error, distinct from a UUID mismatch.
+func TestUnitValidateNodeServerUUID_APIReadFailure(t *testing.T) {
+	t.Parallel()
+
+	// validateNodeServerUUID calls the live API, so we test the logic by
+	// inspecting diagnostic summaries. For a unit test without a live
+	// client, we test the pure-logic helper resolveNodeServerUUIDFromDetails
+	// and the diagnostic construction separately.
+
+	// Simulate: API returned an error — we check diagnostic summary wording.
+	// Since validateNodeServerUUID calls the real API, we instead verify the
+	// function signature contract by calling it with a nil-context client
+	// that will fail immediately.
+	ctx := context.Background()
+
+	// Create a client with an invalid base URL to force an API error.
+	cfg := sdk.NewConfiguration()
+	cfg.Servers = sdk.ServerConfigurations{{URL: "http://127.0.0.1:1"}}
+	client := sdk.NewAPIClient(cfg)
+
+	diags := validateNodeServerUUID(ctx, client, 999, 100, "requested-uuid")
+
+	if !diags.HasError() {
+		t.Fatal("expected an error diagnostic for API read failure")
+	}
+
+	found := false
+	for _, d := range diags.Errors() {
+		if strings.Contains(d.Summary(), "failed to read instance for server UUID validation") {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected diagnostic summary to mention read failure, got: %v", diags)
+	}
+
+	// Must NOT contain the "silently ignored" message — that's a mismatch, not a read failure.
+	for _, d := range diags.Errors() {
+		if strings.Contains(d.Detail(), "silently ignored") {
+			t.Error("API read failure must not be reported as a UUID mismatch")
+		}
+	}
+}
+
+// TestUnitValidateNodeServerUUID_ContainerNotFound verifies that a missing
+// container produces its own distinct diagnostic.
+func TestUnitValidateNodeServerUUID_ContainerNotFound(t *testing.T) {
+	t.Parallel()
+
+	diags := resolveAndValidateNodeUUID(
+		[]sdk.InstanceContainer2{
+			{Id: ptr(int64(200)), Server: &sdk.InstanceContainerServer2{
+				Uuid: ptr("other-uuid"),
+			}},
+		},
+		42,  // instanceID
+		100, // containerID not in the list
+		"requested-uuid",
+	)
+
+	if !diags.HasError() {
+		t.Fatal("expected error when container not found")
+	}
+
+	found := false
+	for _, d := range diags.Errors() {
+		if strings.Contains(d.Summary(), "container not found") {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected 'container not found' summary, got: %v", diags)
+	}
+}
+
+// TestUnitValidateNodeServerUUID_UUIDMismatch verifies the "silently ignored"
+// message when the UUID genuinely differs.
+func TestUnitValidateNodeServerUUID_UUIDMismatch(t *testing.T) {
+	t.Parallel()
+
+	diags := resolveAndValidateNodeUUID(
+		[]sdk.InstanceContainer2{
+			{Id: ptr(int64(100)), Server: &sdk.InstanceContainerServer2{
+				Uuid: ptr("actual-uuid"),
+			}},
+		},
+		42, // instanceID
+		100,
+		"requested-uuid",
+	)
+
+	if !diags.HasError() {
+		t.Fatal("expected error for UUID mismatch")
+	}
+
+	found := false
+	for _, d := range diags.Errors() {
+		if strings.Contains(d.Detail(), "silently ignored") {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected 'silently ignored' in detail, got: %v", diags)
+	}
+}
+
+// TestUnitValidateNodeServerUUID_UUIDMatches verifies no diagnostics when
+// the UUID matches.
+func TestUnitValidateNodeServerUUID_UUIDMatches(t *testing.T) {
+	t.Parallel()
+
+	diags := resolveAndValidateNodeUUID(
+		[]sdk.InstanceContainer2{
+			{Id: ptr(int64(100)), Server: &sdk.InstanceContainerServer2{
+				Uuid: ptr("requested-uuid"),
+			}},
+		},
+		42, // instanceID
+		100,
+		"requested-uuid",
+	)
+
+	if diags.HasError() {
+		t.Errorf("expected no errors when UUID matches, got: %v", diags)
+	}
+}

--- a/morpheus/framework/resources/instancenode/create_test.go
+++ b/morpheus/framework/resources/instancenode/create_test.go
@@ -378,3 +378,84 @@ func TestUnitPollForNewContainerErrorMessage(t *testing.T) {
 		}
 	}
 }
+
+func TestUnitBuildAddNodeEnvelope_ServerUUIDSet(t *testing.T) {
+	t.Parallel()
+
+	plan := &instanceNodeModel{
+		ResourcePoolID: types.Int64Null(),
+		PreProvisioned: types.BoolNull(),
+		ServerUUID:     types.StringValue("custom-uuid-123"),
+	}
+
+	env := buildAddNodeEnvelope(plan, "generic-add-node")
+
+	uuids, ok := env["serverUUIDs"]
+	if !ok {
+		t.Fatal("serverUUIDs key should be present when server_uuid is set")
+	}
+
+	uuidList, ok := uuids.([]string)
+	if !ok {
+		t.Fatalf("serverUUIDs should be []string, got %T", uuids)
+	}
+
+	if len(uuidList) != 1 || uuidList[0] != "custom-uuid-123" {
+		t.Errorf("expected [custom-uuid-123], got %v", uuidList)
+	}
+}
+
+func TestUnitBuildAddNodeEnvelope_ServerUUIDUnset(t *testing.T) {
+	t.Parallel()
+
+	plan := &instanceNodeModel{
+		ResourcePoolID: types.Int64Null(),
+		PreProvisioned: types.BoolNull(),
+		ServerUUID:     types.StringNull(),
+	}
+
+	env := buildAddNodeEnvelope(plan, "generic-add-node")
+
+	if _, ok := env["serverUUIDs"]; ok {
+		t.Error("serverUUIDs key should be absent when server_uuid is null")
+	}
+}
+
+func TestUnitBuildAddNodeEnvelope_ServerUUIDUnknown(t *testing.T) {
+	t.Parallel()
+
+	plan := &instanceNodeModel{
+		ResourcePoolID: types.Int64Null(),
+		PreProvisioned: types.BoolNull(),
+		ServerUUID:     types.StringUnknown(),
+	}
+
+	env := buildAddNodeEnvelope(plan, "generic-add-node")
+
+	if _, ok := env["serverUUIDs"]; ok {
+		t.Error("serverUUIDs key should be absent when server_uuid is unknown")
+	}
+}
+
+// TestUnitResolveNodeServerUUID_Found verifies that the UUID is extracted
+// from the correct container.
+func TestUnitResolveNodeServerUUID_Found(t *testing.T) {
+	t.Parallel()
+
+	// We cannot unit-test resolveNodeServerUUID directly without an API client,
+	// but we can verify the logic by using findNewContainerInDetails as a proxy.
+	// The actual validation logic is tested via the integration flow.
+	// This test validates the envelope construction guarantees.
+	plan := &instanceNodeModel{
+		ResourcePoolID: types.Int64Null(),
+		PreProvisioned: types.BoolNull(),
+		ServerUUID:     types.StringValue("my-uuid"),
+	}
+
+	env := buildAddNodeEnvelope(plan, "test-add-node")
+	uuids := env["serverUUIDs"].([]string)
+
+	if len(uuids) != 1 || uuids[0] != "my-uuid" {
+		t.Errorf("expected serverUUIDs=[my-uuid], got %v", uuids)
+	}
+}

--- a/morpheus/framework/resources/instancenode/read.go
+++ b/morpheus/framework/resources/instancenode/read.go
@@ -114,9 +114,11 @@ func populateInstanceNodeMetadata(state *instanceNodeModel, cd *sdk.InstanceCont
 	if cd.Server != nil {
 		state.ServerID = convert.Int64ToType(cd.Server.Id)
 		state.ServerResourcePoolID = convert.Int64ToType(cd.Server.ResourcePoolId)
+		state.ServerUUID = convert.StrToType(cd.Server.Uuid)
 	} else {
 		state.ServerID = types.Int64Null()
 		state.ServerResourcePoolID = types.Int64Null()
+		state.ServerUUID = types.StringNull()
 	}
 
 	if cd.Ip != nil && containerip.Ready(*cd.Ip) {

--- a/morpheus/framework/resources/instancenode/read.go
+++ b/morpheus/framework/resources/instancenode/read.go
@@ -109,7 +109,7 @@ func populateInstanceNodeMetadata(state *instanceNodeModel, cd *sdk.InstanceCont
 	state.ID = convert.Int64ToType(cd.Id)
 	state.ContainerID = convert.Int64ToType(cd.Id)
 	state.Name = convert.StrToType(cd.Name)
-	state.UUID = convert.StrToType(cd.Uuid)
+	state.ContainerUUID = convert.StrToType(cd.Uuid)
 
 	if cd.Server != nil {
 		state.ServerID = convert.Int64ToType(cd.Server.Id)

--- a/morpheus/framework/resources/instancenode/read_unit_test.go
+++ b/morpheus/framework/resources/instancenode/read_unit_test.go
@@ -231,3 +231,116 @@ func TestUnitResourcePoolID_NotReadBack(t *testing.T) {
 	// But server_resource_pool_id must reflect the server's pool.
 	assert.Equal(t, types.Int64Value(99), state.ServerResourcePoolID)
 }
+
+// TestUnitServerUUID_PopulatedFromOwnedContainer verifies that server_uuid
+// is populated from the container this resource owns.
+func TestUnitServerUUID_PopulatedFromOwnedContainer(t *testing.T) {
+	t.Parallel()
+
+	state := &instanceNodeModel{}
+	cd := &sdk.InstanceContainer2{
+		Id: ptr(int64(100)),
+		Server: &sdk.InstanceContainerServer2{
+			Id:   ptr(int64(200)),
+			Uuid: ptr("abc-123-def"),
+		},
+	}
+
+	populateInstanceNodeMetadata(state, cd)
+
+	assert.Equal(t, types.StringValue("abc-123-def"), state.ServerUUID)
+}
+
+// TestUnitServerUUID_NullWhenNoServer verifies that server_uuid is null when
+// there is no server.
+func TestUnitServerUUID_NullWhenNoServer(t *testing.T) {
+	t.Parallel()
+
+	state := &instanceNodeModel{}
+	cd := &sdk.InstanceContainer2{
+		Id: ptr(int64(100)),
+	}
+
+	populateInstanceNodeMetadata(state, cd)
+
+	assert.True(t, state.ServerUUID.IsNull())
+}
+
+// TestUnitServerUUID_NullWhenServerHasNoUUID verifies that server_uuid is
+// null when the server exists but has no UUID field set.
+func TestUnitServerUUID_NullWhenServerHasNoUUID(t *testing.T) {
+	t.Parallel()
+
+	state := &instanceNodeModel{}
+	cd := &sdk.InstanceContainer2{
+		Id:     ptr(int64(100)),
+		Server: &sdk.InstanceContainerServer2{Id: ptr(int64(200))},
+	}
+
+	populateInstanceNodeMetadata(state, cd)
+
+	assert.True(t, state.ServerUUID.IsNull())
+}
+
+// TestUnitServerUUID_OnlyFromOwnedContainer verifies that server_uuid is
+// read only from the owned container, not from other containers.
+func TestUnitServerUUID_OnlyFromOwnedContainer(t *testing.T) {
+	t.Parallel()
+
+	// Simulate two containers — the owned one (100) and another (200).
+	// Only the owned one's UUID should be populated.
+	stateOwned := &instanceNodeModel{}
+	ownedCD := &sdk.InstanceContainer2{
+		Id: ptr(int64(100)),
+		Server: &sdk.InstanceContainerServer2{
+			Id:   ptr(int64(300)),
+			Uuid: ptr("owned-uuid"),
+		},
+	}
+
+	populateInstanceNodeMetadata(stateOwned, ownedCD)
+
+	assert.Equal(t, types.StringValue("owned-uuid"), stateOwned.ServerUUID,
+		"server_uuid must come from the owned container")
+
+	// Calling with a different container must give a different UUID.
+	stateOther := &instanceNodeModel{}
+	otherCD := &sdk.InstanceContainer2{
+		Id: ptr(int64(200)),
+		Server: &sdk.InstanceContainerServer2{
+			Id:   ptr(int64(400)),
+			Uuid: ptr("other-uuid"),
+		},
+	}
+
+	populateInstanceNodeMetadata(stateOther, otherCD)
+
+	assert.Equal(t, types.StringValue("other-uuid"), stateOther.ServerUUID,
+		"each container gets its own UUID")
+	// The original state must be unchanged.
+	assert.Equal(t, types.StringValue("owned-uuid"), stateOwned.ServerUUID,
+		"owned container's UUID must not be affected by populating another")
+}
+
+// TestUnitServerUUID_UnsetByPractitioner_PopulatedOnRead verifies that when
+// the practitioner does not set server_uuid, it gets populated from the read.
+func TestUnitServerUUID_UnsetByPractitioner_PopulatedOnRead(t *testing.T) {
+	t.Parallel()
+
+	// Start with server_uuid as null (practitioner didn't set it).
+	state := &instanceNodeModel{
+		ServerUUID: types.StringNull(),
+	}
+	cd := &sdk.InstanceContainer2{
+		Id: ptr(int64(100)),
+		Server: &sdk.InstanceContainerServer2{
+			Id:   ptr(int64(200)),
+			Uuid: ptr("morpheus-generated-uuid"),
+		},
+	}
+
+	populateInstanceNodeMetadata(state, cd)
+
+	assert.Equal(t, types.StringValue("morpheus-generated-uuid"), state.ServerUUID,
+		"server_uuid must be populated on read even when unset by practitioner")
+}

--- a/morpheus/framework/resources/instancenode/resource.go
+++ b/morpheus/framework/resources/instancenode/resource.go
@@ -48,6 +48,7 @@ type instanceNodeModel struct {
 	InternalIP           types.String   `tfsdk:"internal_ip"`
 	ExternalFQDN         types.String   `tfsdk:"external_fqdn"`
 	MacAddress           types.String   `tfsdk:"mac_address"`
+	ServerUUID           types.String   `tfsdk:"server_uuid"`
 	Timeouts             timeouts.Value `tfsdk:"timeouts"`
 }
 
@@ -259,6 +260,22 @@ func (r *Resource) Schema(
 					"from. For virtual instances it reflects the hypervisor pool. " +
 					"Compare with `resource_pool_id` (the placement requested at " +
 					"create time, bare-metal only) to detect drift.",
+			},
+			"server_uuid": schema.StringAttribute{
+				Optional: true,
+				Description: "UUID to assign to the node's server. Sent as a single-element " +
+					"serverUUIDs list in the add-node action envelope. A UUID already " +
+					"in use by another server is silently ignored by the API; the " +
+					"provider detects this after create and fails the apply. Changing " +
+					"it forces replacement.",
+				MarkdownDescription: "UUID to assign to the node's server. Sent as a single-element " +
+					"`serverUUIDs` list in the add-node action envelope. A UUID already " +
+					"in use by another server is silently ignored by the API; the " +
+					"provider detects this after create and fails the apply. Changing " +
+					"it forces replacement.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,

--- a/morpheus/framework/resources/instancenode/resource.go
+++ b/morpheus/framework/resources/instancenode/resource.go
@@ -263,6 +263,7 @@ func (r *Resource) Schema(
 			},
 			"server_uuid": schema.StringAttribute{
 				Optional: true,
+				Computed: true,
 				Description: "UUID to assign to the node's underlying compute server, " +
 					"distinct from container_uuid which is the container's own " +
 					"identifier. Sent as a single-element " +
@@ -278,6 +279,7 @@ func (r *Resource) Schema(
 					"provider detects this after create and fails the apply. Changing " +
 					"it forces replacement.",
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/morpheus/framework/resources/instancenode/resource.go
+++ b/morpheus/framework/resources/instancenode/resource.go
@@ -42,7 +42,7 @@ type instanceNodeModel struct {
 	ContainerID          types.Int64    `tfsdk:"container_id"`
 	ServerID             types.Int64    `tfsdk:"server_id"`
 	Name                 types.String   `tfsdk:"name"`
-	UUID                 types.String   `tfsdk:"uuid"`
+	ContainerUUID        types.String   `tfsdk:"container_uuid"`
 	IPAddress            types.String   `tfsdk:"ip_address"`
 	Hostname             types.String   `tfsdk:"hostname"`
 	InternalIP           types.String   `tfsdk:"internal_ip"`
@@ -212,7 +212,7 @@ func (r *Resource) Schema(
 				MarkdownDescription: "The name of the node container, " +
 					"assigned by the appliance.",
 			},
-			"uuid": schema.StringAttribute{
+			"container_uuid": schema.StringAttribute{
 				Computed: true,
 				Description: "The UUID of the node container, " +
 					"assigned by the appliance.",
@@ -263,12 +263,16 @@ func (r *Resource) Schema(
 			},
 			"server_uuid": schema.StringAttribute{
 				Optional: true,
-				Description: "UUID to assign to the node's server. Sent as a single-element " +
+				Description: "UUID to assign to the node's underlying compute server, " +
+					"distinct from container_uuid which is the container's own " +
+					"identifier. Sent as a single-element " +
 					"serverUUIDs list in the add-node action envelope. A UUID already " +
 					"in use by another server is silently ignored by the API; the " +
 					"provider detects this after create and fails the apply. Changing " +
 					"it forces replacement.",
-				MarkdownDescription: "UUID to assign to the node's server. Sent as a single-element " +
+				MarkdownDescription: "UUID to assign to the node's underlying compute server, " +
+					"distinct from `container_uuid` which is the container's own " +
+					"identifier. Sent as a single-element " +
 					"`serverUUIDs` list in the add-node action envelope. A UUID already " +
 					"in use by another server is silently ignored by the API; the " +
 					"provider detects this after create and fails the apply. Changing " +

--- a/morpheus/framework/resources/instancenode/update.go
+++ b/morpheus/framework/resources/instancenode/update.go
@@ -49,7 +49,7 @@ func (r *Resource) Update(
 	plan.ServerID = state.ServerID
 	plan.IPAddress = state.IPAddress
 	plan.Name = state.Name
-	plan.UUID = state.UUID
+	plan.ContainerUUID = state.ContainerUUID
 
 	if plan.WaitForIPAddress.ValueBool() &&
 		(!state.IPAddress.IsNull() && containerip.Ready(state.IPAddress.ValueString())) {

--- a/specs/resources/instance/config.yaml
+++ b/specs/resources/instance/config.yaml
@@ -43,32 +43,39 @@ instance:
         element_type:
           string: {}
         description: Organization labels (keywords) assigned to the instance.
-    server_uuids:
-      set:
+    server_uuid:
+      string:
         computed_optional_required: computed_optional
-        element_type:
-          string: {}
         description: |-
-          Optional UUIDs to assign to the servers provisioned for this instance.
-          Supply at most one value. The API assigns UUIDs by position, but this
-          attribute is a set and Terraform sets are unordered, so with more than
-          one value it is not defined which UUID reaches which server. An
-          instance provisions a single server in practice (layout_size is one),
-          so one value is all that is used; scaling is done with
-          hpe_morpheus_instance_node. A UUID already in use by another server is
-          silently ignored by the API, which assigns a generated one instead;
-          the provider detects that after create and fails the apply. Set at
-          provision time only; changing it forces replacement. When not set,
-          Morpheus generates the UUIDs and they are read back here.
+          UUID to assign to the single server provisioned for this instance.
+          Morpheus assigns UUIDs strictly by position; an instance provisions
+          exactly one server (layout_size is always 1), so this is the only UUID
+          that takes effect. Use hpe_morpheus_instance_node to set UUIDs on
+          scaled nodes. A UUID already in use by another server is silently
+          ignored by the API, which assigns a generated one instead; the provider
+          detects that after create and fails the apply. Set at provision time
+          only; changing it forces replacement.
         plan_modifiers:
         - custom:
             imports:
-            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier
-            schema_definition: setplanmodifier.UseStateForUnknown()
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier
+            schema_definition: stringplanmodifier.RequiresReplace()
         - custom:
             imports:
-            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier
-            schema_definition: setplanmodifier.RequiresReplace()
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier
+            schema_definition: stringplanmodifier.UseStateForUnknown()
+    container_id:
+      int64:
+        computed_optional_required: computed
+        description: |-
+          The container ID of the single container provisioned by this instance.
+          Populated at create time and preserved across reads. Used internally to
+          scope the server_uuid read-back to the owned container only.
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
+            schema_definition: int64planmodifier.UseStateForUnknown()
     wait_for_ip_address:
       bool:
         computed_optional_required: computed_optional
@@ -486,7 +493,8 @@ instance:
     - template-id: id
     - template-host_name: host_name
     - template-labels: labels
-    - template-server_uuids: server_uuids
+    - template-server_uuid: server_uuid
+    - template-container_id: container_id
     - template-wait_for_ip_address: wait_for_ip_address
     - template-instance_type_id: instance_type_id
     - template-layout_id: layout_id

--- a/specs/resources/instance/config.yaml
+++ b/specs/resources/instance/config.yaml
@@ -64,6 +64,35 @@ instance:
             imports:
             - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier
             schema_definition: stringplanmodifier.UseStateForUnknown()
+    server_uuids:
+      set:
+        computed_optional_required: computed_optional
+        element_type:
+          string: {}
+        deprecation_message: "Deprecated: use server_uuid instead. server_uuids is retained for backward compatibility and will be removed in a future major version."
+        description: |-
+          Deprecated: use server_uuid instead. This attribute will be removed in
+          a future major version.
+          Optional UUIDs to assign to the servers provisioned for this instance.
+          Supply at most one value. The API assigns UUIDs by position, but this
+          attribute is a set and Terraform sets are unordered, so with more than
+          one value it is not defined which UUID reaches which server. An
+          instance provisions a single server in practice (layout_size is one),
+          so one value is all that is used; scaling is done with
+          hpe_morpheus_instance_node. A UUID already in use by another server is
+          silently ignored by the API, which assigns a generated one instead;
+          the provider detects that after create and fails the apply. Set at
+          provision time only; changing it forces replacement. When not set,
+          Morpheus generates the UUIDs and they are read back here.
+        plan_modifiers:
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier
+            schema_definition: setplanmodifier.UseStateForUnknown()
+        - custom:
+            imports:
+            - path: github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier
+            schema_definition: setplanmodifier.RequiresReplace()
     container_id:
       int64:
         computed_optional_required: computed
@@ -494,6 +523,7 @@ instance:
     - template-host_name: host_name
     - template-labels: labels
     - template-server_uuid: server_uuid
+    - template-server_uuids: server_uuids
     - template-container_id: container_id
     - template-wait_for_ip_address: wait_for_ip_address
     - template-instance_type_id: instance_type_id


### PR DESCRIPTION
Implements MORPH-15552. Follows on from #1329, which shipped the create-time detection this builds on.

## Why

`server_uuids` shipped in v1.6.0 as a `Set of String`. Morpheus assigns UUIDs strictly by position — `ServerService.groovy:623`, `serverUUIDs[index]` — and an instance provisions exactly one server, since `layout_size` is always 1 and scaling is done with `hpe_morpheus_instance_node`.

So only the first value was ever used, the rest were discarded without a word, and a set discards the ordering the API depends on.

## What changed

**`server_uuid` (String) is added; `server_uuids` is deprecated, not removed.** Both work, and a config validator makes them mutually exclusive. `server_uuids` keeps its existing create and read behaviour unchanged — it is deprecated, so its semantics should not shift under anyone still using it. The deprecation reaches practitioners through the schema, which emits a warning naming the replacement.

**No changelog entry.** Release notes for this line should be written for the release as a whole rather than accumulated a PR at a time — doing it piecemeal here produced a wrong framing, listing an attribute added to `hpe_morpheus_instance_node` as an enhancement to an existing resource when the resource itself is new in this line. Whoever assembles the 2.0.0 notes will need to pick up, from this PR: the `server_uuids` deprecation, the new `container_id` on the instance, and the new `server_uuid` and renamed `container_uuid` on the node.

**`hpe_morpheus_instance` gains a computed `container_id`.** This is what makes reading the UUID back safe. Without it the resource could not distinguish its own server from one added by `hpe_morpheus_instance_node`, and reading all containers would have changed the value after scaling — and because the attribute forces replacement, asked Terraform to **destroy a working instance**. The read is scoped to the recorded container, with a regression test for that case.

**`hpe_morpheus_instance_node` gains `server_uuid`.** Verified against a live appliance before the attribute was written — a node added with `serverUUIDs` in the action envelope carried the requested value:

```
cid=10903  server=2447  uuid=e9fc6207-cb2d-408c-8709-84b7975d2415   (original)
cid=10904  server=2448  uuid=deadbeef-0000-4000-8000-1786115008000  (requested, applied)
```

It carries the same post-create verification as the instance, because the API silently ignores a UUID already in use on that path too.

**`hpe_morpheus_instance_node.uuid` is renamed `container_uuid`.** It holds the container's UUID and was unambiguous while it was the only UUID on the resource. With `server_uuid` beside it, a bare `uuid` gave no way to tell which object it identified, when every neighbouring attribute is explicit. The pairs are now symmetric:

```
container_id / container_uuid
server_id    / server_uuid
```

This attribute has not appeared in a release — it merged to `dev-2.0` in #1324 — so no published configuration is affected. Once this line ships, correcting it would be breaking.

## One thing worth reviewing closely

`server_uuid` is **Optional + Computed**, not Optional alone. My first attempt made it Optional-only and the acceptance suite caught it:

```
Error: Provider produced inconsistent result after apply
.server_uuid: was null, but now cty.StringVal("e3bc5121-...")
```

When unset, the planned value is null but the read supplies what Morpheus generated. `Computed` plus `UseStateForUnknown` is what `server_uuids` already had, and is needed here for the same reason.

## Verification

Against a live appliance, after every change including the rename: `ExampleOk` and `WaitForIPAddress` on the instance, and both `instancenode` acceptance tests. `make lint` clean repo-wide, docs regenerated, appliance left as found.

