### PR TITLE
Adding documentation for v2.0.0 of tfmigrator + hpegl migration

### DIFF
--- a/docs/guides/hpegl_to_hpe_migration.md
+++ b/docs/guides/hpegl_to_hpe_migration.md
@@ -23,6 +23,11 @@ provider (hpegl used the Terraform Plugin SDK v2; the HPE provider uses the Plug
 resource therefore requires Terraform-generated configuration and manual post-migration review. The
 process documented for [tfmigrator](./tfmigrator_migration.md) handles this generation for you.
 
+## Prerequisites
+
+- Terraform >= 1.5.0 (required for `import` blocks)
+- HPE provider >= 2.0.0
+
 ## Provider Block Transformation
 
 The largest difference between an hpegl configuration and an HPE configuration is the provider block.
@@ -66,6 +71,17 @@ provider "hpe" {
 ### GreenLake IAM - Disconnected (`iam_version = "glp"`)
 
 ```HCL
+# Before (hpegl)
+provider "hpegl" {
+  iam_version      = "glp"
+  iam_service_url  = "https://client.greenlake.hpe.com/..."
+  vmaas {
+    location   = "HPE-Data-Center"
+    space_name = "my-space"
+    broker_url = "https://vmaas-broker.example.com"
+  }
+}
+
 # After (hpe)
 provider "hpe" {
   morpheus {
@@ -84,10 +100,18 @@ provider "hpe" {
 ### Direct-connect (`vmaas.morpheus_url` present)
 
 When the hpegl `vmaas` block sets `morpheus_url`, the provider connects directly to Morpheus with no
-GreenLake IAM broker. In that case the credentials land directly inside the `morpheus` block and no
-`pce_identity` sub-block is emitted:
+GreenLake IAM broker. In that case the credentials land directly inside the `morpheus` block, with
+neither a `pce_identity` nor a `pce_disconnected_identity` sub-block emitted:
 
 ```HCL
+# Before (hpegl)
+provider "hpegl" {
+  vmaas {
+    morpheus_url   = "https://morpheus.example.com"
+    morpheus_token = var.hpe_morpheus_access_token
+  }
+}
+
 # After (hpe)
 provider "hpe" {
   morpheus {

--- a/docs/guides/hpegl_to_hpe_migration.md
+++ b/docs/guides/hpegl_to_hpe_migration.md
@@ -188,7 +188,7 @@ The following hpegl data source has no HPE equivalent and is removed during migr
 ## Migration Workflow
 
 The end-to-end command workflow - installation, the one-shot `tfmigrator migrate` command, and the
-individual `migrate-providers` -> `generate` -> `merge` -> `migrate-datasources` steps - is documented
+individual `migrate-providers` -> `generate` -> `merge` -> `migrate-datasources` -> `cleanup-providers` steps - is documented
 in the [tfmigrator guide](./tfmigrator_migration.md). tfmigrator auto-detects the hpegl provider in
 your workspace, so the same commands apply here. For common issues, see
 [tfmigrator Troubleshooting](./tfmigrator_troubleshooting.md).

--- a/docs/guides/hpegl_to_hpe_migration.md
+++ b/docs/guides/hpegl_to_hpe_migration.md
@@ -1,0 +1,194 @@
+---
+page_title: "hpegl to HPE"
+subcategory: "Migration"
+---
+
+# Migrate hpegl VMaaS Provider Resources to HPE Provider Resources
+
+To migrate resources from the hpegl (`hpe/hpegl`) VMaaS provider to the HPE Terraform provider
+(`HPE/hpe`) the basic principle is to import the existing resources created with the hpegl provider
+into the HPE provider. HashiCorp documentation on import can be found
+[here](https://developer.hashicorp.com/terraform/language/import).
+
+-> [tfmigrator](./tfmigrator_migration.md) has been developed in order to assist with migration. By
+following the documented process, this tooling ports `hpegl_vmaas_*` resources to their corresponding
+`hpe_morpheus_*` resources - including handling for the provider block transformation, modules, and
+variables. See the [tfmigrator guide](./tfmigrator_migration.md) for the full command workflow (both
+the one-shot `migrate` command and the individual steps).<br><br>
+The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
+requires provider support for the `List` RPC. The HPE provider does not currently support `List`,
+this is something that we are considering for a future release.<br><br>
+Unlike the Morpheus provider, **every** hpegl VMaaS resource has a different schema in the HPE
+provider (hpegl used the Terraform Plugin SDK v2; the HPE provider uses the Plugin Framework). Every
+resource therefore requires Terraform-generated configuration and manual post-migration review. The
+process documented for [tfmigrator](./tfmigrator_migration.md) handles this generation for you.
+
+## Provider Block Transformation
+
+The largest difference between an hpegl configuration and an HPE configuration is the provider block.
+hpegl authenticates through the GreenLake IAM broker, while the HPE provider connects to Morpheus
+either through GreenLake IAM or directly. The [`migrate-providers`](./tfmigrator_migration.md) step
+performs this transformation automatically (including emitting credential `variable` blocks and a
+`credentials.auto.tfvars` file), but the mapping is summarised here for reference.
+
+The generated block depends on the `iam_version` attribute of the hpegl provider (falling back to the
+`HPEGL_IAM_VERSION` environment variable):
+
+### GreenLake IAM - Connected (`iam_version = "glcs"`)
+
+```HCL
+# Before (hpegl)
+provider "hpegl" {
+  iam_version      = "glcs"
+  iam_service_url  = "https://client.greenlake.hpe.com/..."
+  vmaas {
+    location   = "HPE-Data-Center"
+    space_name = "my-space"
+    broker_url = "https://vmaas-broker.example.com"
+  }
+}
+
+# After (hpe)
+provider "hpe" {
+  morpheus {
+    pce_identity {
+      location      = "HPE-Data-Center"
+      space         = "my-space"
+      broker_url    = "https://vmaas-broker.example.com"
+      issuer_url    = "https://client.greenlake.hpe.com/..."
+      client_id     = var.hpe_pce_client_id
+      client_secret = var.hpe_pce_client_secret
+    }
+  }
+}
+```
+
+### GreenLake IAM - Disconnected (`iam_version = "glp"`)
+
+```HCL
+# After (hpe)
+provider "hpe" {
+  morpheus {
+    pce_disconnected_identity {
+      location         = "HPE-Data-Center"
+      workspace_id     = "my-space"
+      broker_url       = "https://vmaas-broker.example.com"
+      token_issuer_url = "https://client.greenlake.hpe.com/..."
+      client_id        = var.hpe_pce_client_id
+      client_secret    = var.hpe_pce_client_secret
+    }
+  }
+}
+```
+
+### Direct-connect (`vmaas.morpheus_url` present)
+
+When the hpegl `vmaas` block sets `morpheus_url`, the provider connects directly to Morpheus with no
+GreenLake IAM broker. In that case the credentials land directly inside the `morpheus` block and no
+`pce_identity` sub-block is emitted:
+
+```HCL
+# After (hpe)
+provider "hpe" {
+  morpheus {
+    url          = "https://morpheus.example.com"
+    access_token = var.hpe_morpheus_access_token
+  }
+}
+```
+
+## Resource Definitions
+
+All hpegl VMaaS resources have a different schema in the HPE provider, so Terraform is used to
+generate the HPE resource definition (this is how [tfmigrator](./tfmigrator_migration.md) handles
+these resources). In addition to the generated resource definitions, an `import` block must be
+supplied for each resource. After the import ensure that a `terraform plan` shows no changes; if
+there are changes then the resource definitions need to be adjusted to match the existing resources.
+
+| hpegl Provider Resource Name             | HPE Provider Resource Name                     |
+|------------------------------------------|------------------------------------------------|
+| hpegl_vmaas_instance                     | hpe_morpheus_instance                          |
+| hpegl_vmaas_instance_clone               | hpe_morpheus_instance_clone                    |
+| hpegl_vmaas_network                      | hpe_morpheus_network                           |
+| hpegl_vmaas_dhcp_server                  | hpe_morpheus_network_dhcp_server               |
+| hpegl_vmaas_router                       | hpe_morpheus_network_router                    |
+| hpegl_vmaas_router_bgp_neighbor          | hpe_morpheus_network_router_bgp_neighbor       |
+| hpegl_vmaas_router_nat_rule              | hpe_morpheus_network_router_nat                |
+| hpegl_vmaas_router_route                 | hpe_morpheus_network_router_route              |
+| hpegl_vmaas_router_firewall_rule_group   | hpe_morpheus_network_router_firewall_rule_group |
+| hpegl_vmaas_load_balancer                | hpe_morpheus_load_balancer                     |
+| hpegl_vmaas_load_balancer_monitor        | hpe_morpheus_load_balancer_monitor             |
+| hpegl_vmaas_load_balancer_pool           | hpe_morpheus_load_balancer_pool                |
+| hpegl_vmaas_load_balancer_profile        | hpe_morpheus_load_balancer_profile             |
+| hpegl_vmaas_load_balancer_virtual_server | hpe_morpheus_load_balancer_virtual_server      |
+
+### Composite Import IDs
+
+Most resources import with a simple integer ID. The following resources are sub-resources whose HPE
+equivalent requires a **composite** import ID rather than a bare integer. tfmigrator constructs these
+automatically from the resource state; they are listed here so the generated `import` blocks make
+sense during review.
+
+| hpegl Provider Resource Name             | Import ID format                |
+|------------------------------------------|---------------------------------|
+| hpegl_vmaas_router_bgp_neighbor          | `{router_id}.{id}`              |
+| hpegl_vmaas_router_nat_rule              | `{router_id}.{id}`              |
+| hpegl_vmaas_router_route                 | `{router_id}.{id}`              |
+| hpegl_vmaas_router_firewall_rule_group   | `{router_id}.{id}`              |
+| hpegl_vmaas_dhcp_server                  | `{network_server_id}.{id}`      |
+| hpegl_vmaas_load_balancer_monitor        | `{lb_id}.{id}`                  |
+| hpegl_vmaas_load_balancer_virtual_server | `{lb_id}.{id}`                  |
+| hpegl_vmaas_load_balancer_pool           | `{lb_id}/{id}`                  |
+| hpegl_vmaas_load_balancer_profile        | `{lb_id}/{id}`                  |
+
+## Data Source Definitions
+
+Data sources are migrated in the same way, by updating the data source type. The following table
+lists the hpegl provider data sources and their HPE equivalents.
+
+| hpegl Provider Data Source Name                   | HPE Provider Data Source Name              |
+|---------------------------------------------------|--------------------------------------------|
+| hpegl_vmaas_cloud                                 | hpe_morpheus_cloud                         |
+| hpegl_vmaas_group                                 | hpe_morpheus_group                         |
+| hpegl_vmaas_plan                                  | hpe_morpheus_service_plan                  |
+| hpegl_vmaas_layout                                | hpe_morpheus_instance_type_layout          |
+| hpegl_vmaas_network                               | hpe_morpheus_network                       |
+| hpegl_vmaas_datastore                             | hpe_morpheus_datastore                     |
+| hpegl_vmaas_template                              | hpe_morpheus_image                         |
+| hpegl_vmaas_environment                           | hpe_morpheus_environment                   |
+| hpegl_vmaas_network_type                          | hpe_morpheus_network_type                  |
+| hpegl_vmaas_network_pool                          | hpe_morpheus_network_pool                  |
+| hpegl_vmaas_network_domain                        | hpe_morpheus_network_domain                |
+| hpegl_vmaas_router                                | hpe_morpheus_network_router                |
+| hpegl_vmaas_edge_cluster                          | hpe_morpheus_network_edge_cluster          |
+| hpegl_vmaas_transport_zone                        | hpe_morpheus_network_transport_zone        |
+| hpegl_vmaas_load_balancer                         | hpe_morpheus_load_balancer                 |
+| hpegl_vmaas_load_balancer_monitor                 | hpe_morpheus_load_balancer_monitor         |
+| hpegl_vmaas_load_balancer_pool                    | hpe_morpheus_load_balancer_pool            |
+| hpegl_vmaas_load_balancer_profile                 | hpe_morpheus_load_balancer_profile         |
+| hpegl_vmaas_load_balancer_virtual_server          | hpe_morpheus_load_balancer_virtual_server  |
+| hpegl_vmaas_dhcp_server                           | hpe_morpheus_network_dhcp_server           |
+| hpegl_vmaas_resource_pool                         | hpe_morpheus_resource_pool                 |
+| hpegl_vmaas_power_schedule                        | hpe_morpheus_power_schedule                |
+| hpegl_vmaas_cloud_folder                          | hpe_morpheus_cloud_folder                  |
+| hpegl_vmaas_network_proxy                         | hpe_morpheus_network_proxy                 |
+| hpegl_vmaas_network_interface                     | hpe_morpheus_network_interface_type        |
+| hpegl_vmaas_instance_storage_controller           | hpe_morpheus_instance_storage_controller   |
+| hpegl_vmaas_lb_pool_member_group                  | hpe_morpheus_network_server_group          |
+| hpegl_vmaas_instance_disk_type                    | hpe_morpheus_instance_disk_type            |
+| hpegl_vmaas_load_balancer_virtual_server_ssl_cert | hpe_morpheus_certificate                   |
+
+### Removed Data Sources
+
+The following hpegl data source has no HPE equivalent and is removed during migration:
+
+- `hpegl_vmaas_morpheus_details` - the provider-chain broker data source; its role is replaced by the
+  provider block transformation performed by [`migrate-providers`](./tfmigrator_migration.md).
+
+## Migration Workflow
+
+The end-to-end command workflow - installation, the one-shot `tfmigrator migrate` command, and the
+individual `migrate-providers` -> `generate` -> `merge` -> `migrate-datasources` steps - is documented
+in the [tfmigrator guide](./tfmigrator_migration.md). tfmigrator auto-detects the hpegl provider in
+your workspace, so the same commands apply here. For common issues, see
+[tfmigrator Troubleshooting](./tfmigrator_troubleshooting.md).

--- a/docs/guides/opsramp_to_hpe_migration.md
+++ b/docs/guides/opsramp_to_hpe_migration.md
@@ -10,7 +10,7 @@ This guide describes how to migrate existing Terraform configurations from the s
 ## Prerequisites
 
 - Terraform >= 1.5.0 (required for `import` blocks)
-- HPE provider >= 1.6.0
+- HPE provider >= 2.0.0
 - Access to your existing OpsRamp resource IDs (from state or the OpsRamp API)
 
 ## Step 1: Update the Provider Declaration
@@ -44,7 +44,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.6.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -173,63 +173,9 @@ Before starting, ensure you have:
 terraform show -json > state.json
 ```
 
-2. Your HPE provider setup in Terraform configuration (root and modules as needed).
+2. Your original Terraform configuration directory, containing the source (`morpheus` / `hpegl`) provider configuration.
 
-3. Your original Terraform configuration directory.
-
-Ensure provider setup is already in your Terraform files before running migration.
-
----
-
-## Basic Provider Setup (Do This First)
-
-Set up `required_providers` and provider blocks in your Terraform code before using `tfmigrator`. Update the `required_providers` block in root and modules as needed.
-
-```hcl
-terraform {
-  required_providers {
-    morpheus = {
-      source  = "gomorpheus/morpheus"
-      version = "0.14.1"
-    }
-    hpe = {
-      source  = "HPE/hpe"
-      version = ">= 2.0.0"
-    }
-  }
-}
-
-
-provider "morpheus" {
-  url      = var.morpheus_url
-  username = var.morpheus_username
-  password = var.morpheus_password
-}
-
-provider "hpe" {
-  morpheus {
-    url      = var.morpheus_url
-    username = var.morpheus_username
-    password = var.morpheus_password
-  }
-}
-
-variable "morpheus_url" {
-  type = string
-}
-
-variable "morpheus_username" {
-  type = string
-}
-
-variable "morpheus_password" {
-  type      = string
-  sensitive = true
-}
-```
-
-This setup is expected to exist before migration.
-
+-> The `migrate` and `migrate-providers` commands generate the `hpe` provider block for you automatically from your existing configuration - you do **not** need to hand-author an `hpe` provider block for the recommended workflow. A hand-authored provider block is only required if you run `generate` on its own without `migrate-providers` (see [Step 2](#step-2-generate-migration-artifacts)).
 
 ---
 
@@ -351,7 +297,16 @@ tfmigrator generate \
 - `generated/import.tf`
   - Import blocks for migrated resources
 
-- `--provider-config` should point to wherever your HPE provider is configured for the migration context (for example, `./provider.tf` or `./main.tf`). Alternatively - create a temporary file for this step (i.e. `.provider/provider.tf`) that follows the below format:
+- Cleanup is run automatically at the end of `generate` unless you pass `--no-cleanup`.
+
+### Provider context (standalone `generate` only)
+
+`generate` runs Terraform internally to produce the configuration, so it needs a provider context via `--provider-config`.
+
+- If you ran `migrate-providers` first (or used the full `migrate` command), this is already handled for you - point `--provider-config` at the generated `provider-config/` directory. No manual provider block is required.
+- If you are running `generate` **on its own**, supply a `--provider-config` file that configures the `hpe` provider (and the source provider used for planning). This can be an existing file such as `./provider.tf` or `./main.tf`, or a temporary file created just for this step.
+
+A minimal `--provider-config` file using variables:
 
 ```hcl
 terraform {
@@ -369,22 +324,34 @@ terraform {
 
 
 provider "morpheus" {
-  url      = "YOURURLHERE"
-  username = "YOURUSERNAMEHERE"
-  password = "YOURPASSWORDHERE"
+  url      = var.morpheus_url
+  username = var.morpheus_username
+  password = var.morpheus_password
 }
 
 provider "hpe" {
   morpheus {
-    url      = "YOURURLHERE"
-    username = "YOURUSERNAMEHERE"
-    password = "YOURPASSWORDHERE"
+    url      = var.morpheus_url
+    username = var.morpheus_username
+    password = var.morpheus_password
   }
 }
-```
--> If variables are used in the `--provider-config` - the respective `variable` blocks are expected to be provided in that file. The values themselves can then be passed in via `--provider-var-file` or `--provider-var`.
 
-- Cleanup is run automatically at the end of `generate` unless you pass `--no-cleanup`.
+variable "morpheus_url" {
+  type = string
+}
+
+variable "morpheus_username" {
+  type = string
+}
+
+variable "morpheus_password" {
+  type      = string
+  sensitive = true
+}
+```
+
+-> If variables are used in the `--provider-config`, the respective `variable` blocks are expected to be provided in that file. The values themselves can then be passed in via `--provider-var-file` or `--provider-var`. Alternatively, for a quick throwaway context you can inline literal values in place of the `var.*` references (for example a `.provider/provider.tf` with `url = "YOURURLHERE"`, `username = "YOURUSERNAMEHERE"`, `password = "YOURPASSWORDHERE"`) and skip the `variable` blocks.
 
 ---
 

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -30,7 +30,7 @@ This can be useful in environments that do not allow direct access to the Intern
 
 ### Install Scripts
 
-See [linux](https://github.com/HPE/terraform-provider-hpe/blob/main/scripts/install-tfmigrator.sh), [windows](https://github.com/HPE/terraform-provider-hpe/blob/main/scripts/install-tfmigrator-windows.ps1), and [macOS](https://github.com/HPE/terraform-provider-hpe/blob/main/scripts/install-tfmigrator-macos.sh) install scripts that will download the latest release of tfmigrator and install it in the appropriate location for your operating system.
+See [linux](https://github.com/HPE/terraform-provider-hpe/blob/-/scripts/install-tfmigrator.sh), [windows](https://github.com/HPE/terraform-provider-hpe/blob/-/scripts/install-tfmigrator-windows.ps1), and [macOS](https://github.com/HPE/terraform-provider-hpe/blob/-/scripts/install-tfmigrator-macos.sh) install scripts that will download the latest release of tfmigrator and install it in the appropriate location for your operating system.
 
 ### Linux
 

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -16,7 +16,7 @@ This document is a step-by-step guide for migrating Terraform configuration to H
 `tfmigrator` supports two ways of running the migration:
 
 - **Full pipeline** - a single `migrate` command that runs every step end to end.
-- **Individual steps** - run `migrate-providers`, `generate`, `merge`, and `migrate-datasources` yourself for finer control.
+- **Individual steps** - run `migrate-providers`, `generate`, `merge`, `migrate-datasources`, and `cleanup-providers` yourself for finer control.
 
 Both approaches are documented below.
 
@@ -150,12 +150,13 @@ The following examples use PowerShell on Windows (x64).
 - `generate` - extract resources from state, build `generated.tf` + `import.tf`
 - `merge` - merge generated resources into original config while preserving user intent
 - `migrate-datasources` - rewrite `hpegl_vmaas_*` / `morpheus_*` data source blocks to `hpe_morpheus_*` equivalents
+- `cleanup-providers` - remove the superseded source/intermediary provider blocks, the broker data source, and unused `required_providers` entries that the migration has replaced (run automatically by `migrate`)
 - `clean` - post-process a generated file with cleanup rules (run automatically by `generate`)
 
 A typical migration is either:
 
 - **Full pipeline:** `migrate` followed by `terraform init / plan / apply --refresh-only / apply` in the migrated output, or
-- **Individual steps:** `migrate-providers` → `generate` → `merge` → `migrate-datasources`, then the same Terraform validation/apply flow.
+- **Individual steps:** `migrate-providers` → `generate` → `merge` → `migrate-datasources` → `cleanup-providers`, then the same Terraform validation/apply flow.
 
 Optional:
 
@@ -183,7 +184,13 @@ terraform show -json > state.json
 
 The `migrate` command runs the entire migration end to end. It auto-detects the source provider
 (Morpheus or hpegl) in your workspace and runs `migrate-providers` → `generate` → `merge` →
-`migrate-datasources` in sequence.
+`migrate-datasources` in sequence. As part of this it also removes the superseded source and
+intermediary provider blocks and the broker data source (before `migrate-datasources`) and prunes the
+now-unused `required_providers` entries (after `migrate-datasources`) - the same work the standalone
+[`cleanup-providers`](#step-5-remove-superseded-provider-configuration-cleanup-providers) command
+performs for the individual flow. `migrate` interleaves this around its `migrate-datasources` step
+deliberately, to keep the output quiet; the individual flow runs it once at the end instead (see
+[Step 5](#step-5-remove-superseded-provider-configuration-cleanup-providers)).
 
 ### Basic command
 
@@ -212,7 +219,7 @@ tfmigrator migrate \
 
 - `migrated/provider-config/` - generated `hpe` provider blocks and `credentials.auto.tfvars` (from `migrate-providers`)
 - `migrated/generated/` - `generated.tf` + `import.tf` (from `generate`)
-- `migrated/final/` - the merged, ready-to-review configuration (from `merge`, then rewritten in place by `migrate-datasources`)
+- `migrated/final/` - the merged, ready-to-review configuration (from `merge`, with the superseded provider blocks removed, then rewritten in place by `migrate-datasources`, and its `required_providers` pruned)
 
 The `migrate` command derives the provider context and credentials from your existing configuration
 automatically, so you do not need to hand-author a `--provider-config` file as you would when running
@@ -240,7 +247,7 @@ the one-shot `migrate` command, for example to review the transformed provider b
 configuration before merging.
 
 The individual flow is: **Step 1** `migrate-providers` → **Step 2** `generate` → **Step 3** `merge`
-→ **Step 4** `migrate-datasources`.
+→ **Step 4** `migrate-datasources` → **Step 5** `cleanup-providers`.
 
 ---
 
@@ -454,6 +461,49 @@ tfmigrator migrate-datasources \
 Point `--input` at your merged output (for example `./migrated` from Step 3) and use `--in-place` to
 rewrite the data source blocks there. The one-shot `migrate` command runs this step automatically
 against `migrated/final/`.
+
+---
+
+## Step 5: Remove Superseded Provider Configuration (`cleanup-providers`)
+
+The migrated output still carries the original source provider blocks, the intermediary provider
+blocks, and the broker data source that chained them together (for example
+`hpegl_vmaas_morpheus_details`). These have been replaced by the generated `hpe` provider block, so
+what remains is dead configuration that still asks Terraform to install and authenticate the old
+providers. `cleanup-providers` removes those blocks and then prunes the `required_providers` entries
+that nothing references any more. Run it last, as a final tidy-up over the migrated output.
+
+Detection runs against your **original** configuration (`--working-dir`), while the removal is applied
+to the **migrated output** (`--target-dir`). The two are deliberately separate: a provider chain
+cannot be reconstructed from the migrated output alone, because `migrate-datasources` has removed the
+broker data source that identifies the chain.
+
+-> Running `cleanup-providers` after `migrate-datasources` (Step 4) is expected to surface two harmless
+messages. Step 4 will already have reported `⚠  Removed N data source(s) with no HPE equivalent ...
+(referenced in ...)` for the broker data source, and `cleanup-providers` may print a `note:` that an
+intermediary provider block references a broker data source no longer declared in the target. Both are
+benign: detection uses `--working-dir` (the untouched original), so the removal completes correctly and
+the final result is identical to what the one-shot `migrate` command produces. `migrate` simply
+interleaves the same work around its own `migrate-datasources` step to suppress those messages.
+
+### Basic command
+
+```bash
+tfmigrator cleanup-providers \
+  --working-dir . \
+  --target-dir ./migrated
+```
+
+### Cleanup-providers flags
+
+- `--working-dir, -w` Original configuration to detect against (default `.`)
+- `--target-dir, -t` Migrated output to clean up (default `./migrated/final`)
+- `--config, -c` Migration config: `auto` to detect from the workspace, or an embedded config name (`hpegl`, `morpheus`) (default `auto`)
+- `--dry-run` Show what would be removed without writing files (default `false`)
+
+The default `--target-dir` (`./migrated/final`) matches the layout the full `migrate` command produces.
+For the individual flow, point `--target-dir` at the output directory `merge` wrote to in Step 3
+(`./migrated` by default), as shown above.
 
 ---
 

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -145,7 +145,7 @@ The following examples use PowerShell on Windows (x64).
 
 `tfmigrator` provides the following commands:
 
-- `migrate` - run the full pipeline (`migrate-providers` → `generate` → `merge` → `migrate-datasources`) in one command
+- `migrate` - run the full pipeline (`migrate-providers` → `generate` → `merge` → `migrate-datasources` → `cleanup-providers`) in one command
 - `migrate-providers` - transform source (Morpheus / hpegl) provider blocks into `hpe` provider blocks
 - `generate` - extract resources from state, build `generated.tf` + `import.tf`
 - `merge` - merge generated resources into original config while preserving user intent
@@ -184,12 +184,16 @@ terraform show -json > state.json
 
 The `migrate` command runs the entire migration end to end. It auto-detects the source provider
 (Morpheus or hpegl) in your workspace and runs `migrate-providers` → `generate` → `merge` →
-`migrate-datasources` in sequence. As part of this it also removes the superseded source and
-intermediary provider blocks and the broker data source (before `migrate-datasources`) and prunes the
-now-unused `required_providers` entries (after `migrate-datasources`) - the same work the standalone
-[`cleanup-providers`](#step-5-remove-superseded-provider-configuration-cleanup-providers) command
-performs for the individual flow. `migrate` interleaves this around its `migrate-datasources` step
-deliberately, to keep the output quiet; the individual flow runs it once at the end instead (see
+`migrate-datasources` in sequence. It also performs the same work as the standalone
+[`cleanup-providers`](#step-5-remove-superseded-provider-configuration-cleanup-providers) command,
+interleaved around the `migrate-datasources` step:
+
+1. Before `migrate-datasources`: it removes the superseded source and intermediary provider blocks
+   and the broker data source.
+2. After `migrate-datasources`: it prunes the now-unused `required_providers` entries.
+
+`migrate` interleaves the cleanup this way deliberately, to keep the output quiet. The individual
+flow instead runs `cleanup-providers` once at the end (see
 [Step 5](#step-5-remove-superseded-provider-configuration-cleanup-providers)).
 
 ### Basic command

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -1,16 +1,24 @@
 ---
-page_title: "tfmigrator: Morpheus to HPE"
+page_title: "tfmigrator"
 subcategory: "Migration"
 ---
 
 
 ## What This Guide Covers
 
-This document is a step-by-step guide for migrating Terraform configuration from Morpheus provider resources to HPE provider resources using `tfmigrator`.
+This document is a step-by-step guide for migrating Terraform configuration to HPE provider resources using `tfmigrator`. It applies both to the [Morpheus](./morpheus_to_hpe_migration.md) and [hpegl](./hpegl_to_hpe_migration.md) providers as migration sources - `tfmigrator` auto-detects the source provider in your workspace.
 
 - Preserve your variables, modules, expressions, and overall configuration structure.
 - Update resource types and schemas to HPE provider resources.
+- Transform the source provider block (Morpheus or hpegl) into an `hpe` provider block.
 - Run migration into a separate output directory so you can review before apply.
+
+`tfmigrator` supports two ways of running the migration:
+
+- **Full pipeline** - a single `migrate` command that runs every step end to end.
+- **Individual steps** - run `migrate-providers`, `generate`, `merge`, and `migrate-datasources` yourself for finer control.
+
+Both approaches are documented below.
 
 ---
 
@@ -135,15 +143,23 @@ The following examples use PowerShell on Windows (x64).
 
 ## Command Summary
 
-`tfmigrator` migration flow is typically:
+`tfmigrator` provides the following commands:
 
-1. `generate` - extract resources from state, build `generated.tf` + `import.tf`
-2. `merge` - merge generated resources into original config while preserving user intent
-3. `terraform init / plan / apply --refresh-only / apply` - validate and apply in migrated output
+- `migrate` - run the full pipeline (`migrate-providers` → `generate` → `merge` → `migrate-datasources`) in one command
+- `migrate-providers` - transform source (Morpheus / hpegl) provider blocks into `hpe` provider blocks
+- `generate` - extract resources from state, build `generated.tf` + `import.tf`
+- `merge` - merge generated resources into original config while preserving user intent
+- `migrate-datasources` - rewrite `hpegl_vmaas_*` / `morpheus_*` data source blocks to `hpe_morpheus_*` equivalents
+- `clean` - post-process a generated file with cleanup rules (run automatically by `generate`)
+
+A typical migration is either:
+
+- **Full pipeline:** `migrate` followed by `terraform init / plan / apply --refresh-only / apply` in the migrated output, or
+- **Individual steps:** `migrate-providers` → `generate` → `merge` → `migrate-datasources`, then the same Terraform validation/apply flow.
 
 Optional:
 
-1. `clean` - run if you generated raw Terraform config externally and need cleanup rules - or after running `generate --no-cleanup`
+- `clean` - run if you generated raw Terraform config externally and need cleanup rules - or after running `generate --no-cleanup`
 
 ---
 
@@ -178,7 +194,7 @@ terraform {
     }
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.3.0"
+      version = ">= 2.0.0"
     }
   }
 }
@@ -217,7 +233,98 @@ This setup is expected to exist before migration.
 
 ---
 
-## Step 1: Generate Migration Artifacts
+## Full Pipeline (`migrate`)
+
+The `migrate` command runs the entire migration end to end. It auto-detects the source provider
+(Morpheus or hpegl) in your workspace and runs `migrate-providers` → `generate` → `merge` →
+`migrate-datasources` in sequence.
+
+### Basic command
+
+```bash
+tfmigrator migrate \
+  --state state.json \
+  --working-dir .
+```
+
+### Migrate flags
+
+- `--state, -s` Path to Terraform state JSON from `terraform show -json > state.json` (required)
+- `--working-dir, -w` Workspace directory containing the original Terraform configuration (default `.`)
+- `--output-dir, -o` Root output directory (default `./migrated`)
+- `--terraform-path` Path to the `terraform` binary (default `terraform`)
+- `--var-file` Variable file(s) passed to Terraform plan during generation, repeatable (default none)
+- `--var` Individual variable value(s) passed to Terraform plan in `key=value` format, repeatable (default none)
+- `--original` Original Terraform file(s)/directory(ies) to include in the final merge, repeatable (defaults to `--working-dir`)
+- `--dry-run` Show what would be done without writing files (default `false`)
+
+### Migrate output
+
+`migrate` writes into subdirectories of `--output-dir`:
+
+- `migrated/provider-config/` - generated `hpe` provider blocks and `credentials.auto.tfvars` (from `migrate-providers`)
+- `migrated/generated/` - `generated.tf` + `import.tf` (from `generate`)
+- `migrated/final/` - the merged, ready-to-review configuration (from `merge`, then rewritten in place by `migrate-datasources`)
+
+The `migrate` command derives the provider context and credentials from your existing configuration
+automatically, so you do not need to hand-author a `--provider-config` file as you would when running
+`generate` on its own.
+
+### Next steps after `migrate`
+
+```bash
+cd migrated/final
+terraform init
+terraform fmt
+terraform validate
+terraform plan
+# Check that everything is just imports
+terraform apply --refresh-only
+terraform apply
+```
+
+---
+
+# Individual Steps
+
+The remaining sections document each step individually. Run these when you want finer control than
+the one-shot `migrate` command, for example to review the transformed provider blocks or the generated
+configuration before merging.
+
+The individual flow is: **Step 1** `migrate-providers` → **Step 2** `generate` → **Step 3** `merge`
+→ **Step 4** `migrate-datasources`.
+
+---
+
+## Step 1: Transform Provider Blocks (`migrate-providers`)
+
+`migrate-providers` scans your workspace for source (Morpheus / hpegl) provider configurations and
+generates the equivalent `hpe` provider blocks, along with credential `variable` blocks and a
+`credentials.auto.tfvars` file. This is especially important for hpegl, where the GreenLake IAM
+configuration is transformed into a `morpheus { pce_identity { ... } }` block. See the
+[hpegl migration guide](./hpegl_to_hpe_migration.md) for the details of that transformation.
+
+### Basic command
+
+```bash
+tfmigrator migrate-providers \
+  --working-dir . \
+  --output-dir ./provider-config
+```
+
+### Migrate-providers flags
+
+- `--working-dir, -w` Workspace directory to scan for provider configurations (default `.`)
+- `--output-dir, -o` Output directory for generated provider files (default `./provider-config`)
+- `--config, -c` Migration config: `auto` to detect from the workspace, an embedded config name (`hpegl`, `morpheus`), or a filesystem path (default `auto`)
+- `--dry-run` Show what would be generated without writing files (default `false`)
+
+The generated `./provider-config` directory can then be passed to `generate` via `--provider-config`,
+and `credentials.auto.tfvars` supplied via `--provider-var-file`.
+
+---
+
+## Step 2: Generate Migration Artifacts
 
 ### Basic command
 
@@ -255,7 +362,7 @@ terraform {
     }
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.3.0"
+      version = ">= 2.0.0"
     }
   }
 }
@@ -281,7 +388,7 @@ provider "hpe" {
 
 ---
 
-## Optional Step 1.5: Run `clean` Manually
+## Optional Step 2.5: Run `clean` Manually
 
 Use this when:
 
@@ -305,11 +412,11 @@ tfmigrator clean \
   --output ./generated/cleaned.tf
 ```
 
-If you write to `cleaned.tf`, use that file as the `--generated` input in Step 2.
+If you write to `cleaned.tf`, use that file as the `--generated` input in Step 3.
 
 ---
 
-## Step 2: Merge Into Original Config
+## Step 3: Merge Into Original Config
 
 ### Recommended command
 
@@ -334,6 +441,36 @@ tfmigrator merge \
 - Same-schema resources are renamed while keeping existing expressions/variables where possible.
 - Different-schema resources are merged from generated output.
 - Result is written to your `--output-dir` so you can review before applying.
+
+---
+
+## Step 4: Rewrite Data Sources (`migrate-datasources`)
+
+`migrate-datasources` rewrites `hpegl_vmaas_*` and `morpheus_*` data source blocks to their
+`hpe_morpheus_*` equivalents, updates references to them, and removes data sources that have no HPE
+equivalent (for example `hpegl_vmaas_morpheus_details`).
+
+### Basic command
+
+```bash
+tfmigrator migrate-datasources \
+  --input ./migrated \
+  --in-place
+```
+
+### Migrate-datasources flags
+
+- `--input, -i` Input directory/files to process, repeatable (default `.`)
+- `--output-dir, -o` Output directory for rewritten files (default `./migrated`)
+- `--config, -c` Config source: `auto` (all embedded sets), a single embedded name (`hpegl`, `morpheus`), or a filesystem path (default `auto`)
+- `--in-place` Modify files in place instead of writing to `--output-dir` (default `false`)
+- `--dry-run` Preview changes without writing (default `false`)
+- `--no-color` Disable ANSI color in the dry-run diff (default `false`)
+- `--verbose, -v` Show detailed transformation info (default `false`)
+
+Point `--input` at your merged output (for example `./migrated` from Step 3) and use `--in-place` to
+rewrite the data source blocks there. The one-shot `migrate` command runs this step automatically
+against `migrated/final/`.
 
 ---
 

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -40,19 +40,19 @@ The following examples use Bash on Linux (x64).
 
    ```console
    RELEASE=x.y.z
-   wget -q https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/migration_tool_${RELEASE}_linux_amd64.zip
+   wget -q https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/tfmigrator_${RELEASE}_linux_amd64.zip
    ```
 
 2. Extract the archive.
 
    ```console
-   unzip migration_tool_${RELEASE}_linux_amd64.zip
+   unzip tfmigrator_${RELEASE}_linux_amd64.zip
    ```
 
 3. Move the binary to a directory in your PATH.
 
    ```console
-   sudo mv migration_tool_v${RELEASE} /usr/local/bin/tfmigrator
+   sudo mv tfmigrator_v${RELEASE} /usr/local/bin/tfmigrator
    chmod +x /usr/local/bin/tfmigrator
    ```
 
@@ -76,20 +76,20 @@ The following example uses Zsh (default) on macOS (Apple Silicon).
 
    ```console
    RELEASE=x.y.z
-   wget -q https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/migration_tool_${RELEASE}_darwin_arm64.zip
+   wget -q https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/tfmigrator_${RELEASE}_darwin_arm64.zip
    ```
 
 3. Extract the archive.
 
    ```console
-   unzip migration_tool_${RELEASE}_darwin_arm64.zip
+   unzip tfmigrator_${RELEASE}_darwin_arm64.zip
    ```
 
 4. Move the binary to a directory in your PATH.
 
 
    ```console
-   sudo mv migration_tool_v${RELEASE} /usr/local/bin/tfmigrator
+   sudo mv tfmigrator_v${RELEASE} /usr/local/bin/tfmigrator
    chmod +x /usr/local/bin/tfmigrator
    ```
 
@@ -107,20 +107,20 @@ The following examples use PowerShell on Windows (x64).
 
    ```powershell
    Set-Variable -Name "RELEASE" -Value "x.y.z"
-   Invoke-WebRequest https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/migration_tool_${RELEASE}_windows_amd64.zip -outfile migration_tool_${RELEASE}_windows_amd64.zip
+   Invoke-WebRequest https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/tfmigrator_${RELEASE}_windows_amd64.zip -outfile tfmigrator_${RELEASE}_windows_amd64.zip
    ```
 
 2. Extract the archive.
 
    ```powershell
-   Expand-Archive migration_tool_${RELEASE}_windows_amd64.zip
-   cd migration_tool_${RELEASE}_windows_amd64
+   Expand-Archive tfmigrator_${RELEASE}_windows_amd64.zip
+   cd tfmigrator_${RELEASE}_windows_amd64
    ```
 
 3. Move the binary to a directory in your PATH.
 
    ```powershell
-   Move-Item migration_tool_v${RELEASE}.exe C:\Windows\System32\tfmigrator.exe
+   Move-Item tfmigrator_v${RELEASE}.exe C:\Windows\System32\tfmigrator.exe
    ```
 
 4. Verify the installation.

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -190,7 +190,9 @@ The `migrate` command runs the entire migration end to end. It auto-detects the 
 ```bash
 tfmigrator migrate \
   --state state.json \
-  --working-dir .
+  --working-dir . \
+  --var-file terraform.tfvars \
+  --original .
 ```
 
 ### Migrate flags
@@ -277,7 +279,8 @@ and `credentials.auto.tfvars` supplied via `--provider-var-file`.
 ```bash
 tfmigrator generate \
   --state state.json \
-  --provider-config ./provider.tf
+  --provider-config ./provider.tf \
+  --provider-var-file terraform.tfvars
 ```
 
 ### Generate flags
@@ -366,18 +369,30 @@ Use this when:
 Recommended in-place cleanup:
 
 ```bash
+# Morpheus source
 tfmigrator clean \
-  --input ./generated/generated.tf \
+  --input ./generated/generated_morpheus.tf \
+  --config morpheus \
+  --in-place
+
+# hpegl source
+tfmigrator clean \
+  --input ./generated/generated_hpegl.tf \
+  --config hpegl \
   --in-place
 ```
 
 If you prefer a separate output file:
 
 ```bash
+# Morpheus source
 tfmigrator clean \
-  --input ./generated/generated.tf \
+  --input ./generated/generated_morpheus.tf \
+  --config morpheus \
   --output ./generated/cleaned.tf
 ```
+
+The `--config` flag is required and takes an embedded config name (`morpheus` or `hpegl`) or a filesystem path to a cleanup config directory - use the value matching your source provider.
 
 If you write to `cleaned.tf`, use that file as the `--generated` input in Step 3.
 

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -650,6 +650,8 @@ This allows it to identify which resources belong to modules on a merge and upda
 
 -> Ensure that the module configuration (located in `./user-policy` in the above example) is included as part of what is passed into `merge` as the `--original` configuration. Note that `--original` searches for Terraform configuration files recursively so passing in `--original .` while in the working directory where all modules are available as subdirectories is generally sufficient.  
 
+-> Modules must be available locally on disk to be migrated. `tfmigrator` only rewrites `.tf` files it can read from the paths passed to `--original`; it does not fetch remote modules. If a module is sourced remotely, copy its configuration locally, point the module `source` at the local path, and ensure that directory is reachable from `--original`. Modules that remain remote-only will be left unmigrated.
+
 ---
 
 ## Common Patterns

--- a/docs/guides/tfmigrator_migration.md
+++ b/docs/guides/tfmigrator_migration.md
@@ -287,6 +287,7 @@ tfmigrator generate \
 
 - `--state, -s` Path to Terraform state JSON from `terraform show -json > state.json` (required)
 - `--output-dir, -o` Output directory for generated files (default `./generated`)
+- `--terraform-path` Path to the `terraform` binary (default `terraform`)
 - `--provider-config` Path to a Terraform provider context file containing `terraform` and provider blocks (and optional `variable` / `locals` blocks)
 - `--provider-var-file` Optional var-file(s) for provider context, repeatable (default none)
 - `--provider-var` Optional variable(s) passed to Terraform plan in `key=value` format, repeatable (default none)
@@ -409,8 +410,8 @@ tfmigrator merge \
 
 ### Merge flags
 
-- `--generated, -g` Path to generated Terraform file (default `./generated/generated.tf`)
-- `--original, -o` Original Terraform configuration file(s) and/or directories, repeatable
+- `--generated, -g` Path(s) to generated Terraform file(s), repeatable. If omitted, auto-discovers `generated.tf` and `generated_*.tf` from `./generated`
+- `--original, -o` Original Terraform configuration file(s) and/or directories, repeatable (required)
 - `--output-dir, -d` Output directory for merged configuration (default `./migrated`)
 - `--imports-file` Explicit imports file path (auto-discovered from generated file location when omitted)
 - `--var-file` Var-file(s) to copy into output directory, repeatable (default none)

--- a/docs/guides/tfmigrator_troubleshooting.md
+++ b/docs/guides/tfmigrator_troubleshooting.md
@@ -25,7 +25,7 @@ terraform {
     }
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.3.0"
+      version = ">= 2.0.0"
     }
   }
 }
@@ -119,7 +119,7 @@ terraform {
     }
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.3.0"
+      version = ">= 2.0.0"
     }
   }
 }
@@ -138,7 +138,7 @@ Attribute config_vmware.nested_virtualization value must be one of: ["on" "off"]
 ```
 
 Fix:
-- Ensure the HPE provider is at version `1.2.0` or later.
+- Ensure the HPE provider is at version `2.0.0` or later.
 - Alternatively, set `nested_virtualization` values to `"on"` or `"off"` in the migrated configuration.
 
 

--- a/scripts/install-tfmigrator-macos.sh
+++ b/scripts/install-tfmigrator-macos.sh
@@ -27,15 +27,15 @@ download_and_install () {
   local tmp_dir
   tmp_dir=$(mktemp -d)
   
-  local archive_name="migration_tool_${version_number}_${os}_${arch}.zip"
+  local archive_name="tfmigrator_${version_number}_${os}_${arch}.zip"
   local download_url="https://github.com/${repo}/releases/download/${VERSION}/${archive_name}"
   
   cd "$tmp_dir"
   curl -sL "$download_url" -o "$archive_name" && \
     unzip -q "$archive_name"
   
-  # Binary is named migration_tool_v${version_number}
-  local binary_path="migration_tool_v${version_number}"
+  # Binary is named tfmigrator_v${version_number}
+  local binary_path="tfmigrator_v${version_number}"
   if [[ ! -f "$binary_path" ]]; then
     echo "Error: Could not find binary ${binary_path} in archive"
     rm -rf "$tmp_dir"

--- a/scripts/install-tfmigrator-windows.ps1
+++ b/scripts/install-tfmigrator-windows.ps1
@@ -27,7 +27,7 @@ if (!$VERSION) {
 $version_number=$VERSION -replace 'v'  
 
 $tmp_dir="${env:TEMP}\tfmigrator-install-$(Get-Random)"
-$archive_name="migration_tool_${version_number}_${os}_${arch}.zip"
+$archive_name="tfmigrator_${version_number}_${os}_${arch}.zip"
 $archive_path="${tmp_dir}\${archive_name}"
 $download_url="https://github.com/${repo}/releases/download/${VERSION}/${archive_name}"
 
@@ -50,9 +50,9 @@ catch {
 Write-Host "Extracting release files"
 Expand-Archive $archive_path -Force
 
-# Binary is named migration_tool_v${version_number}.exe
+# Binary is named tfmigrator_v${version_number}.exe
 $extract_dir = $archive_name -replace '.zip'
-$binary_path = "${extract_dir}\migration_tool_v${version_number}.exe"
+$binary_path = "${extract_dir}\tfmigrator_v${version_number}.exe"
 if (!(Test-Path $binary_path)) {
     Write-Host "Error: Could not find binary ${binary_path} in archive"
     Set-Location "${users_pwd}"

--- a/scripts/install-tfmigrator.sh
+++ b/scripts/install-tfmigrator.sh
@@ -17,15 +17,15 @@ download_and_install () {
   local tmp_dir
   tmp_dir=$(mktemp -d)
   
-  local archive_name="migration_tool_${version_number}_${os}_${arch}.zip"
+  local archive_name="tfmigrator_${version_number}_${os}_${arch}.zip"
   local download_url="https://github.com/${repo}/releases/download/${VERSION}/${archive_name}"
   
   cd "$tmp_dir"
   curl -sL "$download_url" -o "$archive_name" && \
     unzip -q "$archive_name"
   
-  # Binary is named migration_tool_v${version_number}
-  local binary_path="migration_tool_v${version_number}"
+  # Binary is named tfmigrator_v${version_number}
+  local binary_path="tfmigrator_v${version_number}"
   if [[ ! -f "$binary_path" ]]; then
     echo "Error: Could not find binary ${binary_path} in archive"
     rm -rf "$tmp_dir"

--- a/templates/guides/hpegl_to_hpe_migration.md
+++ b/templates/guides/hpegl_to_hpe_migration.md
@@ -23,6 +23,11 @@ provider (hpegl used the Terraform Plugin SDK v2; the HPE provider uses the Plug
 resource therefore requires Terraform-generated configuration and manual post-migration review. The
 process documented for [tfmigrator](./tfmigrator_migration.md) handles this generation for you.
 
+## Prerequisites
+
+- Terraform >= 1.5.0 (required for `import` blocks)
+- HPE provider >= 2.0.0
+
 ## Provider Block Transformation
 
 The largest difference between an hpegl configuration and an HPE configuration is the provider block.
@@ -66,6 +71,17 @@ provider "hpe" {
 ### GreenLake IAM - Disconnected (`iam_version = "glp"`)
 
 ```HCL
+# Before (hpegl)
+provider "hpegl" {
+  iam_version      = "glp"
+  iam_service_url  = "https://client.greenlake.hpe.com/..."
+  vmaas {
+    location   = "HPE-Data-Center"
+    space_name = "my-space"
+    broker_url = "https://vmaas-broker.example.com"
+  }
+}
+
 # After (hpe)
 provider "hpe" {
   morpheus {
@@ -84,10 +100,18 @@ provider "hpe" {
 ### Direct-connect (`vmaas.morpheus_url` present)
 
 When the hpegl `vmaas` block sets `morpheus_url`, the provider connects directly to Morpheus with no
-GreenLake IAM broker. In that case the credentials land directly inside the `morpheus` block and no
-`pce_identity` sub-block is emitted:
+GreenLake IAM broker. In that case the credentials land directly inside the `morpheus` block, with
+neither a `pce_identity` nor a `pce_disconnected_identity` sub-block emitted:
 
 ```HCL
+# Before (hpegl)
+provider "hpegl" {
+  vmaas {
+    morpheus_url   = "https://morpheus.example.com"
+    morpheus_token = var.hpe_morpheus_access_token
+  }
+}
+
 # After (hpe)
 provider "hpe" {
   morpheus {

--- a/templates/guides/hpegl_to_hpe_migration.md
+++ b/templates/guides/hpegl_to_hpe_migration.md
@@ -188,7 +188,7 @@ The following hpegl data source has no HPE equivalent and is removed during migr
 ## Migration Workflow
 
 The end-to-end command workflow - installation, the one-shot `tfmigrator migrate` command, and the
-individual `migrate-providers` -> `generate` -> `merge` -> `migrate-datasources` steps - is documented
+individual `migrate-providers` -> `generate` -> `merge` -> `migrate-datasources` -> `cleanup-providers` steps - is documented
 in the [tfmigrator guide](./tfmigrator_migration.md). tfmigrator auto-detects the hpegl provider in
 your workspace, so the same commands apply here. For common issues, see
 [tfmigrator Troubleshooting](./tfmigrator_troubleshooting.md).

--- a/templates/guides/hpegl_to_hpe_migration.md
+++ b/templates/guides/hpegl_to_hpe_migration.md
@@ -1,0 +1,194 @@
+---
+page_title: "hpegl to HPE"
+subcategory: "Migration"
+---
+
+# Migrate hpegl VMaaS Provider Resources to HPE Provider Resources
+
+To migrate resources from the hpegl (`hpe/hpegl`) VMaaS provider to the HPE Terraform provider
+(`HPE/hpe`) the basic principle is to import the existing resources created with the hpegl provider
+into the HPE provider. HashiCorp documentation on import can be found
+[here](https://developer.hashicorp.com/terraform/language/import).
+
+-> [tfmigrator](./tfmigrator_migration.md) has been developed in order to assist with migration. By
+following the documented process, this tooling ports `hpegl_vmaas_*` resources to their corresponding
+`hpe_morpheus_*` resources - including handling for the provider block transformation, modules, and
+variables. See the [tfmigrator guide](./tfmigrator_migration.md) for the full command workflow (both
+the one-shot `migrate` command and the individual steps).<br><br>
+The section on [Bulk Import](https://developer.hashicorp.com/terraform/language/v1.14.x/import/bulk?page=import&page=bulk)
+requires provider support for the `List` RPC. The HPE provider does not currently support `List`,
+this is something that we are considering for a future release.<br><br>
+Unlike the Morpheus provider, **every** hpegl VMaaS resource has a different schema in the HPE
+provider (hpegl used the Terraform Plugin SDK v2; the HPE provider uses the Plugin Framework). Every
+resource therefore requires Terraform-generated configuration and manual post-migration review. The
+process documented for [tfmigrator](./tfmigrator_migration.md) handles this generation for you.
+
+## Provider Block Transformation
+
+The largest difference between an hpegl configuration and an HPE configuration is the provider block.
+hpegl authenticates through the GreenLake IAM broker, while the HPE provider connects to Morpheus
+either through GreenLake IAM or directly. The [`migrate-providers`](./tfmigrator_migration.md) step
+performs this transformation automatically (including emitting credential `variable` blocks and a
+`credentials.auto.tfvars` file), but the mapping is summarised here for reference.
+
+The generated block depends on the `iam_version` attribute of the hpegl provider (falling back to the
+`HPEGL_IAM_VERSION` environment variable):
+
+### GreenLake IAM - Connected (`iam_version = "glcs"`)
+
+```HCL
+# Before (hpegl)
+provider "hpegl" {
+  iam_version      = "glcs"
+  iam_service_url  = "https://client.greenlake.hpe.com/..."
+  vmaas {
+    location   = "HPE-Data-Center"
+    space_name = "my-space"
+    broker_url = "https://vmaas-broker.example.com"
+  }
+}
+
+# After (hpe)
+provider "hpe" {
+  morpheus {
+    pce_identity {
+      location      = "HPE-Data-Center"
+      space         = "my-space"
+      broker_url    = "https://vmaas-broker.example.com"
+      issuer_url    = "https://client.greenlake.hpe.com/..."
+      client_id     = var.hpe_pce_client_id
+      client_secret = var.hpe_pce_client_secret
+    }
+  }
+}
+```
+
+### GreenLake IAM - Disconnected (`iam_version = "glp"`)
+
+```HCL
+# After (hpe)
+provider "hpe" {
+  morpheus {
+    pce_disconnected_identity {
+      location         = "HPE-Data-Center"
+      workspace_id     = "my-space"
+      broker_url       = "https://vmaas-broker.example.com"
+      token_issuer_url = "https://client.greenlake.hpe.com/..."
+      client_id        = var.hpe_pce_client_id
+      client_secret    = var.hpe_pce_client_secret
+    }
+  }
+}
+```
+
+### Direct-connect (`vmaas.morpheus_url` present)
+
+When the hpegl `vmaas` block sets `morpheus_url`, the provider connects directly to Morpheus with no
+GreenLake IAM broker. In that case the credentials land directly inside the `morpheus` block and no
+`pce_identity` sub-block is emitted:
+
+```HCL
+# After (hpe)
+provider "hpe" {
+  morpheus {
+    url          = "https://morpheus.example.com"
+    access_token = var.hpe_morpheus_access_token
+  }
+}
+```
+
+## Resource Definitions
+
+All hpegl VMaaS resources have a different schema in the HPE provider, so Terraform is used to
+generate the HPE resource definition (this is how [tfmigrator](./tfmigrator_migration.md) handles
+these resources). In addition to the generated resource definitions, an `import` block must be
+supplied for each resource. After the import ensure that a `terraform plan` shows no changes; if
+there are changes then the resource definitions need to be adjusted to match the existing resources.
+
+| hpegl Provider Resource Name             | HPE Provider Resource Name                     |
+|------------------------------------------|------------------------------------------------|
+| hpegl_vmaas_instance                     | hpe_morpheus_instance                          |
+| hpegl_vmaas_instance_clone               | hpe_morpheus_instance_clone                    |
+| hpegl_vmaas_network                      | hpe_morpheus_network                           |
+| hpegl_vmaas_dhcp_server                  | hpe_morpheus_network_dhcp_server               |
+| hpegl_vmaas_router                       | hpe_morpheus_network_router                    |
+| hpegl_vmaas_router_bgp_neighbor          | hpe_morpheus_network_router_bgp_neighbor       |
+| hpegl_vmaas_router_nat_rule              | hpe_morpheus_network_router_nat                |
+| hpegl_vmaas_router_route                 | hpe_morpheus_network_router_route              |
+| hpegl_vmaas_router_firewall_rule_group   | hpe_morpheus_network_router_firewall_rule_group |
+| hpegl_vmaas_load_balancer                | hpe_morpheus_load_balancer                     |
+| hpegl_vmaas_load_balancer_monitor        | hpe_morpheus_load_balancer_monitor             |
+| hpegl_vmaas_load_balancer_pool           | hpe_morpheus_load_balancer_pool                |
+| hpegl_vmaas_load_balancer_profile        | hpe_morpheus_load_balancer_profile             |
+| hpegl_vmaas_load_balancer_virtual_server | hpe_morpheus_load_balancer_virtual_server      |
+
+### Composite Import IDs
+
+Most resources import with a simple integer ID. The following resources are sub-resources whose HPE
+equivalent requires a **composite** import ID rather than a bare integer. tfmigrator constructs these
+automatically from the resource state; they are listed here so the generated `import` blocks make
+sense during review.
+
+| hpegl Provider Resource Name             | Import ID format                |
+|------------------------------------------|---------------------------------|
+| hpegl_vmaas_router_bgp_neighbor          | `{router_id}.{id}`              |
+| hpegl_vmaas_router_nat_rule              | `{router_id}.{id}`              |
+| hpegl_vmaas_router_route                 | `{router_id}.{id}`              |
+| hpegl_vmaas_router_firewall_rule_group   | `{router_id}.{id}`              |
+| hpegl_vmaas_dhcp_server                  | `{network_server_id}.{id}`      |
+| hpegl_vmaas_load_balancer_monitor        | `{lb_id}.{id}`                  |
+| hpegl_vmaas_load_balancer_virtual_server | `{lb_id}.{id}`                  |
+| hpegl_vmaas_load_balancer_pool           | `{lb_id}/{id}`                  |
+| hpegl_vmaas_load_balancer_profile        | `{lb_id}/{id}`                  |
+
+## Data Source Definitions
+
+Data sources are migrated in the same way, by updating the data source type. The following table
+lists the hpegl provider data sources and their HPE equivalents.
+
+| hpegl Provider Data Source Name                   | HPE Provider Data Source Name              |
+|---------------------------------------------------|--------------------------------------------|
+| hpegl_vmaas_cloud                                 | hpe_morpheus_cloud                         |
+| hpegl_vmaas_group                                 | hpe_morpheus_group                         |
+| hpegl_vmaas_plan                                  | hpe_morpheus_service_plan                  |
+| hpegl_vmaas_layout                                | hpe_morpheus_instance_type_layout          |
+| hpegl_vmaas_network                               | hpe_morpheus_network                       |
+| hpegl_vmaas_datastore                             | hpe_morpheus_datastore                     |
+| hpegl_vmaas_template                              | hpe_morpheus_image                         |
+| hpegl_vmaas_environment                           | hpe_morpheus_environment                   |
+| hpegl_vmaas_network_type                          | hpe_morpheus_network_type                  |
+| hpegl_vmaas_network_pool                          | hpe_morpheus_network_pool                  |
+| hpegl_vmaas_network_domain                        | hpe_morpheus_network_domain                |
+| hpegl_vmaas_router                                | hpe_morpheus_network_router                |
+| hpegl_vmaas_edge_cluster                          | hpe_morpheus_network_edge_cluster          |
+| hpegl_vmaas_transport_zone                        | hpe_morpheus_network_transport_zone        |
+| hpegl_vmaas_load_balancer                         | hpe_morpheus_load_balancer                 |
+| hpegl_vmaas_load_balancer_monitor                 | hpe_morpheus_load_balancer_monitor         |
+| hpegl_vmaas_load_balancer_pool                    | hpe_morpheus_load_balancer_pool            |
+| hpegl_vmaas_load_balancer_profile                 | hpe_morpheus_load_balancer_profile         |
+| hpegl_vmaas_load_balancer_virtual_server          | hpe_morpheus_load_balancer_virtual_server  |
+| hpegl_vmaas_dhcp_server                           | hpe_morpheus_network_dhcp_server           |
+| hpegl_vmaas_resource_pool                         | hpe_morpheus_resource_pool                 |
+| hpegl_vmaas_power_schedule                        | hpe_morpheus_power_schedule                |
+| hpegl_vmaas_cloud_folder                          | hpe_morpheus_cloud_folder                  |
+| hpegl_vmaas_network_proxy                         | hpe_morpheus_network_proxy                 |
+| hpegl_vmaas_network_interface                     | hpe_morpheus_network_interface_type        |
+| hpegl_vmaas_instance_storage_controller           | hpe_morpheus_instance_storage_controller   |
+| hpegl_vmaas_lb_pool_member_group                  | hpe_morpheus_network_server_group          |
+| hpegl_vmaas_instance_disk_type                    | hpe_morpheus_instance_disk_type            |
+| hpegl_vmaas_load_balancer_virtual_server_ssl_cert | hpe_morpheus_certificate                   |
+
+### Removed Data Sources
+
+The following hpegl data source has no HPE equivalent and is removed during migration:
+
+- `hpegl_vmaas_morpheus_details` - the provider-chain broker data source; its role is replaced by the
+  provider block transformation performed by [`migrate-providers`](./tfmigrator_migration.md).
+
+## Migration Workflow
+
+The end-to-end command workflow - installation, the one-shot `tfmigrator migrate` command, and the
+individual `migrate-providers` -> `generate` -> `merge` -> `migrate-datasources` steps - is documented
+in the [tfmigrator guide](./tfmigrator_migration.md). tfmigrator auto-detects the hpegl provider in
+your workspace, so the same commands apply here. For common issues, see
+[tfmigrator Troubleshooting](./tfmigrator_troubleshooting.md).

--- a/templates/guides/opsramp_to_hpe_migration.md
+++ b/templates/guides/opsramp_to_hpe_migration.md
@@ -10,7 +10,7 @@ This guide describes how to migrate existing Terraform configurations from the s
 ## Prerequisites
 
 - Terraform >= 1.5.0 (required for `import` blocks)
-- HPE provider >= 1.6.0
+- HPE provider >= 2.0.0
 - Access to your existing OpsRamp resource IDs (from state or the OpsRamp API)
 
 ## Step 1: Update the Provider Declaration
@@ -44,7 +44,7 @@ terraform {
   required_providers {
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.6.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -173,63 +173,9 @@ Before starting, ensure you have:
 terraform show -json > state.json
 ```
 
-2. Your HPE provider setup in Terraform configuration (root and modules as needed).
+2. Your original Terraform configuration directory, containing the source (`morpheus` / `hpegl`) provider configuration.
 
-3. Your original Terraform configuration directory.
-
-Ensure provider setup is already in your Terraform files before running migration.
-
----
-
-## Basic Provider Setup (Do This First)
-
-Set up `required_providers` and provider blocks in your Terraform code before using `tfmigrator`. Update the `required_providers` block in root and modules as needed.
-
-```hcl
-terraform {
-  required_providers {
-    morpheus = {
-      source  = "gomorpheus/morpheus"
-      version = "0.14.1"
-    }
-    hpe = {
-      source  = "HPE/hpe"
-      version = ">= 2.0.0"
-    }
-  }
-}
-
-
-provider "morpheus" {
-  url      = var.morpheus_url
-  username = var.morpheus_username
-  password = var.morpheus_password
-}
-
-provider "hpe" {
-  morpheus {
-    url      = var.morpheus_url
-    username = var.morpheus_username
-    password = var.morpheus_password
-  }
-}
-
-variable "morpheus_url" {
-  type = string
-}
-
-variable "morpheus_username" {
-  type = string
-}
-
-variable "morpheus_password" {
-  type      = string
-  sensitive = true
-}
-```
-
-This setup is expected to exist before migration.
-
+-> The `migrate` and `migrate-providers` commands generate the `hpe` provider block for you automatically from your existing configuration - you do **not** need to hand-author an `hpe` provider block for the recommended workflow. A hand-authored provider block is only required if you run `generate` on its own without `migrate-providers` (see [Step 2](#step-2-generate-migration-artifacts)).
 
 ---
 
@@ -351,7 +297,16 @@ tfmigrator generate \
 - `generated/import.tf`
   - Import blocks for migrated resources
 
-- `--provider-config` should point to wherever your HPE provider is configured for the migration context (for example, `./provider.tf` or `./main.tf`). Alternatively - create a temporary file for this step (i.e. `.provider/provider.tf`) that follows the below format:
+- Cleanup is run automatically at the end of `generate` unless you pass `--no-cleanup`.
+
+### Provider context (standalone `generate` only)
+
+`generate` runs Terraform internally to produce the configuration, so it needs a provider context via `--provider-config`.
+
+- If you ran `migrate-providers` first (or used the full `migrate` command), this is already handled for you - point `--provider-config` at the generated `provider-config/` directory. No manual provider block is required.
+- If you are running `generate` **on its own**, supply a `--provider-config` file that configures the `hpe` provider (and the source provider used for planning). This can be an existing file such as `./provider.tf` or `./main.tf`, or a temporary file created just for this step.
+
+A minimal `--provider-config` file using variables:
 
 ```hcl
 terraform {
@@ -369,22 +324,34 @@ terraform {
 
 
 provider "morpheus" {
-  url      = "YOURURLHERE"
-  username = "YOURUSERNAMEHERE"
-  password = "YOURPASSWORDHERE"
+  url      = var.morpheus_url
+  username = var.morpheus_username
+  password = var.morpheus_password
 }
 
 provider "hpe" {
   morpheus {
-    url      = "YOURURLHERE"
-    username = "YOURUSERNAMEHERE"
-    password = "YOURPASSWORDHERE"
+    url      = var.morpheus_url
+    username = var.morpheus_username
+    password = var.morpheus_password
   }
 }
-```
--> If variables are used in the `--provider-config` - the respective `variable` blocks are expected to be provided in that file. The values themselves can then be passed in via `--provider-var-file` or `--provider-var`.
 
-- Cleanup is run automatically at the end of `generate` unless you pass `--no-cleanup`.
+variable "morpheus_url" {
+  type = string
+}
+
+variable "morpheus_username" {
+  type = string
+}
+
+variable "morpheus_password" {
+  type      = string
+  sensitive = true
+}
+```
+
+-> If variables are used in the `--provider-config`, the respective `variable` blocks are expected to be provided in that file. The values themselves can then be passed in via `--provider-var-file` or `--provider-var`. Alternatively, for a quick throwaway context you can inline literal values in place of the `var.*` references (for example a `.provider/provider.tf` with `url = "YOURURLHERE"`, `username = "YOURUSERNAMEHERE"`, `password = "YOURPASSWORDHERE"`) and skip the `variable` blocks.
 
 ---
 

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -30,7 +30,7 @@ This can be useful in environments that do not allow direct access to the Intern
 
 ### Install Scripts
 
-See [linux](https://github.com/HPE/terraform-provider-hpe/blob/main/scripts/install-tfmigrator.sh), [windows](https://github.com/HPE/terraform-provider-hpe/blob/main/scripts/install-tfmigrator-windows.ps1), and [macOS](https://github.com/HPE/terraform-provider-hpe/blob/main/scripts/install-tfmigrator-macos.sh) install scripts that will download the latest release of tfmigrator and install it in the appropriate location for your operating system.
+See [linux](https://github.com/HPE/terraform-provider-hpe/blob/-/scripts/install-tfmigrator.sh), [windows](https://github.com/HPE/terraform-provider-hpe/blob/-/scripts/install-tfmigrator-windows.ps1), and [macOS](https://github.com/HPE/terraform-provider-hpe/blob/-/scripts/install-tfmigrator-macos.sh) install scripts that will download the latest release of tfmigrator and install it in the appropriate location for your operating system.
 
 ### Linux
 

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -16,7 +16,7 @@ This document is a step-by-step guide for migrating Terraform configuration to H
 `tfmigrator` supports two ways of running the migration:
 
 - **Full pipeline** - a single `migrate` command that runs every step end to end.
-- **Individual steps** - run `migrate-providers`, `generate`, `merge`, and `migrate-datasources` yourself for finer control.
+- **Individual steps** - run `migrate-providers`, `generate`, `merge`, `migrate-datasources`, and `cleanup-providers` yourself for finer control.
 
 Both approaches are documented below.
 
@@ -150,12 +150,13 @@ The following examples use PowerShell on Windows (x64).
 - `generate` - extract resources from state, build `generated.tf` + `import.tf`
 - `merge` - merge generated resources into original config while preserving user intent
 - `migrate-datasources` - rewrite `hpegl_vmaas_*` / `morpheus_*` data source blocks to `hpe_morpheus_*` equivalents
+- `cleanup-providers` - remove the superseded source/intermediary provider blocks, the broker data source, and unused `required_providers` entries that the migration has replaced (run automatically by `migrate`)
 - `clean` - post-process a generated file with cleanup rules (run automatically by `generate`)
 
 A typical migration is either:
 
 - **Full pipeline:** `migrate` followed by `terraform init / plan / apply --refresh-only / apply` in the migrated output, or
-- **Individual steps:** `migrate-providers` → `generate` → `merge` → `migrate-datasources`, then the same Terraform validation/apply flow.
+- **Individual steps:** `migrate-providers` → `generate` → `merge` → `migrate-datasources` → `cleanup-providers`, then the same Terraform validation/apply flow.
 
 Optional:
 
@@ -183,7 +184,13 @@ terraform show -json > state.json
 
 The `migrate` command runs the entire migration end to end. It auto-detects the source provider
 (Morpheus or hpegl) in your workspace and runs `migrate-providers` → `generate` → `merge` →
-`migrate-datasources` in sequence.
+`migrate-datasources` in sequence. As part of this it also removes the superseded source and
+intermediary provider blocks and the broker data source (before `migrate-datasources`) and prunes the
+now-unused `required_providers` entries (after `migrate-datasources`) - the same work the standalone
+[`cleanup-providers`](#step-5-remove-superseded-provider-configuration-cleanup-providers) command
+performs for the individual flow. `migrate` interleaves this around its `migrate-datasources` step
+deliberately, to keep the output quiet; the individual flow runs it once at the end instead (see
+[Step 5](#step-5-remove-superseded-provider-configuration-cleanup-providers)).
 
 ### Basic command
 
@@ -212,7 +219,7 @@ tfmigrator migrate \
 
 - `migrated/provider-config/` - generated `hpe` provider blocks and `credentials.auto.tfvars` (from `migrate-providers`)
 - `migrated/generated/` - `generated.tf` + `import.tf` (from `generate`)
-- `migrated/final/` - the merged, ready-to-review configuration (from `merge`, then rewritten in place by `migrate-datasources`)
+- `migrated/final/` - the merged, ready-to-review configuration (from `merge`, with the superseded provider blocks removed, then rewritten in place by `migrate-datasources`, and its `required_providers` pruned)
 
 The `migrate` command derives the provider context and credentials from your existing configuration
 automatically, so you do not need to hand-author a `--provider-config` file as you would when running
@@ -240,7 +247,7 @@ the one-shot `migrate` command, for example to review the transformed provider b
 configuration before merging.
 
 The individual flow is: **Step 1** `migrate-providers` → **Step 2** `generate` → **Step 3** `merge`
-→ **Step 4** `migrate-datasources`.
+→ **Step 4** `migrate-datasources` → **Step 5** `cleanup-providers`.
 
 ---
 
@@ -454,6 +461,49 @@ tfmigrator migrate-datasources \
 Point `--input` at your merged output (for example `./migrated` from Step 3) and use `--in-place` to
 rewrite the data source blocks there. The one-shot `migrate` command runs this step automatically
 against `migrated/final/`.
+
+---
+
+## Step 5: Remove Superseded Provider Configuration (`cleanup-providers`)
+
+The migrated output still carries the original source provider blocks, the intermediary provider
+blocks, and the broker data source that chained them together (for example
+`hpegl_vmaas_morpheus_details`). These have been replaced by the generated `hpe` provider block, so
+what remains is dead configuration that still asks Terraform to install and authenticate the old
+providers. `cleanup-providers` removes those blocks and then prunes the `required_providers` entries
+that nothing references any more. Run it last, as a final tidy-up over the migrated output.
+
+Detection runs against your **original** configuration (`--working-dir`), while the removal is applied
+to the **migrated output** (`--target-dir`). The two are deliberately separate: a provider chain
+cannot be reconstructed from the migrated output alone, because `migrate-datasources` has removed the
+broker data source that identifies the chain.
+
+-> Running `cleanup-providers` after `migrate-datasources` (Step 4) is expected to surface two harmless
+messages. Step 4 will already have reported `⚠  Removed N data source(s) with no HPE equivalent ...
+(referenced in ...)` for the broker data source, and `cleanup-providers` may print a `note:` that an
+intermediary provider block references a broker data source no longer declared in the target. Both are
+benign: detection uses `--working-dir` (the untouched original), so the removal completes correctly and
+the final result is identical to what the one-shot `migrate` command produces. `migrate` simply
+interleaves the same work around its own `migrate-datasources` step to suppress those messages.
+
+### Basic command
+
+```bash
+tfmigrator cleanup-providers \
+  --working-dir . \
+  --target-dir ./migrated
+```
+
+### Cleanup-providers flags
+
+- `--working-dir, -w` Original configuration to detect against (default `.`)
+- `--target-dir, -t` Migrated output to clean up (default `./migrated/final`)
+- `--config, -c` Migration config: `auto` to detect from the workspace, or an embedded config name (`hpegl`, `morpheus`) (default `auto`)
+- `--dry-run` Show what would be removed without writing files (default `false`)
+
+The default `--target-dir` (`./migrated/final`) matches the layout the full `migrate` command produces.
+For the individual flow, point `--target-dir` at the output directory `merge` wrote to in Step 3
+(`./migrated` by default), as shown above.
 
 ---
 

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -145,7 +145,7 @@ The following examples use PowerShell on Windows (x64).
 
 `tfmigrator` provides the following commands:
 
-- `migrate` - run the full pipeline (`migrate-providers` → `generate` → `merge` → `migrate-datasources`) in one command
+- `migrate` - run the full pipeline (`migrate-providers` → `generate` → `merge` → `migrate-datasources` → `cleanup-providers`) in one command
 - `migrate-providers` - transform source (Morpheus / hpegl) provider blocks into `hpe` provider blocks
 - `generate` - extract resources from state, build `generated.tf` + `import.tf`
 - `merge` - merge generated resources into original config while preserving user intent
@@ -184,12 +184,16 @@ terraform show -json > state.json
 
 The `migrate` command runs the entire migration end to end. It auto-detects the source provider
 (Morpheus or hpegl) in your workspace and runs `migrate-providers` → `generate` → `merge` →
-`migrate-datasources` in sequence. As part of this it also removes the superseded source and
-intermediary provider blocks and the broker data source (before `migrate-datasources`) and prunes the
-now-unused `required_providers` entries (after `migrate-datasources`) - the same work the standalone
-[`cleanup-providers`](#step-5-remove-superseded-provider-configuration-cleanup-providers) command
-performs for the individual flow. `migrate` interleaves this around its `migrate-datasources` step
-deliberately, to keep the output quiet; the individual flow runs it once at the end instead (see
+`migrate-datasources` in sequence. It also performs the same work as the standalone
+[`cleanup-providers`](#step-5-remove-superseded-provider-configuration-cleanup-providers) command,
+interleaved around the `migrate-datasources` step:
+
+1. Before `migrate-datasources`: it removes the superseded source and intermediary provider blocks
+   and the broker data source.
+2. After `migrate-datasources`: it prunes the now-unused `required_providers` entries.
+
+`migrate` interleaves the cleanup this way deliberately, to keep the output quiet. The individual
+flow instead runs `cleanup-providers` once at the end (see
 [Step 5](#step-5-remove-superseded-provider-configuration-cleanup-providers)).
 
 ### Basic command

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -1,16 +1,24 @@
 ---
-page_title: "tfmigrator: Morpheus to HPE"
+page_title: "tfmigrator"
 subcategory: "Migration"
 ---
 
 
 ## What This Guide Covers
 
-This document is a step-by-step guide for migrating Terraform configuration from Morpheus provider resources to HPE provider resources using `tfmigrator`.
+This document is a step-by-step guide for migrating Terraform configuration to HPE provider resources using `tfmigrator`. It applies both to the [Morpheus](./morpheus_to_hpe_migration.md) and [hpegl](./hpegl_to_hpe_migration.md) providers as migration sources - `tfmigrator` auto-detects the source provider in your workspace.
 
 - Preserve your variables, modules, expressions, and overall configuration structure.
 - Update resource types and schemas to HPE provider resources.
+- Transform the source provider block (Morpheus or hpegl) into an `hpe` provider block.
 - Run migration into a separate output directory so you can review before apply.
+
+`tfmigrator` supports two ways of running the migration:
+
+- **Full pipeline** - a single `migrate` command that runs every step end to end.
+- **Individual steps** - run `migrate-providers`, `generate`, `merge`, and `migrate-datasources` yourself for finer control.
+
+Both approaches are documented below.
 
 ---
 
@@ -135,15 +143,23 @@ The following examples use PowerShell on Windows (x64).
 
 ## Command Summary
 
-`tfmigrator` migration flow is typically:
+`tfmigrator` provides the following commands:
 
-1. `generate` - extract resources from state, build `generated.tf` + `import.tf`
-2. `merge` - merge generated resources into original config while preserving user intent
-3. `terraform init / plan / apply --refresh-only / apply` - validate and apply in migrated output
+- `migrate` - run the full pipeline (`migrate-providers` → `generate` → `merge` → `migrate-datasources`) in one command
+- `migrate-providers` - transform source (Morpheus / hpegl) provider blocks into `hpe` provider blocks
+- `generate` - extract resources from state, build `generated.tf` + `import.tf`
+- `merge` - merge generated resources into original config while preserving user intent
+- `migrate-datasources` - rewrite `hpegl_vmaas_*` / `morpheus_*` data source blocks to `hpe_morpheus_*` equivalents
+- `clean` - post-process a generated file with cleanup rules (run automatically by `generate`)
+
+A typical migration is either:
+
+- **Full pipeline:** `migrate` followed by `terraform init / plan / apply --refresh-only / apply` in the migrated output, or
+- **Individual steps:** `migrate-providers` → `generate` → `merge` → `migrate-datasources`, then the same Terraform validation/apply flow.
 
 Optional:
 
-1. `clean` - run if you generated raw Terraform config externally and need cleanup rules - or after running `generate --no-cleanup`
+- `clean` - run if you generated raw Terraform config externally and need cleanup rules - or after running `generate --no-cleanup`
 
 ---
 
@@ -178,7 +194,7 @@ terraform {
     }
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.3.0"
+      version = ">= 2.0.0"
     }
   }
 }
@@ -217,7 +233,98 @@ This setup is expected to exist before migration.
 
 ---
 
-## Step 1: Generate Migration Artifacts
+## Full Pipeline (`migrate`)
+
+The `migrate` command runs the entire migration end to end. It auto-detects the source provider
+(Morpheus or hpegl) in your workspace and runs `migrate-providers` → `generate` → `merge` →
+`migrate-datasources` in sequence.
+
+### Basic command
+
+```bash
+tfmigrator migrate \
+  --state state.json \
+  --working-dir .
+```
+
+### Migrate flags
+
+- `--state, -s` Path to Terraform state JSON from `terraform show -json > state.json` (required)
+- `--working-dir, -w` Workspace directory containing the original Terraform configuration (default `.`)
+- `--output-dir, -o` Root output directory (default `./migrated`)
+- `--terraform-path` Path to the `terraform` binary (default `terraform`)
+- `--var-file` Variable file(s) passed to Terraform plan during generation, repeatable (default none)
+- `--var` Individual variable value(s) passed to Terraform plan in `key=value` format, repeatable (default none)
+- `--original` Original Terraform file(s)/directory(ies) to include in the final merge, repeatable (defaults to `--working-dir`)
+- `--dry-run` Show what would be done without writing files (default `false`)
+
+### Migrate output
+
+`migrate` writes into subdirectories of `--output-dir`:
+
+- `migrated/provider-config/` - generated `hpe` provider blocks and `credentials.auto.tfvars` (from `migrate-providers`)
+- `migrated/generated/` - `generated.tf` + `import.tf` (from `generate`)
+- `migrated/final/` - the merged, ready-to-review configuration (from `merge`, then rewritten in place by `migrate-datasources`)
+
+The `migrate` command derives the provider context and credentials from your existing configuration
+automatically, so you do not need to hand-author a `--provider-config` file as you would when running
+`generate` on its own.
+
+### Next steps after `migrate`
+
+```bash
+cd migrated/final
+terraform init
+terraform fmt
+terraform validate
+terraform plan
+# Check that everything is just imports
+terraform apply --refresh-only
+terraform apply
+```
+
+---
+
+# Individual Steps
+
+The remaining sections document each step individually. Run these when you want finer control than
+the one-shot `migrate` command, for example to review the transformed provider blocks or the generated
+configuration before merging.
+
+The individual flow is: **Step 1** `migrate-providers` → **Step 2** `generate` → **Step 3** `merge`
+→ **Step 4** `migrate-datasources`.
+
+---
+
+## Step 1: Transform Provider Blocks (`migrate-providers`)
+
+`migrate-providers` scans your workspace for source (Morpheus / hpegl) provider configurations and
+generates the equivalent `hpe` provider blocks, along with credential `variable` blocks and a
+`credentials.auto.tfvars` file. This is especially important for hpegl, where the GreenLake IAM
+configuration is transformed into a `morpheus { pce_identity { ... } }` block. See the
+[hpegl migration guide](./hpegl_to_hpe_migration.md) for the details of that transformation.
+
+### Basic command
+
+```bash
+tfmigrator migrate-providers \
+  --working-dir . \
+  --output-dir ./provider-config
+```
+
+### Migrate-providers flags
+
+- `--working-dir, -w` Workspace directory to scan for provider configurations (default `.`)
+- `--output-dir, -o` Output directory for generated provider files (default `./provider-config`)
+- `--config, -c` Migration config: `auto` to detect from the workspace, an embedded config name (`hpegl`, `morpheus`), or a filesystem path (default `auto`)
+- `--dry-run` Show what would be generated without writing files (default `false`)
+
+The generated `./provider-config` directory can then be passed to `generate` via `--provider-config`,
+and `credentials.auto.tfvars` supplied via `--provider-var-file`.
+
+---
+
+## Step 2: Generate Migration Artifacts
 
 ### Basic command
 
@@ -255,7 +362,7 @@ terraform {
     }
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.3.0"
+      version = ">= 2.0.0"
     }
   }
 }
@@ -281,7 +388,7 @@ provider "hpe" {
 
 ---
 
-## Optional Step 1.5: Run `clean` Manually
+## Optional Step 2.5: Run `clean` Manually
 
 Use this when:
 
@@ -305,11 +412,11 @@ tfmigrator clean \
   --output ./generated/cleaned.tf
 ```
 
-If you write to `cleaned.tf`, use that file as the `--generated` input in Step 2.
+If you write to `cleaned.tf`, use that file as the `--generated` input in Step 3.
 
 ---
 
-## Step 2: Merge Into Original Config
+## Step 3: Merge Into Original Config
 
 ### Recommended command
 
@@ -334,6 +441,36 @@ tfmigrator merge \
 - Same-schema resources are renamed while keeping existing expressions/variables where possible.
 - Different-schema resources are merged from generated output.
 - Result is written to your `--output-dir` so you can review before applying.
+
+---
+
+## Step 4: Rewrite Data Sources (`migrate-datasources`)
+
+`migrate-datasources` rewrites `hpegl_vmaas_*` and `morpheus_*` data source blocks to their
+`hpe_morpheus_*` equivalents, updates references to them, and removes data sources that have no HPE
+equivalent (for example `hpegl_vmaas_morpheus_details`).
+
+### Basic command
+
+```bash
+tfmigrator migrate-datasources \
+  --input ./migrated \
+  --in-place
+```
+
+### Migrate-datasources flags
+
+- `--input, -i` Input directory/files to process, repeatable (default `.`)
+- `--output-dir, -o` Output directory for rewritten files (default `./migrated`)
+- `--config, -c` Config source: `auto` (all embedded sets), a single embedded name (`hpegl`, `morpheus`), or a filesystem path (default `auto`)
+- `--in-place` Modify files in place instead of writing to `--output-dir` (default `false`)
+- `--dry-run` Preview changes without writing (default `false`)
+- `--no-color` Disable ANSI color in the dry-run diff (default `false`)
+- `--verbose, -v` Show detailed transformation info (default `false`)
+
+Point `--input` at your merged output (for example `./migrated` from Step 3) and use `--in-place` to
+rewrite the data source blocks there. The one-shot `migrate` command runs this step automatically
+against `migrated/final/`.
 
 ---
 

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -40,19 +40,19 @@ The following examples use Bash on Linux (x64).
 
    ```console
    RELEASE=x.y.z
-   wget -q https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/migration_tool_${RELEASE}_linux_amd64.zip
+   wget -q https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/tfmigrator_${RELEASE}_linux_amd64.zip
    ```
 
 2. Extract the archive.
 
    ```console
-   unzip migration_tool_${RELEASE}_linux_amd64.zip
+   unzip tfmigrator_${RELEASE}_linux_amd64.zip
    ```
 
 3. Move the binary to a directory in your PATH.
 
    ```console
-   sudo mv migration_tool_v${RELEASE} /usr/local/bin/tfmigrator
+   sudo mv tfmigrator_v${RELEASE} /usr/local/bin/tfmigrator
    chmod +x /usr/local/bin/tfmigrator
    ```
 
@@ -76,20 +76,20 @@ The following example uses Zsh (default) on macOS (Apple Silicon).
 
    ```console
    RELEASE=x.y.z
-   wget -q https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/migration_tool_${RELEASE}_darwin_arm64.zip
+   wget -q https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/tfmigrator_${RELEASE}_darwin_arm64.zip
    ```
 
 3. Extract the archive.
 
    ```console
-   unzip migration_tool_${RELEASE}_darwin_arm64.zip
+   unzip tfmigrator_${RELEASE}_darwin_arm64.zip
    ```
 
 4. Move the binary to a directory in your PATH.
 
 
    ```console
-   sudo mv migration_tool_v${RELEASE} /usr/local/bin/tfmigrator
+   sudo mv tfmigrator_v${RELEASE} /usr/local/bin/tfmigrator
    chmod +x /usr/local/bin/tfmigrator
    ```
 
@@ -107,20 +107,20 @@ The following examples use PowerShell on Windows (x64).
 
    ```powershell
    Set-Variable -Name "RELEASE" -Value "x.y.z"
-   Invoke-WebRequest https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/migration_tool_${RELEASE}_windows_amd64.zip -outfile migration_tool_${RELEASE}_windows_amd64.zip
+   Invoke-WebRequest https://github.com/HPE/terraform-provider-hpe/releases/download/v${RELEASE}/tfmigrator_${RELEASE}_windows_amd64.zip -outfile tfmigrator_${RELEASE}_windows_amd64.zip
    ```
 
 2. Extract the archive.
 
    ```powershell
-   Expand-Archive migration_tool_${RELEASE}_windows_amd64.zip
-   cd migration_tool_${RELEASE}_windows_amd64
+   Expand-Archive tfmigrator_${RELEASE}_windows_amd64.zip
+   cd tfmigrator_${RELEASE}_windows_amd64
    ```
 
 3. Move the binary to a directory in your PATH.
 
    ```powershell
-   Move-Item migration_tool_v${RELEASE}.exe C:\Windows\System32\tfmigrator.exe
+   Move-Item tfmigrator_v${RELEASE}.exe C:\Windows\System32\tfmigrator.exe
    ```
 
 4. Verify the installation.

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -190,7 +190,9 @@ The `migrate` command runs the entire migration end to end. It auto-detects the 
 ```bash
 tfmigrator migrate \
   --state state.json \
-  --working-dir .
+  --working-dir . \
+  --var-file terraform.tfvars \
+  --original .
 ```
 
 ### Migrate flags
@@ -277,7 +279,8 @@ and `credentials.auto.tfvars` supplied via `--provider-var-file`.
 ```bash
 tfmigrator generate \
   --state state.json \
-  --provider-config ./provider.tf
+  --provider-config ./provider.tf \
+  --provider-var-file terraform.tfvars
 ```
 
 ### Generate flags
@@ -366,18 +369,30 @@ Use this when:
 Recommended in-place cleanup:
 
 ```bash
+# Morpheus source
 tfmigrator clean \
-  --input ./generated/generated.tf \
+  --input ./generated/generated_morpheus.tf \
+  --config morpheus \
+  --in-place
+
+# hpegl source
+tfmigrator clean \
+  --input ./generated/generated_hpegl.tf \
+  --config hpegl \
   --in-place
 ```
 
 If you prefer a separate output file:
 
 ```bash
+# Morpheus source
 tfmigrator clean \
-  --input ./generated/generated.tf \
+  --input ./generated/generated_morpheus.tf \
+  --config morpheus \
   --output ./generated/cleaned.tf
 ```
+
+The `--config` flag is required and takes an embedded config name (`morpheus` or `hpegl`) or a filesystem path to a cleanup config directory - use the value matching your source provider.
 
 If you write to `cleaned.tf`, use that file as the `--generated` input in Step 3.
 

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -650,6 +650,8 @@ This allows it to identify which resources belong to modules on a merge and upda
 
 -> Ensure that the module configuration (located in `./user-policy` in the above example) is included as part of what is passed into `merge` as the `--original` configuration. Note that `--original` searches for Terraform configuration files recursively so passing in `--original .` while in the working directory where all modules are available as subdirectories is generally sufficient.  
 
+-> Modules must be available locally on disk to be migrated. `tfmigrator` only rewrites `.tf` files it can read from the paths passed to `--original`; it does not fetch remote modules. If a module is sourced remotely, copy its configuration locally, point the module `source` at the local path, and ensure that directory is reachable from `--original`. Modules that remain remote-only will be left unmigrated.
+
 ---
 
 ## Common Patterns

--- a/templates/guides/tfmigrator_migration.md
+++ b/templates/guides/tfmigrator_migration.md
@@ -287,6 +287,7 @@ tfmigrator generate \
 
 - `--state, -s` Path to Terraform state JSON from `terraform show -json > state.json` (required)
 - `--output-dir, -o` Output directory for generated files (default `./generated`)
+- `--terraform-path` Path to the `terraform` binary (default `terraform`)
 - `--provider-config` Path to a Terraform provider context file containing `terraform` and provider blocks (and optional `variable` / `locals` blocks)
 - `--provider-var-file` Optional var-file(s) for provider context, repeatable (default none)
 - `--provider-var` Optional variable(s) passed to Terraform plan in `key=value` format, repeatable (default none)
@@ -409,8 +410,8 @@ tfmigrator merge \
 
 ### Merge flags
 
-- `--generated, -g` Path to generated Terraform file (default `./generated/generated.tf`)
-- `--original, -o` Original Terraform configuration file(s) and/or directories, repeatable
+- `--generated, -g` Path(s) to generated Terraform file(s), repeatable. If omitted, auto-discovers `generated.tf` and `generated_*.tf` from `./generated`
+- `--original, -o` Original Terraform configuration file(s) and/or directories, repeatable (required)
 - `--output-dir, -d` Output directory for merged configuration (default `./migrated`)
 - `--imports-file` Explicit imports file path (auto-discovered from generated file location when omitted)
 - `--var-file` Var-file(s) to copy into output directory, repeatable (default none)

--- a/templates/guides/tfmigrator_troubleshooting.md
+++ b/templates/guides/tfmigrator_troubleshooting.md
@@ -25,7 +25,7 @@ terraform {
     }
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.3.0"
+      version = ">= 2.0.0"
     }
   }
 }
@@ -119,7 +119,7 @@ terraform {
     }
     hpe = {
       source  = "HPE/hpe"
-      version = ">= 1.3.0"
+      version = ">= 2.0.0"
     }
   }
 }
@@ -138,7 +138,7 @@ Attribute config_vmware.nested_virtualization value must be one of: ["on" "off"]
 ```
 
 Fix:
-- Ensure the HPE provider is at version `1.2.0` or later.
+- Ensure the HPE provider is at version `2.0.0` or later.
 - Alternatively, set `nested_virtualization` values to `"on"` or `"off"` in the migrated configuration.
 
 


### PR DESCRIPTION
Adding docs for new tfmigrator workflow and hpegl migration, including a table mapping each resource and datasource in hpegl to its hpe equivalent.

Also standardized 2.0.0 versioning for opsramp 