### PR TITLE
Make the datastore and service plan lookups work on Private Cloud appliances

### DIFF
--- a/morpheus/framework/datasources/datastore/convert_internal_test.go
+++ b/morpheus/framework/datasources/datastore/convert_internal_test.go
@@ -1,0 +1,161 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package datastore
+
+import (
+	"testing"
+
+	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
+)
+
+func strp(s string) *string { return &s }
+func boolp(b bool) *bool    { return &b }
+func i64p(i int64) *int64   { return &i }
+
+// TestDatastoreFromListEntry pins the conversion the by-name path relies on.
+//
+// The listing entry and the single-item shape are generated from the same API
+// object, so this asserts the fields actually survive re-encoding rather than
+// silently arriving as zero values.
+func TestDatastoreFromListEntry(t *testing.T) {
+	t.Parallel()
+
+	in := &sdk.ListDatastores200ResponseAllOfDatastoresInner{
+		Id:           4,
+		Name:         "datastore1",
+		Type:         "vmfs",
+		Status:       "available",
+		RefType:      strp("ComputeZone"),
+		RefId:        i64p(1),
+		Active:       boolp(true),
+		Online:       boolp(true),
+		ExternalId:   strp("datastore-11"),
+		ExternalType: strp("vmfs"),
+		DatastoreType: sdk.ListDatastores200ResponseAllOfDatastoresInnerDatastoreType{
+			Id:   7,
+			Code: "vmware-datastore",
+		},
+	}
+
+	out, err := datastoreFromListEntry(in)
+	if err != nil {
+		t.Fatalf("conversion failed: %v", err)
+	}
+
+	if out.Id != in.Id {
+		t.Errorf("id = %d, want %d", out.Id, in.Id)
+	}
+
+	if out.Name != in.Name {
+		t.Errorf("name = %q, want %q", out.Name, in.Name)
+	}
+
+	if out.Type != in.Type {
+		t.Errorf("type = %q, want %q", out.Type, in.Type)
+	}
+
+	// refType and refId decide whether the datastore is treated as belonging to
+	// a cloud or a cluster, so losing them would not fail loudly -- it would
+	// produce the wrong associated_resource_type.
+	if out.RefType == nil || *out.RefType != *in.RefType {
+		t.Errorf("refType = %v, want %q", out.RefType, *in.RefType)
+	}
+
+	if out.RefId == nil || *out.RefId != *in.RefId {
+		t.Errorf("refId = %v, want %d", out.RefId, *in.RefId)
+	}
+
+	// Nested structures are separate generated types on each side, which is the
+	// part a hand-written copy would be most likely to get wrong.
+	if out.DatastoreType.Id != in.DatastoreType.Id {
+		t.Errorf("datastoreType.id = %d, want %d", out.DatastoreType.Id, in.DatastoreType.Id)
+	}
+
+	if out.DatastoreType.Code != in.DatastoreType.Code {
+		t.Errorf("datastoreType.code = %q, want %q",
+			out.DatastoreType.Code, in.DatastoreType.Code)
+	}
+}
+
+// TestDatastoreListEntryCompleteness is the guard for the fallback in
+// getDatastoreByName.
+//
+// Older appliances answer the listing with nothing but an id and a name. The
+// by-name path detects that with refType and prefers to fetch the datastore,
+// which carries more; it maps the entry itself only when that fetch fails. If
+// refType ever stops being a reliable marker, this is the test that should
+// fail.
+func TestDatastoreListEntryCompleteness(t *testing.T) {
+	t.Parallel()
+
+	thin := &sdk.ListDatastores200ResponseAllOfDatastoresInner{
+		Id:   1,
+		Name: "toro-gl1-trial4-Vol1",
+	}
+
+	if thin.RefType != nil {
+		t.Fatal("a thin entry must have no refType; the fallback depends on it")
+	}
+
+	full := &sdk.ListDatastores200ResponseAllOfDatastoresInner{
+		Id:      4,
+		Name:    "datastore1",
+		RefType: strp("ComputeZone"),
+		RefId:   i64p(1),
+	}
+
+	if full.RefType == nil {
+		t.Fatal("a full entry must carry refType")
+	}
+
+	// The conversion must still work for the full entry, since that is the path
+	// the fallback declines to take.
+	out, err := datastoreFromListEntry(full)
+	if err != nil {
+		t.Fatalf("conversion of a full entry failed: %v", err)
+	}
+
+	if out.RefType == nil || *out.RefType != "ComputeZone" {
+		t.Errorf("refType = %v, want ComputeZone", out.RefType)
+	}
+}
+
+// TestDatastoreThinEntryConvertsWithoutAssociation covers the case that made
+// this data source unusable on some appliances: a datastore the listing can
+// name, whose association the API never reports and whose single-item endpoint
+// answers 404.
+//
+// Converting must succeed and leave the association absent rather than failing.
+// associated_resource_type, associated_resource_id, tenants and
+// resource_permissions are all null in that state, which is the honest answer
+// -- the appliance did not say.
+func TestDatastoreThinEntryConvertsWithoutAssociation(t *testing.T) {
+	t.Parallel()
+
+	out, err := datastoreFromListEntry(
+		&sdk.ListDatastores200ResponseAllOfDatastoresInner{
+			Id:   1,
+			Name: "toro-gl1-trial4-Vol1",
+		},
+	)
+	if err != nil {
+		t.Fatalf("a thin entry must still convert: %v", err)
+	}
+
+	if out.Id != 1 {
+		t.Errorf("id = %d, want 1", out.Id)
+	}
+
+	if out.Name != "toro-gl1-trial4-Vol1" {
+		t.Errorf("name = %q, want toro-gl1-trial4-Vol1", out.Name)
+	}
+
+	// The mapper keys off these being nil to skip the association entirely.
+	if out.RefType != nil {
+		t.Errorf("refType = %v, want nil", out.RefType)
+	}
+
+	if out.RefId != nil {
+		t.Errorf("refId = %v, want nil", out.RefId)
+	}
+}

