### PR TITLE
Add PCE identity end-to-end auth flow acceptance test

### DIFF
--- a/morpheus/pce_identity_test.go
+++ b/morpheus/pce_identity_test.go
@@ -1,0 +1,52 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package morpheus_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers"
+	"github.com/HPE/terraform-provider-hpe/morpheus/testhelpers/capabilities"
+	"github.com/HPE/terraform-provider-hpe/provider/adapter"
+)
+
+// Test end to end the auth flow to PCE.
+func TestAccMorpheusPCEIdentityAuthFlowOk(t *testing.T) {
+	defer testhelpers.RecordResult(t)
+
+	capabilities.MustHaveOrSkip(t, capabilities.PCE)
+
+	fixture := testhelpers.RequirePceIdentityFixture(t)
+
+	dsName := "data.hpe_morpheus_cloud.test"
+	cloudName := fixture.CloudName
+
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping slow test in short mode")
+	}
+
+	providerConfig := testhelpers.ProviderBlockPceIdentity()
+
+	// We'll test we can find something using pce identity creds.
+	datasourceConfig := `
+data "hpe_morpheus_cloud" "test" {
+  name = "` + cloudName + `"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.GetAccTestFactories(t, adapter.NewMorpheus(), nil),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + datasourceConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dsName, "name", cloudName),
+					resource.TestCheckResourceAttrSet(dsName, "id"),
+				),
+			},
+		},
+	})
+}

--- a/morpheus/testhelpers/capabilities/README.md
+++ b/morpheus/testhelpers/capabilities/README.md
@@ -114,6 +114,12 @@ When `TF_ACC_CAPABILITIES` is set, tests silently return (not skip) if their req
 | `Alletra` | `alletra` | HPE Alletra storage |
 | `VDI` | `vdi` | VDI pools/apps/gateways |
 
+### Identity / Platform
+
+| Capability | Env Value | Description |
+|------------|-----------|-------------|
+| `PCE` | `pce` | A live PCE (Private Cloud Enterprise) instance reachable via GreenLake IAM. Gates the end-to-end `pce_identity` auth-flow test, which authenticates through GreenLake rather than the main appliance credentials. The test skips unless `TF_VAR_testacc_pce_identity_client_id`, `_client_secret`, `_issuer_url`, `_location`, `_space` and `TF_ACC_PCE_IDENTITY_CLOUD_NAME` are all set |
+
 ### Special Capabilities
 
 | Capability | Env Value | Description |
@@ -248,6 +254,13 @@ Exit codes:
 | `TF_VAR_testacc_morpheus_affinity_cloud_id` | ID of a cloud that supports affinity groups. Required by the `affinity_group` + `vmware` tests, which skip without it |
 | `TF_VAR_testacc_morpheus_affinity_cluster_id` | ID of an HVM cluster that supports affinity groups. Required by the `affinity_group` + `hvm` tests, which skip without it |
 | `TF_VAR_testacc_morpheus_affinity_pool_id` | ID of a resource pool of type Cluster on the cloud above. Morpheus rejects a cloud affinity group created without a pool, so the `affinity_group` + `vmware` resource tests skip without it |
+| `TF_VAR_testacc_pce_identity_client_id` | GreenLake API client ID. Required by the `pce` test |
+| `TF_VAR_testacc_pce_identity_client_secret` | GreenLake API client secret. Required by the `pce` test |
+| `TF_VAR_testacc_pce_identity_issuer_url` | GreenLake IAM issuer URL used to mint access tokens. Required by the `pce` test |
+| `TF_VAR_testacc_pce_identity_location` | PCE instance location. Required by the `pce` test — the `pce_identity` block rejects a null `location` |
+| `TF_VAR_testacc_pce_identity_space` | GreenLake space containing the PCE instance. Required by the `pce` test — the `pce_identity` block rejects a null `space` |
+| `TF_VAR_testacc_pce_identity_broker_url` | PCE broker URL override. Optional; leave unset to use the HPE-hosted cloud broker |
+| `TF_ACC_PCE_IDENTITY_CLOUD_NAME` | Name of a cloud to read back through the PCE token exchange. Required by the `pce` test; there is no default, as the reachable clouds differ per GreenLake tenant. Not a `TF_VAR_`, because the test renders it into HCL rather than passing it through a Terraform variable |
 
 ### Examples
 

--- a/morpheus/testhelpers/capabilities/capabilities.go
+++ b/morpheus/testhelpers/capabilities/capabilities.go
@@ -125,6 +125,9 @@ const (
 
 	// Bare Metal
 	Metal Capability = "metal"
+
+	// PCE - For tests against a live PCE Cloud system.
+	PCE Capability = "pce"
 )
 
 // String returns the string representation of the capability.

--- a/morpheus/testhelpers/config.go
+++ b/morpheus/testhelpers/config.go
@@ -256,3 +256,48 @@ provider "hpe" {
 func ProviderBlockUnitTest() string {
 	return providerConfigUnitTest
 }
+
+// If broker_url is null, it'll default to the cloud broker.
+// So don't set testacc_pce_identity_broker_url if we wish to test the cloud broker.
+const providerConfigPceIdentity = `
+variable "testacc_pce_identity_client_id" {
+  default = null
+}
+
+variable "testacc_pce_identity_client_secret" {
+  default = null
+}
+
+variable "testacc_pce_identity_issuer_url" {
+  default = null
+}
+
+variable "testacc_pce_identity_location" {
+  default = null
+}
+
+variable "testacc_pce_identity_space" {
+  default = null
+}
+
+variable "testacc_pce_identity_broker_url" {
+  default = null
+}
+
+provider "hpe" {
+  morpheus {
+    pce_identity {
+      client_id     = var.testacc_pce_identity_client_id
+      client_secret = var.testacc_pce_identity_client_secret
+      issuer_url    = var.testacc_pce_identity_issuer_url
+      location      = var.testacc_pce_identity_location
+      space         = var.testacc_pce_identity_space
+      broker_url    = var.testacc_pce_identity_broker_url
+    }
+  }
+}
+`
+
+func ProviderBlockPceIdentity() string {
+	return providerConfigPceIdentity
+}

--- a/morpheus/testhelpers/pce_identity_fixture.go
+++ b/morpheus/testhelpers/pce_identity_fixture.go
@@ -1,0 +1,113 @@
+// (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package testhelpers
+
+import (
+	"os"
+	"testing"
+)
+
+// The PCE identity acceptance test authenticates through GreenLake IAM rather
+// than the appliance credentials the rest of the suite uses, so it needs an API
+// client, the PCE instance it belongs to, and a cloud to read back through the
+// resulting token. None of that can be created from Terraform, so it must
+// already exist in the GreenLake tenant under test.
+//
+// The naming splits on who consumes the value. The six credentials must carry
+// the TF_VAR_ prefix: the provider block returned by ProviderBlockPceIdentity
+// declares matching Terraform variables, and Terraform reads them from the
+// environment itself. CloudName has no Terraform variable behind it -- the test
+// renders it straight into HCL -- so it takes the TF_ACC_ prefix used by the
+// NSX-T fixture.
+const (
+	EnvPceIdentityClientID = "TF_VAR_testacc_pce_identity_client_id"
+	// #nosec G101 -- environment variable name, not an embedded credential.
+	EnvPceIdentityClientSecret = "TF_VAR_testacc_pce_identity_client_secret"
+	EnvPceIdentityIssuerURL    = "TF_VAR_testacc_pce_identity_issuer_url"
+	EnvPceIdentityLocation     = "TF_VAR_testacc_pce_identity_location"
+	EnvPceIdentitySpace        = "TF_VAR_testacc_pce_identity_space"
+	EnvPceIdentityBrokerURL    = "TF_VAR_testacc_pce_identity_broker_url"
+	EnvPceIdentityCloudName    = "TF_ACC_PCE_IDENTITY_CLOUD_NAME"
+)
+
+// PceIdentityFixture identifies the GreenLake API client and PCE instance that
+// the PCE identity auth-flow test authenticates with.
+//
+// Only CloudName is rendered into HCL by the test. The credentials are consumed
+// by Terraform, which reads them from the TF_VAR_ environment directly, so the
+// remaining fields are captured to define the fixture's surface and to drive
+// the presence check in RequirePceIdentityFixture -- they are deliberately not
+// dead weight to be removed, and having them to hand means a future assertion
+// on, say, Location needs no new plumbing.
+type PceIdentityFixture struct {
+	// ClientID is the GreenLake API client used to mint an IAM token.
+	ClientID string
+	// ClientSecret is the secret for ClientID.
+	ClientSecret string
+	// IssuerURL is the GreenLake IAM issuer that mints the access token. It is
+	// the "Issuer" URL shown for the API client.
+	IssuerURL string
+	// Location is the PCE instance's location.
+	Location string
+	// Space is the GreenLake space the PCE instance sits in.
+	Space string
+	// BrokerURL overrides the PCE broker. It is optional and therefore not
+	// required by RequirePceIdentityFixture: leaving it empty selects the
+	// HPE-hosted cloud broker, which is the case worth exercising by default.
+	BrokerURL string
+	// CloudName is the name of a cloud visible through the token exchange. The
+	// test renders it into HCL and reads it via the hpe_morpheus_cloud data
+	// source to prove the exchange produced a usable Morpheus session.
+	CloudName string
+}
+
+// RequirePceIdentityFixture returns the PCE identity fixture for the GreenLake
+// tenant under test, skipping the test when it has not been configured.
+//
+// It skips rather than fails: a runner without GreenLake access is a legitimate
+// target for the rest of the suite, and turning that into a failure would train
+// people to ignore red results.
+func RequirePceIdentityFixture(t *testing.T) PceIdentityFixture {
+	t.Helper()
+
+	fixture := PceIdentityFixture{
+		ClientID:     os.Getenv(EnvPceIdentityClientID),
+		ClientSecret: os.Getenv(EnvPceIdentityClientSecret),
+		IssuerURL:    os.Getenv(EnvPceIdentityIssuerURL),
+		Location:     os.Getenv(EnvPceIdentityLocation),
+		Space:        os.Getenv(EnvPceIdentitySpace),
+		BrokerURL:    os.Getenv(EnvPceIdentityBrokerURL),
+		CloudName:    os.Getenv(EnvPceIdentityCloudName),
+	}
+
+	var missing []string
+
+	// BrokerURL is absent by design: it is optional, and an empty value is the
+	// meaningful default rather than a misconfiguration.
+	for _, v := range []struct {
+		name  string
+		value string
+	}{
+		{EnvPceIdentityClientID, fixture.ClientID},
+		{EnvPceIdentityClientSecret, fixture.ClientSecret},
+		{EnvPceIdentityIssuerURL, fixture.IssuerURL},
+		{EnvPceIdentityLocation, fixture.Location},
+		{EnvPceIdentitySpace, fixture.Space},
+		{EnvPceIdentityCloudName, fixture.CloudName},
+	} {
+		if v.value == "" {
+			missing = append(missing, v.name)
+		}
+	}
+
+	if len(missing) > 0 {
+		msg := "PCE identity fixture not configured; set:"
+		for _, name := range missing {
+			msg += " " + name
+		}
+
+		t.Skip(msg)
+	}
+
+	return fixture
+}


### PR DESCRIPTION

## Summary

Adds an acceptance test that exercises the full GreenLake IAM -> PCE broker ->
Morpheus token exchange end to end, so the `pce_identity` provider block is
covered by a live auth flow rather than by unit tests alone.

## Changes

- **New `pce` capability** (`capabilities.PCE`) gating tests that need a live
  PCE instance reachable through GreenLake IAM.
- **New `TestAccMorpheusPCEIdentityAuthFlowOk`** - configures the provider with
  a `pce_identity` block and reads a `hpe_morpheus_cloud` data source through
  the resulting session, proving the exchange produced a usable Morpheus token.
- **New `testhelpers.RequirePceIdentityFixture`** - modelled on
  `RequireNsxtFixture`. Collects the GreenLake configuration from the
  environment and skips the test naming any missing variables, so an
  environment without GreenLake access records a skip rather than a failure.
- **New `testhelpers.ProviderBlockPceIdentity`** - a provider block wired to the
  `testacc_pce_identity_*` Terraform variables.

## Configuration

| Variable | Required | Purpose |
|---|---|---|
| `TF_VAR_testacc_pce_identity_client_id` | yes | GreenLake API client ID |
| `TF_VAR_testacc_pce_identity_client_secret` | yes | GreenLake API client secret |
| `TF_VAR_testacc_pce_identity_issuer_url` | yes | GreenLake IAM issuer URL |
| `TF_VAR_testacc_pce_identity_location` | yes | PCE instance location |
| `TF_VAR_testacc_pce_identity_space` | yes | GreenLake space |
| `TF_VAR_testacc_pce_identity_broker_url` | no | Broker override; leave unset to select the HPE-hosted cloud broker |
| `TF_ACC_PCE_IDENTITY_CLOUD_NAME` | yes | Cloud to read back through the exchange |

The six credentials carry the `TF_VAR_` prefix because Terraform reads them
directly, through matching `variable` declarations in the provider block. The
cloud name has no Terraform variable behind it - the test renders it into HCL -
so it follows the `TF_ACC_*` convention already used by the NSX-T fixture.

## Notes

The fixture treats `space` as required, matching a companion change that makes
it `Required` in the `pce_identity` schema.

## Testing

- `make lint`, `go build ./...` and `go vet ./morpheus/...` all clean.
- Skip paths verified end to end: capability absent ->
  `missing required capabilities: pce`; capability present but configuration
  incomplete -> a single skip naming exactly the missing variables.
