### PR TITLE
Stop an imported instance planning changes nobody made

### DIFF
--- a/morpheus/framework/resources/instance/instance_read.go
+++ b/morpheus/framework/resources/instance/instance_read.go
@@ -970,16 +970,25 @@ func getNoAgent(
 	return nil, diags
 }
 
+// nestedVirtualizationDefault mirrors the schema default for
+// config_vmware.nested_virtualization and config_hvm.nested_virtualization.
+var nestedVirtualizationDefault = "off"
+
 func getNestedVirtualization(
 	id int64,
 	apiConfig *apiConfigType,
 ) (*string, diag.Diagnostics) {
-	// nestedVirtualization is optional: hpegl never sets it, so Morpheus omits
-	// it from the GET response entirely (IsSet() == false).  Treat absence as
-	// nil rather than an error — the caller passes nil to convert.StrToType
-	// which produces a null value, valid for this Optional+Computed attribute.
+	// nestedVirtualization is optional and Morpheus omits it from the GET
+	// response entirely when it was never set (IsSet() == false).
+	//
+	// Absence resolves to the schema default rather than to nil. The attribute
+	// is Optional+Computed with a default of "off", so a configuration that
+	// leaves it out plans "off"; returning nil would put null in state, and
+	// null against "off" is a change Terraform acts on. On an instance that
+	// means a permanent diff on config_vmware after import, for an attribute
+	// nobody set. Same reasoning as ipModeOrDefault.
 	if !apiConfig.NestedVirtualization.IsSet() {
-		return nil, nil
+		return &nestedVirtualizationDefault, nil
 	}
 
 	return apiConfig.NestedVirtualization.Get(), nil
@@ -1720,6 +1729,27 @@ func getConnectionInfo(
 }
 
 // getStateInterfaces get the interfaces to be returned as state entries
+// ipModeOrDefault converts an API ip_mode into state, substituting the schema
+// default for an absent value.
+//
+// The API omits ipMode from interface responses when it is unset, which arrives
+// as nil and would otherwise become null. The schema declares ip_mode as
+// Optional+Computed with a default of "", so a configuration that leaves it out
+// plans "" -- and null in state against "" in the plan is a change Terraform
+// will act on. On an instance that means a diff on network_interfaces, which
+// before appliance 8.1.2 forces the instance to be replaced.
+//
+// Normalising here rather than in one caller keeps every path consistent: the
+// import path returns interfaces straight from the instance response and never
+// reaches the server/instance merge, which is where this was previously handled.
+func ipModeOrDefault(apiValue *string) basetypes.StringValue {
+	if apiValue == nil {
+		return types.StringValue("")
+	}
+
+	return convert.StrToType(apiValue)
+}
+
 func getStateInterfaces(
 	ctx context.Context,
 	instance sdk.GetInstance200ResponseInstance,
@@ -1759,12 +1789,6 @@ func getStateInterfaces(
 		}
 		if intfsFromServer[i].IpMode.IsNull() || intfsFromServer[i].IpMode.IsUnknown() {
 			intfsFromServer[i].IpMode = intfsFromInstance[i].IpMode
-		}
-		// IpMode: the API omits ipMode from both instance-level and server-level
-		// interface responses when it is empty/unset, producing null in both paths.
-		// Fall back to the schema default ("") to stay consistent with the plan.
-		if intfsFromServer[i].IpMode.IsNull() {
-			intfsFromServer[i].IpMode = types.StringValue("")
 		}
 	}
 
@@ -1842,7 +1866,7 @@ func getStateInterfacesFromInstance(
 		ifaceVal := NetworkInterfacesValue{}
 		ifaceVal.Id = types.Int64Null()
 		ifaceVal.IpAddress = convert.StrToType(instIntf.IpAddress)
-		ifaceVal.IpMode = convert.StrToType(instIntf.IpMode)
+		ifaceVal.IpMode = ipModeOrDefault(instIntf.IpMode)
 		ifaceVal.PrimaryInterface = types.BoolNull()
 		ifaceVal.Name = types.StringNull()
 		ifaceVal.NetworkId = types.Int64Null()
@@ -1894,7 +1918,7 @@ func getInstanceInterfacesChildNetworks(
 		ifaceVal := ChildVirtualNetworksValue{}
 		ifaceVal.Id = types.Int64Null()
 		ifaceVal.IpAddress = convert.StrToType(instIntf.IpAddress)
-		ifaceVal.IpMode = convert.StrToType(instIntf.IpMode)
+		ifaceVal.IpMode = ipModeOrDefault(instIntf.IpMode)
 		ifaceVal.PrimaryInterface = types.BoolNull()
 		ifaceVal.Name = types.StringNull()
 		ifaceVal.NetworkId = types.Int64Null()
@@ -1945,7 +1969,7 @@ func getStateInterfacesFromInstanceServer(
 		ifaceVal := NetworkInterfacesValue{}
 		ifaceVal.Id = convert.Int64ToType(iface.Id)
 		ifaceVal.IpAddress = convert.StrToType(iface.IpAddress)
-		ifaceVal.IpMode = convert.StrToType(iface.IpMode)
+		ifaceVal.IpMode = ipModeOrDefault(iface.IpMode)
 		ifaceVal.NetworkGroupId = types.Int64Null()
 		if iface.NetworkGroup != nil {
 			ifaceVal.NetworkGroupId = convert.Int64ToType(iface.NetworkGroup.Id)
@@ -2136,7 +2160,7 @@ func getChildNetworks(
 		}
 		ifaceVal.Id = convert.Int64ToType(iface.Id)
 		ifaceVal.IpAddress = convert.StrToType(iface.IpAddress)
-		ifaceVal.IpMode = convert.StrToType(iface.IpMode)
+		ifaceVal.IpMode = ipModeOrDefault(iface.IpMode)
 		ifaceVal.NetworkGroupId = types.Int64Null()
 		if iface.NetworkGroup != nil {
 			ifaceVal.NetworkGroupId = convert.Int64ToType(iface.NetworkGroup.Id)

--- a/morpheus/framework/resources/instance/resource.go
+++ b/morpheus/framework/resources/instance/resource.go
@@ -12,9 +12,9 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/cenkalti/backoff/v5"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/HPE/terraform-provider-hpe/morpheus/configure"
 	"github.com/HPE/terraform-provider-hpe/morpheus/utils/versioncheck"
@@ -114,8 +114,8 @@ func (g *Resource) ModifyPlan(
 	// Check for network updates that require a resource replacement
 	networkConstraint := &morpheusConstraint{
 		morphVersion: morphVersion,
-		plan:         plan.NetworkInterfaces,
-		state:        state.NetworkInterfaces,
+		planRaw:      resp.Plan.Raw,
+		stateRaw:     req.State.Raw,
 		constraint:   ">= 8.1.2",
 		hclAttribute: "network_interfaces",
 		mnemonic:     "network",
@@ -125,8 +125,8 @@ func (g *Resource) ModifyPlan(
 	// Check for service plan options updates that require a resource replacement
 	servicePlanOptionsConstraint := &morpheusConstraint{
 		morphVersion: morphVersion,
-		plan:         plan.ServicePlanOptions,
-		state:        state.ServicePlanOptions,
+		planRaw:      resp.Plan.Raw,
+		stateRaw:     req.State.Raw,
 		constraint:   ">= 8.1.2",
 		hclAttribute: "service_plan_options",
 		mnemonic:     "Service Plan Options",
@@ -136,8 +136,8 @@ func (g *Resource) ModifyPlan(
 
 type morpheusConstraint struct {
 	morphVersion *versioncheck.Version
-	plan         attr.Value
-	state        attr.Value
+	planRaw      tftypes.Value
+	stateRaw     tftypes.Value
 	constraint   string
 	hclAttribute string
 	mnemonic     string
@@ -146,8 +146,19 @@ type morpheusConstraint struct {
 func (m *morpheusConstraint) checkForAttributeUpdate(
 	resp *resource.ModifyPlanResponse,
 ) {
-	// Has there been a change in the "shape" of the attribute?
-	if m.plan.Equal(m.state) {
+	// Has the practitioner changed the shape of the attribute?
+	//
+	// Unknowns are filled from prior state before comparing, which is how
+	// restoreUnchangedComputedAttributes already decides whether a collection
+	// was touched. The two are now consistent.
+	//
+	// A strict comparison counted the framework's own "(known after apply)"
+	// placeholders as a change. The framework marks every null computed
+	// attribute unknown whenever anything in the resource differs, so editing
+	// an unrelated attribute left the interface and volume collections unknown
+	// and looked like a reconfiguration -- forcing a replacement, on appliances
+	// below the constraint, of an instance whose networking nobody had touched.
+	if !attributeChanged(m.planRaw, m.stateRaw, m.hclAttribute) {
 		return
 	}
 


### PR DESCRIPTION
## Summary

Importing an instance and planning it reported changes nobody had made, and on
appliances before 8.1.2 escalated them to a replacement -- destroying and
recreating a running VM.

## The problem

Two attributes declare a schema default the read path could not produce:

| attribute | schema default | read path produced |
|---|---|---|
| `network_interfaces[].ip_mode` | `""` | `null` |
| `config_vmware.nested_virtualization` | `"off"` | `null` |

The API omits both when they were never set. Null in state against a default in
the plan is a change Terraform acts on, so the diff could never settle. On
`network_interfaces` that meets the `>= 8.1.2` constraint, which turns a
cosmetic difference into `1 to destroy`.

`ip_mode` was already handled -- but in one caller rather than at the source.
The normalisation sat in the loop that merges server and instance interfaces,
and the import path returns before reaching it:

```go
// If this is an import, then return intfsFromInstance
if plan.Name.IsNull() || plan.Name.IsUnknown() {
    return intfsFromInstance, diags
}
```

`nested_virtualization` had no normalisation at all. Its comment reasoned that
null was *"valid for this Optional+Computed attribute"*, which overlooked the
default.

## What changed

**Both are resolved where the value is built**, so every caller sees the same
thing regardless of path. The special case in the merge loop is gone rather
than duplicated.

**The version constraint now compares the way the plan modifiers already do.**
`checkForAttributeUpdate` compared plan against state strictly, while
`restoreUnchangedComputedAttributes` deliberately fills unknowns from state
first. The framework marks every null computed attribute unknown whenever
anything in the resource differs, so editing an unrelated attribute left the
interface and volume collections unknown and looked like a reconfiguration. The
two are now consistent.

## Verification

Against a Private Cloud appliance at 8.0.7, which is below the constraint and so
shows the worst case:

| | before | after |
|---|---|---|
| plan after import | `1 to import, 1 to add, 1 to destroy` | `1 to import, 0 to add, 0 to change, 0 to destroy` |
| plan after apply | — | `No changes` |

Found while migrating a configuration from the hpegl provider, but it is not
specific to that: `terraform import` followed by `terraform plan` showed the
same diff.

## Worth a reviewer's attention

The version-gate change is the one to scrutinise. It makes a replacement less
likely, which is the safe direction, but it means a genuine reconfiguration
must now differ in a *known* value to trigger the constraint. That is the
intent -- unknowns carry no practitioner intent -- and it matches the reasoning
already documented in `instance_plan_modifiers.go`.

## Out of scope

`hpe_morpheus_instance` declares 17 schema defaults. Two are fixed here; the
rest (`create_user`, `no_agent`, `public_ip_type`, `instance_profile`,
`enforce_raid_boot_volume`, `wait_for_ip_address`) have not been checked for the
same shape, and the pattern is not confined to this resource. Any attribute with
a schema default whose read path can write null will diff after import. That
sweep deserves its own change.
