### PR TITLE
pce_disconnected_identity: rename issuer_url to token_issuer_url

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,8 @@ For the first two the URL of the Morpheus instance must be provided as `url`.
 
 For the last two the URL and access token are obtained from GreenLake, so `url` must not be set.
 Provide a `pce_identity` or `pce_disconnected_identity` block instead, using either GreenLake API
-client credentials (`client_id`, `client_secret` and `issuer_url`) or a pre-generated `iam_token`.
+client credentials (`client_id`, `client_secret` and `issuer_url`, or `token_issuer_url` in the
+Disconnected block) or a pre-generated `iam_token`.
 The two blocks are mutually exclusive, and neither can be combined with `url`, `username`,
 `password`, `access_token` or `tenant_subdomain`.
 
@@ -223,12 +224,12 @@ provider "hpe" {
   # Provide morpheus block if you want to create morpheus resources
   morpheus {
     pce_disconnected_identity {
-      client_id     = "client_id"
-      client_secret = "client_secret"
-      issuer_url    = "https://issuer.example.com"
-      location      = "location"
-      workspace_id  = "workspace_id"
-      broker_url    = "https://broker.example.com"
+      client_id        = "client_id"
+      client_secret    = "client_secret"
+      token_issuer_url = "https://issuer.example.com"
+      location         = "location"
+      workspace_id     = "workspace_id"
+      broker_url       = "https://broker.example.com"
     }
   }
 }
@@ -648,7 +649,7 @@ Optional:
 - `client_id` (String) GreenLake API client ID used for authentication.
 - `client_secret` (String, Sensitive) GreenLake API client secret used for authentication.
 - `iam_token` (String, Sensitive) GreenLake IAM access token. If set, token generation from credentials is skipped.
-- `issuer_url` (String) GreenLake IAM Issuer URL used to generate access tokens. This should be set to the "Issuer" URL of the API client.
+- `token_issuer_url` (String) GreenLake IAM Issuer URL used to generate access tokens. This should be set to the "Issuer" URL of the API client.
 
 
 <a id="nestedblock--morpheus--pce_identity"></a>

--- a/examples/provider/morpheus/provider-pce-disconnected-identity.tf
+++ b/examples/provider/morpheus/provider-pce-disconnected-identity.tf
@@ -13,12 +13,12 @@ provider "hpe" {
   # Provide morpheus block if you want to create morpheus resources
   morpheus {
     pce_disconnected_identity {
-      client_id     = "client_id"
-      client_secret = "client_secret"
-      issuer_url    = "https://issuer.example.com"
-      location      = "location"
-      workspace_id  = "workspace_id"
-      broker_url    = "https://broker.example.com"
+      client_id        = "client_id"
+      client_secret    = "client_secret"
+      token_issuer_url = "https://issuer.example.com"
+      location         = "location"
+      workspace_id     = "workspace_id"
+      broker_url       = "https://broker.example.com"
     }
   }
 }

