### PR TITLE
Adding provider_id back to network router resource

### DIFF
--- a/docs/resources/morpheus_network_router.md
+++ b/docs/resources/morpheus_network_router.md
@@ -81,6 +81,7 @@ resource "hpe_morpheus_network_router" "example" {
 
 - `code` (String)
 - `id` (Number) The ID of this resource.
+- `provider_id` (String)
 
 <a id="nestedatt--config_nsxt_gateway_tier0"></a>
 ### Nested Schema for `config_nsxt_gateway_tier0`

--- a/morpheus/framework/resources/networkrouter/read.go
+++ b/morpheus/framework/resources/networkrouter/read.go
@@ -52,6 +52,7 @@ func getRouterAsState(
 	state.Code = convert.StrToType(router.Code)
 	state.Enabled = convert.BoolToType(router.Enabled)
 	state.EnableBgp = convert.BoolToType(router.EnableBgp)
+	state.ProviderId = convert.StrToType(router.ProviderId)
 
 	// Preserve plan values for immutable fields
 	state.GroupId = plan.GroupId

--- a/morpheus/framework/resources/networkrouter/schema_gen.go
+++ b/morpheus/framework/resources/networkrouter/schema_gen.go
@@ -381,6 +381,9 @@ func NetworkRouterResourceSchema(ctx context.Context) schema.Schema {
 					}...),
 				},
 			},
+			"provider_id": schema.StringAttribute{
+				Computed: true,
+			},
 			"shared_group_access": schema.BoolAttribute{
 				Optional:            true,
 				Description:         "Used to enable shared group access. Conflicts with group_id. Cannot be used when setting tenant permissions.",
@@ -444,6 +447,7 @@ type NetworkRouterModel struct {
 	Id                     types.Int64                 `tfsdk:"id"`
 	Name                   types.String                `tfsdk:"name"`
 	NetworkIntegrationId   types.Int64                 `tfsdk:"network_integration_id"`
+	ProviderId             types.String                `tfsdk:"provider_id"`
 	SharedGroupAccess      types.Bool                  `tfsdk:"shared_group_access"`
 	TenantIds              types.Set                   `tfsdk:"tenant_ids"`
 	TypeId                 types.Int64                 `tfsdk:"type_id"`

--- a/specs/resources/network_router/config.yaml
+++ b/specs/resources/network_router/config.yaml
@@ -195,7 +195,6 @@ network_router:
     - external_network
     - instance
     - last_updated
-    - provider_id
     - router_type
     - status
     - success


### PR DESCRIPTION
This is needed for common scenarios where provider_id is used to create other resources that depend on the network router provider_id such as under gateway.
```
 Error: Unsupported attribute
│
│   on hpegl_all.tf line 78, in resource "hpe_morpheus_network" "static_net":
│   78:   connected_gateway     = hpe_morpheus_network_router.tf_tier1.provider_id
│
│ This object has no argument, nested block, or exported attribute named "provider_id".
╵
╷
│ Error: Unsupported attribute
│
│   on hpegl_all.tf line 186, in resource "hpe_morpheus_load_balancer" "tf_lb":
│  186:     tier1_gateway = hpe_morpheus_network_router.tf_tier1.provider_id
│
│ This object has no argument, nested block, or exported attribute named "provider_id".
╵
╷

```