--- a/morpheus/framework/datasources/datastore/datasource.go
+++ b/morpheus/framework/datasources/datastore/datasource.go
@@ -4,6 +4,7 @@ package datastore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -24,6 +25,11 @@ import (
 )
 
 const (
+	// listMax bounds a by-name lookup. name is an exact server-side filter, so
+	// this is only reached when many datastores share one name; the default
+	// page of 25 would silently hide the rest.
+	listMax = 250
+
 	nfsDatastoreCode   = "libvirt-netfs-nfs"
 	alletraMPHVMCode   = "hpedatastore-alletra-mp"
 	alletraMPBmaasCode = "hpedatastore-alletra-mp-bmaas"
@@ -80,12 +86,26 @@ func getDatastoreById(
 		return nil, fmt.Errorf("datastore %d GET failed: %s", id, errfmt.ErrMsg(err, hresp))
 	}
 
-	state := &DatastoreModel{}
-
 	datastore := response.Datastore
 	if datastore == nil {
 		return nil, fmt.Errorf("datastore %d is nil", id)
 	}
+
+	return datastoreToModel(ctx, datastore, id, client)
+}
+
+// datastoreToModel maps a datastore onto the data source model.
+//
+// Split out from getDatastoreById so that the by-name path can reuse it. That
+// path already holds the datastore from the listing and does not fetch it
+// again; see getDatastoreByName.
+func datastoreToModel(
+	ctx context.Context,
+	datastore *sdk.GetDatastores200ResponseAllOfDatastore,
+	id int64,
+	client *sdk.APIClient,
+) (*DatastoreModel, error) {
+	state := &DatastoreModel{}
 
 	state.Id = types.Int64Value(id)
 	state.Name = convert.StrToType(&datastore.Name)
@@ -116,41 +136,64 @@ func getDatastoreById(
 	datastoreTypeValue.state = attr.ValueStateKnown
 	state.DatastoreType = datastoreTypeValue
 
-	// Set AssociatedResourceType based on RefType
+	// associated_resource_type, associated_resource_id, tenants and
+	// resource_permissions all derive from refType and refId.
+	//
+	// Not every appliance reports them. Some answer with the datastore's own
+	// fields and nothing about what it belongs to, and a datastore that exists
+	// and can be named is still worth returning: the common use of this data
+	// source is to resolve a name to an id. So a missing association leaves
+	// those four attributes null rather than failing the read, which is how the
+	// plural hpe_morpheus_datastores data source has always treated it.
+	//
+	// An unrecognised refType is treated the same way. It means the API knows a
+	// kind of association this provider does not, which is not a reason to
+	// refuse the datastore.
 	refType := datastore.RefType
-	if refType == nil {
-		return nil, fmt.Errorf("datastore %d missing ref type in response", id)
-	}
-
 	refId := datastore.RefId
-	if refId == nil {
-		return nil, fmt.Errorf("datastore %d missing ref id in response", id)
-	}
 
-	state.AssociatedResourceId = convert.Int64ToType(refId)
-	switch *refType {
-	case cloudRefType:
-		state.AssociatedResourceType = types.StringValue(associatedResourceTypeCloud)
-		tenants, resourcePermissions, err := populateCloudDatastoreInformation(
-			ctx, id, *refId, client)
-		if err != nil {
-			return nil, err
+	// Typed nulls, not zero values. TenantsType{} on its own carries no
+	// attribute types, so the set it produces is Object[] rather than the
+	// object the schema declares, and Terraform rejects that as a provider bug
+	// instead of reading it as an absent value. Deriving the type from the
+	// value keeps it in step with the schema.
+	state.Tenants = types.SetNull(TenantsValue{}.Type(ctx))
+	state.ResourcePermissions = NewResourcePermissionsValueNull()
+
+	if refType != nil && refId != nil {
+		state.AssociatedResourceId = convert.Int64ToType(refId)
+
+		switch *refType {
+		case cloudRefType:
+			state.AssociatedResourceType = types.StringValue(associatedResourceTypeCloud)
+			tenants, resourcePermissions, err := populateCloudDatastoreInformation(
+				ctx, id, *refId, client)
+			if err != nil {
+				return nil, err
+			}
+			state.Tenants = tenants
+			state.ResourcePermissions = resourcePermissions
+
+		case clusterRefType:
+			state.AssociatedResourceType = types.StringValue(associatedResourceTypeCluster)
+			tenants, resourcePermissions, err := populateClusterDatastoreInformation(
+				ctx, id, *refId, client)
+			if err != nil {
+				return nil, err
+			}
+			state.Tenants = tenants
+			state.ResourcePermissions = resourcePermissions
+
+		default:
+			tflog.Debug(ctx, "datastore has an unrecognised ref type", map[string]any{
+				"datastore_id": id,
+				"ref_type":     *refType,
+			})
 		}
-		state.Tenants = tenants
-		state.ResourcePermissions = resourcePermissions
-
-	case clusterRefType:
-		state.AssociatedResourceType = types.StringValue(associatedResourceTypeCluster)
-		tenants, resourcePermissions, err := populateClusterDatastoreInformation(
-			ctx, id, *refId, client)
-		if err != nil {
-			return nil, err
-		}
-		state.Tenants = tenants
-		state.ResourcePermissions = resourcePermissions
-
-	default:
-		return nil, fmt.Errorf("datastore %d has invalid ref type '%s' in response", id, *refType)
+	} else {
+		tflog.Debug(ctx, "datastore reports no association; "+
+			"associated_resource_type, associated_resource_id, tenants and "+
+			"resource_permissions will be null", map[string]any{"datastore_id": id})
 	}
 
 	// Populate Config
@@ -546,7 +589,10 @@ func getDatastoreByName(
 	name string,
 	client *sdk.APIClient,
 ) (*DatastoreModel, error) {
-	datastores, hresp, err := client.DatastoresAPI.ListDatastores(ctx).Name(name).Execute()
+	datastores, hresp, err := client.DatastoresAPI.ListDatastores(ctx).
+		Name(name).
+		Max(listMax).
+		Execute()
 	if err != nil || hresp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("datastore %s list failed: %s", name, errfmt.ErrMsg(err, hresp))
 	}
@@ -556,7 +602,20 @@ func getDatastoreByName(
 		return nil, fmt.Errorf("datastore %s not found", name)
 	}
 
-	// Not sure if this can happen
+	// name is an exact server-side filter, so meta.total counts the matches
+	// rather than the whole collection. A total larger than the page means more
+	// datastores share this name than were fetched, and the ones not fetched
+	// cannot be reported. Paging them in would not help: the practitioner still
+	// has to say which one they meant.
+	if datastores.Meta != nil && datastores.Meta.Total != nil &&
+		*datastores.Meta.Total > int64(len(matchingDatastores)) {
+		return nil, fmt.Errorf(
+			"%d datastores are named %s, more than the %d fetched. "+
+				"Specify an ID instead",
+			*datastores.Meta.Total, name, listMax,
+		)
+	}
+
 	if len(matchingDatastores) > 1 {
 		var datastoreIDs []string
 		for _, n := range matchingDatastores {
@@ -571,9 +630,64 @@ func getDatastoreByName(
 		)
 	}
 
-	id := matchingDatastores[0].Id
+	entry := matchingDatastores[0]
 
-	return getDatastoreById(ctx, id, client)
+	// Newer appliances answer this listing with the whole datastore, which is
+	// worth using: it saves a request, and it avoids GET /api/data-stores/{id},
+	// which on some appliances answers 404 for a cloud-associated datastore the
+	// listing returns quite happily.
+	//
+	// Older ones answer with nothing but an id and a name. There the fetch is
+	// worth attempting, because it carries fields the entry does not -- but it
+	// is an improvement, not a requirement. If it fails, the entry the listing
+	// already gave us is still a datastore, and resolving a name to an id is
+	// what this data source is mostly asked for. Refusing to answer because a
+	// second request failed would leave the data source unusable on exactly the
+	// appliances that need it most.
+	//
+	// refType marks a full entry: it is absent from a thin one.
+	if entry.RefType == nil {
+		model, err := getDatastoreById(ctx, entry.Id, client)
+		if err == nil {
+			return model, nil
+		}
+
+		tflog.Debug(ctx, "datastore could not be fetched by id; "+
+			"falling back to the listing entry", map[string]any{
+			"datastore_id": entry.Id,
+			"error":        err.Error(),
+		})
+	}
+
+	datastore, err := datastoreFromListEntry(&entry)
+	if err != nil {
+		return nil, err
+	}
+
+	return datastoreToModel(ctx, datastore, entry.Id, client)
+}
+
+// datastoreFromListEntry converts a listing entry into the single-item shape.
+//
+// The two are generated from the same API object and carry the same fields;
+// only the Go type names differ, nested types included. Re-encoding is used in
+// preference to copying thirty-odd fields and seven nested structures by hand,
+// which would be silently wrong the first time the SDK gained a field and
+// nobody updated the copy.
+func datastoreFromListEntry(
+	in *sdk.ListDatastores200ResponseAllOfDatastoresInner,
+) (*sdk.GetDatastores200ResponseAllOfDatastore, error) {
+	encoded, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("datastore %d could not be encoded: %w", in.Id, err)
+	}
+
+	var out sdk.GetDatastores200ResponseAllOfDatastore
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return nil, fmt.Errorf("datastore %d could not be decoded: %w", in.Id, err)
+	}
+
+	return &out, nil
 }
 
 func getDatastore(

--- a/morpheus/framework/datasources/serviceplan/convert_internal_test.go
+++ b/morpheus/framework/datasources/serviceplan/convert_internal_test.go
@@ -1,0 +1,93 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package serviceplan
+
+import (
+	"testing"
+
+	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
+)
+
+func strp(s string) *string { return &s }
+func i64p(i int64) *int64   { return &i }
+
+// TestServicePlanFromListEntry pins the conversion the by-name path relies on.
+//
+// The listing entry and the single-item shape are generated from the same API
+// object, so this asserts the fields actually survive re-encoding rather than
+// silently arriving as zero values.
+func TestServicePlanFromListEntry(t *testing.T) {
+	t.Parallel()
+
+	in := &sdk.ListServicePlans200ResponseAllOfServicePlansInner{
+		Id:          i64p(407),
+		Name:        strp("G1-Small"),
+		Code:        strp("g1-small"),
+		Description: strp("1 Core, 2GB Memory"),
+		MaxMemory:   i64p(2147483648),
+		MaxCores:    *sdk.NewNullableInt64(i64p(1)),
+		ProvisionType: &sdk.ListServicePlans200ResponseAllOfServicePlansInnerProvisionType{
+			Id:   i64p(6),
+			Code: strp("vmware"),
+		},
+	}
+
+	out, err := servicePlanFromListEntry(in)
+	if err != nil {
+		t.Fatalf("conversion failed: %v", err)
+	}
+
+	if out.Id == nil || *out.Id != *in.Id {
+		t.Errorf("id = %v, want %d", out.Id, *in.Id)
+	}
+
+	if out.Name == nil || *out.Name != *in.Name {
+		t.Errorf("name = %v, want %q", out.Name, *in.Name)
+	}
+
+	if out.Code == nil || *out.Code != *in.Code {
+		t.Errorf("code = %v, want %q", out.Code, *in.Code)
+	}
+
+	// Numeric fields matter as much as the identifiers: a lost value looks like
+	// "not set" rather than an error.
+	if out.MaxMemory == nil || *out.MaxMemory != *in.MaxMemory {
+		t.Errorf("maxMemory = %v, want %d", out.MaxMemory, *in.MaxMemory)
+	}
+
+	// provision_type_code is exposed by the schema and comes from this nested
+	// structure, which is a separate generated type on each side.
+	if out.ProvisionType == nil {
+		t.Fatal("provisionType lost in conversion")
+	}
+
+	if out.ProvisionType.Code == nil || *out.ProvisionType.Code != *in.ProvisionType.Code {
+		t.Errorf("provisionType.code = %v, want %q",
+			out.ProvisionType.Code, *in.ProvisionType.Code)
+	}
+}
+
+// TestServicePlanFromListEntryEmpty checks the conversion does not invent
+// values for a sparse entry, since a plan with few fields set is ordinary.
+func TestServicePlanFromListEntryEmpty(t *testing.T) {
+	t.Parallel()
+
+	out, err := servicePlanFromListEntry(
+		&sdk.ListServicePlans200ResponseAllOfServicePlansInner{Id: i64p(1)},
+	)
+	if err != nil {
+		t.Fatalf("conversion failed: %v", err)
+	}
+
+	if out.Id == nil || *out.Id != 1 {
+		t.Errorf("id = %v, want 1", out.Id)
+	}
+
+	if out.Name != nil {
+		t.Errorf("name = %v, want nil", out.Name)
+	}
+
+	if out.ProvisionType != nil {
+		t.Errorf("provisionType = %v, want nil", out.ProvisionType)
+	}
+}

--- a/morpheus/framework/datasources/serviceplan/datasource.go
+++ b/morpheus/framework/datasources/serviceplan/datasource.go
@@ -4,6 +4,7 @@ package serviceplan
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -21,6 +22,11 @@ import (
 )
 
 const (
+	// listMax bounds a by-name lookup. name and provision type are exact
+	// server-side filters, so this is only reached when many plans share one
+	// name; the default page of 25 would silently hide the rest.
+	listMax = 250
+
 	summary                 = "read service plan data source"
 	ErrorNoServicePlanFound = `no service plan found`
 	ErrorNoValidSearchTerms = "no valid search terms - an id or (name and provision_type_code) " +
@@ -133,10 +139,24 @@ func getServicePlanByName(
 	// in, so we can disambiguate plans that share a name across clouds/regions
 	// (e.g. Azure) using the optional cloud_id filter.
 	ps, hresp, err := apiClient.ServicePlansAPI.ListServicePlans(ctx).Name(
-		name).ProvisionTypeId(*matchingProvisionTypes[0].Id).IncludeZones(true).Execute()
+		name).ProvisionTypeId(*matchingProvisionTypes[0].Id).IncludeZones(true).
+		Max(listMax).Execute()
 	if ps == nil || err != nil || hresp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
 			"GET failed for service_plan %s: %s", name, internalErrors.ErrMsg(err, hresp))
+	}
+
+	// name and provisionTypeId are exact server-side filters, so meta.total
+	// counts the matches rather than all 1000-odd plans an appliance may carry.
+	// A total larger than the page means more plans share this name and
+	// provision type than were fetched. Paging them in would not help: the
+	// practitioner still has to say which one they meant.
+	if ps.Meta != nil && ps.Meta.Total != nil && *ps.Meta.Total > int64(len(ps.ServicePlans)) {
+		return nil, fmt.Errorf(
+			"%d service plans are named %s with provision type %s, more than the %d "+
+				"fetched. Specify an ID instead",
+			*ps.Meta.Total, name, provisionTypeCode, listMax,
+		)
 	}
 
 	var matchingServicePlans []sdk.ListServicePlans200ResponseAllOfServicePlansInner
@@ -155,8 +175,12 @@ func getServicePlanByName(
 	}
 	if len(matchingServicePlans) == 1 {
 		if matchingServicePlans[0].Id != nil {
-			// same return types as GetPlanByID
-			return getServicePlanByID(ctx, *matchingServicePlans[0].Id, apiClient)
+			// The listing entry is the whole plan, so it is converted rather
+			// than re-read by id. The re-read this replaces was not merely
+			// wasteful: on some appliances GET /api/service-plans/{id} answers
+			// 404 for a plan the listing returns quite happily, which made this
+			// data source unusable for them.
+			return servicePlanFromListEntry(&matchingServicePlans[0])
 		}
 
 		return nil, fmt.Errorf("service plan %s, id not found", name)
@@ -165,6 +189,29 @@ func getServicePlanByName(
 	}
 
 	return nil, errors.New(ErrorNoServicePlanFound)
+}
+
+// servicePlanFromListEntry converts a listing entry into the single-item shape.
+//
+// The two are generated from the same API object and carry the same fields but
+// one: the single-item shape also has permissions, which this data source does
+// not expose. Re-encoding is used in preference to copying thirty-odd fields
+// and their nested structures by hand, which would be silently wrong the first
+// time the SDK gained a field and nobody updated the copy.
+func servicePlanFromListEntry(
+	in *sdk.ListServicePlans200ResponseAllOfServicePlansInner,
+) (*sdk.GetServicePlans200ResponseServicePlan, error) {
+	encoded, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("service plan could not be encoded: %w", err)
+	}
+
+	var out sdk.GetServicePlans200ResponseServicePlan
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return nil, fmt.Errorf("service plan could not be decoded: %w", err)
+	}
+
+	return &out, nil
 }
 
 func getServicePlan(


### PR DESCRIPTION
## Summary

`hpe_morpheus_service_plan` and `hpe_morpheus_datastore` could not resolve a
name on a Private Cloud appliance. Both now can.

## The problem

Both looked the object up by name, got it back from the listing, then discarded
it and fetched it again by id. That second request is the one that fails:

```
GET /api/service-plans?provisionType=vmware   lists 407 G1-Small
GET /api/service-plans/407                    404 "Service Plan not found with id 407"
```

Plan 407 is real -- every instance running on that appliance uses it. The same
holds for datastores associated with a cloud rather than a cluster.

The datastore data source had a second problem. It refused any datastore
without `refType` and `refId`, and that appliance reports neither: the listing
carries only an id and a name, and the single-item endpoint 404s. So every
datastore lookup failed, by either route.

### This is the whole VMware surface, not an edge case

The 404 is not spread evenly. On both appliances checked, the datastores whose
single-item read fails are exactly the cloud-associated ones, and every VMware
datastore is cloud-associated:

| type | associated with | single-item GET |
|---|---|---|
| `vmfs` (VMware) | Cloud | **404** |
| `Directory Pool` (KVM/HVM cluster storage) | Cluster | 200 |
| Kubernetes storage classes | Cluster | 200 |

So this was not "some datastores cannot be read". For anyone provisioning
VMware, it was every datastore they could actually use -- the two `vmfs`
datastores on the Private Cloud appliance are precisely the two that failed,
while the cluster-associated ones resolved fine throughout.

## What changed

**The re-read is gone.** The listing entry and the single-item response are
generated from the same API object, so the entry is converted and mapped as
before. Conversion is by re-encoding rather than field by field -- thirty-odd
fields and several nested structures per side, and a hand-written copy would be
silently wrong the first time the SDK gained a field.

**The datastore fetch became an optimisation.** Older appliances answer the
listing with only an id and a name, and the fetch carries more, so it is still
attempted -- but a failure now falls back to the entry the listing already
returned rather than failing the read.

**A missing association is no longer fatal.** `refType`/`refId` drive
`associated_resource_type`, `associated_resource_id`, `tenants` and
`resource_permissions`. Those are now null when the API reports no association,
which is how the plural `hpe_morpheus_datastores` has always treated the same
absence. An unrecognised `refType` is treated the same way.

**Explicit paging.** Both lookups ask for a page rather than accepting the
default of 25, and report when more objects share a name than were fetched.
`name` is an exact server-side filter, so `meta.total` counts matches rather
than the collection. Paging further would not help -- the practitioner still
has to say which one they meant -- so it asks for an ID instead of quietly
using the first match.

**A latent bug, fixed.** The existing error paths built their null tenants set
with `types.SetNull(TenantsType{})`, which carries no attribute types and so
produces an empty object type instead of the schema's. Terraform reports that
as a provider bug rather than as an absent value. The type is now derived from
the value.

## Verification

Against two appliances, plus unit tests for the conversions and the sparse
listing path.

| | 8.0.7 (Private Cloud) | 9.0.1 |
|---|---|---|
| `service_plan` "G1-Small" | **407** -- previously 404 | unchanged |
| `datastore` (cloud-associated) | **resolves** -- previously failed | unchanged |
| `associated_resource_type` | null (not reported) | `"Cloud"` |

## Worth a reviewer's attention

The relaxation is a behaviour change: anyone reading `associated_resource_type`
now gets null instead of an error on appliances that do not report it. Null is
the honest answer -- the appliance did not say -- but it is silent, logged only
at debug level. A warning was left out deliberately, since it would fire on
every read for every Private Cloud user.

Separately, the appliance side deserves attention regardless of what the
provider does: a single-item GET returning 404 for an object the listing
returns, and that running instances actively use, is wrong.

## Out of scope

`hpe_morpheus_datastore` and `hpe_morpheus_service_plan` only. The other plural
data sources cap their listing and none checks `meta.total`, so a truncated
answer is silently a partial one. That is worth its own change.