--- a/morpheus/model/model.go
+++ b/morpheus/model/model.go
@@ -44,9 +44,12 @@ type PCEIdentityModel struct {
 type PCEDisconnectedIdentityModel struct {
 	ClientID     types.String `tfsdk:"client_id"`
 	ClientSecret types.String `tfsdk:"client_secret"`
-	IssuerURL    types.String `tfsdk:"issuer_url"`
-	IAMToken     types.String `tfsdk:"iam_token"`
-	Location     types.String `tfsdk:"location"`
-	WorkspaceID  types.String `tfsdk:"workspace_id"`
-	BrokerURL    types.String `tfsdk:"broker_url"`
+	// TokenIssuerURL is this block's spelling of the Connected block's
+	// issuer_url: GLP names the same value differently. The two blocks are
+	// configured independently, so the Connected spelling is left as it is.
+	TokenIssuerURL types.String `tfsdk:"token_issuer_url"`
+	IAMToken       types.String `tfsdk:"iam_token"`
+	Location       types.String `tfsdk:"location"`
+	WorkspaceID    types.String `tfsdk:"workspace_id"`
+	BrokerURL      types.String `tfsdk:"broker_url"`
 }

--- a/morpheus/provider.go
+++ b/morpheus/provider.go
@@ -296,7 +296,7 @@ func (p *MorpheusProvider) Schema(ctx context.Context, req provider.SchemaReques
 							Validators: []validator.String{
 								stringvalidator.AlsoRequires(
 									path.MatchRelative().AtParent().AtName("client_secret"),
-									path.MatchRelative().AtParent().AtName("issuer_url"),
+									path.MatchRelative().AtParent().AtName("token_issuer_url"),
 								),
 							},
 						},
@@ -307,11 +307,11 @@ func (p *MorpheusProvider) Schema(ctx context.Context, req provider.SchemaReques
 							Validators: []validator.String{
 								stringvalidator.AlsoRequires(
 									path.MatchRelative().AtParent().AtName("client_id"),
-									path.MatchRelative().AtParent().AtName("issuer_url"),
+									path.MatchRelative().AtParent().AtName("token_issuer_url"),
 								),
 							},
 						},
-						"issuer_url": schema.StringAttribute{
+						"token_issuer_url": schema.StringAttribute{
 							Description: `GreenLake IAM Issuer URL used to generate access tokens. ` +
 								`This should be set to the "Issuer" URL of the API client.`,
 							Optional: true,
@@ -331,7 +331,7 @@ func (p *MorpheusProvider) Schema(ctx context.Context, req provider.SchemaReques
 								stringvalidator.ConflictsWith(
 									path.MatchRelative().AtParent().AtName("client_id"),
 									path.MatchRelative().AtParent().AtName("client_secret"),
-									path.MatchRelative().AtParent().AtName("issuer_url"),
+									path.MatchRelative().AtParent().AtName("token_issuer_url"),
 								),
 							},
 						},
@@ -401,7 +401,7 @@ func pceDisconnectedIdentityTokenExchange(
 	return pce.TokenExchange(ctx, pce.Config{
 		ClientID:     m.ClientID.ValueString(),
 		ClientSecret: m.ClientSecret.ValueString(),
-		IssuerURL:    m.IssuerURL.ValueString(),
+		IssuerURL:    m.TokenIssuerURL.ValueString(),
 		IAMToken:     m.IAMToken.ValueString(),
 		Location:     m.Location.ValueString(),
 		WorkspaceID:  m.WorkspaceID.ValueString(),

--- a/morpheus/provider_examples_test.go
+++ b/morpheus/provider_examples_test.go
@@ -43,13 +43,15 @@ var identityExamples = map[string]struct {
 	},
 	"provider-pce-disconnected-identity.tf": {
 		block: "pce_disconnected_identity",
+		// #nosec G101 -- token_issuer_url names an IAM endpoint, not a
+		// credential, and the value is the documentation's example URL.
 		attrs: map[string]string{
-			"client_id":     "client_id",
-			"client_secret": "client_secret",
-			"issuer_url":    "https://issuer.example.com",
-			"location":      "location",
-			"workspace_id":  "workspace_id",
-			"broker_url":    "https://broker.example.com",
+			"client_id":        "client_id",
+			"client_secret":    "client_secret",
+			"token_issuer_url": "https://issuer.example.com",
+			"location":         "location",
+			"workspace_id":     "workspace_id",
+			"broker_url":       "https://broker.example.com",
 		},
 	},
 	"provider-pce-disconnected-identity-iamtoken.tf": {

--- a/morpheus/provider_identity_test.go
+++ b/morpheus/provider_identity_test.go
@@ -348,6 +348,18 @@ func identityBlockAttrs(block string) map[string]string {
 	return attrs
 }
 
+// identityIssuerAttr returns the name a block gives the GreenLake issuer URL.
+// The Disconnected block calls it token_issuer_url where the Connected block
+// calls it issuer_url, and neither has the other's spelling, so a test that
+// covers both blocks has to ask rather than assume.
+func identityIssuerAttr(block string) string {
+	if block == "pce_disconnected_identity" {
+		return "token_issuer_url"
+	}
+
+	return "issuer_url"
+}
+
 // A pre-generated token and the credentials it would be generated from are two
 // ways of obtaining the same thing, so configuring both is rejected. Each
 // conflicting attribute is reported, rather than only the first.
@@ -359,7 +371,7 @@ func TestValidateProviderConfigRejectsIamTokenWithCredentials(t *testing.T) {
 				attrs["iam_token"] = "token"
 				attrs["client_id"] = "client-id"
 				attrs["client_secret"] = "client-secret"
-				attrs["issuer_url"] = "https://issuer.example.invalid"
+				attrs[identityIssuerAttr(block)] = "https://issuer.example.invalid"
 
 				diags := validateProviderConfig(t, absent,
 					func(t *testing.T, obj tftypes.Object, absent absentBlocks) map[string]tftypes.Value {
@@ -368,7 +380,13 @@ func TestValidateProviderConfigRejectsIamTokenWithCredentials(t *testing.T) {
 						}
 					})
 
-				for _, conflicting := range []string{"client_id", "client_secret", "issuer_url"} {
+				conflicts := []string{
+					"client_id",
+					"client_secret",
+					identityIssuerAttr(block),
+				}
+
+				for _, conflicting := range conflicts {
 					want := fmt.Sprintf(
 						`Attribute "morpheus[0].%s[0].%s" cannot be specified when `+
 							`"morpheus[0].%s[0].iam_token" is specified`,
@@ -394,7 +412,7 @@ func TestValidateProviderConfigAcceptsCredentialsWithoutIamToken(t *testing.T) {
 				attrs := identityBlockAttrs(block)
 				attrs["client_id"] = "client-id"
 				attrs["client_secret"] = "client-secret"
-				attrs["issuer_url"] = "https://issuer.example.invalid"
+				attrs[identityIssuerAttr(block)] = "https://issuer.example.invalid"
 
 				diags := validateProviderConfig(t, absent,
 					func(t *testing.T, obj tftypes.Object, absent absentBlocks) map[string]tftypes.Value {
@@ -430,8 +448,8 @@ func TestValidateProviderConfigRejectsIdentityBlockWithoutCredentials(t *testing
 					})
 
 				want := "Configure either the GreenLake API client credentials " +
-					"(client_id, client_secret and issuer_url) or a pre-generated " +
-					"iam_token."
+					"(client_id, client_secret and issuer_url or " +
+					"token_issuer_url) or a pre-generated iam_token."
 
 				if !containsDiag(diags, want) {
 					t.Errorf("ValidateProviderConfig() diagnostics = %v, want one containing %q",

--- a/morpheus/provider_schema_parity_test.go
+++ b/morpheus/provider_schema_parity_test.go
@@ -99,13 +99,13 @@ func TestIdentityRequiredAttributesSurviveConversion(t *testing.T) {
 			"broker_url":    false,
 		},
 		"pce_disconnected_identity": {
-			"broker_url":    true,
-			"location":      true,
-			"workspace_id":  true,
-			"client_id":     false,
-			"client_secret": false,
-			"issuer_url":    false,
-			"iam_token":     false,
+			"broker_url":       true,
+			"location":         true,
+			"workspace_id":     true,
+			"client_id":        false,
+			"client_secret":    false,
+			"token_issuer_url": false,
+			"iam_token":        false,
 		},
 	}
 

--- a/morpheus/sdkv2/provider.go
+++ b/morpheus/sdkv2/provider.go
@@ -399,7 +399,7 @@ func providerSchemaMorpheus() *schema.Schema {
 								Description: "GreenLake API client ID used for authentication.",
 								RequiredWith: []string{
 									"morpheus.0.pce_disconnected_identity.0.client_secret",
-									"morpheus.0.pce_disconnected_identity.0.issuer_url",
+									"morpheus.0.pce_disconnected_identity.0.token_issuer_url",
 								},
 							},
 
@@ -410,11 +410,11 @@ func providerSchemaMorpheus() *schema.Schema {
 								Description: "GreenLake API client secret used for authentication.",
 								RequiredWith: []string{
 									"morpheus.0.pce_disconnected_identity.0.client_id",
-									"morpheus.0.pce_disconnected_identity.0.issuer_url",
+									"morpheus.0.pce_disconnected_identity.0.token_issuer_url",
 								},
 							},
 
-							"issuer_url": {
+							"token_issuer_url": {
 								Type:     schema.TypeString,
 								Optional: true,
 								Description: `GreenLake IAM Issuer URL used to generate access tokens. ` +
@@ -434,7 +434,7 @@ func providerSchemaMorpheus() *schema.Schema {
 								ConflictsWith: []string{
 									"morpheus.0.pce_disconnected_identity.0.client_id",
 									"morpheus.0.pce_disconnected_identity.0.client_secret",
-									"morpheus.0.pce_disconnected_identity.0.issuer_url",
+									"morpheus.0.pce_disconnected_identity.0.token_issuer_url",
 								},
 							},
 
@@ -615,7 +615,7 @@ func pceDisconnectedIdentityConfig(morpheusConfig map[string]interface{}) (pce.C
 	return pce.Config{
 		ClientID:     stringAttr(block, "client_id"),
 		ClientSecret: stringAttr(block, "client_secret"),
-		IssuerURL:    stringAttr(block, "issuer_url"),
+		IssuerURL:    stringAttr(block, "token_issuer_url"),
 		IAMToken:     stringAttr(block, "iam_token"),
 		Location:     stringAttr(block, "location"),
 		WorkspaceID:  stringAttr(block, "workspace_id"),

--- a/morpheus/utils/validators/credentials_or_token.go
+++ b/morpheus/utils/validators/credentials_or_token.go
@@ -12,10 +12,16 @@ import (
 
 // identityCredentialAttributes are the attributes of an identity block that can
 // supply a way of authenticating with GreenLake. At least one has to be set.
+//
+// The list spans both identity blocks, which name the issuer URL differently:
+// the Connected block calls it issuer_url and the Disconnected block
+// token_issuer_url. A block only has one of the two, and an attribute this list
+// names but the block does not have is skipped.
 var identityCredentialAttributes = []string{
 	"client_id",
 	"client_secret",
 	"issuer_url",
+	"token_issuer_url",
 	"iam_token",
 }
 
@@ -78,6 +84,7 @@ func (v identityCredentialsOrTokenValidator) ValidateObject(
 		req.Path,
 		"Missing GreenLake credentials",
 		"Configure either the GreenLake API client credentials (client_id, "+
-			"client_secret and issuer_url) or a pre-generated iam_token.",
+			"client_secret and issuer_url or token_issuer_url) or a "+
+			"pre-generated iam_token.",
 	)
 }

--- a/morpheus/utils/validators/credentials_or_token_test.go
+++ b/morpheus/utils/validators/credentials_or_token_test.go
@@ -19,11 +19,12 @@ func identityObject(t *testing.T, set map[string]attr.Value) basetypes.ObjectVal
 	t.Helper()
 
 	attributeTypes := map[string]attr.Type{
-		"client_id":     types.StringType,
-		"client_secret": types.StringType,
-		"issuer_url":    types.StringType,
-		"iam_token":     types.StringType,
-		"location":      types.StringType,
+		"client_id":        types.StringType,
+		"client_secret":    types.StringType,
+		"issuer_url":       types.StringType,
+		"token_issuer_url": types.StringType,
+		"iam_token":        types.StringType,
+		"location":         types.StringType,
 	}
 
 	values := map[string]attr.Value{}
@@ -69,6 +70,12 @@ func TestIdentityCredentialsOrTokenValidator(t *testing.T) {
 		"issuer url only": {
 			value: identityObject(t, map[string]attr.Value{
 				"issuer_url": types.StringValue("https://issuer.example.invalid"),
+			}),
+		},
+		// The Disconnected block's spelling of the same credential.
+		"token issuer url only": {
+			value: identityObject(t, map[string]attr.Value{
+				"token_issuer_url": types.StringValue("https://issuer.example.invalid"),
 			}),
 		},
 		"iam token only": {
@@ -128,6 +135,60 @@ func TestIdentityCredentialsOrTokenValidator(t *testing.T) {
 			if got := resp.Diagnostics.HasError(); got != tc.wantError {
 				t.Errorf("HasError = %v, want %v (diags: %v)",
 					got, tc.wantError, resp.Diagnostics)
+			}
+		})
+	}
+}
+
+// The two identity blocks name the issuer URL differently, and neither has the
+// other's spelling. The credential list spans both, so it names an attribute
+// that any given block does not have: that has to be skipped rather than
+// treated as unset, and the block's own spelling has to still be found.
+func TestIdentityCredentialsOrTokenValidatorPerBlockIssuerAttribute(t *testing.T) {
+	t.Parallel()
+
+	for block, issuerAttr := range map[string]string{
+		"pce_identity":              "issuer_url",
+		"pce_disconnected_identity": "token_issuer_url",
+	} {
+		name, attribute := block, issuerAttr
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Only the attributes this block actually has, so the other
+			// block's issuer spelling is absent from the object entirely.
+			obj, diags := types.ObjectValue(
+				map[string]attr.Type{
+					"client_id":     types.StringType,
+					"client_secret": types.StringType,
+					attribute:       types.StringType,
+					"iam_token":     types.StringType,
+				},
+				map[string]attr.Value{
+					"client_id":     types.StringNull(),
+					"client_secret": types.StringNull(),
+					attribute:       types.StringValue("https://issuer.example.invalid"),
+					"iam_token":     types.StringNull(),
+				},
+			)
+			if diags.HasError() {
+				t.Fatalf("could not build the object value: %v", diags)
+			}
+
+			resp := &validator.ObjectResponse{}
+			IdentityCredentialsOrTokenValidator().ValidateObject(
+				context.Background(),
+				validator.ObjectRequest{
+					Path:        path.Root(name),
+					ConfigValue: obj,
+				},
+				resp,
+			)
+
+			if resp.Diagnostics.HasError() {
+				t.Errorf("HasError = true for %s set on %s, want false: %v",
+					attribute, name, resp.Diagnostics)
 			}
 		})
 	}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -43,7 +43,8 @@ For the first two the URL of the Morpheus instance must be provided as `url`.
 
 For the last two the URL and access token are obtained from GreenLake, so `url` must not be set.
 Provide a `pce_identity` or `pce_disconnected_identity` block instead, using either GreenLake API
-client credentials (`client_id`, `client_secret` and `issuer_url`) or a pre-generated `iam_token`.
+client credentials (`client_id`, `client_secret` and `issuer_url`, or `token_issuer_url` in the
+Disconnected block) or a pre-generated `iam_token`.
 The two blocks are mutually exclusive, and neither can be combined with `url`, `username`,
 `password`, `access_token` or `tenant_subdomain`.
 


### PR DESCRIPTION
Renames the `issuer_url` attribute in the `pce_disconnected_identity` provider
block to `token_issuer_url`, matching the name GreenLake gives the value.

`pce_identity` is deliberately left alone: it shipped in v1.6.0, so renaming its
`issuer_url` would break existing configurations. The two blocks are configured
independently, so the divergence is contained.

This is not a breaking change — `pce_disconnected_identity` is not present in
the v1.6.0 tag, so no released configuration can be using it. No deprecation
shim or state upgrade is needed.

## Changes

- Framework provider schema: attribute renamed, along with the three
  cross-references to it (the `client_id` / `client_secret` "also requires"
  rules and the `iam_token` conflict rule). The description text is unchanged.
- Mirrored SDKv2 schema: the same key and its four `RequiredWith` /
  `ConflictsWith` paths.
- `pceDisconnectedIdentityConfig` now reads `token_issuer_url`. This is the one
  functional change rather than a rename: `main.go` replaces the SDKv2 schema
  with one derived from the framework schema, so the config keys follow the
  framework names. Left as `issuer_url` this would have silently dropped the
  issuer URL from the Disconnected token exchange, with no error and a failure
  only much later at token exchange time.
- `PCEDisconnectedIdentityModel.IssuerURL` renamed to `TokenIssuerURL`. The
  internal `pce.Config.IssuerURL` is unchanged: it is shared with the Connected
  flow and is not a Terraform attribute name.
- The shared `IdentityCredentialsOrTokenValidator` credential list now spans
  both spellings. The existing loop already skips an attribute the block does
  not have, so one list serves both blocks; the diagnostic names both.

## Tests

- Tests that cover both blocks resolved the issuer attribute per block instead
  of hardcoding one name — without this the Disconnected subtests fail on an
  unknown attribute.
- Added a validator test proving a block carrying only `token_issuer_url`, with
  no `issuer_url` key at all, is accepted.
- Parity and example-attribute tests rekeyed.
- The examples test needed a `#nosec G101`: the key now contains "token" and the
  value is a URL literal, which trips gosec's hardcoded-credentials heuristic.
  Suppressed narrowly, with justification, rather than excluding gosec from all
  test files.

## Docs

`templates/index.md.tmpl` names both spellings; the example `.tf` was renamed
and realigned; `docs/index.md` was regenerated with `make docs`.

## Verification

- `go build ./...`
- `make lint` — 0 issues
- `go test -count=1` on the affected packages — all pass
- `make docs` is idempotent, so the docs check is clean
- Audited: every remaining bare `issuer_url` is either in a `pce_identity`
  context or in a comment that deliberately names both spellings
