### PR TITLE
Make space required in the pce_identity block

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -657,6 +657,7 @@ Optional:
 Required:
 
 - `location` (String) The PCE instance's Location.
+- `space` (String) The name of the GreenLake Space that the PCE instance is in.
 
 Optional:
 
@@ -665,7 +666,6 @@ Optional:
 - `client_secret` (String, Sensitive) GreenLake API client secret used for authentication.
 - `iam_token` (String, Sensitive) GreenLake IAM access token. If set, token generation from credentials is skipped.
 - `issuer_url` (String) GreenLake IAM Issuer URL used to generate access tokens. This should be set to the "Issuer" URL of the API client.
-- `space` (String) The name of the GreenLake Space that the PCE instance is in.
 
 
 

--- a/morpheus/provider.go
+++ b/morpheus/provider.go
@@ -239,7 +239,7 @@ func (p *MorpheusProvider) Schema(ctx context.Context, req provider.SchemaReques
 						},
 						"space": schema.StringAttribute{
 							Description: "The name of the GreenLake Space that the PCE instance is in.",
-							Optional:    true,
+							Required:    true,
 						},
 						"issuer_url": schema.StringAttribute{
 							Description: `GreenLake IAM Issuer URL used to generate access tokens. ` +

--- a/morpheus/provider_identity_test.go
+++ b/morpheus/provider_identity_test.go
@@ -255,6 +255,7 @@ func TestValidateProviderConfigRejectsIdentityBlockWithDirectURL(t *testing.T) {
 				"pce_identity": identityBlockValue(t, obj, absent, "pce_identity", map[string]string{
 					"iam_token": "token",
 					"location":  "site-a",
+					"space":     "space",
 				}),
 			}
 		})
@@ -281,6 +282,7 @@ func TestValidateProviderConfigRejectsBothIdentityBlocks(t *testing.T) {
 				"pce_identity": identityBlockValue(t, obj, absent, "pce_identity", map[string]string{
 					"iam_token": "token",
 					"location":  "site-a",
+					"space":     "space",
 				}),
 				"pce_disconnected_identity": identityBlockValue(t, obj, absent, "pce_disconnected_identity",
 					map[string]string{
@@ -316,6 +318,7 @@ func TestValidateProviderConfigIgnoresUnknownConnectionDetails(t *testing.T) {
 				"pce_identity": identityBlockValue(t, obj, absent, "pce_identity", map[string]string{
 					"iam_token": "token",
 					"location":  "site-a",
+					"space":     "space",
 				}),
 			}
 		})
@@ -331,6 +334,10 @@ func TestValidateProviderConfigIgnoresUnknownConnectionDetails(t *testing.T) {
 func identityBlockAttrs(block string) map[string]string {
 	attrs := map[string]string{
 		"location": "site-a",
+	}
+
+	if block == "pce_identity" {
+		attrs["space"] = "space"
 	}
 
 	if block == "pce_disconnected_identity" {

--- a/morpheus/provider_schema_parity_test.go
+++ b/morpheus/provider_schema_parity_test.go
@@ -83,15 +83,17 @@ func TestIdentityBlocksDeriveMaxItems(t *testing.T) {
 
 // Both identity blocks need a location: the broker resolves it to a service
 // instance and to the zone that the returned token's roles are granted against,
-// and rejects a request without one. The disconnected block additionally has no
-// HPE hosted broker to fall back to and no implicit workspace.
+// and rejects a request without one. Each block also needs whatever scopes its
+// broker request: the connected block a space, the disconnected block a
+// workspace. The disconnected block additionally has no HPE hosted broker to
+// fall back to.
 func TestIdentityRequiredAttributesSurviveConversion(t *testing.T) {
 	tests := map[string]map[string]bool{
 		"pce_identity": {
 			"location":      true,
+			"space":         true,
 			"client_id":     false,
 			"client_secret": false,
-			"space":         false,
 			"issuer_url":    false,
 			"iam_token":     false,
 			"broker_url":    false,

--- a/morpheus/sdkv2/provider.go
+++ b/morpheus/sdkv2/provider.go
@@ -336,7 +336,7 @@ func providerSchemaMorpheus() *schema.Schema {
 
 							"space": {
 								Type:        schema.TypeString,
-								Optional:    true,
+								Required:    true,
 								Description: "The name of the GreenLake Space that the PCE instance is in.",
 							},
 


### PR DESCRIPTION
## Summary

`space` in the `pce_identity` block of the `morpheus` provider block is now **required**. It was optional.

`space` names the GreenLake Space that the PCE instance is in, and scopes the broker lookup that resolves the Morpheus URL and access token. Left unset, the lookup went out unscoped, so a block could satisfy the schema while under-specifying which instance it meant. The Disconnected block already requires its equivalent, `workspace_id`.

## Changes

- `morpheus/provider.go` — framework schema: `space` is `Required` rather than `Optional`
- `morpheus/sdkv2/provider.go` — the same change in the hand-written SDKv2 mirror. The two providers are muxed and Terraform requires their schemas to be identical, so both have to move together
- `morpheus/provider_schema_parity_test.go` — required-attribute expectation updated, and the comment now explains that each identity block requires whatever scopes its broker request
- `morpheus/provider_identity_test.go` — the `pce_identity` fixtures set `space`, so they stay configurations a user could actually write
- `docs/index.md` — regenerated: `space` moves from Optional to Required under `morpheus.pce_identity`

Both published `pce_identity` examples already set `space`, so no example changed and `TestPublishedIdentityExamplesAreValid` passes unmodified.

## Impact

This is a schema-breaking change for a configuration that omits `space`, which will now fail at `terraform validate` with a missing required argument. PCE Identity has not shipped in a release yet, so no existing user configuration is affected.

## Testing

- `go build ./...`
- `go test ./morpheus/ -run 'TestIdentity|TestHandWritten|TestValidateProviderConfig|TestPublished'`
- `go test ./morpheus/sdkv2/ ./morpheus/pce/... ./utils/convert/`
- `make lint` — 0 issues
- `make docs` — idempotent, producing only the expected change

Note that `make unit-tests`, which is what CI runs, excludes the `morpheus` package itself, so the parity and identity tests above were run explicitly.
