### PR TITLE
Treat an unknown value as absent when converting to Go types

### DIFF
--- a/utils/convert/valuetoany.go
+++ b/utils/convert/valuetoany.go
@@ -14,7 +14,18 @@ import (
 // This function handles null values, primitive types, and complex types
 // like objects, lists, sets, tuples and maps.
 func ValueToAny(ctx context.Context, v attr.Value) (any, error) {
-	if v == nil || v.IsNull() {
+	// Unknown is treated as absent, the same as null.
+	//
+	// A value that is not yet known cannot be converted, and the accessors do
+	// not tolerate being asked: an unknown NumberValue returns a nil
+	// *big.Float, so ValueBigFloat().Float64() dereferences nil and panics.
+	//
+	// The callers are validators, which have nothing to validate until the
+	// value is resolved. Guarding only null was enough while every value came
+	// from a literal, and became a crash the moment one came from a variable,
+	// a count or for_each reference, or any other expression deferred to
+	// apply.
+	if v == nil || v.IsNull() || v.IsUnknown() {
 		return nil, nil
 	}
 
@@ -50,7 +61,7 @@ func ValueToAny(ctx context.Context, v attr.Value) (any, error) {
 }
 
 func ListToAny(ctx context.Context, l basetypes.ListValue) ([]any, error) {
-	if l.IsNull() {
+	if l.IsNull() || l.IsUnknown() {
 		return nil, nil
 	}
 
@@ -69,7 +80,7 @@ func ListToAny(ctx context.Context, l basetypes.ListValue) ([]any, error) {
 }
 
 func SetToAny(ctx context.Context, s basetypes.SetValue) ([]any, error) {
-	if s.IsNull() {
+	if s.IsNull() || s.IsUnknown() {
 		return nil, nil
 	}
 
@@ -88,7 +99,7 @@ func SetToAny(ctx context.Context, s basetypes.SetValue) ([]any, error) {
 }
 
 func MapToAny(ctx context.Context, m basetypes.MapValue) (map[string]any, error) {
-	if m.IsNull() {
+	if m.IsNull() || m.IsUnknown() {
 		return nil, nil
 	}
 
@@ -107,7 +118,7 @@ func MapToAny(ctx context.Context, m basetypes.MapValue) (map[string]any, error)
 }
 
 func ObjectToAny(ctx context.Context, o basetypes.ObjectValue) (map[string]any, error) {
-	if o.IsNull() {
+	if o.IsNull() || o.IsUnknown() {
 		return nil, nil
 	}
 
@@ -126,7 +137,7 @@ func ObjectToAny(ctx context.Context, o basetypes.ObjectValue) (map[string]any, 
 }
 
 func TupleToAny(ctx context.Context, t basetypes.TupleValue) ([]any, error) {
-	if t.IsNull() {
+	if t.IsNull() || t.IsUnknown() {
 		return nil, nil
 	}
 

--- a/utils/convert/valuetoany_unknown_test.go
+++ b/utils/convert/valuetoany_unknown_test.go
@@ -1,0 +1,125 @@
+package convert
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValueToAnyUnknown is the regression guard for the panic reported against
+// v1.6.0 (MORPH-16244).
+//
+// An unknown NumberValue holds a nil *big.Float, so ValueBigFloat().Float64()
+// dereferences nil. The guard only covered null, which was enough while every
+// value came from a literal and became a crash the moment one came from a
+// variable, a count or for_each reference, or anything else deferred to apply.
+//
+// Every case here panics without the fix rather than merely returning the wrong
+// thing, so a failure is unmissable.
+func TestUnitValueToAnyUnknown(t *testing.T) {
+	t.Parallel()
+
+	elem := map[string]attr.Type{"id": types.NumberType}
+
+	cases := map[string]attr.Value{
+		"number":  types.NumberUnknown(),
+		"string":  types.StringUnknown(),
+		"bool":    types.BoolUnknown(),
+		"int64":   types.Int64Unknown(),
+		"float64": types.Float64Unknown(),
+		"list":    types.ListUnknown(types.NumberType),
+		"set":     types.SetUnknown(types.NumberType),
+		"map":     types.MapUnknown(types.NumberType),
+		"object":  types.ObjectUnknown(elem),
+		"tuple":   types.TupleUnknown([]attr.Type{types.NumberType}),
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ValueToAny(context.Background(), value)
+			require.NoError(t, err)
+			require.Nil(t, got, "an unknown value carries nothing to convert")
+		})
+	}
+}
+
+// TestValueToAnyNestedUnknown covers the shape the customer actually hit.
+//
+// The validator guards the outer value, but `config = { templateId = var.x }`
+// is an object whose type is known and only whose member is unknown. The outer
+// guard passes, the walk reaches the member, and that is where it panicked.
+func TestUnitValueToAnyNestedUnknown(t *testing.T) {
+	t.Parallel()
+
+	obj := types.ObjectValueMust(
+		map[string]attr.Type{
+			"templateId": types.NumberType,
+			"noAgent":    types.BoolType,
+		},
+		map[string]attr.Value{
+			"templateId": types.NumberUnknown(),
+			"noAgent":    types.BoolValue(true),
+		},
+	)
+
+	got, err := ValueToAny(context.Background(), obj)
+	require.NoError(t, err)
+
+	m, ok := got.(map[string]any)
+	require.True(t, ok, "an object converts to a map")
+
+	// The known sibling survives; the unknown member is absent rather than a
+	// zero value, so a caller cannot mistake "not yet known" for "set to 0".
+	require.Equal(t, true, m["noAgent"])
+	require.Nil(t, m["templateId"])
+}
+
+// TestValueToAnyIntegerBecomesFloat pins current behaviour rather than
+// endorsing it.
+//
+// A Terraform number is a big.Float, and this converts it to float64
+// regardless of whether the practitioner wrote an integer. An image id of 187
+// arrives back as float64(187), not int64(187).
+//
+// That is fine for JSON, which does not distinguish them, and matches what the
+// customer saw working with a literal. It is recorded here because the
+// conversion is lossy in one direction that does matter: see the precision
+// case below.
+func TestUnitValueToAnyIntegerBecomesFloat(t *testing.T) {
+	t.Parallel()
+
+	got, err := ValueToAny(
+		context.Background(),
+		types.NumberValue(big.NewFloat(187)),
+	)
+	require.NoError(t, err)
+
+	require.IsType(t, float64(0), got,
+		"a whole number still converts through float64")
+	require.InDelta(t, 187, got, 0)
+}
+
+// TestValueToAnyLargeIntegerLosesPrecision records the edge the float64
+// conversion cannot represent.
+//
+// Beyond 2^53 an integer has no exact float64, so the conversion reports a loss
+// of precision and fails rather than silently rounding. That is the right
+// answer, but it means a sufficiently large id cannot be passed through a
+// dynamic attribute at all.
+func TestUnitValueToAnyLargeIntegerLosesPrecision(t *testing.T) {
+	t.Parallel()
+
+	// 2^53 + 1: the first integer float64 cannot hold exactly.
+	big53 := new(big.Float).SetInt64(1<<53 + 1)
+
+	_, err := ValueToAny(context.Background(), types.NumberValue(big53))
+	require.Error(t, err,
+		"an integer beyond float64's exact range is refused, not rounded")
+	require.Contains(t, err.Error(), "loss of precision")
+}


### PR DESCRIPTION
Fixes MORPH-16244.

## Summary

`ValueToAny` guarded null but not unknown. An unknown `NumberValue` holds a nil
`*big.Float`, so `ValueBigFloat().Float64()` dereferenced nil and panicked the
provider.

## How it was reached

The path is a dynamic attribute. Its validator guards the value it is given:

```go
if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
    return
}
```

but `config = { templateId = var.image_id }` is an object that is itself
**known** — only its member is unknown. The guard passes, `ObjectToAny` walks
the members, and the unknown number panics.

That explains a confusing symptom: a literal works, and so does arithmetic
between literals because Terraform folds it at parse time. The crash appears
only once a value is deferred to apply — a variable, a `count`/`for_each`
reference, a map lookup, `tonumber()`. Taking an id from a `.tfvars` file is
enough.

## What changed

Unknown is treated as absent, the same as null, in `ValueToAny` and in the five
collection helpers beside it (`ListToAny`, `SetToAny`, `MapToAny`,
`ObjectToAny`, `TupleToAny`), which all had the same omission.

Callers get `nil` rather than a zero value, so "not yet known" cannot be
mistaken for "set to zero".

## Verification

Reverting the guard reproduces the panic under test:

```
--- FAIL: TestUnitValueToAnyUnknown/number
panic: runtime error: invalid memory address or nil pointer dereference
```

Tests cover every type the conversion handles, plus the nested case actually
reached in practice.

## Two properties of the number conversion, pinned rather than changed

A Terraform number is a `big.Float`, and this converts through `float64`. Two
consequences are now recorded in tests so they are visible rather than
discovered:

- a whole number still arrives as `float64` — fine for JSON, which does not
  distinguish, but it is not an integer round-trip
- an integer beyond float64's exact range (2^53) is **refused** with a loss of
  precision error rather than silently rounded

The second means a sufficiently large id cannot pass through a dynamic
attribute at all. That is the safe behaviour, but it is a real limit and worth
knowing about.

## Scope

Not specific to any one attribute or provider. Any dynamic attribute given a
computed value whose conversion dereferences an unknown would panic.
