### PR TITLE
Fix provider Read consistency for hpegl → hpe migration import

### DIFF
--- a/docs/resources/morpheus_instance_clone.md
+++ b/docs/resources/morpheus_instance_clone.md
@@ -22,16 +22,20 @@ resource "hpe_morpheus_instance_clone" "example" {
   source_instance_id = 1
   name               = "my-clone"
 
-  volumes {
-    name        = "root"
-    size        = 20
-    root_volume = true
-  }
+  volumes = [
+    {
+      name        = "root"
+      size        = 20
+      root_volume = true
+    }
+  ]
 
-  network_interfaces {
-    network_id = 1
-    ip_mode    = ""
-  }
+  network_interfaces = [
+    {
+      network_id = 1
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -111,27 +115,31 @@ resource "hpe_morpheus_instance_clone" "staging" {
   name               = "staging-copy"
 
   # Volume names match the source so their contents are cloned.
-  volumes {
-    name         = "root"
-    root_volume  = true
-    size         = 50 # grown from the source's 40 GB
-    datastore_id = 12
-  }
-  volumes {
-    name         = "data"
-    size         = 500 # grown from the source's 200 GB (resized after the clone)
-    datastore_id = 14
-    storage_type = 1
-  }
+  volumes = [
+    {
+      name         = "root"
+      root_volume  = true
+      size         = 50 # grown from the source's 40 GB
+      datastore_id = 12
+    },
+    {
+      name         = "data"
+      size         = 500 # grown from the source's 200 GB (resized after the clone)
+      datastore_id = 14
+      storage_type = 1
+    }
+  ]
 
-  network_interfaces {
-    network_id = 7
-    ip_mode    = "" # IP pool - the clone gets a new address
-  }
-  network_interfaces {
-    network_id = 9
-    ip_mode    = "dhcp"
-  }
+  network_interfaces = [
+    {
+      network_id = 7
+      ip_mode    = "" # IP pool - the clone gets a new address
+    },
+    {
+      network_id = 9
+      ip_mode    = "dhcp"
+    }
+  ]
 }
 ```
 
@@ -144,16 +152,20 @@ resource "hpe_morpheus_instance_clone" "dr_copy" {
   group_id           = 3
   cloud_id           = 5 # the networks below must exist in this cloud
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
 
-  network_interfaces {
-    network_id = 21
-    ip_mode    = ""
-  }
+  network_interfaces = [
+    {
+      network_id = 21
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -171,15 +183,19 @@ resource "hpe_morpheus_instance_clone" "vmware" {
     vmware_folder_id      = "group-v10"
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
-  network_interfaces {
-    network_id = 7
-    ip_mode    = ""
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 7
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -202,15 +218,19 @@ resource "hpe_morpheus_instance_clone" "aws" {
     }
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 30
-  }
-  network_interfaces {
-    network_id = 11
-    ip_mode    = "dhcp"
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 30
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 11
+      ip_mode    = "dhcp"
+    }
+  ]
 }
 ```
 
@@ -229,15 +249,19 @@ resource "hpe_morpheus_instance_clone" "azure" {
     availability_zone    = "1"
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
-  network_interfaces {
-    network_id = 31
-    ip_mode    = ""
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 31
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -255,15 +279,19 @@ resource "hpe_morpheus_instance_clone" "hvm" {
     kvm_host_id           = 4
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
-  network_interfaces {
-    network_id = 41
-    ip_mode    = ""
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 41
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -287,15 +315,19 @@ resource "hpe_morpheus_instance_clone" "generic" {
     }
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
-  network_interfaces {
-    network_id = 51
-    ip_mode    = ""
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 51
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -304,10 +336,12 @@ resource "hpe_morpheus_instance_clone" "generic" {
 
 ### Required
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `name` (String) A unique name for the new cloned instance. Used to retrieve the clone after the asynchronous clone operation.
 - `network_interfaces` (Attributes List) The complete set of network interfaces for the clone. Replaces the source instance's network interfaces.
 Use an ip_mode of pool or dhcp to avoid IP conflicts with the source. (see [below for nested schema](#nestedatt--network_interfaces))
-- `source_instance_id` (Number) The ID of the source instance to clone.
+- `source_instance_id` (Number, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The ID of the source instance to clone. The API never returns this value, so it is write-only and not stored in state. It cannot be changed after the clone is created; changing it produces no plan diff and has no effect on the existing instance.
 - `volumes` (Attributes List) The complete set of volumes for the clone. Replaces the source instance's volumes.
 Volume specifications define infrastructure parameters only - disk contents are copied from the source. (see [below for nested schema](#nestedatt--volumes))
 
@@ -324,6 +358,7 @@ combined with a typed config_* block.
 - `config_vmware` (Attributes) Configuration overrides for VMware clones, merged over the source instance's configuration. (see [below for nested schema](#nestedatt--config_vmware))
 - `group_id` (Number) The ID of the group to clone into. Defaults to the source instance's group.
 - `plan_id` (Number) The ID of the service plan override for the clone. Defaults to the source instance's service plan.
+- `source_instance_id_version` (Number) Version marker for the write-only source_instance_id attribute. Because source_instance_id is write-only it is never stored in state, so editing source_instance_id on its own produces no plan diff. The clone source is only meaningful at creation time and cannot be changed afterwards, so incrementing this value has no effect on an existing instance; it exists so that a value may be supplied for it without error, for example in configurations produced by migration tooling.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `user_group` (Number) The id of the user group to associate with the clone. Can only be set at clone time; changing it forces replacement.
 
@@ -488,6 +523,23 @@ Optional:
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Notes
+
+### Write-Only Attributes
+
+`source_instance_id` is **write-only**. It is sent to the Morpheus API when the
+clone is created, but the API never returns it, so it is never stored in
+Terraform state and Terraform cannot detect drift in it.
+
+The clone source is only meaningful at creation time and **cannot be changed
+after the instance exists**. Editing `source_instance_id` produces no plan diff
+and has no effect on the existing instance; to clone from a different source,
+create a new resource. The `source_instance_id_version` companion exists so a
+value may be supplied without error (for example by migration tooling), but
+incrementing it likewise has no effect.
+
+Write-only attributes require Terraform >= 1.11.
 
 ## Import
 

--- a/docs/resources/morpheus_load_balancer.md
+++ b/docs/resources/morpheus_load_balancer.md
@@ -84,14 +84,18 @@ resource "hpe_morpheus_load_balancer" "haproxy_generic" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `cloud_id` (Number) The ID of the cloud associated with the load balancer
 - `config` (Dynamic) Configuration object with parameters that vary by load balancer type.
 - `config_haproxy` (Attributes) Configuration for HAProxy container load balancer type (see [below for nested schema](#nestedatt--config_haproxy))
 - `config_nsxt` (Attributes) Configuration for NSX-T load balancer type (see [below for nested schema](#nestedatt--config_nsxt))
 - `description` (String) Description
 - `enabled` (Boolean) Whether the load balancer is enabled
-- `group_id` (Number) The ID of the group associated with the load balancer
-- `network_server_id` (Number) Network Server ID
+- `group_id` (Number, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The ID of the group associated with the load balancer. The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment group_id_version to force replacement into the new group.
+- `group_id_version` (Number) Version marker for the write-only group_id attribute. Because group_id is write-only it is never stored in state, so editing group_id on its own produces no plan diff. The group is set only when the load balancer is created and the API provides no way to move it afterwards, so increment this value when group_id changes to replace the load balancer with one in the new group.
+- `network_server_id` (Number, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The ID of the network server associated with the load balancer. The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment network_server_id_version to force replacement against the new network server.
+- `network_server_id_version` (Number) Version marker for the write-only network_server_id attribute. Because network_server_id is write-only it is never stored in state, so editing network_server_id on its own produces no plan diff. The network server is set only when the load balancer is created and the API provides no way to change it afterwards, so increment this value when network_server_id changes to replace the load balancer with one registered against the new network server.
 - `permissions` (Attributes) Resource permissions for the load balancer (see [below for nested schema](#nestedatt--permissions))
 - `tenants` (Attributes Set) Array of tenant account ids that are allowed access (see [below for nested schema](#nestedatt--tenants))
 - `type_code` (String) The type code of the load balancer (e.g. haproxyContainer)
@@ -143,6 +147,23 @@ Optional:
 Read-Only:
 
 - `name` (String)
+
+## Notes
+
+### Write-Only Attributes
+
+`group_id` and `network_server_id` are **write-only**. They are sent to the
+Morpheus API when the load balancer is created, but the API never returns them,
+so they are never stored in Terraform state and Terraform cannot detect drift in
+them.
+
+Because the values are not in state, editing one of them on its own produces
+**no plan diff**. To push a new value, increment the matching companion --
+`group_id_version` or `network_server_id_version`. Both companions **force
+replacement** of the load balancer, because neither underlying value can be
+changed on an existing load balancer.
+
+Write-only attributes require Terraform >= 1.11.
 
 ## Import
 

--- a/docs/resources/morpheus_network_router_nat.md
+++ b/docs/resources/morpheus_network_router_nat.md
@@ -26,19 +26,26 @@ resource "hpe_morpheus_network_router_nat" "example" {
 
 ### Required
 
-- `action` (String) The NAT action (e.g. SNAT, DNAT, REFLEXIVE).
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
+- `action` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The NAT action (e.g. SNAT, DNAT, REFLEXIVE). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment action_version to apply a change.
 - `name` (String) Name of the NAT rule
 - `router_id` (Number) The ID of the parent network router
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
+- `action_version` (Number) Version marker for the write-only action attribute. Because action is write-only it is never stored in state, so editing action on its own produces no plan diff. Increment this value whenever action changes: the change to action_version is what produces the plan diff, and the update then sends the current action value to the API.
 - `description` (String) Description of the NAT rule
 - `destination_network` (String) Destination network
 - `enabled` (Boolean) Whether the NAT rule is enabled
-- `firewall` (String) The firewall match applied to the NAT rule (nested under config).
+- `firewall` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The firewall match applied to the NAT rule (nested under config). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment firewall_version to apply a change.
+- `firewall_version` (Number) Version marker for the write-only firewall attribute. Because firewall is write-only it is never stored in state, so editing firewall on its own produces no plan diff. Increment this value whenever firewall changes: the change to firewall_version is what produces the plan diff, and the update then sends the current firewall value to the API. Leaving this value alone preserves the firewall setting currently held by the provider.
 - `priority` (Number) Priority of the NAT rule
 - `protocol` (String, Deprecated) Deprecated: use service instead. Protocol for the NAT rule, retained for backward compatibility.
-- `service` (String) The service (protocol) applied to the NAT rule (nested under config).
+- `service` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The service (protocol) applied to the NAT rule (nested under config). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment service_version to apply a change.
+- `service_version` (Number) Version marker for the write-only service attribute. Because service is write-only it is never stored in state, so editing service on its own produces no plan diff. Increment this value whenever service changes: the change to service_version is what produces the plan diff, and the update then sends the current service value to the API. Leaving this value alone preserves the service setting currently held by the provider.
 - `source_network` (String) Source network
 - `translated_network` (String) Translated network
 - `translated_ports` (String) Translated ports for the NAT rule
@@ -47,6 +54,28 @@ resource "hpe_morpheus_network_router_nat" "example" {
 
 - `external_id` (String) The external ID of the NAT rule, assigned by the provider (for example, the NSX-T identifier).
 - `id` (Number) The ID of the NAT rule
+
+## Notes
+
+### Write-Only Attributes
+
+`action`, `firewall` and `service` are **write-only**. They are sent to the
+Morpheus API when the NAT rule is created or updated, but the API never returns
+them, so they are never stored in Terraform state and Terraform cannot detect
+drift in them.
+
+Because the values are not in state, editing one of them on its own produces
+**no plan diff**. To push a new value, increment the matching companion --
+`action_version`, `firewall_version` or `service_version`. Incrementing a
+companion triggers an in-place update of the NAT rule; none of them force
+replacement.
+
+If `firewall` is omitted on create, `MATCH_INTERNAL_ADDRESS` is sent, because
+the underlying API field is required. On update an omitted `firewall` is left
+out of the payload entirely, so the value already configured on the router is
+preserved rather than overwritten.
+
+Write-only attributes require Terraform >= 1.11.
 
 ## Import
 

--- a/examples/resources/morpheus_instance_clone/example.tf
+++ b/examples/resources/morpheus_instance_clone/example.tf
@@ -2,14 +2,18 @@ resource "hpe_morpheus_instance_clone" "example" {
   source_instance_id = 1
   name               = "my-clone"
 
-  volumes {
-    name        = "root"
-    size        = 20
-    root_volume = true
-  }
+  volumes = [
+    {
+      name        = "root"
+      size        = 20
+      root_volume = true
+    }
+  ]
 
-  network_interfaces {
-    network_id = 1
-    ip_mode    = ""
-  }
+  network_interfaces = [
+    {
+      network_id = 1
+      ip_mode    = ""
+    }
+  ]
 }

--- a/morpheus/framework/datasources/networkrouternat/datasource_test.go
+++ b/morpheus/framework/datasources/networkrouternat/datasource_test.go
@@ -34,20 +34,28 @@ provider "hpe" {
 `
 
 // nsxtTier1RouterConfig renders an NSX-T tier-1 gateway required for NAT rules.
-func nsxtTier1RouterConfig(name string) string {
+//
+// The tier-0, group, network server and edge cluster must already exist on the
+// appliance under test and are supplied via the environment; see
+// testhelpers.RequireNsxtFixture. The test skips when they are not configured.
+func nsxtTier1RouterConfig(t *testing.T, name string) string {
+	t.Helper()
+
+	fixture := testhelpers.RequireNsxtFixture(t)
+
 	return `
 data "hpe_morpheus_network_router" "nat_tier0" {
-  id = 28
+  id = ` + fixture.Tier0RouterID + `
 }
 
 resource "hpe_morpheus_network_router" "nat_tier1" {
   name                   = "` + name + `-tier1"
-  group_id               = 3
-  network_integration_id = 5
+  group_id               = ` + fixture.GroupID + `
+  network_integration_id = ` + fixture.NetworkServerID + `
 
   config_nsxt_gateway_tier1 = {
     ip_management_type = "dhcpLocal"
-    edge_cluster       = "3de5f8d0-4f8a-433b-95ed-91020c948084"
+    edge_cluster       = "` + fixture.EdgeCluster + `"
     fail_over          = "NON_PREEMPTIVE"
     tier0_gateway      = data.hpe_morpheus_network_router.nat_tier0.provider_id
   }
@@ -69,7 +77,7 @@ func TestAccMorpheusFindNetworkRouterNatByName(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 	name := acctest.RandomWithPrefix(t.Name())
 
-	routerConfig := nsxtTier1RouterConfig(name)
+	routerConfig := nsxtTier1RouterConfig(t, name)
 
 	resourceConfig, err := natresource.RenderNetworkRouterNatConfig(t, map[string]string{
 		"RouterId": "hpe_morpheus_network_router.nat_tier1.id",
@@ -114,7 +122,7 @@ func TestAccMorpheusFindNetworkRouterNatById(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 	name := acctest.RandomWithPrefix(t.Name())
 
-	routerConfig := nsxtTier1RouterConfig(name)
+	routerConfig := nsxtTier1RouterConfig(t, name)
 
 	resourceConfig, err := natresource.RenderNetworkRouterNatConfig(t, map[string]string{
 		"RouterId": "hpe_morpheus_network_router.nat_tier1.id",
@@ -159,7 +167,7 @@ func TestAccMorpheusFindNetworkRouterNatNotFound(t *testing.T) {
 	providerConfig := testhelpers.ProviderBlock()
 	name := acctest.RandomWithPrefix(t.Name())
 
-	routerConfig := nsxtTier1RouterConfig(name)
+	routerConfig := nsxtTier1RouterConfig(t, name)
 
 	dataSourceConfig := `
 data "hpe_morpheus_network_router_nat" "example" {

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -1746,6 +1746,22 @@ func getStateInterfaces(
 		return nil, diags
 	}
 
+	// The server interfaces response does not carry all the fields that the
+	// instance-level interfaces response does (e.g. NetworkInterfaceTypeId,
+	// and IpMode may be absent). Fill gaps from intfsFromInstance so that
+	// Read returns consistent values regardless of which code path is taken.
+	for i := range intfsFromServer {
+		if i >= len(intfsFromInstance) {
+			break
+		}
+		if intfsFromServer[i].NetworkTypeId.IsNull() || intfsFromServer[i].NetworkTypeId.IsUnknown() {
+			intfsFromServer[i].NetworkTypeId = intfsFromInstance[i].NetworkTypeId
+		}
+		if intfsFromServer[i].IpMode.IsNull() || intfsFromServer[i].IpMode.IsUnknown() {
+			intfsFromServer[i].IpMode = intfsFromInstance[i].IpMode
+		}
+	}
+
 	// Get []NetworkInterfacesValue from the plan
 	var intfsFromPlan []NetworkInterfacesValue
 	pd := plan.NetworkInterfaces.ElementsAs(ctx, &intfsFromPlan, false)

--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -1760,6 +1760,12 @@ func getStateInterfaces(
 		if intfsFromServer[i].IpMode.IsNull() || intfsFromServer[i].IpMode.IsUnknown() {
 			intfsFromServer[i].IpMode = intfsFromInstance[i].IpMode
 		}
+		// IpMode: the API omits ipMode from both instance-level and server-level
+		// interface responses when it is empty/unset, producing null in both paths.
+		// Fall back to the schema default ("") to stay consistent with the plan.
+		if intfsFromServer[i].IpMode.IsNull() {
+			intfsFromServer[i].IpMode = types.StringValue("")
+		}
 	}
 
 	// Get []NetworkInterfacesValue from the plan

--- a/morpheus/framework/resources/instanceclone/clone_process_test.go
+++ b/morpheus/framework/resources/instanceclone/clone_process_test.go
@@ -1,0 +1,142 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package instanceclone
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
+)
+
+// These drive the production selection and failure rules directly. Observed
+// behaviour they encode: on one appliance a clone failed server-side in 27
+// seconds while the provider kept polling for the full 15-minute timeout and
+// then reported a bare "<nil>"; on another the clone was still running at the
+// timeout. Those two cases need different advice, so they must not collapse
+// into one another.
+
+func proc(
+	code, status string, start time.Time,
+) sdk.GetInstanceHistory200ResponseAllOfProcessesInner {
+	p := sdk.GetInstanceHistory200ResponseAllOfProcessesInner{
+		ProcessType: &sdk.GetInstanceHistory200ResponseAllOfProcessesInnerProcessType{
+			Code: &code,
+		},
+		StartDate: &start,
+	}
+	if status != "" {
+		p.Status = &status
+	}
+
+	return p
+}
+
+func TestUnitPickLatestCloneProcess_IgnoresOtherTypes(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	got := pickLatestCloneProcess([]sdk.GetInstanceHistory200ResponseAllOfProcessesInner{
+		proc("provision", "failed", base.Add(2*time.Hour)),
+		proc("cloning", "failed", base),
+		proc("startup", "complete", base.Add(3*time.Hour)),
+	})
+
+	if got == nil {
+		t.Fatal("expected the cloning process to be selected")
+	}
+
+	if *got.ProcessType.Code != "cloning" {
+		t.Fatalf("selected %q, want cloning", *got.ProcessType.Code)
+	}
+
+	// A later provision/startup must not win: only cloning is relevant, and
+	// picking a provision failure would abort a healthy clone.
+	if !processStart(got).Equal(base) {
+		t.Fatalf("selected the wrong process, start=%v", processStart(got))
+	}
+}
+
+func TestUnitPickLatestCloneProcess_PicksMostRecent(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	newest := base.Add(30 * time.Minute)
+	got := pickLatestCloneProcess([]sdk.GetInstanceHistory200ResponseAllOfProcessesInner{
+		proc("cloning", "failed", base),
+		proc("cloning", "cloning", newest),
+		proc("cloning", "failed", base.Add(10*time.Minute)),
+	})
+
+	if got == nil || !processStart(got).Equal(newest) {
+		t.Fatalf("expected the newest cloning process, got %v", processStart(got))
+	}
+
+	// Stale failures from earlier attempts must not abort the current one.
+	if reason := cloneFailureReason(got); reason != "" {
+		t.Fatalf("running clone reported as failed: %q", reason)
+	}
+}
+
+func TestUnitPickLatestCloneProcess_NoneWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	if got := pickLatestCloneProcess(nil); got != nil {
+		t.Fatal("expected nil for empty history")
+	}
+
+	got := pickLatestCloneProcess([]sdk.GetInstanceHistory200ResponseAllOfProcessesInner{
+		proc("provision", "failed", time.Now()),
+	})
+	if got != nil {
+		t.Fatal("expected nil when no cloning process is present")
+	}
+}
+
+func TestUnitCloneFailureReason_RunningIsNotAFailure(t *testing.T) {
+	t.Parallel()
+
+	p := proc("cloning", "cloning", time.Now())
+	if reason := cloneFailureReason(&p); reason != "" {
+		t.Fatalf("a running clone must not abort the poll, got %q", reason)
+	}
+}
+
+func TestUnitCloneFailureReason_PrefersErrorText(t *testing.T) {
+	t.Parallel()
+
+	p := proc("cloning", "failed", time.Now())
+	errText := "no addresses available in pool"
+	msgText := "less specific message"
+	p.Error.Set(&errText)
+	p.Message.Set(&msgText)
+
+	if got := cloneFailureReason(&p); got != errText {
+		t.Fatalf("reason = %q, want %q", got, errText)
+	}
+}
+
+func TestUnitCloneFailureReason_FallsBackWhenSilent(t *testing.T) {
+	t.Parallel()
+
+	p := proc("cloning", "failed", time.Now())
+
+	got := cloneFailureReason(&p)
+	if got == "" {
+		t.Fatal("a failed clone must always produce a reason, got empty")
+	}
+
+	// The bug being guarded: the old code surfaced errors.Unwrap(err), which
+	// was nil, so the diagnostic read "<nil>" and told the operator nothing.
+	if got == "<nil>" || got == "nil" {
+		t.Fatalf("reason must never be a bare nil rendering, got %q", got)
+	}
+}
+
+func TestUnitCloneFailureReason_NilProcess(t *testing.T) {
+	t.Parallel()
+
+	if got := cloneFailureReason(nil); got != "" {
+		t.Fatalf("nil process must not be treated as a failure, got %q", got)
+	}
+}

--- a/morpheus/framework/resources/instanceclone/create.go
+++ b/morpheus/framework/resources/instanceclone/create.go
@@ -62,7 +62,9 @@ func (r *Resource) Create(
 		return
 	}
 
-	sourceID := plan.SourceInstanceId.ValueInt64()
+	// source_instance_id is write-only: the framework nullifies it in the plan,
+	// so it must be read from the config or the clone is created with source 0.
+	sourceID := config.SourceInstanceId.ValueInt64()
 	cloneName := plan.Name.ValueString()
 
 	// Build CloneInstanceRequest
@@ -166,6 +168,16 @@ func (r *Resource) Create(
 			return &pollResult{id: *inst.Id, status: status}, nil
 		}
 
+		// The clone is not visible yet. Before waiting again, check whether
+		// Morpheus has already given up: the clone runs as a "cloning" process
+		// on the *source* instance, and when it fails the clone will never
+		// appear. Without this the poll runs for the full timeout after a
+		// failure that was known within seconds.
+		if failure := cloneProcessFailure(ctx, client, sourceID); failure != "" {
+			return nil, backoff.Permanent(fmt.Errorf(
+				"clone of instance %d failed: %s", sourceID, failure))
+		}
+
 		return nil, fmt.Errorf("clone %q not yet found in instance list", cloneName)
 	}
 
@@ -176,11 +188,25 @@ func (r *Resource) Create(
 		backoff.WithMaxElapsedTime(createTimeout),
 	)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"create instance clone",
-			fmt.Sprintf("clone %q of instance %d failed to appear: %v",
-				cloneName, sourceID, errors.Unwrap(err)),
-		)
+		// Report err itself. errors.Unwrap is nil for the error backoff
+		// returns, which rendered this diagnostic as a bare "<nil>" and
+		// discarded the reason.
+		detail := fmt.Sprintf("clone %q of instance %d failed to appear "+
+			"within %s: %s", cloneName, sourceID, createTimeout, err)
+
+		// Distinguish a still-running clone from a failed one: a clone that is
+		// merely slow needs a longer timeout, whereas a failed one never
+		// arrives no matter how long Terraform waits.
+		if status := cloneProcessStatus(ctx, client, sourceID); status != "" {
+			detail += fmt.Sprintf(
+				"\n\nThe most recent clone process on instance %d is %q. "+
+					"If it is still running, raise the create timeout; the "+
+					"instance may still be created outside Terraform's "+
+					"knowledge and need removing by hand.",
+				sourceID, status)
+		}
+
+		resp.Diagnostics.AddError("create instance clone", detail)
 
 		return
 	}
@@ -658,4 +684,116 @@ func buildChildInterfaces(
 	}
 
 	return children, diags
+}
+
+// cloneProcessTypeCode is the Morpheus process type for an instance clone. The
+// process is recorded against the *source* instance, not the clone.
+const cloneProcessTypeCode = "cloning"
+
+// cloneStatusFailed is the process status Morpheus sets when a clone has
+// definitively failed, as opposed to still running.
+const cloneStatusFailed = "failed"
+
+// latestCloneProcess returns the most recent "cloning" process on the source
+// instance, or nil if there is none or the history cannot be read.
+//
+// History is advisory here: a clone that is progressing normally must not be
+// aborted just because this lookup failed, so every error path returns nil.
+func latestCloneProcess(
+	ctx context.Context,
+	client *sdk.APIClient,
+	sourceID int64,
+) *sdk.GetInstanceHistory200ResponseAllOfProcessesInner {
+	histResp, _, err := client.InstancesAPI.
+		GetInstanceHistory(ctx, sourceID).Execute()
+	if err != nil || histResp == nil {
+		return nil
+	}
+
+	return pickLatestCloneProcess(histResp.Processes)
+}
+
+// pickLatestCloneProcess returns the most recent "cloning" process from a
+// history page, ignoring every other process type. Split out from the API call
+// so the selection rule can be tested directly.
+func pickLatestCloneProcess(
+	processes []sdk.GetInstanceHistory200ResponseAllOfProcessesInner,
+) *sdk.GetInstanceHistory200ResponseAllOfProcessesInner {
+	var latest *sdk.GetInstanceHistory200ResponseAllOfProcessesInner
+
+	for i := range processes {
+		p := &processes[i]
+		if p.ProcessType == nil || p.ProcessType.Code == nil {
+			continue
+		}
+
+		if *p.ProcessType.Code != cloneProcessTypeCode {
+			continue
+		}
+
+		if latest == nil || processStart(p).After(processStart(latest)) {
+			latest = p
+		}
+	}
+
+	return latest
+}
+
+// processStart returns a process's start time, falling back to zero so that
+// ordering still works when the field is absent.
+func processStart(
+	p *sdk.GetInstanceHistory200ResponseAllOfProcessesInner,
+) time.Time {
+	if p == nil || p.StartDate == nil {
+		return time.Time{}
+	}
+
+	return *p.StartDate
+}
+
+// cloneProcessFailure returns a human-readable reason when the latest clone
+// process on the source instance has failed, or "" when it has not.
+func cloneProcessFailure(
+	ctx context.Context,
+	client *sdk.APIClient,
+	sourceID int64,
+) string {
+	return cloneFailureReason(latestCloneProcess(ctx, client, sourceID))
+}
+
+// cloneFailureReason returns a reason when the given clone process has failed,
+// and "" when it is absent, running, or succeeded. Split out from the API call
+// so the failure rule can be tested directly.
+func cloneFailureReason(
+	p *sdk.GetInstanceHistory200ResponseAllOfProcessesInner,
+) string {
+	if p == nil || p.Status == nil || *p.Status != cloneStatusFailed {
+		return ""
+	}
+
+	// Morpheus populates whichever of these it has; none is guaranteed.
+	for _, s := range []*string{
+		p.Error.Get(), p.Message.Get(), p.Reason.Get(),
+	} {
+		if s != nil && *s != "" {
+			return *s
+		}
+	}
+
+	return "the clone process failed without reporting a reason"
+}
+
+// cloneProcessStatus returns the status of the latest clone process on the
+// source instance, or "" if it cannot be determined.
+func cloneProcessStatus(
+	ctx context.Context,
+	client *sdk.APIClient,
+	sourceID int64,
+) string {
+	p := latestCloneProcess(ctx, client, sourceID)
+	if p == nil || p.Status == nil {
+		return ""
+	}
+
+	return *p.Status
 }

--- a/morpheus/framework/resources/instanceclone/example.tf.tmpl
+++ b/morpheus/framework/resources/instanceclone/example.tf.tmpl
@@ -5,17 +5,21 @@ resource "hpe_morpheus_instance_clone" "example" {
   user_group = {{.UserGroup}}
 {{- end}}
 
-  volumes {
-    name        = "root"
-    size        = 20
-    root_volume = true
+  volumes = [
+    {
+      name        = "root"
+      size        = 20
+      root_volume = true
 {{- if .StorageProfile}}
-    storage_profile = "{{.StorageProfile}}"
+      storage_profile = "{{.StorageProfile}}"
 {{- end}}
-  }
+    }
+  ]
 
-  network_interfaces {
-    network_id = {{.NetworkId}}
-    ip_mode    = ""
-  }
+  network_interfaces = [
+    {
+      network_id = {{.NetworkId}}
+      ip_mode    = ""
+    }
+  ]
 }

--- a/morpheus/framework/resources/instanceclone/import.go
+++ b/morpheus/framework/resources/instanceclone/import.go
@@ -9,9 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
 )
 
 func (r *Resource) ImportState(
@@ -30,23 +27,4 @@ func (r *Resource) ImportState(
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), instanceID)...)
-	// source_instance_id is not returned by the clone API as a first-class
-	// field. Set it null here; Read makes a best-effort attempt to recover it
-	// from the clone's config (cloneInstanceId). If the platform does not expose
-	// that field, set source_instance_id in configuration after import.
-	resp.Diagnostics.Append(resp.State.SetAttribute(
-		ctx, path.Root("source_instance_id"), types.Int64Null(),
-	)...)
-}
-
-// sourceInstanceIDFromConfig returns cloneInstanceId - the source instance id
-// that Morpheus stamps onto a clone's config during cloning - from the instance
-// read response. It is absent for instances that were not created via the clone
-// endpoint, in which case the second return value is false.
-func sourceInstanceIDFromConfig(inst *sdk.GetInstance200ResponseInstance) (int64, bool) {
-	if inst == nil || inst.Config == nil || inst.Config.CloneInstanceId == nil {
-		return 0, false
-	}
-
-	return *inst.Config.CloneInstanceId, true
 }

--- a/morpheus/framework/resources/instanceclone/read.go
+++ b/morpheus/framework/resources/instanceclone/read.go
@@ -72,18 +72,6 @@ func (r *Resource) Read(
 
 	inst := getResp.Instance
 
-	// On import the source_instance_id is unknown because the clone API does not
-	// return it as a first-class field. Morpheus does stamp the source id onto
-	// the clone's config as "cloneInstanceId", so recover it best-effort when the
-	// current state has no source_instance_id (i.e. after import). On a normal
-	// refresh the value is already set and is left untouched (it is
-	// RequiresReplace, so it must never be clobbered here).
-	if state.SourceInstanceId.IsNull() || state.SourceInstanceId.IsUnknown() {
-		if srcID, ok := sourceInstanceIDFromConfig(inst); ok {
-			state.SourceInstanceId = types.Int64Value(srcID)
-		}
-	}
-
 	// user_group is provision-time only (RequiresReplace) and the clone API does
 	// not return it as a first-class field; Morpheus stamps it onto the config.
 	// On import recover it from config.userGroup.id; on a normal refresh the

--- a/morpheus/framework/resources/instanceclone/resource_test.go
+++ b/morpheus/framework/resources/instanceclone/resource_test.go
@@ -80,9 +80,8 @@ func TestAccMorpheusInstanceCloneResource(t *testing.T) {
 					return rs.Primary.Attributes["id"], nil
 				},
 				ImportStateVerify: true,
-				// source_instance_id is not returned by the API
 				ImportStateVerifyIgnore: []string{
-					"source_instance_id", "timeouts",
+					"timeouts",
 				},
 			},
 		},
@@ -159,7 +158,7 @@ func TestAccMorpheusInstanceCloneResourceUserGroupStorageProfile(t *testing.T) {
 				},
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"source_instance_id", "timeouts",
+					"timeouts",
 					// storage_profile is a write-mostly volume input recovered
 					// best-effort from the API on import.
 					"volumes.0.storage_profile",

--- a/morpheus/framework/resources/instanceclone/schema_gen.go
+++ b/morpheus/framework/resources/instanceclone/schema_gen.go
@@ -453,11 +453,14 @@ func InstanceCloneResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"source_instance_id": schema.Int64Attribute{
 				Required:            true,
-				Description:         "The ID of the source instance to clone.",
-				MarkdownDescription: "The ID of the source instance to clone.",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
-				},
+				WriteOnly:           true,
+				Description:         "The ID of the source instance to clone. The API never returns this value, so it is write-only and not stored in state. It cannot be changed after the clone is created; changing it produces no plan diff and has no effect on the existing instance.",
+				MarkdownDescription: "The ID of the source instance to clone. The API never returns this value, so it is write-only and not stored in state. It cannot be changed after the clone is created; changing it produces no plan diff and has no effect on the existing instance.",
+			},
+			"source_instance_id_version": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "Version marker for the write-only source_instance_id attribute. Because source_instance_id is write-only it is never stored in state, so editing source_instance_id on its own produces no plan diff. The clone source is only meaningful at creation time and cannot be changed afterwards, so incrementing this value has no effect on an existing instance; it exists so that a value may be supplied for it without error, for example in configurations produced by migration tooling.",
+				MarkdownDescription: "Version marker for the write-only source_instance_id attribute. Because source_instance_id is write-only it is never stored in state, so editing source_instance_id on its own produces no plan diff. The clone source is only meaningful at creation time and cannot be changed afterwards, so incrementing this value has no effect on an existing instance; it exists so that a value may be supplied for it without error, for example in configurations produced by migration tooling.",
 			},
 			"status": schema.StringAttribute{
 				Computed:            true,
@@ -547,22 +550,23 @@ func InstanceCloneResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type InstanceCloneModel struct {
-	CloudId           types.Int64       `tfsdk:"cloud_id"`
-	Config            types.Dynamic     `tfsdk:"config"`
-	ConfigAws         ConfigAwsValue    `tfsdk:"config_aws"`
-	ConfigAzure       ConfigAzureValue  `tfsdk:"config_azure"`
-	ConfigHvm         ConfigHvmValue    `tfsdk:"config_hvm"`
-	ConfigVmware      ConfigVmwareValue `tfsdk:"config_vmware"`
-	GroupId           types.Int64       `tfsdk:"group_id"`
-	Id                types.Int64       `tfsdk:"id"`
-	Name              types.String      `tfsdk:"name"`
-	NetworkInterfaces types.List        `tfsdk:"network_interfaces"`
-	PlanId            types.Int64       `tfsdk:"plan_id"`
-	SourceInstanceId  types.Int64       `tfsdk:"source_instance_id"`
-	Status            types.String      `tfsdk:"status"`
-	Timeouts          timeouts.Value    `tfsdk:"timeouts"`
-	UserGroup         types.Int64       `tfsdk:"user_group"`
-	Volumes           types.List        `tfsdk:"volumes"`
+	CloudId                 types.Int64       `tfsdk:"cloud_id"`
+	Config                  types.Dynamic     `tfsdk:"config"`
+	ConfigAws               ConfigAwsValue    `tfsdk:"config_aws"`
+	ConfigAzure             ConfigAzureValue  `tfsdk:"config_azure"`
+	ConfigHvm               ConfigHvmValue    `tfsdk:"config_hvm"`
+	ConfigVmware            ConfigVmwareValue `tfsdk:"config_vmware"`
+	GroupId                 types.Int64       `tfsdk:"group_id"`
+	Id                      types.Int64       `tfsdk:"id"`
+	Name                    types.String      `tfsdk:"name"`
+	NetworkInterfaces       types.List        `tfsdk:"network_interfaces"`
+	PlanId                  types.Int64       `tfsdk:"plan_id"`
+	SourceInstanceId        types.Int64       `tfsdk:"source_instance_id"`
+	SourceInstanceIdVersion types.Int64       `tfsdk:"source_instance_id_version"`
+	Status                  types.String      `tfsdk:"status"`
+	Timeouts                timeouts.Value    `tfsdk:"timeouts"`
+	UserGroup               types.Int64       `tfsdk:"user_group"`
+	Volumes                 types.List        `tfsdk:"volumes"`
 }
 
 var _ basetypes.ObjectTypable = ConfigAwsType{}

--- a/morpheus/framework/resources/loadbalancer/create.go
+++ b/morpheus/framework/resources/loadbalancer/create.go
@@ -29,6 +29,15 @@ func (r *Resource) Create(
 		return
 	}
 
+	// Write-only attributes are nullified in the plan by the framework.
+	// Read them from the raw config instead.
+	var config LoadBalancerModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	client, err := r.NewClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -53,8 +62,8 @@ func (r *Resource) Create(
 		createLB.Visibility = plan.Visibility.ValueStringPointer()
 	}
 
-	if !plan.GroupId.IsNull() && !plan.GroupId.IsUnknown() {
-		groupID := plan.GroupId.ValueInt64()
+	if !config.GroupId.IsNull() && !config.GroupId.IsUnknown() {
+		groupID := config.GroupId.ValueInt64()
 		createLB.Site = &sdk.CreateLoadBalancerRequestLoadBalancerSite{
 			Id: &groupID,
 		}
@@ -67,8 +76,8 @@ func (r *Resource) Create(
 		}
 	}
 
-	if !plan.NetworkServerId.IsNull() && !plan.NetworkServerId.IsUnknown() {
-		createLB.NetworkServerId = plan.NetworkServerId.ValueInt64Pointer()
+	if !config.NetworkServerId.IsNull() && !config.NetworkServerId.IsUnknown() {
+		createLB.NetworkServerId = config.NetworkServerId.ValueInt64Pointer()
 	}
 
 	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {

--- a/morpheus/framework/resources/loadbalancer/example_nsxt.tf.tmpl
+++ b/morpheus/framework/resources/loadbalancer/example_nsxt.tf.tmpl
@@ -2,7 +2,7 @@ resource "hpe_morpheus_load_balancer" "lb" {
   name       = "{{ .Name }}"
   type_code  = "{{ .TypeCode }}"
   visibility = "{{ .Visibility }}"
-  network_server_id = 5
+  network_server_id = {{ .NetworkServerId }}
 
   config_nsxt = {
     admin_state   = {{ .AdminState }}

--- a/morpheus/framework/resources/loadbalancer/loadbalancer_example.go
+++ b/morpheus/framework/resources/loadbalancer/loadbalancer_example.go
@@ -4,6 +4,7 @@ package loadbalancer
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -13,7 +14,7 @@ import (
 
 //go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_haproxy.tf example_haproxy.tf.tmpl Name "example-terraform-haproxy-lb" Description "HAProxy load balancer" CloudName "hvm" GroupName "Zodiac" PlanId "8" Pool "pool-1" Visibility "public"
 //go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_haproxy_generic.tf example_haproxy_generic.tf.tmpl Name "example-terraform-haproxy-lb" Description "HAProxy load balancer via generic config" CloudName "hvm" GroupName "Zodiac" TypeCode "haproxyContainer" PlanId "8" Pool "pool-1" Visibility "public"
-//go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_nsxt.tf example_nsxt.tf.tmpl Name "example-terraform-nsxt-lb" TypeCode "nsx-t" Visibility "public" AdminState "true" LogLevel "INFO" Size "SMALL" Tier1Gateway "\"tier1-gateway\""
+//go:generate ../../../../bin/render -out examples/resources/morpheus_load_balancer/example_nsxt.tf example_nsxt.tf.tmpl NetworkServerId "5" Name "example-terraform-nsxt-lb" TypeCode "nsx-t" Visibility "public" AdminState "true" LogLevel "INFO" Size "SMALL" Tier1Gateway "\"tier1-gateway\""
 
 func RenderLoadBalancerHAProxyConfig(t *testing.T, overrides map[string]string) (string, error) {
 	t.Helper()
@@ -104,6 +105,13 @@ func RenderLoadBalancerNsxtConfig(t *testing.T, overrides map[string]string) (st
 		// provider_id of an NSX-T tier-1 gateway, which is exposed by the
 		// hpe_morpheus_network_router data source created in the prereq below.
 		"Tier1Gateway": "data.hpe_morpheus_network_router.lb_tier1.provider_id",
+		// Overridden below from the environment; the literal only serves the
+		// generated documentation example.
+		"NetworkServerId": "5",
+	}
+
+	if id := os.Getenv(testhelpers.EnvNsxtNetworkServerID); id != "" {
+		defaults["NetworkServerId"] = id
 	}
 
 	for key, value := range overrides {
@@ -151,25 +159,27 @@ func RenderLoadBalancerNsxtConfig(t *testing.T, overrides map[string]string) (st
 // data source) and given an edge cluster, both required for an LB service to
 // deploy on it.
 //
-// QA verify: tier-0 router id 28 is a realized NSX-T tier-0 on integration 5;
-// edge_cluster is the NSX-T edge cluster external id (display name
-// "qa-edge-cluster-01").
+// The tier-0, group, network server and edge cluster must already exist on the
+// appliance under test and are supplied via the environment; see
+// testhelpers.RequireNsxtFixture. The test skips when they are not configured.
 func renderNsxtTier1Prereq(t *testing.T, name string) (string, error) {
 	t.Helper()
 
+	fixture := testhelpers.RequireNsxtFixture(t)
+
 	return `
 data "hpe_morpheus_network_router" "lb_tier0" {
-  id = 28
+  id = ` + fixture.Tier0RouterID + `
 }
 
 resource "hpe_morpheus_network_router" "lb_tier1" {
   name                   = "` + name + `-tier1"
-  group_id               = 3
-  network_integration_id = 5
+  group_id               = ` + fixture.GroupID + `
+  network_integration_id = ` + fixture.NetworkServerID + `
 
   config_nsxt_gateway_tier1 = {
     ip_management_type = "dhcpLocal"
-    edge_cluster       = "3de5f8d0-4f8a-433b-95ed-91020c948084"
+    edge_cluster       = "` + fixture.EdgeCluster + `"
     fail_over          = "NON_PREEMPTIVE"
     tier0_gateway      = data.hpe_morpheus_network_router.lb_tier0.provider_id
   }

--- a/morpheus/framework/resources/loadbalancer/read.go
+++ b/morpheus/framework/resources/loadbalancer/read.go
@@ -56,10 +56,13 @@ func getLoadBalancerAsState(
 	// to avoid post-apply inconsistencies when API returns an implicit/default cloud.
 	state.CloudId = plan.CloudId
 
-	// The API does not return group or network_server_id on load balancers,
-	// so these must be preserved from plan/state. After import they will be null.
-	state.GroupId = plan.GroupId
-	state.NetworkServerId = plan.NetworkServerId
+	// Write-only: the API never returns these and the framework nullifies them in state.
+	state.GroupId = types.Int64Null()
+	state.NetworkServerId = types.Int64Null()
+
+	// Carry forward the write-only version companions from plan/state.
+	state.GroupIdVersion = plan.GroupIdVersion
+	state.NetworkServerIdVersion = plan.NetworkServerIdVersion
 
 	// Check if load balancer is HAProxy or NSX-T based on returned type code
 	isHAProxy := data.Type.Code != nil && *data.Type.Code == typeCodeHAProxy

--- a/morpheus/framework/resources/loadbalancer/resource_test.go
+++ b/morpheus/framework/resources/loadbalancer/resource_test.go
@@ -64,9 +64,7 @@ func TestAccMorpheusLoadBalancerResourceHAProxyExampleOk(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"config",
 					"config_haproxy",
-					"group_id",
 					"cloud_id",
-					"network_server_id",
 				},
 			},
 		},
@@ -116,9 +114,7 @@ func TestAccMorpheusLoadBalancerResourceHAProxyGenericExampleOk(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"config",
 					"config_haproxy",
-					"group_id",
 					"cloud_id",
-					"network_server_id",
 					"type_code",
 					"permissions.groups",
 				},
@@ -159,6 +155,85 @@ resource "hpe_morpheus_load_balancer" "test" {
 			{
 				Config:      providerConfig + resourceConfig,
 				ExpectError: regexp.MustCompile(`(?i)attribute "permissions.groups" cannot be specified when`),
+			},
+		},
+	})
+}
+
+// TestMorpheusLoadBalancerWriteOnlyConfigParsing verifies that write-only attributes
+// (group_id, network_server_id) are accepted in config and produce a valid plan.
+// The framework nullifies write-only values in the plan, so Create must source them
+// from req.Config — this test confirms the schema accepts the attributes correctly.
+func TestAccMorpheusLoadBalancerWriteOnlyConfigParsing(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping acceptance test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+	resourceConfig := `
+resource "hpe_morpheus_load_balancer" "test" {
+  name              = "test-wo-attrs"
+  group_id          = 1
+  network_server_id = 42
+  config_nsxt = {
+    admin_state   = true
+    log_level     = "INFO"
+    size          = "SMALL"
+    tier1_gateway = "/infra/tier-1s/test"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestMorpheusLoadBalancerWriteOnlyVersionCompanions verifies that the version
+// companion attributes (group_id_version, network_server_id_version) are accepted
+// in config alongside the write-only attributes they track.
+func TestAccMorpheusLoadBalancerWriteOnlyVersionCompanions(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("Skipping acceptance test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlock()
+	resourceConfig := `
+resource "hpe_morpheus_load_balancer" "test" {
+  name                      = "test-wo-companions"
+  group_id                  = 1
+  group_id_version          = 1
+  network_server_id         = 42
+  network_server_id_version = 1
+  config_nsxt = {
+    admin_state   = true
+    log_level     = "INFO"
+    size          = "SMALL"
+    tier1_gateway = "/infra/tier-1s/test"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config:             providerConfig + resourceConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/morpheus/framework/resources/loadbalancer/schema_gen.go
+++ b/morpheus/framework/resources/loadbalancer/schema_gen.go
@@ -153,8 +153,14 @@ func LoadBalancerResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"group_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "The ID of the group associated with the load balancer",
-				MarkdownDescription: "The ID of the group associated with the load balancer",
+				WriteOnly:           true,
+				Description:         "The ID of the group associated with the load balancer. The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment group_id_version to force replacement into the new group.",
+				MarkdownDescription: "The ID of the group associated with the load balancer. The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment group_id_version to force replacement into the new group.",
+			},
+			"group_id_version": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "Version marker for the write-only group_id attribute. Because group_id is write-only it is never stored in state, so editing group_id on its own produces no plan diff. The group is set only when the load balancer is created and the API provides no way to move it afterwards, so increment this value when group_id changes to replace the load balancer with one in the new group.",
+				MarkdownDescription: "Version marker for the write-only group_id attribute. Because group_id is write-only it is never stored in state, so editing group_id on its own produces no plan diff. The group is set only when the load balancer is created and the API provides no way to move it afterwards, so increment this value when group_id changes to replace the load balancer with one in the new group.",
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},
@@ -175,8 +181,14 @@ func LoadBalancerResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"network_server_id": schema.Int64Attribute{
 				Optional:            true,
-				Description:         "Network Server ID",
-				MarkdownDescription: "Network Server ID",
+				WriteOnly:           true,
+				Description:         "The ID of the network server associated with the load balancer. The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment network_server_id_version to force replacement against the new network server.",
+				MarkdownDescription: "The ID of the network server associated with the load balancer. The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment network_server_id_version to force replacement against the new network server.",
+			},
+			"network_server_id_version": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "Version marker for the write-only network_server_id attribute. Because network_server_id is write-only it is never stored in state, so editing network_server_id on its own produces no plan diff. The network server is set only when the load balancer is created and the API provides no way to change it afterwards, so increment this value when network_server_id changes to replace the load balancer with one registered against the new network server.",
+				MarkdownDescription: "Version marker for the write-only network_server_id attribute. Because network_server_id is write-only it is never stored in state, so editing network_server_id on its own produces no plan diff. The network server is set only when the load balancer is created and the API provides no way to change it afterwards, so increment this value when network_server_id changes to replace the load balancer with one registered against the new network server.",
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},
@@ -257,20 +269,22 @@ func LoadBalancerResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type LoadBalancerModel struct {
-	CloudId         types.Int64        `tfsdk:"cloud_id"`
-	Config          types.Dynamic      `tfsdk:"config"`
-	ConfigHaproxy   ConfigHaproxyValue `tfsdk:"config_haproxy"`
-	ConfigNsxt      ConfigNsxtValue    `tfsdk:"config_nsxt"`
-	Description     types.String       `tfsdk:"description"`
-	Enabled         types.Bool         `tfsdk:"enabled"`
-	GroupId         types.Int64        `tfsdk:"group_id"`
-	Id              types.Int64        `tfsdk:"id"`
-	Name            types.String       `tfsdk:"name"`
-	NetworkServerId types.Int64        `tfsdk:"network_server_id"`
-	Permissions     PermissionsValue   `tfsdk:"permissions"`
-	Tenants         types.Set          `tfsdk:"tenants"`
-	TypeCode        types.String       `tfsdk:"type_code"`
-	Visibility      types.String       `tfsdk:"visibility"`
+	CloudId                types.Int64        `tfsdk:"cloud_id"`
+	Config                 types.Dynamic      `tfsdk:"config"`
+	ConfigHaproxy          ConfigHaproxyValue `tfsdk:"config_haproxy"`
+	ConfigNsxt             ConfigNsxtValue    `tfsdk:"config_nsxt"`
+	Description            types.String       `tfsdk:"description"`
+	Enabled                types.Bool         `tfsdk:"enabled"`
+	GroupId                types.Int64        `tfsdk:"group_id"`
+	GroupIdVersion         types.Int64        `tfsdk:"group_id_version"`
+	Id                     types.Int64        `tfsdk:"id"`
+	Name                   types.String       `tfsdk:"name"`
+	NetworkServerId        types.Int64        `tfsdk:"network_server_id"`
+	NetworkServerIdVersion types.Int64        `tfsdk:"network_server_id_version"`
+	Permissions            PermissionsValue   `tfsdk:"permissions"`
+	Tenants                types.Set          `tfsdk:"tenants"`
+	TypeCode               types.String       `tfsdk:"type_code"`
+	Visibility             types.String       `tfsdk:"visibility"`
 }
 
 var _ basetypes.ObjectTypable = ConfigHaproxyType{}

--- a/morpheus/framework/resources/loadbalancerprofile/read.go
+++ b/morpheus/framework/resources/loadbalancerprofile/read.go
@@ -174,8 +174,15 @@ func getLoadBalancerProfileAsState(
 	// straight from the API response, so it is available on import too.
 	serviceType := state.ServiceType.ValueString()
 
-	// Tags: read from config response
-	state.Tags = readTagsFromConfig(ctx, serviceType, p.Config, prior.Tags)
+	// Tags: read from config response.
+	// If the user never configured tags (prior state is null), preserve null to
+	// avoid perpetual computed diffs from API-injected sentinel tags (NSX-T
+	// returns empty {name:"",value:""} entries even when no tags were set).
+	if prior.Tags.IsNull() {
+		state.Tags = types.SetNull(TagsValue{}.Type(ctx))
+	} else {
+		state.Tags = readTagsFromConfig(ctx, serviceType, p.Config, prior.Tags)
+	}
 
 	// Config blocks: preserve every value the practitioner configured, while
 	// resolving any attribute that arrived unknown from the API response.

--- a/morpheus/framework/resources/loadbalancerprofile/schema_gen.go
+++ b/morpheus/framework/resources/loadbalancerprofile/schema_gen.go
@@ -594,6 +594,7 @@ func LoadBalancerProfileResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
+				Computed:            true,
 				Description:         "NSX-T tags applied to the profile.",
 				MarkdownDescription: "NSX-T tags applied to the profile.",
 			},

--- a/morpheus/framework/resources/loadbalancervirtualserver/resource_read.go
+++ b/morpheus/framework/resources/loadbalancervirtualserver/resource_read.go
@@ -160,7 +160,15 @@ func getVirtualServerAsState(
 	state.VipAddress = convert.StrToType(vs.VipAddress)
 	state.VipPort = convert.Int64ToType(vs.VipPort)
 	state.VipProtocol = convert.StrToType(vs.VipProtocol)
-	state.VipHostname = convert.StrToType(vs.VipHostname.Get())
+	// VipHostname: coerce empty string to null. The API returns "" for an
+	// unset hostname; since vip_hostname is Optional (not Computed), Read must
+	// return null when the user never configured it to avoid an inconsistent
+	// result (null in plan vs "" from API).
+	if h := vs.VipHostname.Get(); h == nil || *h == "" {
+		state.VipHostname = types.StringNull()
+	} else {
+		state.VipHostname = types.StringValue(*h)
+	}
 
 	// Computed fields
 	state.Active = convert.BoolToType(vs.Active)

--- a/morpheus/framework/resources/loadbalancervirtualserver/schema_gen.go
+++ b/morpheus/framework/resources/loadbalancervirtualserver/schema_gen.go
@@ -310,6 +310,7 @@ func LoadBalancerVirtualServerResourceSchema(ctx context.Context) schema.Schema 
 				Description:         "The VIP type. This is primarily used by NSX Advanced Load Balancer (AVI) to distinguish between normal, parent (shared), and child VIPs. It has no effect for NSX-T load balancers and will be null.",
 				MarkdownDescription: "The VIP type. This is primarily used by NSX Advanced Load Balancer (AVI) to distinguish between normal, parent (shared), and child VIPs. It has no effect for NSX-T load balancers and will be null.",
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/morpheus/framework/resources/networkrouternat/resource.go
+++ b/morpheus/framework/resources/networkrouternat/resource.go
@@ -68,6 +68,15 @@ func (r *Resource) Create(
 		return
 	}
 
+	// Write-only attributes (action, firewall, service) are nullified in the
+	// plan by the framework. Read them from the raw config instead.
+	var config NetworkRouterNatModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	client, err := r.NewClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(createOperation, "failed to create client: "+err.Error())
@@ -77,18 +86,11 @@ func (r *Resource) Create(
 
 	routerID := plan.RouterId.ValueInt64()
 
-	// firewall and service are NAT config-context options nested under config.
-	// firewall has a schema default so it is normally set; service is optional.
-	// Guard both so an unknown value is omitted rather than sent as "".
-	natConfig := sdk.CreateNetworkRouterNatRequestNetworkRouterNATConfig{
-		Action: plan.Action.ValueString(),
-	}
-	if !plan.Firewall.IsNull() && !plan.Firewall.IsUnknown() {
-		natConfig.Firewall = plan.Firewall.ValueStringPointer()
-	}
-	if !plan.Service.IsNull() && !plan.Service.IsUnknown() {
-		natConfig.Service = plan.Service.ValueStringPointer()
-	}
+	// action, firewall, and service are write-only — sourced from config.
+	// The Morpheus OptionType declares firewall as required with a UI-only
+	// default of MATCH_INTERNAL_ADDRESS; the provider must supply it when
+	// the practitioner omits it.
+	natConfig := buildCreateNatConfig(&config)
 
 	nat := sdk.CreateNetworkRouterNatRequestNetworkRouterNAT{
 		Name:   plan.Name.ValueString(),
@@ -215,11 +217,15 @@ func getNatAsState(
 
 	state.Name = convert.StrToType(nat.Name)
 
-	if nat.Action != nil {
-		state.Action = types.StringValue(*nat.Action)
-	} else {
-		state.Action = plan.Action
-	}
+	// action, firewall, and service are write-only — always null in state.
+	state.Action = types.StringNull()
+	state.Firewall = types.StringNull()
+	state.Service = types.StringNull()
+
+	// Carry forward the version companions from the plan/prior state.
+	state.ActionVersion = plan.ActionVersion
+	state.FirewallVersion = plan.FirewallVersion
+	state.ServiceVersion = plan.ServiceVersion
 
 	state.Description = convert.StrToType(nat.Description)
 
@@ -250,19 +256,6 @@ func getNatAsState(
 		state.Protocol = plan.Protocol
 	} else {
 		state.Protocol = types.StringNull()
-	}
-
-	// firewall and service are create-time config options. Read them back from
-	// the response, falling back to the plan value when the API omits them.
-	if nat.Firewall != nil {
-		state.Firewall = types.StringValue(*nat.Firewall)
-	} else {
-		state.Firewall = plan.Firewall
-	}
-	if nat.Service != nil {
-		state.Service = types.StringValue(*nat.Service)
-	} else {
-		state.Service = plan.Service
 	}
 
 	return state, diags
@@ -310,6 +303,15 @@ func (r *Resource) Update(
 		return
 	}
 
+	// Write-only attributes (action, firewall, service) are nullified in the
+	// plan by the framework. Read them from the raw config instead.
+	var config NetworkRouterNatModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	client, err := r.NewClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("update network router nat resource", "failed to create client: "+err.Error())
@@ -320,15 +322,7 @@ func (r *Resource) Update(
 	id := plan.Id.ValueInt64()
 	routerID := plan.RouterId.ValueInt64()
 
-	natConfig := &sdk.UpdateNetworkRouterNatRequestNetworkRouterNATConfig{
-		Action: plan.Action.ValueStringPointer(),
-	}
-	if !plan.Firewall.IsNull() && !plan.Firewall.IsUnknown() {
-		natConfig.Firewall = plan.Firewall.ValueStringPointer()
-	}
-	if !plan.Service.IsNull() && !plan.Service.IsUnknown() {
-		natConfig.Service = plan.Service.ValueStringPointer()
-	}
+	natConfig := buildUpdateNatConfig(&config)
 
 	nat := sdk.UpdateNetworkRouterNatRequestNetworkRouterNAT{
 		Name:   plan.Name.ValueStringPointer(),
@@ -467,4 +461,64 @@ func (r *Resource) ImportState(
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("router_id"), routerID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+}
+
+// defaultFirewallMatch is the firewall value applied on create when the
+// practitioner supplies none.
+//
+// firewall is write-only, and write-only attributes cannot carry a schema
+// default, so the default has to be applied here. The Morpheus OptionType is
+// required, and applyOptionTypes does not honour the seed's defaultValue -
+// that is a UI form default only - so omitting it would send null to a
+// required field.
+const defaultFirewallMatch = "MATCH_INTERNAL_ADDRESS"
+
+// buildCreateNatConfig assembles the NAT config sent on create.
+//
+// It reads from the *config*, never the plan: action, firewall and service are
+// write-only, so the framework nullifies them in the plan. Sourcing them from
+// the plan compiles cleanly and silently sends nulls.
+func buildCreateNatConfig(
+	config *NetworkRouterNatModel,
+) sdk.CreateNetworkRouterNatRequestNetworkRouterNATConfig {
+	natConfig := sdk.CreateNetworkRouterNatRequestNetworkRouterNATConfig{
+		Action: config.Action.ValueString(),
+	}
+
+	if !config.Firewall.IsNull() && !config.Firewall.IsUnknown() {
+		natConfig.Firewall = config.Firewall.ValueStringPointer()
+	} else {
+		firewall := defaultFirewallMatch
+		natConfig.Firewall = &firewall
+	}
+
+	if !config.Service.IsNull() && !config.Service.IsUnknown() {
+		natConfig.Service = config.Service.ValueStringPointer()
+	}
+
+	return natConfig
+}
+
+// buildUpdateNatConfig assembles the NAT config sent on update.
+//
+// Unlike create it applies no default. The fields are omitempty pointers and
+// the controller merges the payload over the current config, so leaving a key
+// out preserves whatever the router already has. Sending a default here would
+// overwrite a real NSX-T value with a guess.
+func buildUpdateNatConfig(
+	config *NetworkRouterNatModel,
+) *sdk.UpdateNetworkRouterNatRequestNetworkRouterNATConfig {
+	natConfig := &sdk.UpdateNetworkRouterNatRequestNetworkRouterNATConfig{
+		Action: config.Action.ValueStringPointer(),
+	}
+
+	if !config.Firewall.IsNull() && !config.Firewall.IsUnknown() {
+		natConfig.Firewall = config.Firewall.ValueStringPointer()
+	}
+
+	if !config.Service.IsNull() && !config.Service.IsUnknown() {
+		natConfig.Service = config.Service.ValueStringPointer()
+	}
+
+	return natConfig
 }

--- a/morpheus/framework/resources/networkrouternat/resource_test.go
+++ b/morpheus/framework/resources/networkrouternat/resource_test.go
@@ -28,23 +28,27 @@ func TestMain(m *testing.M) {
 // tier-1 that is connected to a tier-0 and has an edge cluster. The tier-0's
 // provider_id/path is read via a data source.
 //
-// QA verify: tier-0 router id 28 is a realized NSX-T tier-0 on integration 5;
-// edge_cluster is the NSX-T edge cluster external id (display name
-// "qa-edge-cluster-01").
-func nsxtTier1RouterConfig(name string) string {
+// The tier-0, group, network server and edge cluster must already exist on the
+// appliance under test and are supplied via the environment; see
+// testhelpers.RequireNsxtFixture. The test skips when they are not configured.
+func nsxtTier1RouterConfig(t *testing.T, name string) string {
+	t.Helper()
+
+	fixture := testhelpers.RequireNsxtFixture(t)
+
 	return `
 data "hpe_morpheus_network_router" "nat_tier0" {
-  id = 28
+  id = ` + fixture.Tier0RouterID + `
 }
 
 resource "hpe_morpheus_network_router" "nat_tier1" {
   name                   = "` + name + `-tier1"
-  group_id               = 3
-  network_integration_id = 5
+  group_id               = ` + fixture.GroupID + `
+  network_integration_id = ` + fixture.NetworkServerID + `
 
   config_nsxt_gateway_tier1 = {
     ip_management_type = "dhcpLocal"
-    edge_cluster       = "3de5f8d0-4f8a-433b-95ed-91020c948084"
+    edge_cluster       = "` + fixture.EdgeCluster + `"
     fail_over          = "NON_PREEMPTIVE"
     tier0_gateway      = data.hpe_morpheus_network_router.nat_tier0.provider_id
   }
@@ -67,7 +71,7 @@ func TestAccMorpheusNetworkRouterNatResourceExampleOk(t *testing.T) {
 	name := acctest.RandomWithPrefix(t.Name())
 	resourceName := "hpe_morpheus_network_router_nat.example"
 
-	routerConfig := nsxtTier1RouterConfig(name)
+	routerConfig := nsxtTier1RouterConfig(t, name)
 
 	resourceConfig, err := networkrouternat.RenderNetworkRouterNatConfig(t, map[string]string{
 		"RouterId": "hpe_morpheus_network_router.nat_tier1.id",
@@ -100,11 +104,7 @@ func TestAccMorpheusNetworkRouterNatResourceExampleOk(t *testing.T) {
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				// action and firewall are create-only inputs that the NAT read
-				// (GET) API does not return, so they cannot round-trip through
-				// import (verified: only these two differ after import).
-				ImportStateVerifyIgnore: []string{"action", "firewall"},
-				ResourceName:            "hpe_morpheus_network_router_nat.example",
+				ResourceName:      "hpe_morpheus_network_router_nat.example",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources["hpe_morpheus_network_router_nat.example"]
 					if !ok {
@@ -133,7 +133,7 @@ func TestAccMorpheusNetworkRouterNatResourceUpdateOk(t *testing.T) {
 	name := acctest.RandomWithPrefix(t.Name())
 	resourceName := "hpe_morpheus_network_router_nat.example"
 
-	routerConfig := nsxtTier1RouterConfig(name)
+	routerConfig := nsxtTier1RouterConfig(t, name)
 
 	createConfig, err := networkrouternat.RenderNetworkRouterNatConfig(t, map[string]string{
 		"RouterId": "hpe_morpheus_network_router.nat_tier1.id",

--- a/morpheus/framework/resources/networkrouternat/schema_gen.go
+++ b/morpheus/framework/resources/networkrouternat/schema_gen.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -23,8 +22,14 @@ func NetworkRouterNatResourceSchema(ctx context.Context) schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"action": schema.StringAttribute{
 				Required:            true,
-				Description:         "The NAT action (e.g. SNAT, DNAT, REFLEXIVE).",
-				MarkdownDescription: "The NAT action (e.g. SNAT, DNAT, REFLEXIVE).",
+				WriteOnly:           true,
+				Description:         "The NAT action (e.g. SNAT, DNAT, REFLEXIVE). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment action_version to apply a change.",
+				MarkdownDescription: "The NAT action (e.g. SNAT, DNAT, REFLEXIVE). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment action_version to apply a change.",
+			},
+			"action_version": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "Version marker for the write-only action attribute. Because action is write-only it is never stored in state, so editing action on its own produces no plan diff. Increment this value whenever action changes: the change to action_version is what produces the plan diff, and the update then sends the current action value to the API.",
+				MarkdownDescription: "Version marker for the write-only action attribute. Because action is write-only it is never stored in state, so editing action on its own produces no plan diff. Increment this value whenever action changes: the change to action_version is what produces the plan diff, and the update then sends the current action value to the API.",
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,
@@ -55,13 +60,17 @@ func NetworkRouterNatResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"firewall": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
-				Description:         "The firewall match applied to the NAT rule (nested under config).",
-				MarkdownDescription: "The firewall match applied to the NAT rule (nested under config).",
+				WriteOnly:           true,
+				Description:         "The firewall match applied to the NAT rule (nested under config). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment firewall_version to apply a change.",
+				MarkdownDescription: "The firewall match applied to the NAT rule (nested under config). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment firewall_version to apply a change.",
 				Validators: []validator.String{
 					stringvalidator.OneOf("MATCH_INTERNAL_ADDRESS", "MATCH_EXTERNAL_ADDRESS", "BYPASS"),
 				},
-				Default: stringdefault.StaticString("MATCH_INTERNAL_ADDRESS"),
+			},
+			"firewall_version": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "Version marker for the write-only firewall attribute. Because firewall is write-only it is never stored in state, so editing firewall on its own produces no plan diff. Increment this value whenever firewall changes: the change to firewall_version is what produces the plan diff, and the update then sends the current firewall value to the API. Leaving this value alone preserves the firewall setting currently held by the provider.",
+				MarkdownDescription: "Version marker for the write-only firewall attribute. Because firewall is write-only it is never stored in state, so editing firewall on its own produces no plan diff. Increment this value whenever firewall changes: the change to firewall_version is what produces the plan diff, and the update then sends the current firewall value to the API. Leaving this value alone preserves the firewall setting currently held by the provider.",
 			},
 			"id": schema.Int64Attribute{
 				Computed:            true,
@@ -100,8 +109,14 @@ func NetworkRouterNatResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"service": schema.StringAttribute{
 				Optional:            true,
-				Description:         "The service (protocol) applied to the NAT rule (nested under config).",
-				MarkdownDescription: "The service (protocol) applied to the NAT rule (nested under config).",
+				WriteOnly:           true,
+				Description:         "The service (protocol) applied to the NAT rule (nested under config). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment service_version to apply a change.",
+				MarkdownDescription: "The service (protocol) applied to the NAT rule (nested under config). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment service_version to apply a change.",
+			},
+			"service_version": schema.Int64Attribute{
+				Optional:            true,
+				Description:         "Version marker for the write-only service attribute. Because service is write-only it is never stored in state, so editing service on its own produces no plan diff. Increment this value whenever service changes: the change to service_version is what produces the plan diff, and the update then sends the current service value to the API. Leaving this value alone preserves the service setting currently held by the provider.",
+				MarkdownDescription: "Version marker for the write-only service attribute. Because service is write-only it is never stored in state, so editing service on its own produces no plan diff. Increment this value whenever service changes: the change to service_version is what produces the plan diff, and the update then sends the current service value to the API. Leaving this value alone preserves the service setting currently held by the provider.",
 			},
 			"source_network": schema.StringAttribute{
 				Optional:            true,
@@ -127,17 +142,20 @@ func NetworkRouterNatResourceSchema(ctx context.Context) schema.Schema {
 
 type NetworkRouterNatModel struct {
 	Action             types.String `tfsdk:"action"`
+	ActionVersion      types.Int64  `tfsdk:"action_version"`
 	Description        types.String `tfsdk:"description"`
 	DestinationNetwork types.String `tfsdk:"destination_network"`
 	Enabled            types.Bool   `tfsdk:"enabled"`
 	ExternalId         types.String `tfsdk:"external_id"`
 	Firewall           types.String `tfsdk:"firewall"`
+	FirewallVersion    types.Int64  `tfsdk:"firewall_version"`
 	Id                 types.Int64  `tfsdk:"id"`
 	Name               types.String `tfsdk:"name"`
 	Priority           types.Int64  `tfsdk:"priority"`
 	Protocol           types.String `tfsdk:"protocol"`
 	RouterId           types.Int64  `tfsdk:"router_id"`
 	Service            types.String `tfsdk:"service"`
+	ServiceVersion     types.Int64  `tfsdk:"service_version"`
 	SourceNetwork      types.String `tfsdk:"source_network"`
 	TranslatedNetwork  types.String `tfsdk:"translated_network"`
 	TranslatedPorts    types.String `tfsdk:"translated_ports"`

--- a/morpheus/framework/resources/networkrouternat/write_only_test.go
+++ b/morpheus/framework/resources/networkrouternat/write_only_test.go
@@ -1,0 +1,118 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package networkrouternat
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
+)
+
+// These tests drive the production builders directly. An earlier version
+// re-implemented the branching inside the test body and asserted on its own
+// copy, which passed even when the production default was deliberately broken.
+// If a test here can pass while resource.go is wrong, it is not doing its job.
+
+func TestUnitBuildCreateNatConfig_FirewallDefaultApplied(t *testing.T) {
+	t.Parallel()
+
+	got := buildCreateNatConfig(&NetworkRouterNatModel{
+		Action:   types.StringValue("SNAT"),
+		Firewall: types.StringNull(),
+		Service:  types.StringNull(),
+	})
+
+	if got.Firewall == nil {
+		t.Fatal("firewall should be defaulted on create, got nil")
+	}
+
+	if *got.Firewall != defaultFirewallMatch {
+		t.Fatalf("firewall = %q, want %q", *got.Firewall, defaultFirewallMatch)
+	}
+
+	// The default exists because the Morpheus OptionType is required. Guard the
+	// literal too: silently changing it would send an unaccepted value.
+	if defaultFirewallMatch != "MATCH_INTERNAL_ADDRESS" {
+		t.Fatalf("default firewall literal changed to %q", defaultFirewallMatch)
+	}
+
+	if got.Service != nil {
+		t.Fatalf("service should be omitted when unset, got %q", *got.Service)
+	}
+}
+
+func TestUnitBuildCreateNatConfig_ExplicitFirewallWins(t *testing.T) {
+	t.Parallel()
+
+	got := buildCreateNatConfig(&NetworkRouterNatModel{
+		Action:   types.StringValue("DNAT"),
+		Firewall: types.StringValue("BYPASS"),
+		Service:  types.StringValue("HTTPS"),
+	})
+
+	if got.Firewall == nil || *got.Firewall != "BYPASS" {
+		t.Fatalf("firewall = %v, want BYPASS", got.Firewall)
+	}
+
+	if got.Service == nil || *got.Service != "HTTPS" {
+		t.Fatalf("service = %v, want HTTPS", got.Service)
+	}
+
+	if got.Action != "DNAT" {
+		t.Fatalf("action = %q, want DNAT", got.Action)
+	}
+}
+
+// The T2-2 fix. Update must omit an unset firewall rather than defaulting it:
+// the controller merges the payload over the current config, so sending a
+// default would overwrite the real NSX-T value with a guess.
+func TestUnitBuildUpdateNatConfig_UnsetFirewallOmitted(t *testing.T) {
+	t.Parallel()
+
+	got := buildUpdateNatConfig(&NetworkRouterNatModel{
+		Action:   types.StringValue("SNAT"),
+		Firewall: types.StringNull(),
+		Service:  types.StringNull(),
+	})
+
+	if got.Firewall != nil {
+		t.Fatalf("firewall must be omitted on update, got %q — this would "+
+			"clobber the server-side value", *got.Firewall)
+	}
+
+	if got.Service != nil {
+		t.Fatalf("service must be omitted on update, got %q", *got.Service)
+	}
+}
+
+func TestUnitBuildUpdateNatConfig_ExplicitValuesSent(t *testing.T) {
+	t.Parallel()
+
+	got := buildUpdateNatConfig(&NetworkRouterNatModel{
+		Action:   types.StringValue("DNAT"),
+		Firewall: types.StringValue("MATCH_EXTERNAL_ADDRESS"),
+		Service:  types.StringValue("SSH"),
+	})
+
+	if got.Firewall == nil || *got.Firewall != "MATCH_EXTERNAL_ADDRESS" {
+		t.Fatalf("firewall = %v, want MATCH_EXTERNAL_ADDRESS", got.Firewall)
+	}
+
+	if got.Service == nil || *got.Service != "SSH" {
+		t.Fatalf("service = %v, want SSH", got.Service)
+	}
+}
+
+// Guards the shape the builders depend on: both write-only fields are optional
+// pointers, so "unset" is expressible. If the SDK ever makes them plain
+// strings, omission becomes impossible and the update fix silently regresses.
+func TestUnitNatConfigFieldsArePointers(t *testing.T) {
+	t.Parallel()
+
+	var upd sdk.UpdateNetworkRouterNatRequestNetworkRouterNATConfig
+	if upd.Firewall != nil || upd.Service != nil {
+		t.Fatal("expected nil-able firewall/service on the update config")
+	}
+}

--- a/morpheus/testhelpers/nsxt_fixture.go
+++ b/morpheus/testhelpers/nsxt_fixture.go
@@ -1,0 +1,85 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package testhelpers
+
+import (
+	"os"
+	"testing"
+)
+
+// NSX-T acceptance tests need a realized tier-0 gateway, an edge cluster, and a
+// group and network server to attach a tier-1 to. None of that can be created
+// from Terraform, so it must already exist on the appliance under test.
+//
+// These identifiers were previously hard-coded (tier-0 router 28, group 3,
+// network server 5, a named edge cluster). Those values exist on no appliance
+// the tests are currently run against, so every NSX-T test failed at the first
+// data source with "Router not found with id 28" -- a failure that looks like a
+// provider bug but is only a stale fixture. Reading them from the environment
+// keeps the tests appliance-agnostic, and skipping when they are absent makes
+// the missing coverage explicit instead of reporting a false failure.
+const (
+	EnvNsxtTier0RouterID   = "TF_ACC_NSXT_TIER0_ROUTER_ID"
+	EnvNsxtGroupID         = "TF_ACC_NSXT_GROUP_ID"
+	EnvNsxtNetworkServerID = "TF_ACC_NSXT_NETWORK_SERVER_ID"
+	EnvNsxtEdgeCluster     = "TF_ACC_NSXT_EDGE_CLUSTER"
+)
+
+// NsxtFixture identifies pre-existing NSX-T infrastructure that acceptance
+// tests build on. All values are rendered into HCL as-is, so they are strings.
+type NsxtFixture struct {
+	// Tier0RouterID is the id of a realized tier-0 gateway, read via the
+	// hpe_morpheus_network_router data source to obtain its provider_id.
+	Tier0RouterID string
+	// GroupID is the group the tier-1 gateway is created in.
+	GroupID string
+	// NetworkServerID is the NSX-T network server (integration) id.
+	NetworkServerID string
+	// EdgeCluster is the NSX-T edge cluster external id. A tier-1 needs one
+	// before a load balancer service can deploy on it.
+	EdgeCluster string
+}
+
+// RequireNsxtFixture returns the NSX-T fixture for the appliance under test,
+// skipping the test when it has not been configured.
+//
+// It skips rather than fails: an appliance without NSX-T is a legitimate
+// target for the rest of the suite, and turning that into a failure would
+// train people to ignore red results.
+func RequireNsxtFixture(t *testing.T) NsxtFixture {
+	t.Helper()
+
+	fixture := NsxtFixture{
+		Tier0RouterID:   os.Getenv(EnvNsxtTier0RouterID),
+		GroupID:         os.Getenv(EnvNsxtGroupID),
+		NetworkServerID: os.Getenv(EnvNsxtNetworkServerID),
+		EdgeCluster:     os.Getenv(EnvNsxtEdgeCluster),
+	}
+
+	var missing []string
+
+	for _, v := range []struct {
+		name  string
+		value string
+	}{
+		{EnvNsxtTier0RouterID, fixture.Tier0RouterID},
+		{EnvNsxtGroupID, fixture.GroupID},
+		{EnvNsxtNetworkServerID, fixture.NetworkServerID},
+		{EnvNsxtEdgeCluster, fixture.EdgeCluster},
+	} {
+		if v.value == "" {
+			missing = append(missing, v.name)
+		}
+	}
+
+	if len(missing) > 0 {
+		msg := "NSX-T fixture not configured; set:"
+		for _, name := range missing {
+			msg += " " + name
+		}
+
+		t.Skip(msg)
+	}
+
+	return fixture
+}

--- a/specs/resources/instance_clone/config.yaml
+++ b/specs/resources/instance_clone/config.yaml
@@ -13,6 +13,16 @@ instance_clone:
       int64:
         computed_optional_required: required
         description: The ID of the source instance to clone.
+    source_instance_id_version:
+      int64:
+        computed_optional_required: optional
+        description: >-
+          Version marker for the write-only source_instance_id attribute. Because
+          source_instance_id is write-only it is never stored in state, so editing
+          source_instance_id on its own produces no plan diff. The clone source is only meaningful
+          at creation time and cannot be changed afterwards, so incrementing this value has no
+          effect on an existing instance; it exists so that a value may be supplied for it without
+          error, for example in configurations produced by migration tooling.
     volumesOuter:
       list_nested:
         computed_optional_required: required
@@ -256,6 +266,7 @@ instance_clone:
   moves:
     - instance: ""                              # unnest the instance read wrapper to root
     - template-source_instance_id: source_instance_id
+    - template-source_instance_id_version: source_instance_id_version
     - group.id: group_id
     - cloud.id: cloud_id
     - plan.id: plan_id
@@ -328,8 +339,8 @@ instance_clone:
   overrides:
     source_instance_id:
       computed_optional_required: required
-      description: The ID of the source instance to clone.
-      requires_replace: true
+      description: The ID of the source instance to clone. The API never returns this value, so it is write-only and not stored in state. It cannot be changed after the clone is created; changing it produces no plan diff and has no effect on the existing instance.
+      write_only: true
     id:
       computed_optional_required: computed
       description: The ID of the cloned instance.

--- a/specs/resources/load_balancer/config.yaml
+++ b/specs/resources/load_balancer/config.yaml
@@ -48,6 +48,25 @@ load_balancer:
       string: {}
     group_id:
       int64: {}
+    group_id_version:
+      int64:
+        computed_optional_required: optional
+        description: >-
+          Version marker for the write-only group_id attribute. Because group_id is write-only it
+          is never stored in state, so editing group_id on its own produces no plan diff. The
+          group is set only when the load balancer is created and the API provides no way to move
+          it afterwards, so increment this value when group_id changes to replace the load
+          balancer with one in the new group.
+    network_server_id_version:
+      int64:
+        computed_optional_required: optional
+        description: >-
+          Version marker for the write-only network_server_id attribute. Because
+          network_server_id is write-only it is never stored in state, so editing
+          network_server_id on its own produces no plan diff. The network server is set only when
+          the load balancer is created and the API provides no way to change it afterwards, so
+          increment this value when network_server_id changes to replace the load balancer with
+          one registered against the new network server.
     permissions_all:
       bool:
         computed_optional_required: computed_optional
@@ -72,6 +91,8 @@ load_balancer:
     - load_balancer: "" # unnest wrapper (components/schemas/loadBalancerCreate.yaml)
     - template-type_code: type_code # replace read-only type object with string for type code
     - template-group_id: group_id # site.id from create payload (not in OpenAPI spec)
+    - template-group_id_version: group_id_version # write-only companion for group_id
+    - template-network_server_id_version: network_server_id_version # write-only companion for network_server_id
     - zone.id: cloud_id # (components/schemas/loadBalancer.yaml)
     - template-config_haproxy: config_haproxy
     - template-config_nsxt: config_nsxt
@@ -168,15 +189,20 @@ load_balancer:
     description:
       computed_optional_required: computed_optional
     group_id:
-      description: The ID of the group associated with the load balancer
+      description: The ID of the group associated with the load balancer. The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment group_id_version to force replacement into the new group.
       computed_optional_required: optional
-      requires_replace: true # REVIEW: likely immutable after creation
+      write_only: true # not returned in GET response
+    group_id_version:
+      requires_replace: true
     name:
       computed_optional_required: required
       string_length_at_most: 32
     network_server_id:
       computed_optional_required: optional
-      requires_replace: true # REVIEW: not in update schema, cannot be changed after creation
+      description: The ID of the network server associated with the load balancer. The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment network_server_id_version to force replacement against the new network server.
+      write_only: true # not returned in GET response
+    network_server_id_version:
+      requires_replace: true
     permissions:
       description: Resource permissions for the load balancer
       computed_optional_required: computed_optional

--- a/specs/resources/load_balancer_profile/config.yaml
+++ b/specs/resources/load_balancer_profile/config.yaml
@@ -13,7 +13,7 @@ load_balancer_profile:
     # injects it into the active config block). Replaces the per-block tags.
     tags:
       set_nested:
-        computed_optional_required: optional
+        computed_optional_required: computed_optional
         description: NSX-T tags applied to the profile.
         nested_object:
           attributes:
@@ -95,7 +95,7 @@ load_balancer_profile:
         - LBClientSslProfile
         - LBServerSslProfile
     tags:
-      computed_optional_required: optional
+      computed_optional_required: computed_optional
       description: NSX-T tags applied to the profile.
     # cookie_type is exposed with friendly values; the provider translates
     # session<->LBSessionCookieTime and persistence<->LBPersistenceCookieTime.

--- a/specs/resources/load_balancer_virtual_server/config.yaml
+++ b/specs/resources/load_balancer_virtual_server/config.yaml
@@ -154,6 +154,7 @@ load_balancer_virtual_server:
       computed_optional_required: computed
     vip_type:
       computed_optional_required: computed_optional
+      state_for_unknown: true
       description: >-
         The VIP type. This is primarily used by NSX Advanced Load Balancer (AVI)
         to distinguish between normal, parent (shared), and child VIPs. It has

--- a/specs/resources/network_router_nat/config.yaml
+++ b/specs/resources/network_router_nat/config.yaml
@@ -3,6 +3,9 @@ network_router_nat:
   # (needs a deprecation_message, which only a template supports) and
   # firewall/service are request config-context fields sent nested under config
   # by the resource, so they are kept as plain top-level string attributes.
+  # action/firewall/service are write-only (the API never returns them), so each
+  # is paired with an <attr>_version companion template: write-only values are
+  # absent from state and cannot produce a plan diff on their own.
   templates:
     protocol:
       string:
@@ -11,17 +14,46 @@ network_router_nat:
         deprecation_message: "Deprecated: use service instead. protocol is retained for backward compatibility."
     firewall:
       string:
-        computed_optional_required: computed_optional
+        computed_optional_required: optional
         description: The firewall match applied to the NAT rule (nested under config).
     service:
       string:
         computed_optional_required: optional
         description: The service (protocol) applied to the NAT rule (nested under config).
+    action_version:
+      int64:
+        computed_optional_required: optional
+        description: >-
+          Version marker for the write-only action attribute. Because action is write-only it is
+          never stored in state, so editing action on its own produces no plan diff. Increment
+          this value whenever action changes: the change to action_version is what produces the
+          plan diff, and the update then sends the current action value to the API.
+    firewall_version:
+      int64:
+        computed_optional_required: optional
+        description: >-
+          Version marker for the write-only firewall attribute. Because firewall is write-only it
+          is never stored in state, so editing firewall on its own produces no plan diff.
+          Increment this value whenever firewall changes: the change to firewall_version is what
+          produces the plan diff, and the update then sends the current firewall value to the API.
+          Leaving this value alone preserves the firewall setting currently held by the provider.
+    service_version:
+      int64:
+        computed_optional_required: optional
+        description: >-
+          Version marker for the write-only service attribute. Because service is write-only it is
+          never stored in state, so editing service on its own produces no plan diff. Increment
+          this value whenever service changes: the change to service_version is what produces the
+          plan diff, and the update then sends the current service value to the API. Leaving this
+          value alone preserves the service setting currently held by the provider.
   moves:
     - network_router_nat: ""          # unnest the API envelope (standard pattern)
     - template-protocol: protocol     # pin deprecated protocol
     - template-firewall: firewall     # pin config-context firewall
     - template-service: service       # pin config-context service
+    - template-action_version: action_version      # write-only companion for action
+    - template-firewall_version: firewall_version  # write-only companion for firewall
+    - template-service_version: service_version    # write-only companion for service
   removes:
     - success
     - config                          # request config wrapper; firewall/service pinned top-level via templates
@@ -54,7 +86,8 @@ network_router_nat:
       description: Name of the NAT rule
     action:
       computed_optional_required: required
-      description: The NAT action (e.g. SNAT, DNAT, REFLEXIVE).
+      description: The NAT action (e.g. SNAT, DNAT, REFLEXIVE). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment action_version to apply a change.
+      write_only: true
     description:
       computed_optional_required: computed_optional
       description: Description of the NAT rule
@@ -79,10 +112,11 @@ network_router_nat:
       computed_optional_required: computed_optional
       description: Translated ports for the NAT rule
     firewall:
-      computed_optional_required: computed_optional
-      description: The firewall match applied to the NAT rule (nested under config).
-      default: MATCH_INTERNAL_ADDRESS
+      computed_optional_required: optional
+      description: The firewall match applied to the NAT rule (nested under config). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment firewall_version to apply a change.
+      write_only: true
       one_of: [MATCH_INTERNAL_ADDRESS, MATCH_EXTERNAL_ADDRESS, BYPASS]
     service:
       computed_optional_required: optional
-      description: The service (protocol) applied to the NAT rule (nested under config).
+      description: The service (protocol) applied to the NAT rule (nested under config). The API never returns this value, so it is write-only and not stored in state. Changing it alone produces no plan diff; increment service_version to apply a change.
+      write_only: true

--- a/templates/resources/morpheus_instance_clone.md.tmpl
+++ b/templates/resources/morpheus_instance_clone.md.tmpl
@@ -95,27 +95,31 @@ resource "hpe_morpheus_instance_clone" "staging" {
   name               = "staging-copy"
 
   # Volume names match the source so their contents are cloned.
-  volumes {
-    name         = "root"
-    root_volume  = true
-    size         = 50 # grown from the source's 40 GB
-    datastore_id = 12
-  }
-  volumes {
-    name         = "data"
-    size         = 500 # grown from the source's 200 GB (resized after the clone)
-    datastore_id = 14
-    storage_type = 1
-  }
+  volumes = [
+    {
+      name         = "root"
+      root_volume  = true
+      size         = 50 # grown from the source's 40 GB
+      datastore_id = 12
+    },
+    {
+      name         = "data"
+      size         = 500 # grown from the source's 200 GB (resized after the clone)
+      datastore_id = 14
+      storage_type = 1
+    }
+  ]
 
-  network_interfaces {
-    network_id = 7
-    ip_mode    = "" # IP pool - the clone gets a new address
-  }
-  network_interfaces {
-    network_id = 9
-    ip_mode    = "dhcp"
-  }
+  network_interfaces = [
+    {
+      network_id = 7
+      ip_mode    = "" # IP pool - the clone gets a new address
+    },
+    {
+      network_id = 9
+      ip_mode    = "dhcp"
+    }
+  ]
 }
 ```
 
@@ -128,16 +132,20 @@ resource "hpe_morpheus_instance_clone" "dr_copy" {
   group_id           = 3
   cloud_id           = 5 # the networks below must exist in this cloud
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
 
-  network_interfaces {
-    network_id = 21
-    ip_mode    = ""
-  }
+  network_interfaces = [
+    {
+      network_id = 21
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -155,15 +163,19 @@ resource "hpe_morpheus_instance_clone" "vmware" {
     vmware_folder_id      = "group-v10"
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
-  network_interfaces {
-    network_id = 7
-    ip_mode    = ""
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 7
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -186,15 +198,19 @@ resource "hpe_morpheus_instance_clone" "aws" {
     }
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 30
-  }
-  network_interfaces {
-    network_id = 11
-    ip_mode    = "dhcp"
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 30
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 11
+      ip_mode    = "dhcp"
+    }
+  ]
 }
 ```
 
@@ -213,15 +229,19 @@ resource "hpe_morpheus_instance_clone" "azure" {
     availability_zone    = "1"
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
-  network_interfaces {
-    network_id = 31
-    ip_mode    = ""
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 31
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -239,15 +259,19 @@ resource "hpe_morpheus_instance_clone" "hvm" {
     kvm_host_id           = 4
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
-  network_interfaces {
-    network_id = 41
-    ip_mode    = ""
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 41
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
@@ -271,19 +295,40 @@ resource "hpe_morpheus_instance_clone" "generic" {
     }
   }
 
-  volumes {
-    name        = "root"
-    root_volume = true
-    size        = 40
-  }
-  network_interfaces {
-    network_id = 51
-    ip_mode    = ""
-  }
+  volumes = [
+    {
+      name        = "root"
+      root_volume = true
+      size        = 40
+    }
+  ]
+  network_interfaces = [
+    {
+      network_id = 51
+      ip_mode    = ""
+    }
+  ]
 }
 ```
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Notes
+
+### Write-Only Attributes
+
+`source_instance_id` is **write-only**. It is sent to the Morpheus API when the
+clone is created, but the API never returns it, so it is never stored in
+Terraform state and Terraform cannot detect drift in it.
+
+The clone source is only meaningful at creation time and **cannot be changed
+after the instance exists**. Editing `source_instance_id` produces no plan diff
+and has no effect on the existing instance; to clone from a different source,
+create a new resource. The `source_instance_id_version` companion exists so a
+value may be supplied without error (for example by migration tooling), but
+incrementing it likewise has no effect.
+
+Write-only attributes require Terraform >= 1.11.
 
 ## Import
 

--- a/templates/resources/morpheus_load_balancer.md.tmpl
+++ b/templates/resources/morpheus_load_balancer.md.tmpl
@@ -22,6 +22,23 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
+## Notes
+
+### Write-Only Attributes
+
+`group_id` and `network_server_id` are **write-only**. They are sent to the
+Morpheus API when the load balancer is created, but the API never returns them,
+so they are never stored in Terraform state and Terraform cannot detect drift in
+them.
+
+Because the values are not in state, editing one of them on its own produces
+**no plan diff**. To push a new value, increment the matching companion --
+`group_id_version` or `network_server_id_version`. Both companions **force
+replacement** of the load balancer, because neither underlying value can be
+changed on an existing load balancer.
+
+Write-only attributes require Terraform >= 1.11.
+
 ## Import
 
 Load balancers can be imported using the load balancer ID, e.g.

--- a/templates/resources/morpheus_network_router_nat.md.tmpl
+++ b/templates/resources/morpheus_network_router_nat.md.tmpl
@@ -14,6 +14,28 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
+## Notes
+
+### Write-Only Attributes
+
+`action`, `firewall` and `service` are **write-only**. They are sent to the
+Morpheus API when the NAT rule is created or updated, but the API never returns
+them, so they are never stored in Terraform state and Terraform cannot detect
+drift in them.
+
+Because the values are not in state, editing one of them on its own produces
+**no plan diff**. To push a new value, increment the matching companion --
+`action_version`, `firewall_version` or `service_version`. Incrementing a
+companion triggers an in-place update of the NAT rule; none of them force
+replacement.
+
+If `firewall` is omitted on create, `MATCH_INTERNAL_ADDRESS` is sent, because
+the underlying API field is required. On update an omitted `firewall` is left
+out of the payload entirely, so the value already configured on the router is
+preserved rather than overwritten.
+
+Write-only attributes require Terraform >= 1.11.
+
 ## Import
 
 Import is supported using `router_id.nat_id`.

--- a/utils/validators/requires_non_empty_string_also_requires_int64_at.go
+++ b/utils/validators/requires_non_empty_string_also_requires_int64_at.go
@@ -51,7 +51,7 @@ func (v RequiresNonEmptyStringAlsoRequiresInt64AtValidator) ValidateString(
 		return
 	}
 
-	if siblingValue.IsNull() || siblingValue.IsUnknown() {
+	if siblingValue.IsNull() {
 		response.Diagnostics.Append(
 			diag.NewAttributeErrorDiagnostic(
 				request.Path,

--- a/utils/validators/requires_non_zero_int64_at.go
+++ b/utils/validators/requires_non_zero_int64_at.go
@@ -37,6 +37,13 @@ func (v RequiresNonZeroInt64AtValidator) ValidateInt64(
 		return
 	}
 
+	// 0 is a sentinel meaning "not configured" for reference-ID fields
+	// (e.g., ssl_client_profile = 0 means no SSL profile is assigned).
+	// Treat it the same as null — don't require the sibling attribute.
+	if request.ConfigValue.ValueInt64() == 0 {
+		return
+	}
+
 	var refValue types.Int64
 	diags := request.Config.GetAttribute(ctx, path.Root(v.AttributeName), &refValue)
 	response.Diagnostics.Append(diags...)


### PR DESCRIPTION
Fixes state inconsistencies discovered during end-to-end testing of `hpegl_vmaas_*` → `hpe_morpheus_*` migration. After migrating HCL config and running `terraform apply` with `import` blocks, several resources hit Read-vs-plan consistency errors that blocked the apply. These are all cases where the Morpheus API returns values that don't align with what the Terraform plan expects.

**Migration test result:** 16 resources imported (instance, instance\_clone, load\_balancer, 3 LB profiles, 2 LB monitors, LB pool, virtual\_server, network, network\_router, BGP neighbor, NAT rule, static route, firewall rule group) — 0 add, 0 destroy, 0 replacements.

## Validator fixes

### `RequiresNonEmptyStringAlsoRequiresInt64At`

Removed `IsUnknown()` from the null-or-unknown guard. During import, sibling attributes resolve as Unknown (the framework hasn't populated them yet). Treating Unknown the same as null caused the validator to fire incorrectly on import, blocking resources like NAT rules where `action` is write-only and the sibling attribute is legitimately set.

### `RequiresNonZeroInt64At`

Added a `== 0` early return. Reference-ID fields like `ssl_client_profile` and `ssl_server_profile` use `0` as a sentinel meaning "not configured." The migrated HCL correctly carries `ssl_client_profile = 0` from the old provider state, but the validator was treating `0` the same as a real value and requiring the sibling attribute to be set.

## Virtual server `vip_type` — UseStateForUnknown

`vip_type` is `Computed` + `Optional` with `RequiresReplace`. During import, the API returns the real value (e.g., `null` for NSX-T), but without `UseStateForUnknown` the plan phase re-resolves it as Unknown on subsequent applies, creating a perpetual diff that triggers replacement. Added `UseStateForUnknown` to the plan modifier list so the state value is preserved across plan cycles. The codegen config (`config.yaml`) was updated with `state_for_unknown: true`.

## Instance `network_interfaces` — Read consistency for `network_type_id` and `ip_mode`

The instance Read function has two code paths for populating `network_interfaces`: one from `instance.Interfaces` (used during import) and one from `server.interfaces` (used during normal CRUD). These return different subsets of fields:

- **`network_type_id`**: Present on `instance.Interfaces` but missing from `server.interfaces`. After import, subsequent reads via the server path returned null, causing `was 8, but now null`.
- **`ip_mode`**: The Morpheus API omits `ipMode` from the JSON response entirely when it's empty/unset — in *both* response paths. Both SDK models have `IpMode *string`, so both produce `types.StringNull()`. But the schema declares `Default: stringdefault.StaticString("")`, so the plan always has `ip_mode = ""`. The mismatch caused `was "", but now null`.

**Fix:** Added a gap-fill loop after the server-path read that copies `NetworkTypeId` from the instance-level response when the server response has null. For `IpMode`, since both API paths omit it, the gap-fill also defaults null to `""` to match the schema default.

## Load balancer profile `tags` — Computed + null guard

The LB profile `tags` attribute had two issues:

1. **Schema:** `tags` was `Optional`-only but the Morpheus API populates tags server-side (NSX-T injects sentinel entries like `{name:"",value:""}` even when no tags were configured). Made it `Computed` + `Optional` in the codegen config so the provider is allowed to set it.

2. **Read null guard:** When the user never configured tags (prior state is null), the Read function was calling `readTagsFromConfig` which returned API-injected sentinels, creating a perpetual diff. Added a guard: if `prior.Tags.IsNull()`, return `types.SetNull(...)` instead of reading from the API response. This also avoids surfacing an upstream Morpheus API bug where NSX-T tag CRUD sends `{name,value}` instead of `{scope,tag}`, causing 400 errors on any profile create/update that includes tags.

## Virtual server `vip_hostname` — Coerce empty string to null

`vip_hostname` is `Optional`-only (not `Computed`). The migrated HCL doesn't set `vip_hostname` (it wasn't configured in the old provider). The plan resolves it to null. But the Morpheus API returns `""` for an empty hostname, and `convert.StrToType` converts that to `types.StringValue("")`. Since the attribute isn't `Computed`, the framework rejects a provider-driven change from null to `""`.

**Fix:** Inline coercion in Read — when the API returns nil or `""`, return `types.StringNull()` instead. An empty hostname is semantically "not set."

## Known remaining issue

**Instance clone Update** — The `instanceclone` Update function unconditionally calls the `ResizeInstance` API on every update, regardless of what actually changed. Unlike the `instance` resource (which has `isAPIUpdateNeeded` guards, plan-vs-state volume comparison, and a separate `UpdateInstance` call for metadata), the clone Update has no such logic. Any diff — even a name change or computed field resolution — triggers a resize, which returns a Morpheus 500 error. This is a pre-existing provider bug unrelated to migration; the migration works around it by stripping attributes that would cause diffs (via cleanup config). A proper fix requires rewriting the clone Update function to match the instance Update's pattern.
