### PR TITLE
Mark image tenants as known so they remain distinguishable

### DIFF
--- a/morpheus/framework/datasources/image/image.go
+++ b/morpheus/framework/datasources/image/image.go
@@ -360,15 +360,7 @@ func parseAsData(
 	data.Tags = tags
 
 	// tenants
-	tenants, d := convert.ToSetType(
-		ctx, image.Accounts,
-		func(in sdk.GetVirtualImage200ResponseVirtualImageAccountsInner) TenantsValue {
-			return TenantsValue{
-				Name: convert.StrToType(in.Name),
-				Id:   convert.Int64ToType(in.Id),
-			}
-		},
-	)
+	tenants, d := convert.ToSetType(ctx, image.Accounts, tenantValue)
 	diags.Append(d...)
 	data.Tenants = tenants
 
@@ -397,4 +389,26 @@ func parseAsData(
 	data.VmToolsInstalled = convert.BoolToType(image.VmToolsInstalled)
 
 	return diags
+}
+
+// tenantValue maps an account from the API onto the schema's tenant object.
+//
+// state must be set explicitly. A zero ValueState is ValueStateNull, and a null
+// object lowers to a null tftypes value whatever attributes were set on it -- so
+// every tenant became indistinguishable from every other, and SetType.Validate
+// rejected the set as containing duplicates. The effect was that any image with
+// two or more tenants failed to read, with "Duplicate Set Element", whether or
+// not anything was actually duplicated.
+//
+// Named rather than inline so the mapping can be tested directly; the bug is
+// invisible at the attr.Value layer and only appears once the value is lowered
+// to tftypes.
+func tenantValue(
+	in sdk.GetVirtualImage200ResponseVirtualImageAccountsInner,
+) TenantsValue {
+	return TenantsValue{
+		Name:  convert.StrToType(in.Name),
+		Id:    convert.Int64ToType(in.Id),
+		state: attr.ValueStateKnown,
+	}
 }

--- a/morpheus/framework/datasources/image/tenants_test.go
+++ b/morpheus/framework/datasources/image/tenants_test.go
@@ -1,0 +1,100 @@
+package image
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	sdk "github.com/HPE/terraform-provider-hpe/internal/sdk/oapigen"
+
+	"github.com/HPE/terraform-provider-hpe/utils/convert"
+)
+
+type testAccount struct {
+	id   int64
+	name string
+}
+
+// tenantElements builds the tenants set exactly as the read path does, then
+// lowers it to the tftypes values Terraform actually compares.
+//
+// The comparison that matters happens in SetType.Validate, after the value has
+// left the provider, so a test at the attr.Value layer cannot see the failure
+// this guards against.
+func tenantElements(t *testing.T, accounts []testAccount) []tftypes.Value {
+	t.Helper()
+
+	// Drives the production mapper. Building an equivalent value here would
+	// pass whether or not the read path is correct, which is exactly the
+	// mistake this test exists to catch.
+	inputs := make([]sdk.GetVirtualImage200ResponseVirtualImageAccountsInner, 0, len(accounts))
+	for _, a := range accounts {
+		inputs = append(inputs, sdk.GetVirtualImage200ResponseVirtualImageAccountsInner{
+			Id:   &a.id,
+			Name: &a.name,
+		})
+	}
+
+	set, diags := convert.ToSetType(context.Background(), inputs, tenantValue)
+	if diags.HasError() {
+		t.Fatalf("building the tenants set failed: %v", diags.Errors())
+	}
+
+	raw, err := set.ToTerraformValue(context.Background())
+	if err != nil {
+		t.Fatalf("lowering to tftypes failed: %v", err)
+	}
+
+	var elements []tftypes.Value
+	if err := raw.As(&elements); err != nil {
+		t.Fatalf("reading elements failed: %v", err)
+	}
+
+	return elements
+}
+
+// TestTenantsAreDistinguishable is the regression guard for MORPH-16245.
+//
+// TenantsValue is built as a struct literal, and a zero ValueState is
+// ValueStateNull. A null object lowers to a null tftypes value whatever
+// attributes were set on it, so every tenant became identical to every other.
+// SetType.Validate compares elements pairwise and rejected the set with
+// "Duplicate Set Element" -- meaning any image with two or more tenants failed
+// to read, whether or not anything was duplicated.
+func TestUnitImageTenantsAreDistinguishable(t *testing.T) {
+	t.Parallel()
+
+	elements := tenantElements(t, []testAccount{
+		{id: 1, name: "acme"},
+		{id: 2, name: "globex"},
+	})
+
+	if len(elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(elements))
+	}
+
+	if elements[0].Equal(elements[1]) {
+		t.Error(
+			"two tenants with different ids and names compare equal; " +
+				"Terraform will reject the set as containing duplicates",
+		)
+	}
+}
+
+// TestRepeatedTenantsAreEqual is the counterpart. Deduplication is not this
+// data source's job -- if the API genuinely repeats a tenant, the elements
+// should compare equal, and that is a question for the API rather than
+// something to paper over here.
+func TestUnitImageRepeatedTenantsAreEqual(t *testing.T) {
+	t.Parallel()
+
+	elements := tenantElements(t, []testAccount{
+		{id: 1, name: "acme"},
+		{id: 1, name: "acme"},
+	})
+
+	if !elements[0].Equal(elements[1]) {
+		t.Error("genuinely identical tenants should compare equal")
+	}
+}


### PR DESCRIPTION
Fixes MORPH-16245.

## Summary

Reading a virtual image with **two or more tenants** failed with
`Duplicate Set Element` — whether or not anything was actually duplicated.

## Root cause

Tenants were built as struct literals without setting `state`:

```go
return TenantsValue{
    Name: convert.StrToType(in.Name),
    Id:   convert.Int64ToType(in.Id),
}
```

The zero value of `attr.ValueState` is `ValueStateNull`, so every tenant was a
**null object** — and a null object lowers to a null `tftypes` value regardless
of the attributes set on it. `Name` and `Id` were discarded on the way out,
leaving every tenant byte-identical to every other.

## Where the error actually comes from

Not `types.SetValue` at construction — that accepts these values. It is
`SetType.Validate`, which runs **after** the value has left the provider and
compares elements pairwise as `tftypes.Value`.

That has a direct consequence for testing: the fault is **invisible at the
`attr.Value` layer**. A test written there passes against the broken code. This
one lowers the values and compares them, which is where the difference has to
show.

## What changed

`state: attr.ValueStateKnown` when constructing the value. One field.

The mapping is now a named function rather than an inline closure, so the test
can drive the production code rather than a copy of it.

## Verification

Removing the field fails the guard with the diagnosis in the message:

```
--- FAIL: TestUnitImageTenantsAreDistinguishable
    two tenants with different ids and names compare equal;
    Terraform will reject the set as containing duplicates
```

## Worth a reviewer's attention

**The tags mapper in the same file already sets `state` correctly.** So this was
an omission in one of two adjacent mappings, not a misunderstanding of the type
— which makes it the kind of thing that is likely to recur.

Other generated value types built as struct literals may carry the same
omission. That sweep is deliberately **not** attempted here; it wants doing
separately, with its own verification, because the failure mode is silent until
a collection happens to contain more than one element.

## A rejected approach, recorded so it is not revisited

Deduplicating inside `convert.ToSetType` looks like an obvious fix and is
actively harmful. Because every tenant lowers to the same null value, a dedup
pass compares elements that all appear equal, collapses every tenant to one, and
returns **successfully** — converting a loud, correct error into silent data
loss.
